### PR TITLE
chore: cleanup dependencies by using workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,18 @@ members = [
     "nomos-services/network",
     "nomos-services/storage"
 ]
+
+[workspace.dependencies]
+async-trait = "0.1"
+async-graphql = "4"
+bytes = "1.2"
+clap = "4"
+futures = "0.3"
+serde = "1"
+tokio = "1"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-gelf = "0.7"
+tracing-subscriber = "0.3"
+thiserror = "1.0"
+overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }

--- a/nomos-services/log/Cargo.toml
+++ b/nomos-services/log/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
-serde = "1.0"
-tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber =  { version = "0.3", features = ["json"] }
-tracing-gelf = "0.7"
-futures = "0.3"
+async-trait = { workspace = true } 
+overwatch-rs = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber =  { workspace = true, features = ["json"] }
+tracing-gelf = { workspace = true }
+futures = { workspace = true }

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-bytes = "1.2"
-overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
+async-trait = { workspace = true } 
+bytes = { workspace = true } 
+overwatch-rs = { workspace = true }
 multiaddr = "0.15"
-serde = "1.0"
+serde = { workspace = true } 
 sled = { version = "0.34", optional = true }
-tokio = { version = "1", features = ["sync"] }
-thiserror = "1.0"
-tracing = "0.1"
+tokio = { workspace = true, features = ["sync"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 waku = { git = "https://github.com/waku-org/waku-rust-bindings", optional = true }
-tracing-appender = "0.2"
-tracing-subscriber =  { version = "0.3", features = ["json"] }
-tracing-gelf = "0.7"
-futures = "0.3"
+tracing-appender = { workspace = true }
+tracing-subscriber =  { workspace = true, features = ["json"] }
+tracing-gelf = { workspace = true }
+futures = { workspace = true }
 
 [features]
 default = ["waku"]

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -6,14 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-tokio = { version = "1", features = ["sync"] }
-bytes = "1.2"
-overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
-serde = "1.0"
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+bytes = { workspace = true } 
+overwatch-rs = { workspace = true }
+serde = { workspace = true }
 sled = { version = "0.34", optional = true }
-thiserror = "1.0"
-tracing = "0.1"
+thiserror = { workspace = true }
+tracing = { workspace = true } 
+
 
 [dev-dependencies]
 tempfile = "3.3"


### PR DESCRIPTION
In the workspace, many crates have the same dependencies, using `[workspace.dependencies]` to clean up the dependencies.