### PR TITLE
Fix network backend bound

### DIFF
--- a/nomos-services/network/src/backends/mod.rs
+++ b/nomos-services/network/src/backends/mod.rs
@@ -8,7 +8,7 @@ pub mod waku;
 #[async_trait::async_trait]
 pub trait NetworkBackend {
     type Settings: Clone + Debug + Send + Sync + 'static;
-    type State: ServiceState<Settings = Self::Settings> + Clone;
+    type State: ServiceState<Settings = Self::Settings> + Clone + Send + Sync;
     type Message: Debug + Send + Sync + 'static;
     type EventKind: Debug + Send + Sync + 'static;
     type NetworkEvent: Debug + Send + Sync + 'static;


### PR DESCRIPTION
After relaxing bounds on Overwatch network backend was broken because of missing bounds.