### PR TITLE
Fix Nix derivation so it works in a Darwin Nix environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,5 +19,10 @@ pkgs.mkShell {
     pkg-config
     rust-bin.stable."1.67.0".default
     go_1_19 # 1.19.5
+    clang_14
+    llvmPackages_14.libclang
   ];
+  shellHook = ''
+    export LIBCLANG_PATH="${pkgs.llvmPackages_14.libclang.lib}/lib";
+  '';
 }


### PR DESCRIPTION
Explicitly requiring clang and setting env variable