### PR TITLE
chore: add rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+reorder_imports = true
+reorder_modules = true

--- a/simulations/src/runner/mod.rs
+++ b/simulations/src/runner/mod.rs
@@ -5,16 +5,17 @@ mod sync_runner;
 
 // std
 use std::marker::PhantomData;
-
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+
 // crates
-use crate::network::Network;
 use rand::rngs::SmallRng;
 use rand::{RngCore, SeedableRng};
 use rayon::prelude::*;
 use serde::Serialize;
+
 // internal
+use crate::network::Network;
 use crate::node::Node;
 use crate::output_processors::OutData;
 use crate::overlay::Overlay;


### PR DESCRIPTION
Add `rustfmt.toml` file to let `cargo fmt` help us reorder the imports, so that we will not need to care about the imports.

Basically, the imports order will be something like:

```rust
use super::foo;

use crate::bar;

use std::baz;

use external::crate1;
use external::crate2;
```
