### PR TITLE
ci: fix GOCACHE and GOPATH to avoid poisoning

### DIFF
--- a/ci/Jenkinsfile.prs.linux
+++ b/ci/Jenkinsfile.prs.linux
@@ -7,8 +7,9 @@ pipeline {
   }
 
   environment {
-    GOPATH  = '/tmp/go'
-    GOCACHE = '/tmp/'
+    /* Avoid cache poisoning by other jobs. */
+    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
+    GOPATH  = "${env.WORKSPACE_TMP}/go"
   }
 
   options {
@@ -22,9 +23,9 @@ pipeline {
   stages {
     stage('Check') {
       steps {
-      	sh 'cargo check --all --all-features'
-      	sh 'cargo fmt -- --check'
-	sh 'cargo clippy --all --all-features -- --deny warnings'
+        sh 'cargo check --all --all-features'
+        sh 'cargo fmt -- --check'
+        sh 'cargo clippy --all --all-features -- --deny warnings'
       }
     }
 

--- a/ci/Jenkinsfile.prs.macos
+++ b/ci/Jenkinsfile.prs.macos
@@ -2,12 +2,13 @@ library 'status-jenkins-lib@v1.6.0'
 
 pipeline {
   agent {
-    label 'macos && aarch64'
+    label 'macos && aarch64 && nix-2.11'
   }
 
   environment {
-    GOPATH  = '/tmp/go'
-    GOCACHE = '/tmp/'
+    /* Avoid cache poisoning by other jobs. */
+    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
+    GOPATH  = "${env.WORKSPACE_TMP}/go"
   }
 
   options {
@@ -21,9 +22,9 @@ pipeline {
   stages {
     stage('Check') {
       steps { script {
-      	nix.shell('cargo check --all --all-features')
-      	nix.shell('cargo fmt -- --check')
-	nix.shell('cargo clippy --all --all-features -- --deny warnings')
+        nix.shell('cargo check --all --all-features')
+        nix.shell('cargo fmt -- --check')
+        nix.shell('cargo clippy --all --all-features -- --deny warnings')
       } }
     }
 


### PR DESCRIPTION
We've had this issue before with some `go-waku` builds: https://github.com/waku-org/go-waku/pull/512