### PR TITLE
Discriminate proposal messages

### DIFF
--- a/nomos-services/consensus/src/network/adapters/mock.rs
+++ b/nomos-services/consensus/src/network/adapters/mock.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use futures::StreamExt;
 use nomos_network::{
     backends::mock::{
@@ -60,7 +59,7 @@ impl NetworkAdapter for MockAdapter {
     async fn proposal_chunks_stream(
         &self,
         _view: View,
-    ) -> Box<dyn Stream<Item = Bytes> + Send + Sync + Unpin> {
+    ) -> Box<dyn Stream<Item = ProposalChunkMsg> + Send + Sync + Unpin> {
         let stream_channel = self
             .message_subscriber_channel()
             .await
@@ -75,9 +74,7 @@ impl NetworkAdapter for MockAdapter {
                                 == message.content_topic().content_topic_name
                             {
                                 let payload = message.payload();
-                                Some(Bytes::from(
-                                    ProposalChunkMsg::from_bytes(payload.as_bytes()).chunk,
-                                ))
+                                Some(ProposalChunkMsg::from_bytes(payload.as_bytes()))
                             } else {
                                 None
                             }

--- a/nomos-services/consensus/src/network/adapters/waku.rs
+++ b/nomos-services/consensus/src/network/adapters/waku.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 // crates
-use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use tokio_stream::wrappers::BroadcastStream;
 // internal
@@ -138,19 +137,16 @@ impl NetworkAdapter for WakuAdapter {
     async fn proposal_chunks_stream(
         &self,
         view: View,
-    ) -> Box<dyn Stream<Item = Bytes> + Send + Sync + Unpin> {
+    ) -> Box<dyn Stream<Item = ProposalChunkMsg> + Send + Sync + Unpin> {
         Box::new(Box::pin(
             self.cached_stream_with_content_topic(PROPOSAL_CONTENT_TOPIC.clone())
                 .await
                 .filter_map(move |message| {
                     let payload = message.payload();
-                    let ProposalChunkMsg {
-                        view: msg_view,
-                        chunk,
-                    } = ProposalChunkMsg::from_bytes(payload);
+                    let proposal = ProposalChunkMsg::from_bytes(payload);
                     async move {
-                        if view == msg_view {
-                            Some(Bytes::from(chunk))
+                        if view == proposal.view {
+                            Some(proposal)
                         } else {
                             None
                         }

--- a/nomos-services/consensus/src/network/messages.rs
+++ b/nomos-services/consensus/src/network/messages.rs
@@ -3,13 +3,13 @@
 use serde::{Deserialize, Serialize};
 // internal
 use crate::NodeId;
-use consensus_engine::{NewView, Qc, Timeout, TimeoutQc, View, Vote};
+use consensus_engine::{BlockId, NewView, Qc, Timeout, TimeoutQc, View, Vote};
 use nomos_core::wire;
 
-// TODO: Discriminate between different proposals
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ProposalChunkMsg {
     pub chunk: Box<[u8]>,
+    pub proposal: BlockId,
     pub view: View,
 }
 

--- a/nomos-services/consensus/src/network/mod.rs
+++ b/nomos-services/consensus/src/network/mod.rs
@@ -2,7 +2,6 @@ pub mod adapters;
 pub mod messages;
 
 // std
-use bytes::Bytes;
 // crates
 use futures::Stream;
 // internal
@@ -22,7 +21,7 @@ pub trait NetworkAdapter {
     async fn proposal_chunks_stream(
         &self,
         view: View,
-    ) -> Box<dyn Stream<Item = Bytes> + Send + Sync + Unpin>;
+    ) -> Box<dyn Stream<Item = ProposalChunkMsg> + Send + Sync + Unpin>;
     async fn broadcast_block_chunk(&self, chunk_msg: ProposalChunkMsg);
     async fn broadcast_timeout_qc(&self, timeout_qc_msg: TimeoutQcMsg);
     async fn timeout_stream(


### PR DESCRIPTION
Refactor `ProposalChunkMsg` to include the proposal id that it belongs to.
Adapter now return the message type instead of the Bytes, that also adds up consistency to the API as it is what we are doing with the other messages.

Closes #130 