### PR TITLE
fix: `gather_timeout` not to be pending

### DIFF
--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -494,7 +494,6 @@ where
         view: consensus_engine::View,
         threshold: usize,
     ) -> Event<P::Tx> {
-        futures::pending!();
         let timeouts = adapter
             .timeout_stream(committee, view)
             .await


### PR DESCRIPTION
This is a one-line PR that removes an unnecessary `futures::pending!()` which blocks the `gather_timeout` from being processed. Please correct me if I'm wrong, since I'm new to this codebase.