### PR TITLE
fix: prevent skipping the current view when calculating latest_committed_block

### DIFF
--- a/consensus-engine/src/lib.rs
+++ b/consensus-engine/src/lib.rs
@@ -567,7 +567,7 @@ mod test {
         assert_eq!(engine.latest_committed_block(), block1);
         assert_eq!(
             engine.committed_blocks(),
-            vec![block1.id, engine.genesis_block().id]
+            vec![block1.id, engine.genesis_block().id] // without block2 and block3
         );
 
         let block4 = next_block(&block3);
@@ -575,7 +575,7 @@ mod test {
         assert_eq!(engine.latest_committed_block(), block2);
         assert_eq!(
             engine.committed_blocks(),
-            vec![block2.id, block1.id, engine.genesis_block().id]
+            vec![block2.id, block1.id, engine.genesis_block().id] // without block3, block4
         );
     }
 


### PR DESCRIPTION
According to the [nomos-spec](https://github.com/logos-co/nomos-specs/blob/630dd3ac5c3a2c28fd23ca0a05b5089ce9774725/carnot/test_happy_path.py#L123-L123), the block with the current view shouldn't be skipped when the `latest_committed_block` is called, if I understand it correctly.

Plus, I think that the `committed_blocks()` always contain the genesis block, as the [nomos-spec](https://github.com/logos-co/nomos-specs/blob/master/carnot/carnot.py#L316-L316) does.