### PR TITLE
test: add unit tests for consensus-engine happy path

### DIFF
--- a/consensus-engine/src/lib.rs
+++ b/consensus-engine/src/lib.rs
@@ -591,12 +591,7 @@ mod test {
 
         let (engine, send) = engine.approve_block(block.clone());
         assert_eq!(engine.highest_voted_view, block.view);
-        assert_eq!(
-            send.to,
-            vec![engine.overlay.leader(block.view + 1)] // next leader
-                .into_iter()
-                .collect()
-        );
+        assert_eq!(send.to, vec![[0; 32]].into_iter().collect()); // next leader
         assert_eq!(
             send.payload,
             Payload::Vote(Vote {


### PR DESCRIPTION
Based on PR #163 

Tested some cases for `receive_block`, `approve_block`, and `local_timeout`. Before moving forward with `receive_timeout_qc` and `receive_new_view`, I would like ask for your eyes.