### PR TITLE
fix: prevent approving new views not bigger than the last timeout_qc

### DIFF
--- a/consensus-engine/src/lib.rs
+++ b/consensus-engine/src/lib.rs
@@ -396,79 +396,7 @@ mod test {
 
     use super::*;
 
-    // MockOverlay inherits FlatOverlay<RoundRobin> to override `rebuild`.
-    #[derive(Clone, Debug)]
-    struct MockOverlay(FlatOverlay<RoundRobin>);
-
-    impl Overlay for MockOverlay {
-        type Settings = Settings<RoundRobin>;
-        type LeaderSelection = RoundRobin;
-
-        fn new(settings: Self::Settings) -> Self {
-            MockOverlay(FlatOverlay::new(settings))
-        }
-
-        fn root_committee(&self) -> Committee {
-            self.0.root_committee()
-        }
-
-        fn rebuild(&mut self, _: TimeoutQc) {
-            // do nothing, instead of panicking by todo!()
-        }
-
-        fn is_member_of_child_committee(&self, parent: NodeId, child: NodeId) -> bool {
-            self.0.is_member_of_child_committee(parent, child)
-        }
-
-        fn is_member_of_root_committee(&self, id: NodeId) -> bool {
-            self.0.is_member_of_root_committee(id)
-        }
-
-        fn is_member_of_leaf_committee(&self, id: NodeId) -> bool {
-            self.0.is_member_of_leaf_committee(id)
-        }
-
-        fn is_child_of_root_committee(&self, id: NodeId) -> bool {
-            self.0.is_child_of_root_committee(id)
-        }
-
-        fn parent_committee(&self, id: NodeId) -> Committee {
-            self.0.parent_committee(id)
-        }
-
-        fn child_committees(&self, id: NodeId) -> Vec<Committee> {
-            self.0.child_committees(id)
-        }
-
-        fn leaf_committees(&self, id: NodeId) -> Vec<Committee> {
-            self.0.leaf_committees(id)
-        }
-
-        fn node_committee(&self, id: NodeId) -> Committee {
-            self.0.node_committee(id)
-        }
-
-        fn next_leader(&self) -> NodeId {
-            self.0.next_leader()
-        }
-
-        fn super_majority_threshold(&self, id: NodeId) -> usize {
-            self.0.super_majority_threshold(id)
-        }
-
-        fn leader_super_majority_threshold(&self, id: NodeId) -> usize {
-            self.0.leader_super_majority_threshold(id)
-        }
-
-        fn update_leader_selection<F, E>(&self, f: F) -> Result<Self, E>
-        where
-            F: FnOnce(Self::LeaderSelection) -> Result<Self::LeaderSelection, E>,
-        {
-            Ok(MockOverlay(self.0.update_leader_selection(f)?))
-        }
-    }
-
-    fn init_from_genesis() -> Carnot<MockOverlay> {
+    fn init_from_genesis() -> Carnot<FlatOverlay<RoundRobin>> {
         Carnot::from_genesis(
             [0; 32],
             Block {
@@ -477,7 +405,7 @@ mod test {
                 parent_qc: Qc::Standard(StandardQc::genesis()),
                 leader_proof: LeaderProof::LeaderId { leader_id: [0; 32] },
             },
-            MockOverlay::new(Settings {
+            FlatOverlay::new(Settings {
                 nodes: vec![[0; 32]],
                 leader: RoundRobin::default(),
             }),

--- a/consensus-engine/src/overlay/flat_overlay.rs
+++ b/consensus-engine/src/overlay/flat_overlay.rs
@@ -25,7 +25,7 @@ where
     }
 
     fn rebuild(&mut self, _timeout_qc: crate::TimeoutQc) {
-        todo!()
+        // do nothing for now
     }
 
     fn is_member_of_child_committee(&self, _parent: NodeId, _child: NodeId) -> bool {


### PR DESCRIPTION
Based on the PR #163 

According to the Carnot paper below, I thought we have to only approve new views that is bigger than `last_view_timeout_qc`. But, our implementation has been also accepting a new view that is equal to `last_view_timeout_qc`.
Please review this test case first: https://github.com/logos-co/nomos-node/pull/165/files#diff-654a8be71f3218398b4f0b9009ff60c15cc44a7dc9a1c43ec425b9b847d0fa97R738
![image](https://github.com/logos-co/nomos-node/assets/5462944/7d375fda-e562-4016-9f9e-e266e6149d27)
