### PR TITLE
fix: prevent skipping one view when proposing a block in unhappy path

### DIFF
--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -300,23 +300,24 @@ where
                     let (new_carnot, out) = carnot.approve_new_view(timeout_qc.clone(), new_views);
                     carnot = new_carnot;
                     output = Some(Output::Send(out));
-                    let next_view = timeout_qc.view + 2;
+                    let new_view = timeout_qc.view + 1;
+                    let next_view = new_view + 1;
                     if carnot.is_leader_for_view(next_view) {
                         let high_qc = carnot.high_qc();
                         events.push(Box::pin(view_cancel_cache.cancelable_event_future(
-                            timeout_qc.view + 1,
+                            new_view,
                             async move {
                                 let _votes = Self::gather_new_views(
                                     adapter,
                                     leader_committee,
-                                    timeout_qc,
+                                    timeout_qc.clone(),
                                     leader_tally_settings.clone(),
                                 )
                                 .await;
                                 Event::ProposeBlock {
                                     qc: Qc::Aggregated(AggregateQc {
                                         high_qc,
-                                        view: next_view,
+                                        view: new_view,
                                     }),
                                 }
                             },


### PR DESCRIPTION
Although I don't have unit tests yet, I think our implementation has been skipping one view when proposing a new block in unhappy path, as below.
```
Block(view=1, std_qc.view=0) <--- NewView(view=2, timeout_qc.view=1) <--- Block(view=4, agg_qc.view=3)
```
In other word, we don't have either block or new view for the view 3.
In this case, when the `Block(view=4, agg_qc.view=3)` is received, I think the `current_view == 2` isn't increased until we receive the `Block(view=3, qc.view=2)` (that is what we probably don't expect to receive).

So, I would like to ask if it is better to change as below, so that we don't skip the view 3.
```
Block(view=1, std_qc.view=0) <--- NewView(view=2, timeout_qc.view=1) <--- Block(view=3, agg_qc.view=2)
```
As I understand, this is also [how nomos-specs works](https://github.com/logos-co/nomos-specs/blob/630dd3ac5c3a2c28fd23ca0a05b5089ce9774725/carnot/carnot.py#L419-L419).