### PR TITLE
Remove dummy node from the simulations

### DIFF
--- a/simulations/config/carnot.json
+++ b/simulations/config/carnot.json
@@ -19,9 +19,9 @@
   },
   "overlay_settings": "Flat",
   "node_settings": {
-    "seed": 0,
     "timeout": "1000ms"
   },
+  "step_time": "100ms",
   "runner_settings": "Sync",
   "stream_settings": {
     "format": "json"

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -2,28 +2,23 @@
 use anyhow::Ok;
 use serde::Serialize;
 use simulations::node::carnot::CarnotSettings;
-use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 // crates
 use clap::Parser;
 use consensus_engine::overlay::{FlatOverlay, RandomBeaconState, RoundRobin};
 use consensus_engine::Block;
 use crossbeam::channel;
-use parking_lot::RwLock;
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
 use serde::de::DeserializeOwned;
 use simulations::network::behaviour::create_behaviours;
 use simulations::network::regions::{create_regions, RegionsData};
 use simulations::network::{InMemoryNetworkInterface, Network};
-use simulations::node::dummy::DummyNode;
-use simulations::node::{Node, NodeId, OverlayState, ViewOverlay};
+use simulations::node::{Node, NodeId};
 use simulations::output_processors::Record;
-use simulations::overlay::{create_overlay, SimulationOverlay};
 use simulations::runner::SimulationRunnerHandle;
 use simulations::streaming::{
     io::IOSubscriber, naive::NaiveSubscriber, polars::PolarsSubscriber, StreamType,
@@ -70,84 +65,47 @@ impl SimulationApp {
         let regions = create_regions(&node_ids, &mut rng, &simulation_settings.network_settings);
         let behaviours = create_behaviours(&simulation_settings.network_settings);
         let regions_data = RegionsData::new(regions, behaviours);
-        let overlay = create_overlay(&simulation_settings.overlay_settings);
-        let overlays = generate_overlays(
-            &node_ids,
-            &overlay,
-            simulation_settings.views_count,
-            simulation_settings.leaders_count,
-            &mut rng,
-        );
 
-        let overlay_state = Arc::new(RwLock::new(OverlayState {
-            all_nodes: node_ids.clone(),
-            overlay,
-            overlays,
-        }));
-
-        match &simulation_settings.node_settings {
-            simulations::settings::NodeSettings::Carnot { timeout } => {
-                let ids = node_ids.clone();
-                let mut network = Network::new(regions_data);
-                let nodes = node_ids
-                    .iter()
-                    .copied()
-                    .map(|node_id| {
-                        let (node_message_sender, node_message_receiver) = channel::unbounded();
-                        let network_message_receiver =
-                            network.connect(node_id, node_message_receiver);
-                        let network_interface = InMemoryNetworkInterface::new(
-                            node_id,
-                            node_message_sender,
-                            network_message_receiver,
-                        );
-                        let nodes: Vec<NodeId> = ids.clone().into_iter().map(Into::into).collect();
-                        let leader = nodes.first().copied().unwrap();
-                        let overlay_settings = consensus_engine::overlay::Settings {
-                            nodes: nodes.to_vec(),
-                            leader: RoundRobin::new(),
-                        };
-                        // FIXME: Actually use a proposer and a key to generate random beacon state
-                        let genesis = nomos_core::block::Block::new(
-                            0,
-                            Block::genesis().parent_qc,
-                            [].into_iter(),
-                            leader,
-                            RandomBeaconState::Sad {
-                                entropy: Box::new([0; 32]),
-                            },
-                        );
-                        CarnotNode::<FlatOverlay<RoundRobin>>::new(
-                            node_id,
-                            CarnotSettings::new(nodes, *timeout),
-                            overlay_settings,
-                            genesis,
-                            network_interface,
-                            &mut rng,
-                        )
-                    })
-                    .collect();
-                run(network, nodes, simulation_settings, stream_type)?;
-            }
-            simulations::settings::NodeSettings::Dummy => {
-                let mut network = Network::new(regions_data);
-                let nodes = node_ids
-                    .iter()
-                    .map(|node_id| {
-                        let (node_message_sender, node_message_receiver) = channel::unbounded();
-                        let network_message_receiver =
-                            network.connect(*node_id, node_message_receiver);
-                        let network_interface = InMemoryNetworkInterface::new(
-                            *node_id,
-                            node_message_sender,
-                            network_message_receiver,
-                        );
-                        DummyNode::new(*node_id, 0, overlay_state.clone(), network_interface)
-                    })
-                    .collect();
-                run(network, nodes, simulation_settings, stream_type)?;
-            }
-        };
+        let ids = node_ids.clone();
+        let mut network = Network::new(regions_data);
+        let nodes = node_ids
+            .iter()
+            .copied()
+            .map(|node_id| {
+                let (node_message_sender, node_message_receiver) = channel::unbounded();
+                let network_message_receiver = network.connect(node_id, node_message_receiver);
+                let network_interface = InMemoryNetworkInterface::new(
+                    node_id,
+                    node_message_sender,
+                    network_message_receiver,
+                );
+                let nodes: Vec<NodeId> = ids.clone().into_iter().map(Into::into).collect();
+                let leader = nodes.first().copied().unwrap();
+                let overlay_settings = consensus_engine::overlay::Settings {
+                    nodes: nodes.to_vec(),
+                    leader: RoundRobin::new(),
+                };
+                // FIXME: Actually use a proposer and a key to generate random beacon state
+                let genesis = nomos_core::block::Block::new(
+                    0,
+                    Block::genesis().parent_qc,
+                    [].into_iter(),
+                    leader,
+                    RandomBeaconState::Sad {
+                        entropy: Box::new([0; 32]),
+                    },
+                );
+                CarnotNode::<FlatOverlay<RoundRobin>>::new(
+                    node_id,
+                    CarnotSettings::new(nodes, simulation_settings.node_settings.timeout),
+                    overlay_settings,
+                    genesis,
+                    network_interface,
+                    &mut rng,
+                )
+            })
+            .collect();
+        run(network, nodes, simulation_settings, stream_type)?;
         Ok(())
     }
 }
@@ -209,19 +167,6 @@ fn signal<R: Record>(handle: SimulationRunnerHandle<R>) -> anyhow::Result<()> {
 fn load_json_from_file<T: DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
     let f = File::open(path).map_err(Box::new)?;
     Ok(serde_json::from_reader(f)?)
-}
-
-// Helper method to pregenerate views.
-// TODO: Remove once shared overlay can generate new views on demand.
-fn generate_overlays<R: Rng>(
-    _node_ids: &[NodeId],
-    _overlay: &SimulationOverlay,
-    _overlay_count: usize,
-    _leader_count: usize,
-    _rng: &mut R,
-) -> BTreeMap<usize, ViewOverlay> {
-    // TODO: This call needs to be removed
-    Default::default()
 }
 
 fn main() -> anyhow::Result<()> {

--- a/simulations/src/settings.rs
+++ b/simulations/src/settings.rs
@@ -22,14 +22,9 @@ pub enum RunnerSettings {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
-#[serde(untagged)]
-pub enum NodeSettings {
-    Carnot {
-        #[serde(with = "humantime_serde")]
-        timeout: std::time::Duration,
-    },
-    #[default]
-    Dummy,
+pub struct NodeSettings {
+    #[serde(with = "humantime_serde")]
+    pub timeout: std::time::Duration,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Dummy node is no longer needed, it complicates the configuration and runners code.