### PR TITLE
Log message sending failure

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -1,0 +1,17 @@
+log:
+  backend: "Stdout"
+  format: "Json"
+  level: "debug"
+network:
+  backend:
+    host: 0.0.0.0
+    port: 3000
+    log_level: "fatal"
+    nodeKey: null
+    discV5BootstrapNodes: []
+    initial_peers: []
+    relayTopics: []
+http:
+  backend:
+    address: 0.0.0.0:8080
+    cors_origins: []


### PR DESCRIPTION
Fix a todo in nomos-service waku adapter, to avoid panic when running mockpool-node.