### PR TITLE
test(fuzz): add invariant: current_view > high_qc

### DIFF
--- a/consensus-engine/tests/fuzz/sut.rs
+++ b/consensus-engine/tests/fuzz/sut.rs
@@ -129,6 +129,10 @@ impl StateMachineTest for ConsensusEngineTest {
         state: &Self::SystemUnderTest,
         ref_state: &<Self::Reference as ReferenceStateMachine>::State,
     ) {
+        // Check invariants that the engine state must guarantee by itself.
+        assert!(state.engine.current_view() > state.engine.high_qc().view,);
+
+        // Compare state with ref_state to ensure that ref_state reflects the state correctly.
         assert_eq!(state.engine.current_view(), ref_state.current_view());
         assert_eq!(
             state.engine.highest_voted_view(),


### PR DESCRIPTION
I added an invariant that the current_view must be always bigger than the view of the local high_qc. Please correct me if this is not a proper invariant.

As I understand, this is guaranteed by `update_high_qc()` which is called by `receive_block`, `receive_timeout_qc` and `approve_new_view`: https://github.com/logos-co/nomos-node/blob/3eceed5d9a01320ce61bc39512e2735845d3693c/consensus-engine/src/lib.rs#L260-L262

But, the one place that doesn't guarantee this invariant is `receive_timeout_qc`. As discussed in https://github.com/logos-co/nomos-node/pull/226#pullrequestreview-1498098886, if `timeout_qc.view < timeout_qc.high_qc.view()`, the invariant is broken by the code below. 
https://github.com/logos-co/nomos-node/blob/3eceed5d9a01320ce61bc39512e2735845d3693c/consensus-engine/src/lib.rs#L96-L105
Currently, this case isn't covered by the fuzz test. If this invariant is correct, we should add a proper assertion for when the `TimeoutQc` struct is constructed, as @Zeegomo commented: https://github.com/logos-co/nomos-node/pull/226#issuecomment-1607133789.