### PR TITLE
Fix #243 and #244: type wrappers

### DIFF
--- a/consensus-engine/Cargo.toml
+++ b/consensus-engine/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = "0.10"
 bls-signatures = "0.14"
+digest = "0.10"
+derive_more = "0.99"
 integer-encoding = "3"
 sha2 = "0.10"
 rand = "0.8"
@@ -18,6 +20,7 @@ fraction = { version = "0.13" }
 
 [features]
 default = []
+serde = ["dep:serde"]
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/consensus-engine/src/overlay/flat_overlay.rs
+++ b/consensus-engine/src/overlay/flat_overlay.rs
@@ -1,5 +1,5 @@
 use super::LeaderSelection;
-use crate::{Committee, NodeId, Overlay};
+use crate::{Committee, CommitteeId, NodeId, Overlay};
 use fraction::{Fraction, ToPrimitive};
 use serde::{Deserialize, Serialize};
 const LEADER_SUPER_MAJORITY_THRESHOLD_NUM: u64 = 2;
@@ -40,7 +40,11 @@ where
     }
 
     fn root_committee(&self) -> crate::Committee {
-        self.nodes.clone().into_iter().collect()
+        self.nodes
+            .clone()
+            .into_iter()
+            .map::<CommitteeId, _>(From::from)
+            .collect()
     }
 
     fn rebuild(&mut self, _timeout_qc: crate::TimeoutQc) {
@@ -68,7 +72,11 @@ where
     }
 
     fn node_committee(&self, _id: NodeId) -> crate::Committee {
-        self.nodes.clone().into_iter().collect()
+        self.nodes
+            .clone()
+            .into_iter()
+            .map::<CommitteeId, _>(From::from)
+            .collect()
     }
 
     fn child_committees(&self, _id: NodeId) -> Vec<crate::Committee> {

--- a/consensus-engine/src/overlay/random_beacon.rs
+++ b/consensus-engine/src/overlay/random_beacon.rs
@@ -1,6 +1,5 @@
 use crate::types::*;
 use bls_signatures::{PrivateKey, PublicKey, Serialize, Signature};
-use integer_encoding::VarInt;
 use rand::{seq::SliceRandom, SeedableRng};
 use serde::{Deserialize, Serialize as SerdeSerialize};
 use sha2::{Digest, Sha256};
@@ -80,7 +79,7 @@ impl RandomBeaconState {
 }
 
 fn view_to_bytes(view: View) -> Box<[u8]> {
-    View::encode_var_vec(view).into_boxed_slice()
+    view.encode_var_vec().into_boxed_slice()
 }
 
 // FIXME: the spec should be clearer on what is the expected behavior,

--- a/consensus-engine/src/overlay/tree_overlay/tree.rs
+++ b/consensus-engine/src/overlay/tree_overlay/tree.rs
@@ -1,23 +1,12 @@
-use crate::{Committee, NodeId};
-use blake2::{digest::typenum::U32, Blake2b, Digest};
-use std::collections::{HashMap, HashSet};
-
-fn blake2b_hash(committee: &Committee) -> [u8; 32] {
-    let mut hasher = Blake2b::<U32>::new();
-    let mut tmp = committee.iter().collect::<Vec<_>>();
-    tmp.sort();
-    for member in tmp {
-        hasher.update(member);
-    }
-    hasher.finalize().into()
-}
+use crate::{Committee, CommitteeId, NodeId};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub(super) struct Tree {
-    pub(super) inner_committees: Vec<NodeId>,
+    pub(super) inner_committees: Vec<CommitteeId>,
     pub(super) membership_committees: HashMap<usize, Committee>,
-    pub(super) committee_id_to_index: HashMap<NodeId, usize>,
-    pub(super) committees_by_member: HashMap<NodeId, usize>,
+    pub(super) committee_id_to_index: HashMap<CommitteeId, usize>,
+    pub(super) committees_by_member: HashMap<CommitteeId, usize>,
 }
 
 impl Tree {
@@ -50,15 +39,15 @@ impl Tree {
     pub(super) fn build_committee_from_nodes_with_size(
         nodes: &[NodeId],
         number_of_committees: usize,
-    ) -> (Vec<[u8; 32]>, HashMap<usize, Committee>) {
+    ) -> (Vec<CommitteeId>, HashMap<usize, Committee>) {
         let committee_size = nodes.len() / number_of_committees;
         let remainder = nodes.len() % number_of_committees;
 
-        let mut committees: Vec<HashSet<NodeId>> = (0..number_of_committees)
+        let mut committees: Vec<Committee> = (0..number_of_committees)
             .map(|n| {
                 nodes[n * committee_size..(n + 1) * committee_size]
                     .iter()
-                    .cloned()
+                    .map(|n| CommitteeId::from(*n))
                     .collect()
             })
             .collect();
@@ -68,15 +57,18 @@ impl Tree {
             for i in 0..remainder {
                 let node = nodes[nodes.len() - remainder + i];
                 let committee_index = i % number_of_committees;
-                committees[committee_index].insert(node);
+                committees[committee_index].insert(CommitteeId::from(node));
             }
         }
 
-        let hashes = committees.iter().map(blake2b_hash).collect::<Vec<_>>();
+        let hashes = committees
+            .iter()
+            .map(|c| CommitteeId::new(c.hash::<blake2::Blake2b<digest::typenum::U32>>().into()))
+            .collect::<Vec<_>>();
         (hashes, committees.into_iter().enumerate().collect())
     }
 
-    pub(super) fn parent_committee(&self, committee_id: &NodeId) -> Option<&[u8; 32]> {
+    pub(super) fn parent_committee(&self, committee_id: &CommitteeId) -> Option<&CommitteeId> {
         if committee_id == &self.inner_committees[0] {
             None
         } else {
@@ -87,8 +79,8 @@ impl Tree {
     }
 
     pub(super) fn parent_committee_from_member_id(&self, id: &NodeId) -> Committee {
-        let Some(committee_id) = self.committee_id_by_member_id(id) else { return HashSet::new(); };
-        let Some(parent_id) = self.parent_committee(committee_id) else { return HashSet::new(); };
+        let Some(committee_id) = self.committee_id_by_member_id(id) else { return Committee::new(); };
+        let Some(parent_id) = self.parent_committee(committee_id) else { return Committee::new(); };
         self.committee_by_committee_idx(self.committee_id_to_index[parent_id])
             .cloned()
             .unwrap_or_default()
@@ -96,8 +88,8 @@ impl Tree {
 
     pub(super) fn child_committees(
         &self,
-        committee_id: &NodeId,
-    ) -> (Option<&[u8; 32]>, Option<&[u8; 32]>) {
+        committee_id: &CommitteeId,
+    ) -> (Option<&CommitteeId>, Option<&CommitteeId>) {
         let Some(base) = self
             .committee_id_to_index
             .get(committee_id)
@@ -110,7 +102,7 @@ impl Tree {
         )
     }
 
-    pub(super) fn leaf_committees(&self) -> HashMap<&[u8; 32], &Committee> {
+    pub(super) fn leaf_committees(&self) -> HashMap<&CommitteeId, &Committee> {
         let total_leafs = (self.inner_committees.len() + 1) / 2;
         let mut leaf_committees = HashMap::new();
         for i in (self.inner_committees.len() - total_leafs)..self.inner_committees.len() {
@@ -128,12 +120,14 @@ impl Tree {
     }
 
     pub(super) fn committee_idx_by_member_id(&self, member_id: &NodeId) -> Option<usize> {
-        self.committees_by_member.get(member_id).copied()
+        self.committees_by_member
+            .get(&CommitteeId::from(*member_id))
+            .copied()
     }
 
-    pub(super) fn committee_id_by_member_id(&self, member_id: &NodeId) -> Option<&[u8; 32]> {
+    pub(super) fn committee_id_by_member_id(&self, member_id: &NodeId) -> Option<&CommitteeId> {
         self.committees_by_member
-            .get(member_id)
+            .get(&CommitteeId::from(*member_id))
             .map(|&idx| &self.inner_committees[idx])
     }
 
@@ -142,7 +136,10 @@ impl Tree {
             .and_then(|idx| self.committee_by_committee_idx(idx))
     }
 
-    pub(super) fn committee_by_committee_id(&self, committee_id: &NodeId) -> Option<&Committee> {
+    pub(super) fn committee_by_committee_id(
+        &self,
+        committee_id: &CommitteeId,
+    ) -> Option<&Committee> {
         self.committee_id_to_index
             .get(committee_id)
             .and_then(|&idx| self.committee_by_committee_idx(idx))
@@ -155,7 +152,7 @@ mod tests {
 
     #[test]
     fn test_carnot_tree_parenting() {
-        let nodes: Vec<[u8; 32]> = (0..10).map(|i| [i as u8; 32]).collect();
+        let nodes = (0..10).map(|i| [i as u8; 32].into()).collect::<Vec<_>>();
         let tree = Tree::new(&nodes, 3);
 
         let root = &tree.inner_committees[0];
@@ -168,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_carnot_tree_root_parenting() {
-        let nodes: Vec<[u8; 32]> = (0..10).map(|i| [i as u8; 32]).collect();
+        let nodes: Vec<_> = (0..10).map(|i| [i as u8; 32].into()).collect();
         let tree = Tree::new(&nodes, 3);
 
         let root = &tree.inner_committees[0];
@@ -178,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_carnot_tree_childs() {
-        let nodes: Vec<[u8; 32]> = (0..10).map(|i| [i as u8; 32]).collect();
+        let nodes: Vec<_> = (0..10).map(|i| [i as u8; 32].into()).collect();
         let tree = Tree::new(&nodes, 3);
 
         let root = &tree.inner_committees[0];

--- a/consensus-engine/src/types/block_id.rs
+++ b/consensus-engine/src/types/block_id.rs
@@ -1,0 +1,54 @@
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct BlockId(pub(crate) [u8; 32]);
+
+impl BlockId {
+    #[inline]
+    pub const fn new(val: [u8; 32]) -> Self {
+        Self(val)
+    }
+
+    #[inline]
+    pub const fn genesis() -> Self {
+        Self([0; 32])
+    }
+
+    /// Returns a random block id
+    #[inline]
+    pub fn random() -> Self {
+        use rand::RngCore;
+        let mut rng = rand::thread_rng();
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+}
+
+impl From<[u8; 32]> for BlockId {
+    fn from(id: [u8; 32]) -> Self {
+        Self(id)
+    }
+}
+
+impl From<&[u8; 32]> for BlockId {
+    fn from(id: &[u8; 32]) -> Self {
+        Self(*id)
+    }
+}
+
+impl From<BlockId> for [u8; 32] {
+    fn from(id: BlockId) -> Self {
+        id.0
+    }
+}
+
+impl core::fmt::Display for BlockId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x")?;
+        for v in self.0 {
+            write!(f, "{:02x}", v)?;
+        }
+        Ok(())
+    }
+}

--- a/consensus-engine/src/types/commitee.rs
+++ b/consensus-engine/src/types/commitee.rs
@@ -1,0 +1,152 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CommitteeId([u8; 32]);
+
+impl CommitteeId {
+    pub const fn new(val: [u8; 32]) -> Self {
+        Self(val)
+    }
+}
+
+impl From<[u8; 32]> for CommitteeId {
+    fn from(id: [u8; 32]) -> Self {
+        Self(id)
+    }
+}
+
+impl From<CommitteeId> for [u8; 32] {
+    fn from(id: CommitteeId) -> Self {
+        id.0
+    }
+}
+
+// committee id should be able to built from node id
+impl From<super::node_id::NodeId> for CommitteeId {
+    fn from(id: super::node_id::NodeId) -> Self {
+        Self(id.into())
+    }
+}
+
+// committee id should be able to built from node id
+impl From<&super::node_id::NodeId> for CommitteeId {
+    fn from(id: &super::node_id::NodeId) -> Self {
+        Self((*id).into())
+    }
+}
+
+impl core::fmt::Display for CommitteeId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x")?;
+        for v in self.0 {
+            write!(f, "{:02x}", v)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[repr(transparent)]
+pub struct Committee {
+    members: BTreeSet<CommitteeId>,
+}
+
+impl Committee {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            members: BTreeSet::new(),
+        }
+    }
+
+    #[inline]
+    pub fn hash<D: digest::Digest>(
+        &self,
+    ) -> digest::generic_array::GenericArray<u8, <D as digest::OutputSizeUser>::OutputSize> {
+        let mut hasher = D::new();
+        for member in &self.members {
+            hasher.update(member.0);
+        }
+        hasher.finalize()
+    }
+}
+
+impl<'a, T> From<T> for Committee
+where
+    T: Iterator<Item = &'a CommitteeId>,
+{
+    fn from(members: T) -> Self {
+        Self {
+            members: members.into_iter().copied().collect(),
+        }
+    }
+}
+
+impl core::iter::FromIterator<[u8; 32]> for Committee {
+    fn from_iter<T: IntoIterator<Item = [u8; 32]>>(iter: T) -> Self {
+        Self {
+            members: iter.into_iter().map(CommitteeId).collect(),
+        }
+    }
+}
+
+impl<'a> core::iter::FromIterator<&'a [u8; 32]> for Committee {
+    fn from_iter<T: IntoIterator<Item = &'a [u8; 32]>>(iter: T) -> Self {
+        Self {
+            members: iter.into_iter().copied().map(CommitteeId).collect(),
+        }
+    }
+}
+
+impl core::iter::FromIterator<CommitteeId> for Committee {
+    fn from_iter<T: IntoIterator<Item = CommitteeId>>(iter: T) -> Self {
+        Self {
+            members: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl core::iter::IntoIterator for Committee {
+    type Item = CommitteeId;
+
+    type IntoIter = std::collections::btree_set::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.members.into_iter()
+    }
+}
+
+impl<'a> core::iter::IntoIterator for &'a Committee {
+    type Item = &'a CommitteeId;
+
+    type IntoIter = std::collections::btree_set::Iter<'a, CommitteeId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.members.iter()
+    }
+}
+
+impl<'a> FromIterator<&'a CommitteeId> for Committee {
+    fn from_iter<T: IntoIterator<Item = &'a CommitteeId>>(iter: T) -> Self {
+        Self {
+            members: iter.into_iter().copied().collect(),
+        }
+    }
+}
+
+impl core::ops::Deref for Committee {
+    type Target = BTreeSet<CommitteeId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.members
+    }
+}
+
+impl core::ops::DerefMut for Committee {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.members
+    }
+}

--- a/consensus-engine/src/types/node_id.rs
+++ b/consensus-engine/src/types/node_id.rs
@@ -1,0 +1,86 @@
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct NodeId([u8; 32]);
+
+impl NodeId {
+    #[inline]
+    pub const fn new(val: [u8; 32]) -> Self {
+        Self(val)
+    }
+
+    /// Returns a random node id
+    #[inline]
+    pub fn random() -> Self {
+        use rand::RngCore;
+        let mut rng = rand::thread_rng();
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Returns the index of the node, the index is the first [0..size of usize] bytes of the node id
+    #[inline]
+    pub fn index(&self) -> usize {
+        const SIZE: usize = core::mem::size_of::<usize>();
+        let mut bytes = [0u8; SIZE];
+        bytes.copy_from_slice(&self.0[..SIZE]);
+        usize::from_be_bytes(bytes)
+    }
+}
+
+impl From<[u8; 32]> for NodeId {
+    fn from(id: [u8; 32]) -> Self {
+        Self(id)
+    }
+}
+
+impl From<&[u8; 32]> for NodeId {
+    fn from(id: &[u8; 32]) -> Self {
+        Self(*id)
+    }
+}
+
+impl From<NodeId> for [u8; 32] {
+    fn from(id: NodeId) -> Self {
+        id.0
+    }
+}
+
+// A node id should be able to built from committee id
+impl From<super::CommitteeId> for NodeId {
+    fn from(id: super::CommitteeId) -> Self {
+        Self(id.into())
+    }
+}
+
+// A node id should be able to built from committee id
+impl From<&super::CommitteeId> for NodeId {
+    fn from(id: &super::CommitteeId) -> Self {
+        Self((*id).into())
+    }
+}
+
+// A convienient way to build a node id from an index
+//
+// The format is:
+//
+// [0..size of usize]: node index in big endian
+// [size of usize..32]: zeros
+impl From<usize> for NodeId {
+    fn from(id: usize) -> Self {
+        let mut bytes = [0u8; 32];
+        bytes[..core::mem::size_of::<usize>()].copy_from_slice(&id.to_be_bytes());
+        Self(bytes)
+    }
+}
+
+impl core::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x")?;
+        for v in self.0 {
+            write!(f, "{:02x}", v)?;
+        }
+        Ok(())
+    }
+}

--- a/consensus-engine/src/types/view.rs
+++ b/consensus-engine/src/types/view.rs
@@ -1,0 +1,75 @@
+use derive_more::{Add, AddAssign, Sub, SubAssign};
+
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Add, AddAssign, Sub, SubAssign,
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct View(pub(crate) i64);
+
+impl View {
+    pub const GENESIS: Self = Self(-1);
+    pub const ZERO: Self = Self(0);
+
+    pub const fn new(val: i64) -> Self {
+        Self(val)
+    }
+
+    pub const fn genesis() -> Self {
+        Self(-1)
+    }
+
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+
+    pub fn encode_var_vec(&self) -> Vec<u8> {
+        use integer_encoding::VarInt;
+        self.0.encode_var_vec()
+    }
+
+    pub const fn incr(&self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    pub const fn decr(&self) -> Self {
+        Self(self.0 - 1)
+    }
+}
+
+impl From<i64> for View {
+    fn from(id: i64) -> Self {
+        Self(id)
+    }
+}
+
+impl From<View> for i64 {
+    fn from(id: View) -> Self {
+        id.0
+    }
+}
+
+impl core::fmt::Display for View {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// TODO: uncomment this when #[feature(step_trait)] is stabilized
+// impl std::iter::Step for View {
+//   fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+//       if start > end {
+//           None
+//       } else {
+//           Some((end.0 - start.0) as usize)
+//       }
+//   }
+
+//   fn forward_checked(start: Self, count: usize) -> Option<Self> {
+//       start.0.checked_add(count as i64).map(View)
+//   }
+
+//   fn backward_checked(start: Self, count: usize) -> Option<Self> {
+//       start.0.checked_sub(count as i64).map(View)
+//   }
+// }

--- a/consensus-engine/tests/fuzz/sut.rs
+++ b/consensus-engine/tests/fuzz/sut.rs
@@ -19,15 +19,10 @@ pub struct ConsensusEngineTest {
 impl ConsensusEngineTest {
     pub fn new() -> Self {
         let engine = Carnot::from_genesis(
-            [0; 32],
-            Block {
-                view: 0,
-                id: [0; 32],
-                parent_qc: Qc::Standard(StandardQc::genesis()),
-                leader_proof: LeaderProof::LeaderId { leader_id: [0; 32] },
-            },
+            [0; 32].into(),
+            Block::genesis(),
             FlatOverlay::new(Settings {
-                nodes: vec![[0; 32]],
+                nodes: vec![[0; 32].into()],
                 leader: RoundRobin::default(),
                 leader_super_majority_threshold: None,
             }),

--- a/nomos-core/src/block.rs
+++ b/nomos-core/src/block.rs
@@ -5,6 +5,7 @@ use core::hash::Hash;
 // crates
 use crate::wire;
 use bytes::Bytes;
+pub use consensus_engine::BlockId;
 use consensus_engine::{LeaderProof, NodeId, Qc, View};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -20,9 +21,6 @@ pub struct Block<TxId: Clone + Eq + Hash> {
     beacon: RandomBeaconState,
 }
 
-/// Identifier of a block
-pub type BlockId = [u8; 32];
-
 impl<TxId: Clone + Eq + Hash + Serialize + DeserializeOwned> Block<TxId> {
     pub fn new(
         view: View,
@@ -33,7 +31,7 @@ impl<TxId: Clone + Eq + Hash + Serialize + DeserializeOwned> Block<TxId> {
     ) -> Self {
         let transactions = txs.collect();
         let header = consensus_engine::Block {
-            id: [0; 32],
+            id: BlockId::genesis(),
             view,
             parent_qc,
             leader_proof: LeaderProof::LeaderId {
@@ -74,7 +72,7 @@ pub fn block_id_from_wire_content<Tx: Clone + Eq + Hash + Serialize + Deserializ
     let bytes = block.as_bytes();
     let mut hasher = Blake2b::<U32>::new();
     hasher.update(bytes);
-    hasher.finalize().into()
+    consensus_engine::BlockId::new(hasher.finalize().into())
 }
 
 impl<TxId: Clone + Eq + Hash + Serialize + DeserializeOwned> Block<TxId> {

--- a/nomos-services/consensus/src/network/messages.rs
+++ b/nomos-services/consensus/src/network/messages.rs
@@ -2,8 +2,7 @@
 // crates
 use serde::{Deserialize, Serialize};
 // internal
-use crate::NodeId;
-use consensus_engine::{BlockId, NewView, Qc, Timeout, TimeoutQc, View, Vote};
+use consensus_engine::{BlockId, NewView, NodeId, Qc, Timeout, TimeoutQc, View, Vote};
 use nomos_core::wire;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]

--- a/nomos-services/consensus/src/tally/happy.rs
+++ b/nomos-services/consensus/src/tally/happy.rs
@@ -64,7 +64,11 @@ impl Tally for CarnotTally {
             }
 
             // check for individual nodes votes
-            if !self.settings.participating_nodes.contains(&vote.voter) {
+            if !self
+                .settings
+                .participating_nodes
+                .contains(&(vote.voter.into()))
+            {
                 continue;
             }
 

--- a/nomos-services/consensus/src/tally/mod.rs
+++ b/nomos-services/consensus/src/tally/mod.rs
@@ -3,17 +3,16 @@ pub mod timeout;
 pub mod unhappy;
 
 // std
-use std::collections::HashSet;
 
 // crates
 use serde::{Deserialize, Serialize};
 
 // internal
-use consensus_engine::NodeId;
+use consensus_engine::Committee;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CarnotTallySettings {
     pub threshold: usize,
     // TODO: this probably should be dynamic and should change with the view (?)
-    pub participating_nodes: HashSet<NodeId>,
+    pub participating_nodes: Committee,
 }

--- a/nomos-services/consensus/src/tally/timeout.rs
+++ b/nomos-services/consensus/src/tally/timeout.rs
@@ -40,7 +40,11 @@ impl Tally for TimeoutTally {
             }
 
             // check for individual nodes votes
-            if !self.settings.participating_nodes.contains(&vote.voter) {
+            if !self
+                .settings
+                .participating_nodes
+                .contains(&(vote.voter.into()))
+            {
                 continue;
             }
 

--- a/nomos-services/consensus/src/tally/unhappy.rs
+++ b/nomos-services/consensus/src/tally/unhappy.rs
@@ -47,12 +47,16 @@ impl Tally for NewViewTally {
 
         while let Some(vote) = vote_stream.next().await {
             // check vote view is valid
-            if vote.vote.view != timeout_qc.view() + 1 {
+            if vote.vote.view != timeout_qc.view().incr() {
                 continue;
             }
 
             // check for individual nodes votes
-            if !self.settings.participating_nodes.contains(&vote.voter) {
+            if !self
+                .settings
+                .participating_nodes
+                .contains(&(vote.voter.into()))
+            {
                 continue;
             }
             seen.insert(vote.voter);

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -26,7 +26,7 @@ use simulations::streaming::{
 // internal
 use simulations::{
     node::carnot::CarnotNode, output_processors::OutData, runner::SimulationRunner,
-    settings::SimulationSettings, util::node_id,
+    settings::SimulationSettings,
 };
 mod log;
 
@@ -62,7 +62,9 @@ impl SimulationApp {
                 .as_secs()
         });
         let mut rng = SmallRng::seed_from_u64(seed);
-        let mut node_ids: Vec<NodeId> = (0..simulation_settings.node_count).map(node_id).collect();
+        let mut node_ids: Vec<NodeId> = (0..simulation_settings.node_count)
+            .map(Into::into)
+            .collect();
         node_ids.shuffle(&mut rng);
 
         let regions = create_regions(&node_ids, &mut rng, &simulation_settings.network_settings);

--- a/simulations/src/network/mod.rs
+++ b/simulations/src/network/mod.rs
@@ -324,7 +324,7 @@ mod tests {
         regions::{Region, RegionsData},
         Network, NetworkInterface, NetworkMessage,
     };
-    use crate::{network::NetworkBehaviourKey, node::NodeId, util::node_id};
+    use crate::{network::NetworkBehaviourKey, node::NodeId};
     use crossbeam::channel::{self, Receiver, Sender};
     use std::{collections::HashMap, time::Duration};
 
@@ -368,8 +368,8 @@ mod tests {
 
     #[test]
     fn send_receive_messages() {
-        let node_a = node_id(0);
-        let node_b = node_id(1);
+        let node_a = 0.into();
+        let node_b = 1.into();
 
         let regions = HashMap::from([(Region::Europe, vec![node_a, node_b])]);
         let behaviour = HashMap::from([(
@@ -417,9 +417,9 @@ mod tests {
 
     #[test]
     fn regions_send_receive_messages() {
-        let node_a = node_id(0);
-        let node_b = node_id(1);
-        let node_c = node_id(2);
+        let node_a = 0.into();
+        let node_b = 1.into();
+        let node_c = 2.into();
 
         let regions = HashMap::from([
             (Region::Asia, vec![node_a, node_b]),

--- a/simulations/src/network/regions.rs
+++ b/simulations/src/network/regions.rs
@@ -164,7 +164,6 @@ mod tests {
             NetworkSettings,
         },
         node::NodeId,
-        util::node_id,
     };
 
     #[test]
@@ -203,7 +202,9 @@ mod tests {
         let mut rng = StepRng::new(1, 0);
 
         for tcase in test_cases.iter() {
-            let nodes = (0..tcase.node_count).map(node_id).collect::<Vec<NodeId>>();
+            let nodes = (0..tcase.node_count)
+                .map(Into::into)
+                .collect::<Vec<NodeId>>();
 
             let available_regions = vec![
                 Region::NorthAmerica,

--- a/simulations/src/node/carnot/event_builder.rs
+++ b/simulations/src/node/carnot/event_builder.rs
@@ -1,10 +1,9 @@
 use crate::node::carnot::{messages::CarnotMessage, tally::Tally, timeout::TimeoutHandler};
-use crate::util::parse_idx;
+// use crate::util::parse_idx;
 use consensus_engine::{
-    AggregateQc, Carnot, NewView, Overlay, Qc, StandardQc, Timeout, TimeoutQc, View, Vote,
+    AggregateQc, Carnot, NewView, NodeId, Overlay, Qc, StandardQc, Timeout, TimeoutQc, View, Vote,
 };
 use nomos_consensus::network::messages::{NewViewMsg, TimeoutMsg, VoteMsg};
-use nomos_consensus::NodeId;
 use nomos_core::block::Block;
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -69,7 +68,7 @@ impl EventBuilder {
         if engine.highest_voted_view() == -1
             && engine.overlay().is_member_of_leaf_committee(self.id)
         {
-            tracing::info!(node = parse_idx(&self.id), "voting genesis",);
+            tracing::info!(node = %self.id, "voting genesis",);
             let genesis = engine.genesis_block();
             events.push(Event::Approve {
                 qc: Qc::Standard(StandardQc {
@@ -86,7 +85,7 @@ impl EventBuilder {
                 CarnotMessage::Proposal(msg) => {
                     let block = Block::from_bytes(&msg.chunk);
                     tracing::info!(
-                        node=parse_idx(&self.id),
+                        node=%self.id,
                         current_view = engine.current_view(),
                         block_view=block.header().view,
                         block=?block.header().id,
@@ -120,7 +119,7 @@ impl EventBuilder {
                     };
 
                     let Some(qc) = msg.qc.clone() else {
-                        tracing::warn!(node=?parse_idx(&self.id), current_view = engine.current_view(), "received vote without QC");
+                        tracing::warn!(node=%self.id, current_view = engine.current_view(), "received vote without QC");
                         continue;
                     };
 
@@ -139,7 +138,7 @@ impl EventBuilder {
                             .cloned()
                         {
                             tracing::info!(
-                                node=parse_idx(&self.id),
+                                node=%self.id,
                                 votes=votes.len(),
                                 current_view = engine.current_view(),
                                 block_view=block.view,

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -19,7 +19,6 @@ use super::{Node, NodeId};
 use crate::network::{InMemoryNetworkInterface, NetworkInterface, NetworkMessage};
 use crate::node::carnot::event_builder::{CarnotTx, Event};
 use crate::node::carnot::message_cache::MessageCache;
-use crate::util::parse_idx;
 use consensus_engine::overlay::RandomBeaconState;
 use consensus_engine::{
     Block, BlockId, Carnot, Committee, Overlay, Payload, Qc, StandardQc, TimeoutQc, View, Vote,
@@ -251,7 +250,7 @@ impl<O: Overlay> CarnotNode<O> {
             }) => {
                 for node in to {
                     self.network_interface.send_message(
-                        node,
+                        node.into(),
                         CarnotMessage::Vote(VoteMsg {
                             voter: self.id,
                             vote: vote.clone(),
@@ -269,9 +268,9 @@ impl<O: Overlay> CarnotNode<O> {
             }) => {
                 for node in to {
                     self.network_interface.send_message(
-                        node,
+                        node.into(),
                         CarnotMessage::NewView(NewViewMsg {
-                            voter: node,
+                            voter: node.into(),
                             vote: new_view.clone(),
                         }),
                     );
@@ -283,9 +282,9 @@ impl<O: Overlay> CarnotNode<O> {
             }) => {
                 for node in to {
                     self.network_interface.send_message(
-                        node,
+                        node.into(),
                         CarnotMessage::Timeout(TimeoutMsg {
-                            voter: node,
+                            voter: node.into(),
                             vote: timeout.clone(),
                         }),
                     );
@@ -353,7 +352,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                 Event::Proposal { block } => {
                     let current_view = self.engine.current_view();
                     tracing::info!(
-                        node=parse_idx(&self.id),
+                        node=%self.id,
                         last_committed_view=self.engine.latest_committed_view(),
                         current_view = current_view,
                         block_view = block.header().view,
@@ -375,7 +374,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                             }
                         }
                         Err(_) => {
-                            tracing::error!(node = parse_idx(&self.id), current_view = self.engine.current_view(), block_view = block.header().view, block = ?block.header().id, "receive block proposal, but is invalid");
+                            tracing::error!(node = %self.id, current_view = self.engine.current_view(), block_view = block.header().view, block = ?block.header().id, "receive block proposal, but is invalid");
                         }
                     }
 
@@ -393,7 +392,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                 // So we can just call approve_block
                 Event::Approve { block, .. } => {
                     tracing::info!(
-                        node = parse_idx(&self.id),
+                        node = %self.id,
                         current_view = self.engine.current_view(),
                         block_view = block.view,
                         block = ?block.id,
@@ -401,7 +400,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                         "receive approve message"
                     );
                     let (new, out) = self.engine.approve_block(block);
-                    tracing::info!(vote=?out, node=parse_idx(&self.id));
+                    tracing::info!(vote=?out, node=%self.id);
                     output = vec![Output::Send(out)];
                     self.engine = new;
                 }
@@ -426,7 +425,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                     new_views,
                 } => {
                     tracing::info!(
-                        node = parse_idx(&self.id),
+                        node = %self.id,
                         current_view = self.engine.current_view(),
                         timeout_view = timeout_qc.view(),
                         "receive new view message"
@@ -437,7 +436,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                 }
                 Event::TimeoutQc { timeout_qc } => {
                     tracing::info!(
-                        node = parse_idx(&self.id),
+                        node = %self.id,
                         current_view = self.engine.current_view(),
                         timeout_view = timeout_qc.view(),
                         "receive timeout qc message"
@@ -467,7 +466,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
                 }
                 Event::LocalTimeout => {
                     tracing::info!(
-                        node = parse_idx(&self.id),
+                        node = %self.id,
                         current_view = self.engine.current_view(),
                         "receive local timeout message"
                     );
@@ -494,6 +493,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Output<Tx: Clone + Eq + Hash> {
     Send(consensus_engine::Send),
     BroadcastTimeoutQc {

--- a/simulations/src/node/dummy.rs
+++ b/simulations/src/node/dummy.rs
@@ -450,7 +450,6 @@ mod tests {
             tree::{TreeOverlay, TreeSettings},
             Overlay,
         },
-        util::node_id,
     };
 
     use super::{DummyMessage, DummyNode, Intent, Vote};
@@ -522,7 +521,7 @@ mod tests {
             .for_each(|leader_id| {
                 for _ in 0..committee_size {
                     nodes
-                        .get(&node_id(0))
+                        .get(&0.into())
                         .unwrap()
                         .send_message(*leader_id, DummyMessage::Vote(initial_vote.clone()));
                 }
@@ -544,7 +543,7 @@ mod tests {
         let mut network = init_network(&node_ids);
 
         let view = ViewOverlay {
-            leaders: vec![node_id(0), node_id(1), node_id(2)],
+            leaders: vec![0.into(), 1.into(), 2.into()],
             layout: overlay.layout(&node_ids, &mut rng),
         };
         let overlay_state = Arc::new(RwLock::new(OverlayState {
@@ -562,9 +561,9 @@ mod tests {
         let initial_vote = Vote::new(1, Intent::FromRootToLeader);
 
         // Using any node as the sender for initial proposal to leader nodes.
-        nodes[&node_id(0)].send_message(node_id(0), DummyMessage::Vote(initial_vote.clone()));
-        nodes[&node_id(0)].send_message(node_id(1), DummyMessage::Vote(initial_vote.clone()));
-        nodes[&node_id(0)].send_message(node_id(2), DummyMessage::Vote(initial_vote));
+        nodes[&0.into()].send_message(0.into(), DummyMessage::Vote(initial_vote.clone()));
+        nodes[&0.into()].send_message(1.into(), DummyMessage::Vote(initial_vote.clone()));
+        nodes[&0.into()].send_message(2.into(), DummyMessage::Vote(initial_vote));
         network.collect_messages();
 
         for (_, node) in nodes.iter() {
@@ -592,15 +591,15 @@ mod tests {
         }
 
         // Root and Internal haven't sent their votes yet.
-        assert!(!nodes[&node_id(0)].state().view_state[&1].vote_sent); // Root
-        assert!(!nodes[&node_id(1)].state().view_state[&1].vote_sent); // Internal
-        assert!(!nodes[&node_id(2)].state().view_state[&1].vote_sent); // Internal
+        assert!(!nodes[&0.into()].state().view_state[&1].vote_sent); // Root
+        assert!(!nodes[&1.into()].state().view_state[&1].vote_sent); // Internal
+        assert!(!nodes[&2.into()].state().view_state[&1].vote_sent); // Internal
 
         // Leaves should have thier vote sent.
-        assert!(nodes[&node_id(3)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(4)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(5)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(6)].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&3.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&4.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&5.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&6.into()].state().view_state[&1].vote_sent); // Leaf
 
         // 3. Internal nodes send vote to root node.
         network.dispatch_after(elapsed);
@@ -610,15 +609,15 @@ mod tests {
         network.collect_messages();
 
         // Root hasn't sent its votes yet.
-        assert!(!nodes[&node_id(0)].state().view_state[&1].vote_sent); // Root
+        assert!(!nodes[&0.into()].state().view_state[&1].vote_sent); // Root
 
         // Internal and leaves should have thier vote sent.
-        assert!(nodes[&node_id(1)].state().view_state[&1].vote_sent); // Internal
-        assert!(nodes[&node_id(2)].state().view_state[&1].vote_sent); // Internal
-        assert!(nodes[&node_id(3)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(4)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(5)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(6)].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&1.into()].state().view_state[&1].vote_sent); // Internal
+        assert!(nodes[&2.into()].state().view_state[&1].vote_sent); // Internal
+        assert!(nodes[&3.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&4.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&5.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&6.into()].state().view_state[&1].vote_sent); // Leaf
 
         // 4. Root node send vote to next view leader nodes.
         network.dispatch_after(elapsed);
@@ -628,13 +627,13 @@ mod tests {
         network.collect_messages();
 
         // Root has sent its votes.
-        assert!(nodes[&node_id(0)].state().view_state[&1].vote_sent); // Root
-        assert!(nodes[&node_id(1)].state().view_state[&1].vote_sent); // Internal
-        assert!(nodes[&node_id(2)].state().view_state[&1].vote_sent); // Internal
-        assert!(nodes[&node_id(3)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(4)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(5)].state().view_state[&1].vote_sent); // Leaf
-        assert!(nodes[&node_id(6)].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&0.into()].state().view_state[&1].vote_sent); // Root
+        assert!(nodes[&1.into()].state().view_state[&1].vote_sent); // Internal
+        assert!(nodes[&2.into()].state().view_state[&1].vote_sent); // Internal
+        assert!(nodes[&3.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&4.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&5.into()].state().view_state[&1].vote_sent); // Leaf
+        assert!(nodes[&6.into()].state().view_state[&1].vote_sent); // Leaf
 
         // 5. Leaders receive vote and broadcast new Proposal(Block) to all nodes.
         network.dispatch_after(elapsed);
@@ -662,15 +661,15 @@ mod tests {
         }
 
         // Root and Internal haven't sent their votes yet.
-        assert!(!nodes[&node_id(0)].state().view_state[&2].vote_sent); // Root
-        assert!(!nodes[&node_id(1)].state().view_state[&2].vote_sent); // Internal
-        assert!(!nodes[&node_id(2)].state().view_state[&2].vote_sent); // Internal
+        assert!(!nodes[&0.into()].state().view_state[&2].vote_sent); // Root
+        assert!(!nodes[&1.into()].state().view_state[&2].vote_sent); // Internal
+        assert!(!nodes[&2.into()].state().view_state[&2].vote_sent); // Internal
 
         // Leaves should have thier vote sent.
-        assert!(nodes[&node_id(3)].state().view_state[&2].vote_sent); // Leaf
-        assert!(nodes[&node_id(4)].state().view_state[&2].vote_sent); // Leaf
-        assert!(nodes[&node_id(5)].state().view_state[&2].vote_sent); // Leaf
-        assert!(nodes[&node_id(6)].state().view_state[&2].vote_sent); // Leaf
+        assert!(nodes[&3.into()].state().view_state[&2].vote_sent); // Leaf
+        assert!(nodes[&4.into()].state().view_state[&2].vote_sent); // Leaf
+        assert!(nodes[&5.into()].state().view_state[&2].vote_sent); // Leaf
+        assert!(nodes[&6.into()].state().view_state[&2].vote_sent); // Leaf
     }
 
     #[test]
@@ -691,7 +690,7 @@ mod tests {
         }));
 
         // There are more nodes in the network than in a tree overlay.
-        let node_ids: Vec<NodeId> = (0..100).map(node_id).collect();
+        let node_ids: Vec<NodeId> = (0..100).map(Into::into).collect();
         let mut network = init_network(&node_ids);
 
         let overlays = generate_overlays(&node_ids, &overlay, 4, 3, &mut rng);
@@ -741,7 +740,7 @@ mod tests {
         }));
 
         // There are more nodes in the network than in a tree overlay.
-        let node_ids: Vec<NodeId> = (0..10000).map(node_id).collect();
+        let node_ids: Vec<NodeId> = (0..10000).map(Into::into).collect();
         let mut network = init_network(&node_ids);
 
         let overlays = generate_overlays(&node_ids, &overlay, 4, 100, &mut rng);
@@ -791,7 +790,7 @@ mod tests {
         }));
 
         // There are more nodes in the network than in a tree overlay.
-        let node_ids: Vec<NodeId> = (0..100000).map(node_id).collect();
+        let node_ids: Vec<NodeId> = (0..100000).map(Into::into).collect();
         let mut network = init_network(&node_ids);
 
         let overlays = generate_overlays(&node_ids, &overlay, 4, 1000, &mut rng);
@@ -831,42 +830,42 @@ mod tests {
             (
                 0,
                 None,
-                Some(BTreeSet::from([node_id(1), node_id(2)])),
+                Some(BTreeSet::from([1.into(), 2.into()])),
                 vec![DummyRole::Root],
             ),
             (
                 1,
-                Some(BTreeSet::from([node_id(0)])),
-                Some(BTreeSet::from([node_id(3), node_id(4)])),
+                Some(BTreeSet::from([0.into()])),
+                Some(BTreeSet::from([3.into(), 4.into()])),
                 vec![DummyRole::Internal],
             ),
             (
                 2,
-                Some(BTreeSet::from([node_id(0)])),
-                Some(BTreeSet::from([node_id(5), node_id(6)])),
+                Some(BTreeSet::from([0.into()])),
+                Some(BTreeSet::from([5.into(), 6.into()])),
                 vec![DummyRole::Internal],
             ),
             (
                 3,
-                Some(BTreeSet::from([node_id(1)])),
+                Some(BTreeSet::from([1.into()])),
                 None,
                 vec![DummyRole::Leaf],
             ),
             (
                 4,
-                Some(BTreeSet::from([node_id(1)])),
+                Some(BTreeSet::from([1.into()])),
                 None,
                 vec![DummyRole::Leaf],
             ),
             (
                 5,
-                Some(BTreeSet::from([node_id(2)])),
+                Some(BTreeSet::from([2.into()])),
                 None,
                 vec![DummyRole::Leaf],
             ),
             (
                 6,
-                Some(BTreeSet::from([node_id(2)])),
+                Some(BTreeSet::from([2.into()])),
                 None,
                 vec![DummyRole::Leader, DummyRole::Leaf],
             ),
@@ -878,12 +877,12 @@ mod tests {
             committee_size: 1,
         });
         let node_ids: Vec<NodeId> = overlay.nodes();
-        let leaders = vec![node_id(6)];
+        let leaders = vec![6.into()];
         let layout = overlay.layout(&node_ids, &mut rng);
         let view = ViewOverlay { leaders, layout };
 
         for (nid, expected_parents, expected_children, expected_roles) in test_cases {
-            let node_id = node_id(nid);
+            let node_id = nid.into();
             let parents = get_parent_nodes(node_id, &view);
             let children = get_child_nodes(node_id, &view);
             let role = get_roles(node_id, &view, &parents, &children);

--- a/simulations/src/node/mod.rs
+++ b/simulations/src/node/mod.rs
@@ -163,7 +163,7 @@ impl Node for usize {
     type State = Self;
 
     fn id(&self) -> NodeId {
-        crate::util::node_id(*self)
+        (*self).into()
     }
 
     fn current_view(&self) -> usize {

--- a/simulations/src/overlay/flat.rs
+++ b/simulations/src/overlay/flat.rs
@@ -6,7 +6,6 @@ use rand::Rng;
 use super::Overlay;
 use crate::node::NodeId;
 use crate::overlay::{Committee, Layout};
-use crate::util::node_id;
 
 pub struct FlatOverlay;
 impl FlatOverlay {
@@ -23,7 +22,7 @@ impl Default for FlatOverlay {
 
 impl Overlay for FlatOverlay {
     fn nodes(&self) -> Vec<NodeId> {
-        (0..10).map(node_id).collect()
+        (0..10).map(Into::into).collect()
     }
 
     fn leaders<R: Rng>(

--- a/simulations/src/overlay/tree.rs
+++ b/simulations/src/overlay/tree.rs
@@ -5,10 +5,7 @@ use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 // internal
 use super::{Committee, Layout, Overlay};
-use crate::{
-    node::{CommitteeId, NodeId},
-    util::node_id,
-};
+use crate::node::{CommitteeId, NodeId};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum TreeType {
@@ -108,7 +105,7 @@ impl TreeOverlay {
 impl Overlay for TreeOverlay {
     fn nodes(&self) -> Vec<NodeId> {
         let properties = get_tree_properties(&self.settings);
-        (0..properties.node_count).map(node_id).collect()
+        (0..properties.node_count).map(Into::into).collect()
     }
 
     fn leaders<R: rand::Rng>(
@@ -154,7 +151,6 @@ fn get_layer(id: usize) -> CommitteeId {
 
 #[cfg(test)]
 mod tests {
-    use crate::util::node_id;
 
     use super::*;
     use rand::rngs::mock::StepRng;
@@ -229,13 +225,13 @@ mod tests {
 
         let root_nodes = &layout.committees[&CommitteeId::new(0)].nodes;
         assert_eq!(root_nodes.len(), 10);
-        assert_eq!(root_nodes.first(), Some(&node_id(0)));
-        assert_eq!(root_nodes.last(), Some(&node_id(9)));
+        assert_eq!(root_nodes.first(), Some(&0.into()));
+        assert_eq!(root_nodes.last(), Some(&9.into()));
 
         let last_nodes = &layout.committees[&CommitteeId::new(1022)].nodes;
         assert_eq!(last_nodes.len(), 10);
-        assert_eq!(last_nodes.first(), Some(&node_id(10220)));
-        assert_eq!(last_nodes.last(), Some(&node_id(10229)));
+        assert_eq!(last_nodes.first(), Some(&10220.into()));
+        assert_eq!(last_nodes.last(), Some(&10229.into()));
     }
 
     #[test]

--- a/simulations/src/runner/glauber_runner.rs
+++ b/simulations/src/runner/glauber_runner.rs
@@ -1,11 +1,10 @@
 use crate::node::{Node, NodeId};
 use crate::output_processors::Record;
 use crate::runner::SimulationRunner;
-use crate::util::{node_id, parse_idx};
 use crate::warding::SimulationState;
 use crossbeam::channel::bounded;
 use crossbeam::select;
-use rand::prelude::IteratorRandom;
+use rand::seq::IteratorRandom;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -38,7 +37,7 @@ where
 
     let mut inner_runner = runner.inner;
     let nodes = runner.nodes;
-    let nodes_remaining: BTreeSet<NodeId> = (0..nodes.read().len()).map(node_id).collect();
+    let nodes_remaining: BTreeSet<NodeId> = (0..nodes.read().len()).map(Into::into).collect();
     let iterations: Vec<_> = (0..maximum_iterations).collect();
     let (stop_tx, stop_rx) = bounded(1);
     let p = runner.producer.clone();
@@ -61,7 +60,7 @@ where
                         {
                             let mut shared_nodes = nodes.write();
                             let node: &mut N = shared_nodes
-                                .get_mut(parse_idx(&node_id))
+                                .get_mut(node_id.index())
                                 .expect("Node should be present");
                             node.step(elapsed);
                         }

--- a/simulations/src/runner/layered_runner.rs
+++ b/simulations/src/runner/layered_runner.rs
@@ -43,7 +43,6 @@ use serde::Serialize;
 use crate::node::{Node, NodeId};
 use crate::output_processors::Record;
 use crate::runner::SimulationRunner;
-use crate::util::parse_idx;
 use crate::warding::SimulationState;
 
 use super::SimulationRunnerHandle;
@@ -98,7 +97,7 @@ where
                     {
                         let mut shared_nodes = nodes.write();
                         let node: &mut N = shared_nodes
-                            .get_mut(parse_idx(&node_id))
+                            .get_mut(node_id.index())
                             .expect("Node should be present");
                         let prev_view = node.current_view();
                         node.step(elapsed);

--- a/simulations/src/runner/sync_runner.rs
+++ b/simulations/src/runner/sync_runner.rs
@@ -82,7 +82,6 @@ mod tests {
         runner::SimulationRunner,
         settings::SimulationSettings,
         streaming::StreamProducer,
-        util::node_id,
     };
     use crossbeam::channel;
     use parking_lot::RwLock;
@@ -131,7 +130,7 @@ mod tests {
         };
 
         let mut rng = StepRng::new(1, 0);
-        let node_ids: Vec<NodeId> = (0..settings.node_count).map(node_id).collect();
+        let node_ids: Vec<NodeId> = (0..settings.node_count).map(Into::into).collect();
         let overlay = TreeOverlay::new(settings.overlay_settings.clone().try_into().unwrap());
         let mut network = init_network(&node_ids);
         let view = ViewOverlay {
@@ -166,7 +165,7 @@ mod tests {
         };
 
         let mut rng = StepRng::new(1, 0);
-        let node_ids: Vec<NodeId> = (0..settings.node_count).map(node_id).collect();
+        let node_ids: Vec<NodeId> = (0..settings.node_count).map(Into::into).collect();
         let overlay = TreeOverlay::new(settings.overlay_settings.clone().try_into().unwrap());
         let mut network = init_network(&node_ids);
         let view = ViewOverlay {

--- a/simulations/src/streaming/io.rs
+++ b/simulations/src/streaming/io.rs
@@ -121,7 +121,6 @@ mod tests {
         node::{dummy_streaming::DummyStreamingNode, Node, NodeId},
         output_processors::OutData,
         runner::SimulationRunner,
-        util::node_id,
         warding::SimulationState,
     };
 
@@ -153,7 +152,7 @@ mod tests {
         };
 
         let nodes = (0..6)
-            .map(|idx| DummyStreamingNode::new(node_id(idx), ()))
+            .map(|idx| DummyStreamingNode::new(idx.into(), ()))
             .collect::<Vec<_>>();
         let network = Network::new(RegionsData {
             regions: (0..6)
@@ -167,7 +166,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (region, vec![node_id(idx)])
+                    (region, vec![idx.into()])
                 })
                 .collect(),
             node_region: (0..6)
@@ -181,7 +180,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (node_id(idx), region)
+                    (idx.into(), region)
                 })
                 .collect(),
             region_network_behaviour: (0..6)

--- a/simulations/src/streaming/naive.rs
+++ b/simulations/src/streaming/naive.rs
@@ -125,7 +125,6 @@ mod tests {
         node::{dummy_streaming::DummyStreamingNode, Node, NodeId},
         output_processors::OutData,
         runner::SimulationRunner,
-        util::node_id,
         warding::SimulationState,
     };
 
@@ -158,7 +157,7 @@ mod tests {
         };
 
         let nodes = (0..6)
-            .map(|idx| DummyStreamingNode::new(node_id(idx), ()))
+            .map(|idx| DummyStreamingNode::new(idx.into(), ()))
             .collect::<Vec<_>>();
         let network = Network::new(RegionsData {
             regions: (0..6)
@@ -172,7 +171,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (region, vec![node_id(idx)])
+                    (region, vec![idx.into()])
                 })
                 .collect(),
             node_region: (0..6)
@@ -186,7 +185,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (node_id(idx), region)
+                    (idx.into(), region)
                 })
                 .collect(),
             region_network_behaviour: (0..6)

--- a/simulations/src/streaming/runtime_subscriber.rs
+++ b/simulations/src/streaming/runtime_subscriber.rs
@@ -110,7 +110,6 @@ mod tests {
         node::{dummy_streaming::DummyStreamingNode, Node, NodeId},
         output_processors::OutData,
         runner::SimulationRunner,
-        util::node_id,
         warding::SimulationState,
     };
 
@@ -143,7 +142,7 @@ mod tests {
         };
 
         let nodes = (0..6)
-            .map(|idx| DummyStreamingNode::new(node_id(idx), ()))
+            .map(|idx| DummyStreamingNode::new(idx.into(), ()))
             .collect::<Vec<_>>();
         let network = Network::new(RegionsData {
             regions: (0..6)
@@ -157,7 +156,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (region, vec![node_id(idx)])
+                    (region, vec![idx.into()])
                 })
                 .collect(),
             node_region: (0..6)
@@ -171,7 +170,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (node_id(idx), region)
+                    (idx.into(), region)
                 })
                 .collect(),
             region_network_behaviour: (0..6)

--- a/simulations/src/streaming/settings_subscriber.rs
+++ b/simulations/src/streaming/settings_subscriber.rs
@@ -110,7 +110,6 @@ mod tests {
         node::{dummy_streaming::DummyStreamingNode, Node, NodeId},
         output_processors::OutData,
         runner::SimulationRunner,
-        util::node_id,
         warding::SimulationState,
     };
 
@@ -143,7 +142,7 @@ mod tests {
         };
 
         let nodes = (0..6)
-            .map(|idx| DummyStreamingNode::new(node_id(idx), ()))
+            .map(|idx| DummyStreamingNode::new(idx.into(), ()))
             .collect::<Vec<_>>();
         let network = Network::new(RegionsData {
             regions: (0..6)
@@ -157,7 +156,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (region, vec![node_id(idx)])
+                    (region, vec![idx.into()])
                 })
                 .collect(),
             node_region: (0..6)
@@ -171,7 +170,7 @@ mod tests {
                         5 => Region::Australia,
                         _ => unreachable!(),
                     };
-                    (node_id(idx), region)
+                    (idx.into(), region)
                 })
                 .collect(),
             region_network_behaviour: (0..6)

--- a/simulations/src/util.rs
+++ b/simulations/src/util.rs
@@ -1,20 +1,8 @@
-/// Create a random node id.
-///
-/// The format is:
-///
-/// [0..4]: node index in big endian
-/// [4..32]: zeros
-pub fn node_id(id: usize) -> consensus_engine::NodeId {
-    let mut bytes = [0; 32];
-    bytes[..4].copy_from_slice((id as u32).to_be_bytes().as_ref());
-    bytes
-}
+// /// Parse the original index from NodeId
+// pub(crate) fn parse_idx(id: &consensus_engine::NodeId) -> usize {
+//     let mut bytes = [0; 4];
+//     bytes.copy_from_slice(&id[..4]);
+//     u32::from_be_bytes(bytes) as usize
+// }
 
-/// Parse the original index from NodeId
-pub(crate) fn parse_idx(id: &consensus_engine::NodeId) -> usize {
-    let mut bytes = [0; 4];
-    bytes.copy_from_slice(&id[..4]);
-    u32::from_be_bytes(bytes) as usize
-}
-
-pub(crate) mod millis_duration {}
+// pub(crate) mod millis_duration {}


### PR DESCRIPTION
Remove type aliases in the `consensus-engine` crate, and use independent types for `View`, `NodeId`, `Committee`, `CommitteeId`, and `BlockId` so that we will never mess up types when writing code.