### PR TITLE
Simulation network broadcast fix

### DIFF
--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -77,10 +77,17 @@ impl SimulationApp {
             .iter()
             .copied()
             .map(|node_id| {
+                let (node_message_broadcast_sender, node_message_broadcast_receiver) =
+                    channel::unbounded();
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
-                let network_message_receiver = network.connect(node_id, node_message_receiver);
+                let network_message_receiver = network.connect(
+                    node_id,
+                    node_message_receiver,
+                    node_message_broadcast_receiver,
+                );
                 let network_interface = InMemoryNetworkInterface::new(
                     node_id,
+                    node_message_broadcast_sender,
                     node_message_sender,
                     network_message_receiver,
                 );

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -72,7 +72,7 @@ impl SimulationApp {
         let regions_data = RegionsData::new(regions, behaviours);
 
         let ids = node_ids.clone();
-        let mut network = Network::new(regions_data);
+        let mut network = Network::new(regions_data, seed);
         let nodes: Vec<BoxedNode<CarnotSettings, CarnotState>> = node_ids
             .iter()
             .copied()

--- a/simulations/src/network/mod.rs
+++ b/simulations/src/network/mod.rs
@@ -176,24 +176,16 @@ where
 
         let mut broadcast_messages = self
             .from_node_broadcast_receivers
-            .par_iter()
+            .iter()
             .flat_map(|(_, from_node)| {
-                from_node
-                    .try_iter()
-                    .flat_map(|msg| {
-                        self.to_node_senders
-                            .keys()
-                            .map(|recipient| {
-                                let mut msg = msg.clone();
-                                msg.to = Some(*recipient);
-                                msg
-                            })
-                            .collect::<Vec<_>>()
+                from_node.try_iter().flat_map(|msg| {
+                    self.to_node_senders.keys().map(move |recipient| {
+                        let mut m = msg.clone();
+                        m.to = Some(*recipient);
+                        m
                     })
-                    .collect::<Vec<_>>()
+                })
             })
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|m| (self.network_time, m))
             .collect::<Vec<_>>();
         self.messages.append(&mut broadcast_messages);

--- a/simulations/src/network/mod.rs
+++ b/simulations/src/network/mod.rs
@@ -373,12 +373,24 @@ mod tests {
         let mut network = Network::new(regions_data);
 
         let (from_a_sender, from_a_receiver) = channel::unbounded();
-        let to_a_receiver = network.connect(node_a, from_a_receiver);
-        let a = MockNetworkInterface::new(node_a, from_a_sender, to_a_receiver);
+        let (from_a_broadcast_sender, from_a_broadcast_receiver) = channel::unbounded();
+        let to_a_receiver = network.connect(node_a, from_a_receiver, from_a_broadcast_receiver);
+        let a = MockNetworkInterface::new(
+            node_a,
+            from_a_broadcast_sender,
+            from_a_sender,
+            to_a_receiver,
+        );
 
         let (from_b_sender, from_b_receiver) = channel::unbounded();
-        let to_b_receiver = network.connect(node_b, from_b_receiver);
-        let b = MockNetworkInterface::new(node_b, from_b_sender, to_b_receiver);
+        let (from_b_broadcast_sender, from_b_broadcast_receiver) = channel::unbounded();
+        let to_b_receiver = network.connect(node_b, from_b_receiver, from_b_broadcast_receiver);
+        let b = MockNetworkInterface::new(
+            node_b,
+            from_b_broadcast_sender,
+            from_b_sender,
+            to_b_receiver,
+        );
 
         a.send_message(node_b, ());
         network.collect_messages();
@@ -436,16 +448,34 @@ mod tests {
         let mut network = Network::new(regions_data);
 
         let (from_a_sender, from_a_receiver) = channel::unbounded();
-        let to_a_receiver = network.connect(node_a, from_a_receiver);
-        let a = MockNetworkInterface::new(node_a, from_a_sender, to_a_receiver);
+        let (from_a_broadcast_sender, from_a_broadcast_receiver) = channel::unbounded();
+        let to_a_receiver = network.connect(node_a, from_a_receiver, from_a_broadcast_receiver);
+        let a = MockNetworkInterface::new(
+            node_a,
+            from_a_broadcast_sender,
+            from_a_sender,
+            to_a_receiver,
+        );
 
         let (from_b_sender, from_b_receiver) = channel::unbounded();
-        let to_b_receiver = network.connect(node_b, from_b_receiver);
-        let b = MockNetworkInterface::new(node_b, from_b_sender, to_b_receiver);
+        let (from_b_broadcast_sender, from_b_broadcast_receiver) = channel::unbounded();
+        let to_b_receiver = network.connect(node_b, from_b_receiver, from_b_broadcast_receiver);
+        let b = MockNetworkInterface::new(
+            node_b,
+            from_b_broadcast_sender,
+            from_b_sender,
+            to_b_receiver,
+        );
 
         let (from_c_sender, from_c_receiver) = channel::unbounded();
-        let to_c_receiver = network.connect(node_c, from_c_receiver);
-        let c = MockNetworkInterface::new(node_c, from_c_sender, to_c_receiver);
+        let (from_c_broadcast_sender, from_c_broadcast_receiver) = channel::unbounded();
+        let to_c_receiver = network.connect(node_c, from_c_receiver, from_c_broadcast_receiver);
+        let c = MockNetworkInterface::new(
+            node_c,
+            from_c_broadcast_sender,
+            from_c_sender,
+            to_c_receiver,
+        );
 
         a.send_message(node_b, ());
         a.send_message(node_c, ());

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -291,13 +291,11 @@ impl<O: Overlay> CarnotNode<O> {
                 }
             }
             Output::BroadcastTimeoutQc { timeout_qc } => {
-                self.network_interface.send_message(
-                    self.id,
-                    CarnotMessage::TimeoutQc(TimeoutQcMsg {
+                self.network_interface
+                    .broadcast(CarnotMessage::TimeoutQc(TimeoutQcMsg {
                         source: self.id,
                         qc: timeout_qc,
-                    }),
-                );
+                    }));
             }
             Output::BroadcastProposal { proposal } => {
                 self.network_interface

--- a/simulations/src/node/carnot/tally.rs
+++ b/simulations/src/node/carnot/tally.rs
@@ -8,7 +8,7 @@ pub(crate) struct Tally<T: core::hash::Hash + Eq> {
 
 impl<T: core::hash::Hash + Eq> Default for Tally<T> {
     fn default() -> Self {
-        Self::new(0)
+        Self::new(2)
     }
 }
 

--- a/simulations/src/node/dummy.rs
+++ b/simulations/src/node/dummy.rs
@@ -326,13 +326,9 @@ impl DummyNode {
     }
 
     fn handle_message(&mut self, message: &NetworkMessage<DummyMessage>) {
-        let payload = match message {
-            NetworkMessage::Adhoc(m) => m.payload.clone(),
-            NetworkMessage::Broadcast(m) => m.payload.clone(),
-        };
         // The view can change on any message, node needs to change its position
         // and roles if the view changes during the message processing.
-        if let DummyMessage::Proposal(block) = &payload {
+        if let DummyMessage::Proposal(block) = &message.payload {
             if block.view > self.current_view() {
                 self.update_view(block.view);
             }
@@ -341,10 +337,10 @@ impl DummyNode {
 
         for role in roles.iter() {
             match role {
-                DummyRole::Leader => self.handle_leader(&payload),
-                DummyRole::Root => self.handle_root(&payload),
-                DummyRole::Internal => self.handle_internal(&payload),
-                DummyRole::Leaf => self.handle_leaf(&payload),
+                DummyRole::Leader => self.handle_leader(&message.payload),
+                DummyRole::Root => self.handle_root(&message.payload),
+                DummyRole::Internal => self.handle_internal(&message.payload),
+                DummyRole::Leaf => self.handle_leaf(&message.payload),
                 DummyRole::Unknown => (),
             }
         }

--- a/simulations/src/node/dummy.rs
+++ b/simulations/src/node/dummy.rs
@@ -457,7 +457,7 @@ mod tests {
             NetworkBehaviour::new(Duration::from_millis(100), 0.0),
         )]);
         let regions_data = RegionsData::new(regions, behaviour);
-        Network::new(regions_data)
+        Network::new(regions_data, 0)
     }
 
     fn init_dummy_nodes(

--- a/simulations/src/node/dummy.rs
+++ b/simulations/src/node/dummy.rs
@@ -469,9 +469,16 @@ mod tests {
             .iter()
             .map(|node_id| {
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
-                let network_message_receiver = network.connect(*node_id, node_message_receiver);
+                let (node_message_broadcast_sender, node_message_broadcast_receiver) =
+                    channel::unbounded();
+                let network_message_receiver = network.connect(
+                    *node_id,
+                    node_message_receiver,
+                    node_message_broadcast_receiver,
+                );
                 let network_interface = InMemoryNetworkInterface::new(
                     *node_id,
+                    node_message_broadcast_sender,
                     node_message_sender,
                     network_message_receiver,
                 );

--- a/simulations/src/runner/sync_runner.rs
+++ b/simulations/src/runner/sync_runner.rs
@@ -99,7 +99,7 @@ mod tests {
             NetworkBehaviour::new(Duration::from_millis(100), 0.0),
         )]);
         let regions_data = RegionsData::new(regions, behaviour);
-        Network::new(regions_data)
+        Network::new(regions_data, 0)
     }
 
     fn init_dummy_nodes(

--- a/simulations/src/runner/sync_runner.rs
+++ b/simulations/src/runner/sync_runner.rs
@@ -111,9 +111,16 @@ mod tests {
             .iter()
             .map(|node_id| {
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
-                let network_message_receiver = network.connect(*node_id, node_message_receiver);
+                let (node_message_broadcast_sender, node_message_broadcast_receiver) =
+                    channel::unbounded();
+                let network_message_receiver = network.connect(
+                    *node_id,
+                    node_message_receiver,
+                    node_message_broadcast_receiver,
+                );
                 let network_interface = InMemoryNetworkInterface::new(
                     *node_id,
+                    node_message_broadcast_sender,
                     node_message_sender,
                     network_message_receiver,
                 );

--- a/simulations/src/streaming/io.rs
+++ b/simulations/src/streaming/io.rs
@@ -164,56 +164,59 @@ mod tests {
                     >
             })
             .collect::<Vec<_>>();
-        let network = Network::new(RegionsData {
-            regions: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (region, vec![NodeId::from_index(idx)])
-                })
-                .collect(),
-            node_region: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (NodeId::from_index(idx), region)
-                })
-                .collect(),
-            region_network_behaviour: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (
-                        NetworkBehaviourKey::new(region, region),
-                        NetworkBehaviour {
-                            delay: Duration::from_millis(100),
-                            drop: 0.0,
-                        },
-                    )
-                })
-                .collect(),
-        });
+        let network = Network::new(
+            RegionsData {
+                regions: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (region, vec![NodeId::from_index(idx)])
+                    })
+                    .collect(),
+                node_region: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (NodeId::from_index(idx), region)
+                    })
+                    .collect(),
+                region_network_behaviour: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (
+                            NetworkBehaviourKey::new(region, region),
+                            NetworkBehaviour {
+                                delay: Duration::from_millis(100),
+                                drop: 0.0,
+                            },
+                        )
+                    })
+                    .collect(),
+            },
+            0,
+        );
         let simulation_runner: SimulationRunner<(), OutData, (), DummyStreamingState> =
             SimulationRunner::new(network, nodes, Default::default(), simulation_settings).unwrap();
         simulation_runner

--- a/simulations/src/streaming/naive.rs
+++ b/simulations/src/streaming/naive.rs
@@ -169,56 +169,59 @@ mod tests {
                     >
             })
             .collect::<Vec<_>>();
-        let network = Network::new(RegionsData {
-            regions: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (region, vec![NodeId::from_index(idx)])
-                })
-                .collect(),
-            node_region: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (NodeId::from_index(idx), region)
-                })
-                .collect(),
-            region_network_behaviour: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (
-                        NetworkBehaviourKey::new(region, region),
-                        NetworkBehaviour {
-                            delay: Duration::from_millis(100),
-                            drop: 0.0,
-                        },
-                    )
-                })
-                .collect(),
-        });
+        let network = Network::new(
+            RegionsData {
+                regions: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (region, vec![NodeId::from_index(idx)])
+                    })
+                    .collect(),
+                node_region: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (NodeId::from_index(idx), region)
+                    })
+                    .collect(),
+                region_network_behaviour: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (
+                            NetworkBehaviourKey::new(region, region),
+                            NetworkBehaviour {
+                                delay: Duration::from_millis(100),
+                                drop: 0.0,
+                            },
+                        )
+                    })
+                    .collect(),
+            },
+            0,
+        );
         let simulation_runner: SimulationRunner<(), OutData, (), DummyStreamingState> =
             SimulationRunner::new(network, nodes, Default::default(), simulation_settings).unwrap();
         simulation_runner.simulate().unwrap();

--- a/simulations/src/streaming/runtime_subscriber.rs
+++ b/simulations/src/streaming/runtime_subscriber.rs
@@ -154,56 +154,59 @@ mod tests {
                     >
             })
             .collect::<Vec<_>>();
-        let network = Network::new(RegionsData {
-            regions: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (region, vec![NodeId::from_index(idx)])
-                })
-                .collect(),
-            node_region: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (NodeId::from_index(idx), region)
-                })
-                .collect(),
-            region_network_behaviour: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (
-                        NetworkBehaviourKey::new(region, region),
-                        NetworkBehaviour {
-                            delay: Duration::from_millis(100),
-                            drop: 0.0,
-                        },
-                    )
-                })
-                .collect(),
-        });
+        let network = Network::new(
+            RegionsData {
+                regions: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (region, vec![NodeId::from_index(idx)])
+                    })
+                    .collect(),
+                node_region: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (NodeId::from_index(idx), region)
+                    })
+                    .collect(),
+                region_network_behaviour: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (
+                            NetworkBehaviourKey::new(region, region),
+                            NetworkBehaviour {
+                                delay: Duration::from_millis(100),
+                                drop: 0.0,
+                            },
+                        )
+                    })
+                    .collect(),
+            },
+            0,
+        );
         let simulation_runner: SimulationRunner<(), OutData, (), DummyStreamingState> =
             SimulationRunner::new(network, nodes, Default::default(), simulation_settings).unwrap();
         simulation_runner.simulate().unwrap();

--- a/simulations/src/streaming/settings_subscriber.rs
+++ b/simulations/src/streaming/settings_subscriber.rs
@@ -154,56 +154,59 @@ mod tests {
                     >
             })
             .collect::<Vec<_>>();
-        let network = Network::new(RegionsData {
-            regions: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (region, vec![NodeId::from_index(idx)])
-                })
-                .collect(),
-            node_region: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (NodeId::from_index(idx), region)
-                })
-                .collect(),
-            region_network_behaviour: (0..6)
-                .map(|idx| {
-                    let region = match idx % 6 {
-                        0 => Region::Europe,
-                        1 => Region::NorthAmerica,
-                        2 => Region::SouthAmerica,
-                        3 => Region::Asia,
-                        4 => Region::Africa,
-                        5 => Region::Australia,
-                        _ => unreachable!(),
-                    };
-                    (
-                        NetworkBehaviourKey::new(region, region),
-                        NetworkBehaviour {
-                            delay: Duration::from_millis(100),
-                            drop: 0.0,
-                        },
-                    )
-                })
-                .collect(),
-        });
+        let network = Network::new(
+            RegionsData {
+                regions: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (region, vec![NodeId::from_index(idx)])
+                    })
+                    .collect(),
+                node_region: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (NodeId::from_index(idx), region)
+                    })
+                    .collect(),
+                region_network_behaviour: (0..6)
+                    .map(|idx| {
+                        let region = match idx % 6 {
+                            0 => Region::Europe,
+                            1 => Region::NorthAmerica,
+                            2 => Region::SouthAmerica,
+                            3 => Region::Asia,
+                            4 => Region::Africa,
+                            5 => Region::Australia,
+                            _ => unreachable!(),
+                        };
+                        (
+                            NetworkBehaviourKey::new(region, region),
+                            NetworkBehaviour {
+                                delay: Duration::from_millis(100),
+                                drop: 0.0,
+                            },
+                        )
+                    })
+                    .collect(),
+            },
+            0,
+        );
         let simulation_runner: SimulationRunner<(), OutData, (), DummyStreamingState> =
             SimulationRunner::new(network, nodes, Default::default(), simulation_settings).unwrap();
         simulation_runner.simulate().unwrap();


### PR DESCRIPTION
1. Removed different types of network messages that were used to separate adhoc and broadcast messages. That was causing broadcasted but delayed messages be dropped. 
2. Broadcast functionality was added to `Output::BroadcastTimeoutQc` message type.
3. Updated default value of tally to 2.