### PR TITLE
Simulation tally fix

### DIFF
--- a/consensus-engine/src/overlay/flat_overlay.rs
+++ b/consensus-engine/src/overlay/flat_overlay.rs
@@ -1,5 +1,5 @@
 use super::LeaderSelection;
-use crate::{Committee, NodeId, Overlay};
+use crate::{NodeId, Overlay};
 use fraction::{Fraction, ToPrimitive};
 use serde::{Deserialize, Serialize};
 const LEADER_SUPER_MAJORITY_THRESHOLD_NUM: u64 = 2;
@@ -64,7 +64,7 @@ where
     }
 
     fn parent_committee(&self, _id: NodeId) -> crate::Committee {
-        Committee::new()
+        std::iter::once(self.next_leader()).collect()
     }
 
     fn node_committee(&self, _id: NodeId) -> crate::Committee {

--- a/consensus-engine/src/overlay/tree_overlay/overlay.rs
+++ b/consensus-engine/src/overlay/tree_overlay/overlay.rs
@@ -85,7 +85,12 @@ where
     }
 
     fn parent_committee(&self, id: NodeId) -> Committee {
-        self.carnot_tree.parent_committee_from_member_id(&id)
+        let c = self.carnot_tree.parent_committee_from_member_id(&id);
+        if !c.is_empty() {
+            c
+        } else {
+            std::iter::once(self.next_leader()).collect()
+        }
     }
 
     fn child_committees(&self, id: NodeId) -> Vec<Committee> {
@@ -143,20 +148,25 @@ where
             .expect("node is not part of any committee")
     }
 
+    // TODO: Carnot node in sim does not send votes to the next leader from the child committee of
+    // root committee yet. *For now* leader super majority threshold should be calculated only from
+    // the number of root committee nodes. The code will be reverted once vote sending from
+    // child committee of root committee is added to Carnot node.
     fn leader_super_majority_threshold(&self, _id: NodeId) -> usize {
-        let root_committee = &self.carnot_tree.inner_committees[0];
-        let children = self.carnot_tree.child_committees(root_committee);
-        let children_size = children.0.map_or(0, |c| {
-            self.carnot_tree
-                .committee_by_committee_id(c)
-                .map_or(0, |c| c.len())
-        }) + children.1.map_or(0, |c| {
-            self.carnot_tree
-                .committee_by_committee_id(c)
-                .map_or(0, |c| c.len())
-        });
-        let root_size = self.root_committee().len();
-        let committee_size = root_size + children_size;
+        // let root_committee = &self.carnot_tree.inner_committees[0];
+        // let children = self.carnot_tree.child_committees(root_committee);
+        // let children_size = children.0.map_or(0, |c| {
+        //     self.carnot_tree
+        //         .committee_by_committee_id(c)
+        //         .map_or(0, |c| c.len())
+        // }) + children.1.map_or(0, |c| {
+        //     self.carnot_tree
+        //         .committee_by_committee_id(c)
+        //         .map_or(0, |c| c.len())
+        // });
+        // let root_size = self.root_committee().len();
+        // let committee_size = root_size + children_size;
+        let committee_size = self.root_committee().len();
         (committee_size * 2 / 3) + 1
     }
 

--- a/consensus-engine/src/overlay/tree_overlay/tree.rs
+++ b/consensus-engine/src/overlay/tree_overlay/tree.rs
@@ -134,6 +134,7 @@ impl Tree {
             .and_then(|idx| self.committee_by_committee_idx(idx))
     }
 
+    #[allow(dead_code)]
     pub(super) fn committee_by_committee_id(
         &self,
         committee_id: &CommitteeId,

--- a/nomos-services/consensus/src/network/messages.rs
+++ b/nomos-services/consensus/src/network/messages.rs
@@ -23,7 +23,7 @@ impl ProposalChunkMsg {
     }
 }
 
-#[derive(Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
 pub struct VoteMsg {
     pub voter: NodeId,
     pub vote: Vote,
@@ -39,7 +39,7 @@ impl VoteMsg {
     }
 }
 
-#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
 pub struct NewViewMsg {
     pub voter: NodeId,
     pub vote: NewView,
@@ -54,7 +54,7 @@ impl NewViewMsg {
     }
 }
 
-#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
 pub struct TimeoutMsg {
     pub voter: NodeId,
     pub vote: Timeout,
@@ -69,7 +69,7 @@ impl TimeoutMsg {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct TimeoutQcMsg {
     pub source: NodeId,
     pub qc: TimeoutQc,

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -120,7 +120,7 @@ impl SimulationApp {
     }
 }
 
-fn run<M, S, T>(
+fn run<M: std::fmt::Debug, S, T>(
     network: Network<M>,
     nodes: Vec<BoxedNode<S, T>>,
     settings: SimulationSettings,

--- a/simulations/src/network/mod.rs
+++ b/simulations/src/network/mod.rs
@@ -101,7 +101,7 @@ mod network_behaviors_serde {
     }
 }
 
-pub struct Network<M> {
+pub struct Network<M: std::fmt::Debug> {
     pub regions: regions::RegionsData,
     network_time: NetworkTime,
     messages: Vec<(NetworkTime, NetworkMessage<M>)>,
@@ -113,7 +113,7 @@ pub struct Network<M> {
 
 impl<M> Network<M>
 where
-    M: Send + Sync + Clone,
+    M: std::fmt::Debug + Send + Sync + Clone,
 {
     pub fn new(regions: regions::RegionsData, seed: u64) -> Self {
         Self {

--- a/simulations/src/node/carnot/messages.rs
+++ b/simulations/src/node/carnot/messages.rs
@@ -3,7 +3,7 @@ use nomos_consensus::network::messages::{
     NewViewMsg, ProposalChunkMsg, TimeoutMsg, TimeoutQcMsg, VoteMsg,
 };
 
-#[derive(Eq, PartialEq, Hash, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum CarnotMessage {
     Proposal(ProposalChunkMsg),
     Vote(VoteMsg),

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -57,6 +57,7 @@ pub const CARNOT_RECORD_KEYS: &[&str] = &[
 
 static RECORD_SETTINGS: std::sync::OnceLock<HashMap<String, bool>> = std::sync::OnceLock::new();
 
+#[derive(Debug)]
 pub struct CarnotState {
     current_view: View,
     highest_voted_view: View,

--- a/simulations/src/node/carnot/tally.rs
+++ b/simulations/src/node/carnot/tally.rs
@@ -1,18 +1,18 @@
 use consensus_engine::View;
 use std::collections::{HashMap, HashSet};
 
-pub(crate) struct Tally<T: core::hash::Hash + Eq> {
+pub(crate) struct Tally<T: core::hash::Hash + Eq + Clone> {
     cache: HashMap<View, HashSet<T>>,
     threshold: usize,
 }
 
-impl<T: core::hash::Hash + Eq> Default for Tally<T> {
+impl<T: core::hash::Hash + Eq + Clone> Default for Tally<T> {
     fn default() -> Self {
         Self::new(2)
     }
 }
 
-impl<T: core::hash::Hash + Eq> Tally<T> {
+impl<T: core::hash::Hash + Eq + Clone> Tally<T> {
     pub fn new(threshold: usize) -> Self {
         Self {
             cache: Default::default(),
@@ -27,9 +27,9 @@ impl<T: core::hash::Hash + Eq> Tally<T> {
     pub fn tally_by(&mut self, view: View, message: T, threshold: usize) -> Option<HashSet<T>> {
         let entries = self.cache.entry(view).or_default();
         entries.insert(message);
-        let entries = entries.len();
-        if entries == threshold {
-            Some(self.cache.remove(&view).unwrap())
+        let entries_len = entries.len();
+        if entries_len == threshold {
+            Some(entries.clone())
         } else {
             None
         }

--- a/simulations/src/runner/async_runner.rs
+++ b/simulations/src/runner/async_runner.rs
@@ -18,7 +18,7 @@ pub fn simulate<M, R, S, T>(
     chunk_size: usize,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
-    M: Clone + Send + Sync + 'static,
+    M: std::fmt::Debug + Clone + Send + Sync + 'static,
     R: Record
         + for<'a> TryFrom<&'a SimulationState<S, T>, Error = anyhow::Error>
         + Send

--- a/simulations/src/runner/glauber_runner.rs
+++ b/simulations/src/runner/glauber_runner.rs
@@ -21,7 +21,7 @@ pub fn simulate<M, R, S, T>(
     maximum_iterations: usize,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
-    M: Send + Sync + Clone + 'static,
+    M: std::fmt::Debug + Send + Sync + Clone + 'static,
     R: Record
         + for<'a> TryFrom<&'a SimulationState<S, T>, Error = anyhow::Error>
         + Send

--- a/simulations/src/runner/layered_runner.rs
+++ b/simulations/src/runner/layered_runner.rs
@@ -54,7 +54,7 @@ pub fn simulate<M, R, S, T>(
     distribution: Option<Vec<f32>>,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
-    M: Send + Sync + Clone + 'static,
+    M: std::fmt::Debug + Send + Sync + Clone + 'static,
     R: Record
         + for<'a> TryFrom<&'a SimulationState<S, T>, Error = anyhow::Error>
         + Send
@@ -163,7 +163,7 @@ fn choose_random_layer_and_node_id(
     (i, *node_id)
 }
 
-fn build_node_ids_deque<M, R, S, T>(
+fn build_node_ids_deque<M: std::fmt::Debug, R, S, T>(
     gap: usize,
     runner: &SimulationRunner<M, R, S, T>,
 ) -> FixedSliceDeque<BTreeSet<NodeId>> {

--- a/simulations/src/runner/mod.rs
+++ b/simulations/src/runner/mod.rs
@@ -60,7 +60,7 @@ impl<R: Record> SimulationRunnerHandle<R> {
     }
 }
 
-pub(crate) struct SimulationRunnerInner<M> {
+pub(crate) struct SimulationRunnerInner<M: std::fmt::Debug> {
     network: Network<M>,
     wards: Vec<Ward>,
     rng: SmallRng,
@@ -68,7 +68,7 @@ pub(crate) struct SimulationRunnerInner<M> {
 
 impl<M> SimulationRunnerInner<M>
 where
-    M: Send + Sync + Clone,
+    M: std::fmt::Debug + Send + Sync + Clone,
 {
     fn check_wards<S, T>(&mut self, state: &SimulationState<S, T>) -> bool {
         self.wards
@@ -88,7 +88,7 @@ where
 
 /// Encapsulation solution for the simulations runner
 /// Holds the network state, the simulating nodes and the simulation settings.
-pub struct SimulationRunner<M, R, S, T> {
+pub struct SimulationRunner<M: std::fmt::Debug, R, S, T> {
     inner: SimulationRunnerInner<M>,
     nodes: Arc<RwLock<Vec<BoxedNode<S, T>>>>,
     runner_settings: RunnerSettings,
@@ -97,7 +97,7 @@ pub struct SimulationRunner<M, R, S, T> {
 
 impl<M, R, S, T> SimulationRunner<M, R, S, T>
 where
-    M: Clone + Send + Sync + 'static,
+    M: std::fmt::Debug + Clone + Send + Sync + 'static,
     R: Record
         + for<'a> TryFrom<&'a SimulationState<S, T>, Error = anyhow::Error>
         + Send
@@ -172,7 +172,7 @@ where
 
 impl<M, R, S, T> SimulationRunner<M, R, S, T>
 where
-    M: Clone + Send + Sync + 'static,
+    M: std::fmt::Debug + Clone + Send + Sync + 'static,
     R: Record
         + serde::Serialize
         + for<'a> TryFrom<&'a SimulationState<S, T>, Error = anyhow::Error>

--- a/simulations/src/runner/sync_runner.rs
+++ b/simulations/src/runner/sync_runner.rs
@@ -10,7 +10,7 @@ pub fn simulate<M, R, S, T>(
     runner: SimulationRunner<M, R, S, T>,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
-    M: Send + Sync + Clone + 'static,
+    M: std::fmt::Debug + Send + Sync + Clone + 'static,
     R: Record
         + for<'a> TryFrom<&'a SimulationState<S, T>, Error = anyhow::Error>
         + Send


### PR DESCRIPTION
Carnot node in sim does not send votes to the next leader from the child committee of root committee yet. *For now* leader super majority threshold should be calculated only from the number of root committee nodes. The code will be reverted once vote sending from child committee of root committee is added to Carnot node.