### PR TITLE
Get current view directly from the engine

### DIFF
--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -318,7 +318,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
     }
 
     fn current_view(&self) -> View {
-        self.event_builder.current_view
+        self.engine.current_view()
     }
 
     fn state(&self) -> &CarnotState {


### PR DESCRIPTION
The current view method that is also used to check sim wards used event_builder method. Event builder does not track the current view, it uses carnot engine to get this value.
@al8n should I remove current view variable from the event builder completely?