### PR TITLE
Simulatios network throughput

### DIFF
--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -82,6 +82,7 @@ impl SimulationApp {
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
                 let network_message_receiver = network.connect(
                     node_id,
+                    1000,
                     node_message_receiver,
                     node_message_broadcast_receiver,
                 );

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -82,7 +82,7 @@ impl SimulationApp {
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
                 let network_message_receiver = network.connect(
                     node_id,
-                    1000,
+                    simulation_settings.node_settings.network_capacity_kb * 1024,
                     node_message_receiver,
                     node_message_broadcast_receiver,
                 );

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -80,9 +80,14 @@ impl SimulationApp {
                 let (node_message_broadcast_sender, node_message_broadcast_receiver) =
                     channel::unbounded();
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
+                // Dividing milliseconds in second by milliseconds in the step.
+                let step_time_as_second_fraction =
+                    1_000_000 / simulation_settings.step_time.subsec_millis();
+                let capacity_bps = simulation_settings.node_settings.network_capacity_kbps * 1024
+                    / step_time_as_second_fraction;
                 let network_message_receiver = network.connect(
                     node_id,
-                    simulation_settings.node_settings.network_capacity_kb * 1024,
+                    capacity_bps,
                     node_message_receiver,
                     node_message_broadcast_receiver,
                 );

--- a/simulations/src/network/mod.rs
+++ b/simulations/src/network/mod.rs
@@ -105,15 +105,15 @@ mod network_behaviors_serde {
 
 /// Represents node network capacity and current load in bytes.
 struct NodeNetworkCapacity {
-    capacity: u32,
+    capacity_bps: u32,
     current_load: Mutex<u32>,
     load_to_flush: AtomicU32,
 }
 
 impl NodeNetworkCapacity {
-    fn new(capacity: u32) -> Self {
+    fn new(capacity_bps: u32) -> Self {
         Self {
-            capacity,
+            capacity_bps,
             current_load: Mutex::new(0),
             load_to_flush: AtomicU32::new(0),
         }
@@ -121,7 +121,7 @@ impl NodeNetworkCapacity {
 
     fn increase_load(&self, load: u32) -> bool {
         let mut current_load = self.current_load.lock();
-        if *current_load + load <= self.capacity {
+        if *current_load + load <= self.capacity_bps {
             *current_load += load;
             true
         } else {
@@ -183,12 +183,12 @@ where
     pub fn connect(
         &mut self,
         node_id: NodeId,
-        capacity_bytes: u32,
+        capacity_bps: u32,
         node_message_receiver: Receiver<NetworkMessage<M>>,
         node_message_broadcast_receiver: Receiver<NetworkMessage<M>>,
     ) -> Receiver<NetworkMessage<M>> {
         self.node_network_capacity
-            .insert(node_id, NodeNetworkCapacity::new(capacity_bytes));
+            .insert(node_id, NodeNetworkCapacity::new(capacity_bps));
         let (to_node_sender, from_network_receiver) = channel::unbounded();
         self.from_node_receivers
             .insert(node_id, node_message_receiver);

--- a/simulations/src/node/carnot/messages.rs
+++ b/simulations/src/node/carnot/messages.rs
@@ -3,6 +3,8 @@ use nomos_consensus::network::messages::{
     NewViewMsg, ProposalChunkMsg, TimeoutMsg, TimeoutQcMsg, VoteMsg,
 };
 
+use crate::network::PayloadSize;
+
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum CarnotMessage {
     Proposal(ProposalChunkMsg),
@@ -21,5 +23,11 @@ impl CarnotMessage {
             CarnotMessage::Timeout(msg) => msg.vote.view,
             CarnotMessage::NewView(msg) => msg.vote.view,
         }
+    }
+}
+
+impl PayloadSize for CarnotMessage {
+    fn size_bytes(&self) -> u32 {
+        0
     }
 }

--- a/simulations/src/node/carnot/messages.rs
+++ b/simulations/src/node/carnot/messages.rs
@@ -29,11 +29,13 @@ impl CarnotMessage {
 impl PayloadSize for CarnotMessage {
     fn size_bytes(&self) -> u32 {
         match self {
-            CarnotMessage::Proposal(p) => 56 + p.chunk.len() as u32,
-            CarnotMessage::Vote(_) => 128,
-            CarnotMessage::TimeoutQc(_) => 112,
-            CarnotMessage::Timeout(_) => 200,
-            CarnotMessage::NewView(_) => 192,
+            CarnotMessage::Proposal(p) => {
+                (std::mem::size_of::<ProposalChunkMsg>() + p.chunk.len()) as u32
+            }
+            CarnotMessage::Vote(_) => std::mem::size_of::<VoteMsg>() as u32,
+            CarnotMessage::TimeoutQc(_) => std::mem::size_of::<TimeoutQcMsg>() as u32,
+            CarnotMessage::Timeout(_) => std::mem::size_of::<TimeoutMsg>() as u32,
+            CarnotMessage::NewView(_) => std::mem::size_of::<NewViewMsg>() as u32,
         }
     }
 }

--- a/simulations/src/node/carnot/messages.rs
+++ b/simulations/src/node/carnot/messages.rs
@@ -28,6 +28,12 @@ impl CarnotMessage {
 
 impl PayloadSize for CarnotMessage {
     fn size_bytes(&self) -> u32 {
-        0
+        match self {
+            CarnotMessage::Proposal(p) => 56 + p.chunk.len() as u32,
+            CarnotMessage::Vote(_) => 128,
+            CarnotMessage::TimeoutQc(_) => 112,
+            CarnotMessage::Timeout(_) => 200,
+            CarnotMessage::NewView(_) => 192,
+        }
     }
 }

--- a/simulations/src/node/dummy.rs
+++ b/simulations/src/node/dummy.rs
@@ -482,6 +482,7 @@ mod tests {
                     channel::unbounded();
                 let network_message_receiver = network.connect(
                     *node_id,
+                    0,
                     node_message_receiver,
                     node_message_broadcast_receiver,
                 );

--- a/simulations/src/node/dummy.rs
+++ b/simulations/src/node/dummy.rs
@@ -3,6 +3,7 @@ use consensus_engine::View;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 // crates
+use crate::network::PayloadSize;
 use serde::{Deserialize, Serialize};
 // internal
 use crate::{
@@ -88,6 +89,12 @@ impl From<View> for Block {
 pub enum DummyMessage {
     Vote(Vote),
     Proposal(Block),
+}
+
+impl PayloadSize for DummyMessage {
+    fn size_bytes(&self) -> u32 {
+        0
+    }
 }
 
 struct LocalView {

--- a/simulations/src/runner/async_runner.rs
+++ b/simulations/src/runner/async_runner.rs
@@ -16,6 +16,7 @@ use super::SimulationRunnerHandle;
 pub fn simulate<M, R, S, T>(
     runner: SimulationRunner<M, R, S, T>,
     chunk_size: usize,
+    step_time: Duration,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
     M: std::fmt::Debug + Clone + Send + Sync + 'static,
@@ -38,7 +39,6 @@ where
     let (stop_tx, stop_rx) = bounded(1);
     let p = runner.producer.clone();
     let p1 = runner.producer;
-    let elapsed = Duration::from_millis(100);
     let handle = std::thread::spawn(move || {
         loop {
             select! {
@@ -53,7 +53,7 @@ where
                             .write()
                             .par_iter_mut()
                             .filter(|n| ids.contains(&n.id()))
-                            .for_each(|node|node.step(elapsed));
+                            .for_each(|node|node.step(step_time));
 
                         p.send(R::try_from(
                             &simulation_state,

--- a/simulations/src/runner/glauber_runner.rs
+++ b/simulations/src/runner/glauber_runner.rs
@@ -19,6 +19,7 @@ pub fn simulate<M, R, S, T>(
     runner: SimulationRunner<M, R, S, T>,
     update_rate: usize,
     maximum_iterations: usize,
+    step_time: Duration,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
     M: std::fmt::Debug + Send + Sync + Clone + 'static,
@@ -42,7 +43,6 @@ where
     let (stop_tx, stop_rx) = bounded(1);
     let p = runner.producer.clone();
     let p1 = runner.producer;
-    let elapsed = Duration::from_millis(100);
     let handle = std::thread::spawn(move || {
         'main: for chunk in iterations.chunks(update_rate) {
             select! {
@@ -62,7 +62,7 @@ where
                             let node: &mut dyn Node<Settings = S, State = T> = &mut **shared_nodes
                                 .get_mut(node_id.index())
                                 .expect("Node should be present");
-                            node.step(elapsed);
+                            node.step(step_time);
                         }
 
                         // check if any condition makes the simulation stop

--- a/simulations/src/runner/layered_runner.rs
+++ b/simulations/src/runner/layered_runner.rs
@@ -52,6 +52,7 @@ pub fn simulate<M, R, S, T>(
     runner: SimulationRunner<M, R, S, T>,
     gap: usize,
     distribution: Option<Vec<f32>>,
+    step_time: Duration,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
     M: std::fmt::Debug + Send + Sync + Clone + 'static,
@@ -79,7 +80,6 @@ where
     let (stop_tx, stop_rx) = bounded(1);
     let p = runner.producer.clone();
     let p1 = runner.producer;
-    let elapsed = Duration::from_millis(100);
     let handle = std::thread::spawn(move || {
         loop {
             select! {
@@ -99,7 +99,7 @@ where
                             .get_mut(node_id.index())
                             .expect("Node should be present");
                         let prev_view = node.current_view();
-                        node.step(elapsed);
+                        node.step(step_time);
                         let after_view = node.current_view();
                         if after_view > prev_view {
                             // pass node to next step group

--- a/simulations/src/runner/sync_runner.rs
+++ b/simulations/src/runner/sync_runner.rs
@@ -116,6 +116,7 @@ mod tests {
                     channel::unbounded();
                 let network_message_receiver = network.connect(
                     *node_id,
+                    1,
                     node_message_receiver,
                     node_message_broadcast_receiver,
                 );

--- a/simulations/src/runner/sync_runner.rs
+++ b/simulations/src/runner/sync_runner.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 /// Simulate with sending the network state to any subscriber
 pub fn simulate<M, R, S, T>(
     runner: SimulationRunner<M, R, S, T>,
+    step_time: Duration,
 ) -> anyhow::Result<SimulationRunnerHandle<R>>
 where
     M: std::fmt::Debug + Send + Sync + Clone + 'static,
@@ -29,7 +30,6 @@ where
     let (stop_tx, stop_rx) = bounded(1);
     let p = runner.producer.clone();
     let p1 = runner.producer;
-    let elapsed = Duration::from_millis(100);
     let handle = std::thread::spawn(move || {
         p.send(R::try_from(&state)?)?;
         loop {
@@ -43,7 +43,7 @@ where
                     // then dead lock will occur
                     {
                         let mut nodes = nodes.write();
-                        inner_runner.step(&mut nodes, elapsed);
+                        inner_runner.step(&mut nodes, step_time);
                     }
 
                     p.send(R::try_from(&state)?)?;

--- a/simulations/src/settings.rs
+++ b/simulations/src/settings.rs
@@ -37,6 +37,7 @@ pub struct TreeSettings {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NodeSettings {
+    pub network_capacity_kb: u32,
     #[serde(with = "humantime_serde")]
     pub timeout: std::time::Duration,
 }

--- a/simulations/src/settings.rs
+++ b/simulations/src/settings.rs
@@ -37,7 +37,7 @@ pub struct TreeSettings {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NodeSettings {
-    pub network_capacity_kb: u32,
+    pub network_capacity_kbps: u32,
     #[serde(with = "humantime_serde")]
     pub timeout: std::time::Duration,
 }


### PR DESCRIPTION
First approach to introduce network throughput in simulation app. It works by receiving node throughput from the configuration in kilobytes per second and then uses that value to track node load during each step. 

If the network load of the node is at full capacity the message won't get dropped, but added back to the message cache and retried during the next step.

InmemoryNetworkInterface now requires every payload to have a certain virtual size in bytes. This can be used to easily change the BlockProposal message size according to the number of transactions in it or just making that configurable in settings. Current payload sizes are just size of structs, without assuming size appended by the serialization.