### PR TITLE
fix large msg sending logic

### DIFF
--- a/consensus-engine/src/overlay/tree_overlay/tree.rs
+++ b/consensus-engine/src/overlay/tree_overlay/tree.rs
@@ -92,7 +92,10 @@ impl Tree {
         let Some(base) = self
             .committee_id_to_index
             .get(committee_id)
-            .map(|&idx| idx * 2) else { return (None, None); };
+            .map(|&idx| idx * 2)
+        else {
+            return (None, None);
+        };
         let first_child = base + 1;
         let second_child = base + 2;
         (

--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -227,12 +227,15 @@ where
             let network_adapter = adapter.clone();
             task_manager.push(genesis_block.view.next(), async move {
                 let Event::Approve { qc, .. } = Self::gather_votes(
-                        network_adapter,
-                        leader_committee.clone(),
-                        genesis_block,
-                        leader_tally_settings.clone(),
-                    )
-                    .await else { unreachable!() };
+                    network_adapter,
+                    leader_committee.clone(),
+                    genesis_block,
+                    leader_tally_settings.clone(),
+                )
+                .await
+                else {
+                    unreachable!()
+                };
                 Event::ProposeBlock { qc }
             });
         }
@@ -442,13 +445,12 @@ where
 
         if carnot.is_next_leader() {
             task_manager.push(block.view, async move {
-                let Event::Approve { qc, .. } = Self::gather_votes(
-                    adapter,
-                    leader_committee,
-                    block,
-                    leader_tally_settings,
-                )
-                .await else { unreachable!() };
+                let Event::Approve { qc, .. } =
+                    Self::gather_votes(adapter, leader_committee, block, leader_tally_settings)
+                        .await
+                else {
+                    unreachable!()
+                };
                 Event::ProposeBlock { qc }
             });
         }

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -82,12 +82,13 @@ impl SimulationApp {
                 let (node_message_sender, node_message_receiver) = channel::unbounded();
                 // Dividing milliseconds in second by milliseconds in the step.
                 let step_time_as_second_fraction =
-                    1_000_000 / simulation_settings.step_time.subsec_millis();
-                let capacity_bps = simulation_settings.node_settings.network_capacity_kbps * 1024
-                    / step_time_as_second_fraction;
+                    simulation_settings.step_time.subsec_millis() as f32 / 1_000_000_f32;
+                let capacity_bps = simulation_settings.node_settings.network_capacity_kbps as f32
+                    * 1024.0
+                    * step_time_as_second_fraction;
                 let network_message_receiver = network.connect(
                     node_id,
-                    capacity_bps,
+                    capacity_bps as u32,
                     node_message_receiver,
                     node_message_broadcast_receiver,
                 );

--- a/simulations/src/network/regions.rs
+++ b/simulations/src/network/regions.rs
@@ -208,7 +208,7 @@ mod tests {
                 .map(NodeId::from_index)
                 .collect::<Vec<NodeId>>();
 
-            let available_regions = vec![
+            let available_regions = [
                 Region::NorthAmerica,
                 Region::Europe,
                 Region::Asia,

--- a/simulations/src/node/carnot/message_cache.rs
+++ b/simulations/src/node/carnot/message_cache.rs
@@ -1,6 +1,6 @@
 use crate::node::carnot::messages::CarnotMessage;
 use consensus_engine::View;
-use polars::export::ahash::HashMap;
+use std::collections::HashMap;
 
 pub(crate) struct MessageCache {
     cache: HashMap<View, Vec<CarnotMessage>>,

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -505,7 +505,7 @@ impl<L: UpdateableLeaderSelection, O: Overlay<LeaderSelection = L>> Node for Car
             .network_interface
             .receive_messages()
             .into_iter()
-            .map(NetworkMessage::get_payload)
+            .map(NetworkMessage::into_payload)
             .partition(|m| {
                 m.view() == self.engine.current_view()
                     || matches!(m, CarnotMessage::Proposal(_) | CarnotMessage::TimeoutQc(_))


### PR DESCRIPTION
According to @bacv, the problem with the current network throughput is if the message size is bigger than the calculated step throughput, then it never gets sent. 

The solution in this PR is "partial send":

e.g.

Let's say, if we have a large message with size 15, and the throughput is 5. In the first step, we mock partially send behavior, so send 5 (remaining message size is 10). In the second step, partially send another 5 (the remaining message size is 5). In the third step, we send the final 5, so the large message can be sent through 3 steps in total.