### PR TITLE
Optional parent committee

### DIFF
--- a/consensus-engine/src/lib.rs
+++ b/consensus-engine/src/lib.rs
@@ -135,7 +135,10 @@ impl<O: Overlay> Carnot<O> {
         let to = if new_state.overlay.is_member_of_root_committee(new_state.id) {
             [new_state.overlay.next_leader()].into_iter().collect()
         } else {
-            new_state.overlay.parent_committee(self.id)
+            new_state
+                .overlay
+                .parent_committee(self.id)
+                .expect("Non root committee members parent should be present")
         };
         (
             new_state,
@@ -203,7 +206,10 @@ impl<O: Overlay> Carnot<O> {
         let to = if new_state.overlay.is_member_of_root_committee(new_state.id) {
             [new_state.overlay.next_leader()].into_iter().collect()
         } else {
-            new_state.overlay.parent_committee(new_state.id)
+            new_state
+                .overlay
+                .parent_committee(new_state.id)
+                .expect("Non root committee members parent should be present")
         };
         (
             new_state,
@@ -360,7 +366,7 @@ impl<O: Overlay> Carnot<O> {
         self.overlay.child_committees(self.id)
     }
 
-    pub fn parent_committee(&self) -> Committee {
+    pub fn parent_committee(&self) -> Option<Committee> {
         self.overlay.parent_committee(self.id)
     }
 

--- a/consensus-engine/src/overlay/flat_overlay.rs
+++ b/consensus-engine/src/overlay/flat_overlay.rs
@@ -63,12 +63,8 @@ where
         false
     }
 
-    fn parent_committee(&self, _id: NodeId) -> crate::Committee {
-        std::iter::once(self.next_leader()).collect()
-    }
-
-    fn node_committee(&self, _id: NodeId) -> crate::Committee {
-        self.nodes.clone().into_iter().collect()
+    fn parent_committee(&self, _id: NodeId) -> Option<crate::Committee> {
+        Some(std::iter::once(self.next_leader()).collect())
     }
 
     fn child_committees(&self, _id: NodeId) -> Vec<crate::Committee> {
@@ -77,6 +73,10 @@ where
 
     fn leaf_committees(&self, _id: NodeId) -> Vec<crate::Committee> {
         vec![self.root_committee()]
+    }
+
+    fn node_committee(&self, _id: NodeId) -> crate::Committee {
+        self.nodes.clone().into_iter().collect()
     }
 
     fn next_leader(&self) -> NodeId {

--- a/consensus-engine/src/overlay/mod.rs
+++ b/consensus-engine/src/overlay/mod.rs
@@ -21,7 +21,7 @@ pub trait Overlay: Clone {
     fn is_member_of_root_committee(&self, id: NodeId) -> bool;
     fn is_member_of_leaf_committee(&self, id: NodeId) -> bool;
     fn is_child_of_root_committee(&self, id: NodeId) -> bool;
-    fn parent_committee(&self, id: NodeId) -> Committee;
+    fn parent_committee(&self, id: NodeId) -> Option<Committee>;
     fn child_committees(&self, id: NodeId) -> Vec<Committee>;
     fn leaf_committees(&self, id: NodeId) -> Vec<Committee>;
     fn node_committee(&self, id: NodeId) -> Committee;

--- a/consensus-engine/src/overlay/tree_overlay/overlay.rs
+++ b/consensus-engine/src/overlay/tree_overlay/overlay.rs
@@ -66,7 +66,7 @@ where
     fn is_member_of_child_committee(&self, parent: NodeId, child: NodeId) -> bool {
         let child_parent = self.parent_committee(child);
         let parent = self.carnot_tree.committee_by_member_id(&parent);
-        parent.map_or(false, |p| child_parent.eq(p))
+        child_parent.as_ref() == parent
     }
 
     fn is_member_of_root_committee(&self, id: NodeId) -> bool {
@@ -81,16 +81,13 @@ where
     }
 
     fn is_child_of_root_committee(&self, id: NodeId) -> bool {
-        self.parent_committee(id) == self.root_committee()
+        self.parent_committee(id)
+            .map(|c| c == self.root_committee())
+            .unwrap_or(false)
     }
 
-    fn parent_committee(&self, id: NodeId) -> Committee {
-        let c = self.carnot_tree.parent_committee_from_member_id(&id);
-        if !c.is_empty() {
-            c
-        } else {
-            std::iter::once(self.next_leader()).collect()
-        }
+    fn parent_committee(&self, id: NodeId) -> Option<Committee> {
+        self.carnot_tree.parent_committee_from_member_id(&id)
     }
 
     fn child_committees(&self, id: NodeId) -> Vec<Committee> {

--- a/consensus-engine/src/overlay/tree_overlay/tree.rs
+++ b/consensus-engine/src/overlay/tree_overlay/tree.rs
@@ -78,12 +78,11 @@ impl Tree {
         }
     }
 
-    pub(super) fn parent_committee_from_member_id(&self, id: &NodeId) -> Committee {
-        let Some(committee_id) = self.committee_id_by_member_id(id) else { return Committee::new(); };
-        let Some(parent_id) = self.parent_committee(committee_id) else { return Committee::new(); };
+    pub(super) fn parent_committee_from_member_id(&self, id: &NodeId) -> Option<Committee> {
+        let committee_id = self.committee_id_by_member_id(id)?;
+        let parent_id = self.parent_committee(committee_id)?;
         self.committee_by_committee_idx(self.committee_id_to_index[parent_id])
             .cloned()
-            .unwrap_or_default()
     }
 
     pub(super) fn child_committees(


### PR DESCRIPTION
Returning an empty committee in case a node have no parent (usual case of root committee members) leads to errors. Being implicit helps here. Also it is as the specs implementation meant it.