### PR TITLE
Add dummy libp2p adapter for mempool

### DIFF
--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -32,3 +32,4 @@ blake2 = "0.10"
 default = []
 waku = ["nomos-network/waku", "nomos-core/waku", "waku-bindings"]
 mock = ["linked-hash-map", "nomos-network/mock", "rand", "nomos-core/mock"]
+libp2p = ["nomos-network/libp2p"]

--- a/nomos-services/mempool/src/network/adapters/libp2p.rs
+++ b/nomos-services/mempool/src/network/adapters/libp2p.rs
@@ -1,0 +1,38 @@
+// std
+use std::marker::PhantomData;
+// crates
+use futures::Stream;
+use serde::{de::DeserializeOwned, Serialize};
+// internal
+use crate::network::NetworkAdapter;
+use nomos_network::backends::libp2p::Libp2p;
+use nomos_network::NetworkService;
+use overwatch_rs::services::relay::OutboundRelay;
+use overwatch_rs::services::ServiceData;
+
+pub struct Libp2pAdapter<Tx> {
+    _network_relay: OutboundRelay<<NetworkService<Libp2p> as ServiceData>::Message>,
+    _tx: PhantomData<Tx>,
+}
+
+#[async_trait::async_trait]
+impl<Tx> NetworkAdapter for Libp2pAdapter<Tx>
+where
+    Tx: DeserializeOwned + Serialize + Send + Sync + 'static,
+{
+    type Backend = Libp2p;
+    type Tx = Tx;
+
+    async fn new(
+        _network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
+    ) -> Self {
+        Self {
+            _network_relay,
+            _tx: PhantomData,
+        }
+    }
+    async fn transactions_stream(&self) -> Box<dyn Stream<Item = Self::Tx> + Unpin + Send> {
+        // TODO
+        Box::new(futures::stream::empty())
+    }
+}

--- a/nomos-services/mempool/src/network/adapters/mod.rs
+++ b/nomos-services/mempool/src/network/adapters/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "waku")]
 pub mod waku;
 
+#[cfg(feature = "libp2p")]
+pub mod libp2p;
+
 #[cfg(feature = "mock")]
 pub mod mock;


### PR DESCRIPTION
Add a dummy libp2p adapter for mempool. It does not do anything, but neither does the mempool, it's just needed for type bounds