### PR TITLE
Add support for libp2p backend in integration tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,19 +7,20 @@ publish = false
 [dependencies]
 nomos-node = { path = "../nodes/nomos-node" }
 nomos-consensus = { path = "../nomos-services/consensus" }
-nomos-network = { path = "../nomos-services/network", features = ["waku"] }
+nomos-network = { path = "../nomos-services/network" }
 nomos-log = { path = "../nomos-services/log" }
 nomos-http = { path = "../nomos-services/http", features = ["http"] }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
 nomos-core = { path = "../nomos-core" }
 consensus-engine = { path = "../consensus-engine", features = ["serde"] }
-nomos-mempool = { path = "../nomos-services/mempool", features = ["waku", "mock"] }
+nomos-mempool = { path = "../nomos-services/mempool", features = ["mock"] }
 rand = "0.8"
 once_cell = "1"
 rand_xoshiro = "0.6"
 secp256k1 = { version = "0.26", features = ["rand"] }
-waku-bindings = "0.1.1"
+waku-bindings = { version = "0.1.1", optional = true }
 reqwest = { version = "0.11", features = ["json"] }
+nomos-libp2p = { path = "../nomos-libp2p", optional = true }
 tempfile = "3.6"
 serde_yaml = "0.9"
 tokio = "1"
@@ -38,3 +39,5 @@ path = "src/tests/unhappy.rs"
 
 [features]
 metrics = ["nomos-node/metrics"]
+waku  = ["nomos-network/waku", "nomos-mempool/waku", "waku-bindings"]
+libp2p = ["nomos-network/libp2p", "nomos-mempool/libp2p", "nomos-libp2p"]


### PR DESCRIPTION
Ideally, we should test both version in integrations tests, I think it's possible to set up a run for each of the backends right @bacv ?