### PR TITLE
Disable tree rebuild

### DIFF
--- a/consensus-engine/src/overlay/tree_overlay/overlay.rs
+++ b/consensus-engine/src/overlay/tree_overlay/overlay.rs
@@ -60,7 +60,7 @@ where
     }
 
     fn rebuild(&mut self, _timeout_qc: crate::TimeoutQc) {
-        unimplemented!("do nothing for now")
+        // do nothing for now
     }
 
     fn is_member_of_child_committee(&self, parent: NodeId, child: NodeId) -> bool {


### PR DESCRIPTION
This cause simulations/test to break if a timeout is triggered