### PR TITLE
Test for partial message sending in simulation

### DIFF
--- a/consensus-engine/src/lib.rs
+++ b/consensus-engine/src/lib.rs
@@ -406,9 +406,9 @@ impl<O: Overlay> Carnot<O> {
     pub fn prune_older_blocks_by_view(&mut self, threshold_view: View) {
         assert!(threshold_view < self.latest_committed_block().view);
         // do not remove genesis
-        // let view_zero = View::new(0);
-        // self.safe_blocks
-        //     .retain(|_, b| b.view > threshold_view || view_zero == b.view);
+        let view_zero = View::new(0);
+        self.safe_blocks
+            .retain(|_, b| b.view > threshold_view || view_zero == b.view);
     }
 }
 

--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -298,7 +298,7 @@ where
                     local_high_qc: carnot.high_qc(),
                     safe_blocks: carnot.safe_blocks().clone(),
                     last_view_timeout_qc: carnot.last_view_timeout_qc(),
-                    committed_blocks: carnot.committed_blocks(),
+                    committed_blocks: carnot.latest_committed_blocks(),
                 };
                 tx.send(info).unwrap_or_else(|e| {
                     tracing::error!("Could not send consensus info through channel: {:?}", e)

--- a/simulations/src/network/mod.rs
+++ b/simulations/src/network/mod.rs
@@ -426,6 +426,7 @@ mod tests {
         broadcast: Sender<NetworkMessage<()>>,
         sender: Sender<NetworkMessage<()>>,
         receiver: Receiver<NetworkMessage<()>>,
+        message_size: u32,
     }
 
     impl MockNetworkInterface {
@@ -434,12 +435,14 @@ mod tests {
             broadcast: Sender<NetworkMessage<()>>,
             sender: Sender<NetworkMessage<()>>,
             receiver: Receiver<NetworkMessage<()>>,
+            message_size: u32,
         ) -> Self {
             Self {
                 id,
                 broadcast,
                 sender,
                 receiver,
+                message_size,
             }
         }
     }
@@ -448,12 +451,12 @@ mod tests {
         type Payload = ();
 
         fn broadcast(&self, message: Self::Payload) {
-            let message = NetworkMessage::new(self.id, None, message, 1);
+            let message = NetworkMessage::new(self.id, None, message, self.message_size);
             self.broadcast.send(message).unwrap();
         }
 
         fn send_message(&self, address: NodeId, message: Self::Payload) {
-            let message = NetworkMessage::new(self.id, Some(address), message, 1);
+            let message = NetworkMessage::new(self.id, Some(address), message, self.message_size);
             self.sender.send(message).unwrap();
         }
 
@@ -483,6 +486,7 @@ mod tests {
             from_a_broadcast_sender,
             from_a_sender,
             to_a_receiver,
+            1,
         );
 
         let (from_b_sender, from_b_receiver) = channel::unbounded();
@@ -493,6 +497,7 @@ mod tests {
             from_b_broadcast_sender,
             from_b_sender,
             to_b_receiver,
+            1,
         );
 
         a.send_message(node_b, ());
@@ -558,6 +563,7 @@ mod tests {
             from_a_broadcast_sender,
             from_a_sender,
             to_a_receiver,
+            1,
         );
 
         let (from_b_sender, from_b_receiver) = channel::unbounded();
@@ -568,6 +574,7 @@ mod tests {
             from_b_broadcast_sender,
             from_b_sender,
             to_b_receiver,
+            1,
         );
 
         let (from_c_sender, from_c_receiver) = channel::unbounded();
@@ -578,6 +585,7 @@ mod tests {
             from_c_broadcast_sender,
             from_c_sender,
             to_c_receiver,
+            1,
         );
 
         a.send_message(node_b, ());
@@ -633,6 +641,7 @@ mod tests {
             from_a_broadcast_sender,
             from_a_sender,
             to_a_receiver,
+            1,
         );
 
         let (from_b_sender, from_b_receiver) = channel::unbounded();
@@ -643,6 +652,7 @@ mod tests {
             from_b_broadcast_sender,
             from_b_sender,
             to_b_receiver,
+            1,
         );
 
         for _ in 0..6 {
@@ -661,5 +671,73 @@ mod tests {
         network.step(Duration::from_millis(100));
         assert_eq!(a.receive_messages().len(), 0);
         assert_eq!(b.receive_messages().len(), 2);
+    }
+
+    #[test]
+    fn node_network_message_partial_send() {
+        let node_a = NodeId::from_index(0);
+        let node_b = NodeId::from_index(1);
+
+        let regions = HashMap::from([(Region::Europe, vec![node_a, node_b])]);
+        let behaviour = HashMap::from([(
+            NetworkBehaviourKey::new(Region::Europe, Region::Europe),
+            NetworkBehaviour::new(Duration::from_millis(100), 0.0),
+        )]);
+        let regions_data = RegionsData::new(regions, behaviour);
+        let mut network = Network::new(regions_data, 0);
+
+        let (from_a_sender, from_a_receiver) = channel::unbounded();
+        let (from_a_broadcast_sender, from_a_broadcast_receiver) = channel::unbounded();
+
+        // Node A is connected to the network with throuput of 5.
+        let to_a_receiver = network.connect(node_a, 5, from_a_receiver, from_a_broadcast_receiver);
+
+        // Every message sent to Node A with be of size 15.
+        let a = MockNetworkInterface::new(
+            node_a,
+            from_a_broadcast_sender,
+            from_a_sender,
+            to_a_receiver,
+            15,
+        );
+
+        let (from_b_sender, from_b_receiver) = channel::unbounded();
+        let (from_b_broadcast_sender, from_b_broadcast_receiver) = channel::unbounded();
+
+        // Node B is connected to the network with throuput of 1.
+        let to_b_receiver = network.connect(node_b, 1, from_b_receiver, from_b_broadcast_receiver);
+
+        // Every message sent to Node B with be of size 2.
+        let b = MockNetworkInterface::new(
+            node_b,
+            from_b_broadcast_sender,
+            from_b_sender,
+            to_b_receiver,
+            2,
+        );
+
+        // Each node receives one message.
+        // It should take 3 steps for Node A to receive a message.
+        // It should take 2 steps for Node B to receive a message.
+        a.send_message(node_b, ());
+        b.send_message(node_a, ());
+
+        // Step duration matches the latency between nodes, thus Node A can receive 5 units of a
+        // message, Node B - 1 unit of a message during the step.
+        network.step(Duration::from_millis(100));
+        assert_eq!(a.receive_messages().len(), 0);
+        assert_eq!(b.receive_messages().len(), 0);
+
+        // Node B should receive a message during the second step, because it's throuput during the
+        // step is 1, but the message size it receives is 2.
+        network.step(Duration::from_millis(100));
+        assert_eq!(a.receive_messages().len(), 0);
+        assert_eq!(b.receive_messages().len(), 1);
+
+        // Node A should receive a message during the third step, because it's throuput during the
+        // step is 5, but the message it recieves is of size 15.
+        network.step(Duration::from_millis(100));
+        assert_eq!(a.receive_messages().len(), 1);
+        assert_eq!(b.receive_messages().len(), 0);
     }
 }

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -440,9 +440,12 @@ impl<
                     timeout_view = %timeout_qc.view(),
                     "receive new view message"
                 );
-                let (new, out) = self.engine.approve_new_view(timeout_qc, new_views);
-                output = Some(Output::Send(out));
-                self.engine = new;
+                // just process timeout if node have not already process it
+                if timeout_qc.view() == self.engine.current_view() {
+                    let (new, out) = self.engine.approve_new_view(timeout_qc, new_views);
+                    output = Some(Output::Send(out));
+                    self.engine = new;
+                }
             }
             Event::TimeoutQc { timeout_qc } => {
                 tracing::info!(

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -525,6 +525,8 @@ impl<
             .receive_messages()
             .into_iter()
             .map(NetworkMessage::into_payload)
+            // do not care for older view messages
+            .filter(|m| m.view() >= self.engine.current_view())
             .partition(|m| {
                 m.view() == self.engine.current_view()
                     || matches!(m, CarnotMessage::Proposal(_) | CarnotMessage::TimeoutQc(_))

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -346,18 +346,19 @@ impl<
                 match self.engine.receive_block(block.header().clone()) {
                     Ok(mut new) => {
                         if self.engine.current_view() != new.current_view() {
-                            new = new
-                                .update_overlay(|overlay| {
-                                    let overlay = overlay
-                                        .update_leader_selection(|leader_selection| {
-                                            leader_selection.on_new_block_received(&block)
-                                        })
-                                        .expect("Leader selection update should succeed");
-                                    overlay.update_committees(|committee_membership| {
-                                        committee_membership.on_new_block_received(&block)
-                                    })
-                                })
-                                .unwrap_or(new);
+                            // TODO: Refactor this into a method, use for timeout qc as well
+                            // new = new
+                            //     .update_overlay(|overlay| {
+                            //         let overlay = overlay
+                            //             .update_leader_selection(|leader_selection| {
+                            //                 leader_selection.on_new_block_received(&block)
+                            //             })
+                            //             .expect("Leader selection update should succeed");
+                            //         overlay.update_committees(|committee_membership| {
+                            //             committee_membership.on_new_block_received(&block)
+                            //         })
+                            //     })
+                            //     .unwrap_or(new);
                             self.engine = new;
                         }
                     }
@@ -373,7 +374,7 @@ impl<
 
                 if self.engine.overlay().is_member_of_leaf_committee(self.id) {
                     // Check if we are also a member of the parent committee, this is a special case for the flat committee
-                    let to = if self.engine.overlay().is_child_of_root_committee(self.id) {
+                    let to = if self.engine.overlay().is_member_of_root_committee(self.id) {
                         [self.engine.overlay().next_leader()].into_iter().collect()
                     } else {
                         self.engine.parent_committee().expect(

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -344,7 +344,7 @@ impl<
                     "receive block proposal",
                 );
                 match self.engine.receive_block(block.header().clone()) {
-                    Ok(mut new) => {
+                    Ok(new) => {
                         if self.engine.current_view() != new.current_view() {
                             // TODO: Refactor this into a method, use for timeout qc as well
                             // new = new

--- a/simulations/src/node/carnot/mod.rs
+++ b/simulations/src/node/carnot/mod.rs
@@ -190,7 +190,7 @@ impl<O: Overlay> From<&Carnot<O>> for CarnotState {
                 .map(|b| (b.id, b))
                 .collect(),
             last_view_timeout_qc: value.last_view_timeout_qc(),
-            committed_blocks: value.committed_blocks(),
+            committed_blocks: value.latest_committed_blocks(),
             highest_voted_view: Default::default(),
             step_duration: Default::default(),
         }

--- a/simulations/src/node/carnot/tally.rs
+++ b/simulations/src/node/carnot/tally.rs
@@ -3,25 +3,13 @@ use std::collections::{HashMap, HashSet};
 
 pub(crate) struct Tally<T: core::hash::Hash + Eq + Clone> {
     cache: HashMap<View, HashSet<T>>,
-    threshold: usize,
-}
-
-impl<T: core::hash::Hash + Eq + Clone> Default for Tally<T> {
-    fn default() -> Self {
-        Self::new(2)
-    }
 }
 
 impl<T: core::hash::Hash + Eq + Clone> Tally<T> {
-    pub fn new(threshold: usize) -> Self {
+    pub fn new() -> Self {
         Self {
             cache: Default::default(),
-            threshold,
         }
-    }
-
-    pub fn tally(&mut self, view: View, message: T) -> Option<HashSet<T>> {
-        self.tally_by(view, message, self.threshold)
     }
 
     pub fn tally_by(&mut self, view: View, message: T, threshold: usize) -> Option<HashSet<T>> {


### PR DESCRIPTION
After introducing the network throughput, simulation fails to advance beyond the first round of consensus. I failed to notice this issue as I was focused on capturing the report for one consensus round.
Do debug this issue I've added a testcase for partial message send correctness.