### PR TITLE
Mixnet PoC: Split message into packets + Reconstruction

### DIFF
--- a/mixnet/Cargo.toml
+++ b/mixnet/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.29.1", features = ["net"] }
-rand = "0.8"
+rand = "0.7.3"
 tracing = "0.1.37"
 sphinx-packet = "0.1.0"
 thiserror = "1.0.44"
 wire = { path = "../wire" }
-nym-sphinx-addressing = { package = "nym-sphinx-addressing", git = "https://github.com/nymtech/nym", tag = "v1.1.22" }
+nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", tag = "v1.1.22" }

--- a/mixnet/src/config.rs
+++ b/mixnet/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
-use nym_sphinx_addressing::nodes::NymNodeRoutingAddress;
+use nym_sphinx::addressing::nodes::NymNodeRoutingAddress;
 use serde::{Deserialize, Serialize};
 use sphinx_packet::{
     crypto::{PrivateKey, PublicKey, PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE},

--- a/mixnet/src/lib.rs
+++ b/mixnet/src/lib.rs
@@ -1,12 +1,21 @@
 pub mod config;
 
-use std::{error::Error, net::SocketAddr};
+use std::{
+    error::Error,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
 
 use config::{Config, MixNode, Topology};
-use nym_sphinx_addressing::nodes::NymNodeRoutingAddress;
+use nym_sphinx::{
+    addressing::nodes::NymNodeRoutingAddress,
+    chunking::{fragment::Fragment, reconstruction::MessageReconstructor},
+    message::{NymMessage, PaddedMessage},
+    params::PacketSize,
+};
 use rand::{rngs::OsRng, seq::IteratorRandom};
 use sphinx_packet::{
-    constants::{DESTINATION_ADDRESS_LENGTH, IDENTIFIER_LENGTH},
+    constants::IDENTIFIER_LENGTH,
     crypto::{PrivateKey, PublicKey, PUBLIC_KEY_SIZE},
     header::delays::Delay,
     payload::{Payload, PAYLOAD_OVERHEAD_SIZE},
@@ -27,9 +36,33 @@ pub struct Mixnet {
 
     topology: Topology,
     mixnode_rx: mpsc::Receiver<MixNode>,
+
+    message_reconstructor: Arc<Mutex<MessageReconstructor>>,
 }
 
 pub type Message = Box<[u8]>;
+
+enum TcpStreamBodyType {
+    SphinxPacket,
+    FinalPayload,
+}
+
+impl TcpStreamBodyType {
+    fn as_u8(&self) -> u8 {
+        match self {
+            Self::SphinxPacket => 0,
+            Self::FinalPayload => 1,
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::SphinxPacket,
+            1 => Self::FinalPayload,
+            _ => todo!("return error"),
+        }
+    }
+}
 
 impl Mixnet {
     pub fn new(
@@ -45,6 +78,7 @@ impl Mixnet {
             inbound_msg_tx,
             topology,
             mixnode_rx,
+            message_reconstructor: Default::default(),
         }
     }
 
@@ -70,8 +104,9 @@ impl Mixnet {
 
                             let private_key = PrivateKey::from(self.config.private_key);
                             let inbound_msg_tx = self.inbound_msg_tx.clone();
+                            let message_reconstructor = self.message_reconstructor.clone();
                             tokio::spawn(async {
-                                if let Err(e) = Self::handle_connection(socket, private_key, inbound_msg_tx).await {
+                                if let Err(e) = Self::handle_connection(socket, private_key, inbound_msg_tx, message_reconstructor).await {
                                     tracing::error!("failed to handle conn: {e}");
                                 }
                             });
@@ -102,42 +137,98 @@ impl Mixnet {
         mut socket: TcpStream,
         private_key: PrivateKey,
         inbound_msg_tx: broadcast::Sender<Message>,
+        message_reconstructor: Arc<Mutex<MessageReconstructor>>,
     ) -> Result<(), Box<dyn Error>> {
         tracing::debug!("handling connection");
+
+        match TcpStreamBodyType::from_u8(socket.read_u8().await?) {
+            TcpStreamBodyType::SphinxPacket => {
+                Self::handle_sphinx_packet_connection(socket, private_key).await
+            }
+            TcpStreamBodyType::FinalPayload => {
+                Self::handle_final_payload_connection(
+                    socket,
+                    private_key,
+                    inbound_msg_tx,
+                    message_reconstructor,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn handle_sphinx_packet_connection(
+        mut socket: TcpStream,
+        private_key: PrivateKey,
+    ) -> Result<(), Box<dyn Error>> {
+        tracing::debug!("handling sphinx packet connection");
+
         let packet_size = socket.read_u64().await?;
         let mut buf = vec![0; packet_size as usize]; // TODO: handle u64 -> usize failure
         socket.read_exact(&mut buf).await?;
+
         let packet = SphinxPacket::from_bytes(&buf)?;
         tracing::debug!("received a Sphinx packet from the TCP conn");
 
         match packet.process(&private_key)? {
             ProcessedPacket::ForwardHop(packet, next_node_addr, delay) => {
-                Self::forward_to_next_hop(packet, next_node_addr, delay).await
+                Self::forward_packet_to_next_hop(packet, next_node_addr, delay).await
             }
-            ProcessedPacket::FinalHop(_, _, payload) => {
-                Self::send_to_local(payload, inbound_msg_tx).await
+            ProcessedPacket::FinalHop(destination_addr, _, payload) => {
+                Self::forward_payload_to_destination(payload, destination_addr).await
             }
         }
     }
 
-    async fn forward_to_next_hop(
+    async fn handle_final_payload_connection(
+        mut socket: TcpStream,
+        _private_key: PrivateKey,
+        inbound_msg_tx: broadcast::Sender<Message>,
+        message_reconstructor: Arc<Mutex<MessageReconstructor>>,
+    ) -> Result<(), Box<dyn Error>> {
+        tracing::debug!("handling final payload connection");
+
+        let payload_size = socket.read_u64().await?;
+        let mut buf = vec![0; payload_size as usize]; // TODO: handle u64 -> usize failure
+        socket.read_exact(&mut buf).await?;
+
+        let payload = Payload::from_bytes(&buf)?.recover_plaintext()?;
+        let fragment = Fragment::try_from_bytes(&payload)?;
+
+        if let Some((padded_message, _)) = {
+            let mut reconstructor = message_reconstructor.lock().unwrap();
+            reconstructor.insert_new_fragment(fragment)
+        } {
+            tracing::debug!("sending a reconstructed message to the local");
+            let message = Self::remove_padding(padded_message)?;
+            inbound_msg_tx.send(message)?;
+        }
+
+        Ok(())
+    }
+
+    async fn forward_packet_to_next_hop(
         packet: Box<SphinxPacket>,
         next_node_addr: NodeAddressBytes,
         delay: Delay,
     ) -> Result<(), Box<dyn Error>> {
         tracing::debug!("Delaying the packet for {delay:?}");
         tokio::time::sleep(delay.to_duration()).await;
+
         Self::send_packet(packet, next_node_addr).await
     }
 
-    async fn send_to_local(
+    async fn forward_payload_to_destination(
         payload: Payload,
-        inbound_msg_tx: broadcast::Sender<Message>,
+        destination_addr: DestinationAddressBytes,
     ) -> Result<(), Box<dyn Error>> {
-        tracing::debug!("Sending the packet to the local");
-        let message: Message = payload.recover_plaintext()?.into_boxed_slice();
-        inbound_msg_tx.send(message)?;
-        Ok(())
+        tracing::debug!("Forwarding payload to destination");
+
+        Self::send_payload(
+            payload,
+            NodeAddressBytes::from_bytes(destination_addr.as_bytes()),
+        )
+        .await
     }
 
     async fn send_to_mixnet(
@@ -145,13 +236,68 @@ impl Mixnet {
         topology: Topology,
         num_hops: usize,
     ) -> Result<(), Box<dyn Error>> {
-        tracing::debug!("Building a Sphinx packet: {num_hops}");
-        let (packet, first_node) = Self::build_sphinx_packet(msg, topology, num_hops)?;
-        Self::send_packet(Box::new(packet), first_node.address).await
+        let dest_node: route::Node = topology
+            .nodes
+            .values()
+            .choose(&mut OsRng)
+            .expect("topology is not empty")
+            .clone()
+            .try_into()
+            .unwrap();
+        let destination = Destination::new(
+            DestinationAddressBytes::from_bytes(dest_node.address.as_bytes()),
+            [0; IDENTIFIER_LENGTH], // TODO: use a proper SURBIdentifier if we need SURB
+        );
+
+        let mut packets: Vec<(sphinx_packet::SphinxPacket, route::Node)> = Vec::new();
+
+        for fragment in Self::pad_and_split_message(msg) {
+            packets.push(Self::build_sphinx_packet(
+                fragment,
+                &destination,
+                topology.clone(),
+                num_hops,
+            )?);
+        }
+
+        for (packet, first_node) in packets {
+            tokio::spawn(async move {
+                if let Err(e) = Self::send_packet(Box::new(packet), first_node.address).await {
+                    tracing::error!("failed to send packet to the first node: {e}");
+                }
+            });
+        }
+
+        Ok(())
+    }
+
+    fn pad_and_split_message(msg: Message) -> Vec<Fragment> {
+        let nym_message = NymMessage::new_plain(msg.into_vec());
+
+        // TODO: add PUBLIC_KEY_SIZE for encryption for the destination
+        // TODO: add ACK_OVERHEAD if we need SURB-ACKs.
+        // https://github.com/nymtech/nym/blob/3748ab77a132143d5fd1cd75dd06334d33294815/common/nymsphinx/src/message.rs#L181-L181
+        let plaintext_size_per_packet = PacketSize::RegularPacket.plaintext_size();
+
+        nym_message
+            .pad_to_full_packet_lengths(plaintext_size_per_packet)
+            .split_into_fragments(&mut OsRng, plaintext_size_per_packet)
+    }
+
+    fn remove_padding(msg: Vec<u8>) -> Result<Message, Box<dyn Error>> {
+        let padded_message = PaddedMessage::new_reconstructed(msg);
+        // we need this because PaddedMessage.remove_padding requires it for other NymMessage types.
+        let dummy_num_mix_hops = 0;
+
+        match padded_message.remove_padding(dummy_num_mix_hops)? {
+            NymMessage::Plain(msg) => Ok(msg.into_boxed_slice()),
+            _ => todo!("return error"),
+        }
     }
 
     fn build_sphinx_packet(
-        msg: Message,
+        fragment: Fragment,
+        destination: &Destination,
         topology: Topology,
         num_hops: usize,
     ) -> Result<(sphinx_packet::SphinxPacket, route::Node), Box<dyn Error>> {
@@ -163,19 +309,15 @@ impl Mixnet {
             .map(|&mixnode| mixnode.clone().try_into().unwrap())
             .collect();
 
-        // TODO: a dummy destination for now
-        // but we should pick a random destination that gathers all packets
-        // and assembles them into a Message.
-        let destination = Destination::new(
-            DestinationAddressBytes::from_bytes([0; DESTINATION_ADDRESS_LENGTH]),
-            [0; IDENTIFIER_LENGTH],
-        );
         let delays: Vec<Delay> = route.iter().map(|_| Delay::new_from_nanos(0)).collect();
 
-        //TODO: split a msg into fragments
+        // TODO: encryption for the destination
+        // https://github.com/nymtech/nym/blob/3748ab77a132143d5fd1cd75dd06334d33294815/common/nymsphinx/src/preparer/payload.rs#L70
+        let payload = fragment.into_bytes();
+
         let packet = SphinxPacketBuilder::new()
-            .with_payload_size(msg.len() + PAYLOAD_OVERHEAD_SIZE)
-            .build_packet(msg, &route, &destination, &delays)?;
+            .with_payload_size(payload.len() + PAYLOAD_OVERHEAD_SIZE)
+            .build_packet(payload, &route, destination, &delays)?;
 
         let first_mixnode = route.first().cloned().expect("route is not empty");
 
@@ -191,8 +333,27 @@ impl Mixnet {
 
         let mut socket = TcpStream::connect(addr).await?;
 
+        socket
+            .write_u8(TcpStreamBodyType::SphinxPacket.as_u8())
+            .await?;
         socket.write_u64(packet.len() as u64).await?;
         socket.write_all(&packet.to_bytes()).await?;
+        tracing::debug!("Sent a Sphinx packet successuflly to the node: {addr:?}");
+
+        Ok(())
+    }
+
+    async fn send_payload(payload: Payload, addr: NodeAddressBytes) -> Result<(), Box<dyn Error>> {
+        let addr = SocketAddr::try_from(NymNodeRoutingAddress::try_from(addr)?)?;
+        tracing::debug!("Sending a payload to the node: {addr:?}");
+
+        let mut socket = TcpStream::connect(addr).await?;
+
+        socket
+            .write_u8(TcpStreamBodyType::FinalPayload.as_u8())
+            .await?;
+        socket.write_u64(payload.len() as u64).await?;
+        socket.write_all(payload.as_bytes()).await?;
         tracing::debug!("Sent a Sphinx packet successuflly to the node: {addr:?}");
 
         Ok(())


### PR DESCRIPTION
I implemented a missing part in the PR #288,
- splitting a message into several Sphinx packets (with padding)
- reconstructing the message by gathering all Sphinx packets related

This is necessary for measuring the realistic latency amplification of mixnet.

TODO:
- Encrypting the actual payload for the destination mixnode in the route. (Currently, only Sphinx encapsulations are encrypted for each mixnodes).
- Refactoring