### PR TITLE
Simulation graceful shutdown fixes

### DIFF
--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -186,6 +186,7 @@ fn signal<R: Record>(handle: SimulationRunnerHandle<R>) -> anyhow::Result<()> {
             },
             default => {
                 if handle.is_finished() {
+                    handle.shutdown()?;
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(50));

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -2,7 +2,7 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 // crates
 use anyhow::Ok;
 use clap::Parser;
@@ -172,6 +172,7 @@ where
 }
 
 fn signal<R: Record>(handle: SimulationRunnerHandle<R>) -> anyhow::Result<()> {
+    let handle = Arc::new(handle);
     let (tx, rx) = crossbeam::channel::bounded(1);
     ctrlc::set_handler(move || {
         tx.send(()).unwrap();
@@ -180,10 +181,15 @@ fn signal<R: Record>(handle: SimulationRunnerHandle<R>) -> anyhow::Result<()> {
         crossbeam::select! {
             recv(rx) -> _ => {
                 handle.stop()?;
-                tracing::info!("gracefully shutwon the simulation app");
+                tracing::info!("gracefully shutdown the simulation app");
                 break;
             },
-            default => {}
+            default => {
+                if handle.is_finished() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
         }
     }
     Ok(())

--- a/simulations/src/runner/mod.rs
+++ b/simulations/src/runner/mod.rs
@@ -40,7 +40,7 @@ impl<R: Record> SimulationRunnerHandle<R> {
         self.stop()
     }
 
-    pub fn stop(self) -> anyhow::Result<()> {
+    pub fn stop(&self) -> anyhow::Result<()> {
         if !self.handle.is_finished() {
             self.stop_tx.send(())?;
             self.producer.stop()?;
@@ -53,6 +53,10 @@ impl<R: Record> SimulationRunnerHandle<R> {
         settings: S::Settings,
     ) -> anyhow::Result<SubscriberHandle<S>> {
         self.producer.subscribe(settings)
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.handle.is_finished()
     }
 
     pub fn join(self) -> anyhow::Result<()> {

--- a/simulations/src/runner/mod.rs
+++ b/simulations/src/runner/mod.rs
@@ -43,7 +43,7 @@ impl<R: Record> SimulationRunnerHandle<R> {
     pub fn stop(&self) -> anyhow::Result<()> {
         if !self.handle.is_finished() {
             self.stop_tx.send(())?;
-            self.producer.stop()?;
+            self.shutdown()?;
         }
         Ok(())
     }
@@ -57,6 +57,10 @@ impl<R: Record> SimulationRunnerHandle<R> {
 
     pub fn is_finished(&self) -> bool {
         self.handle.is_finished()
+    }
+
+    pub fn shutdown(&self) -> anyhow::Result<()> {
+        self.producer.stop()
     }
 
     pub fn join(self) -> anyhow::Result<()> {

--- a/simulations/src/streaming/io.rs
+++ b/simulations/src/streaming/io.rs
@@ -86,13 +86,13 @@ where
         loop {
             crossbeam::select! {
                 recv(self.recvs.stop_rx) -> finish_tx => {
-                    // collect the run time meta
-                    self.sink(Arc::new(R::from(Runtime::load()?)))?;
-
                     // Flush remaining messages after stop signal.
                     while let Ok(msg) = self.recvs.recv.try_recv() {
                         self.sink(msg)?;
                     }
+
+                    // collect the run time meta
+                    self.sink(Arc::new(R::from(Runtime::load()?)))?;
 
                     finish_tx?.send(())?
                 }

--- a/simulations/src/streaming/mod.rs
+++ b/simulations/src/streaming/mod.rs
@@ -253,7 +253,7 @@ where
         })
     }
 
-    pub fn stop(self) -> anyhow::Result<()> {
+    pub fn stop(&self) -> anyhow::Result<()> {
         let meta_record = Arc::new(R::from(Runtime::load()?));
         let inner = self.inner.lock().unwrap();
 

--- a/simulations/src/streaming/naive.rs
+++ b/simulations/src/streaming/naive.rs
@@ -88,13 +88,13 @@ where
         loop {
             crossbeam::select! {
                 recv(self.recvs.stop_rx) -> finish_tx => {
-                    // collect the run time meta
-                    self.sink(Arc::new(R::from(Runtime::load()?)))?;
-
                     // Flush remaining messages after stop signal.
                     while let Ok(msg) = self.recvs.recv.try_recv() {
                         self.sink(msg)?;
                     }
+
+                    // collect the run time meta
+                    self.sink(Arc::new(R::from(Runtime::load()?)))?;
 
                     finish_tx?.send(())?
                 }

--- a/simulations/src/streaming/naive.rs
+++ b/simulations/src/streaming/naive.rs
@@ -1,5 +1,6 @@
 use super::{Receivers, StreamSettings, Subscriber};
 use crate::output_processors::{RecordType, Runtime};
+use crossbeam::channel::{Receiver, Sender};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -49,8 +50,8 @@ where
     type Settings = NaiveSettings;
 
     fn new(
-        record_recv: crossbeam::channel::Receiver<Arc<Self::Record>>,
-        stop_recv: crossbeam::channel::Receiver<()>,
+        record_recv: Receiver<Arc<Self::Record>>,
+        stop_recv: Receiver<Sender<()>>,
         settings: Self::Settings,
     ) -> anyhow::Result<Self>
     where
@@ -86,18 +87,22 @@ where
     fn run(self) -> anyhow::Result<()> {
         loop {
             crossbeam::select! {
-                recv(self.recvs.stop_rx) -> _ => {
+                recv(self.recvs.stop_rx) -> finish_tx => {
                     // collect the run time meta
                     self.sink(Arc::new(R::from(Runtime::load()?)))?;
-                    break;
+
+                    // Flush remaining messages after stop signal.
+                    while let Ok(msg) = self.recvs.recv.try_recv() {
+                        self.sink(msg)?;
+                    }
+
+                    finish_tx?.send(())?
                 }
                 recv(self.recvs.recv) -> msg => {
                     self.sink(msg?)?;
                 }
             }
         }
-
-        Ok(())
     }
 
     fn sink(&self, state: Arc<Self::Record>) -> anyhow::Result<()> {

--- a/simulations/src/streaming/polars.rs
+++ b/simulations/src/streaming/polars.rs
@@ -139,13 +139,13 @@ where
         loop {
             crossbeam::select! {
                 recv(self.recvs.stop_rx) -> finish_tx => {
-                    // collect the run time meta
-                    self.sink(Arc::new(R::from(Runtime::load()?)))?;
-
                     // Flush remaining messages after stop signal.
                     while let Ok(msg) = self.recvs.recv.try_recv() {
                         self.sink(msg)?;
                     }
+
+                    // collect the run time meta
+                    self.sink(Arc::new(R::from(Runtime::load()?)))?;
 
                     finish_tx?.send(())?;
                     return self.persist();

--- a/simulations/src/streaming/polars.rs
+++ b/simulations/src/streaming/polars.rs
@@ -1,5 +1,6 @@
 use super::{Receivers, StreamSettings};
 use crate::output_processors::{RecordType, Runtime};
+use crossbeam::channel::{Receiver, Sender};
 use parking_lot::Mutex;
 use polars::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -97,8 +98,8 @@ where
     type Settings = PolarsSettings;
 
     fn new(
-        record_recv: crossbeam::channel::Receiver<Arc<Self::Record>>,
-        stop_recv: crossbeam::channel::Receiver<()>,
+        record_recv: Receiver<Arc<Self::Record>>,
+        stop_recv: Receiver<Sender<()>>,
         settings: Self::Settings,
     ) -> anyhow::Result<Self>
     where
@@ -137,9 +138,16 @@ where
     fn run(self) -> anyhow::Result<()> {
         loop {
             crossbeam::select! {
-                recv(self.recvs.stop_rx) -> _ => {
+                recv(self.recvs.stop_rx) -> finish_tx => {
                     // collect the run time meta
                     self.sink(Arc::new(R::from(Runtime::load()?)))?;
+
+                    // Flush remaining messages after stop signal.
+                    while let Ok(msg) = self.recvs.recv.try_recv() {
+                        self.sink(msg)?;
+                    }
+
+                    finish_tx?.send(())?;
                     return self.persist();
                 }
                 recv(self.recvs.recv) -> msg => {

--- a/simulations/src/streaming/runtime_subscriber.rs
+++ b/simulations/src/streaming/runtime_subscriber.rs
@@ -1,5 +1,6 @@
 use super::{Receivers, Subscriber};
 use crate::output_processors::{RecordType, Runtime};
+use crossbeam::channel::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::{File, OpenOptions},
@@ -37,8 +38,8 @@ where
     type Settings = RuntimeSettings;
 
     fn new(
-        record_recv: crossbeam::channel::Receiver<Arc<Self::Record>>,
-        stop_recv: crossbeam::channel::Receiver<()>,
+        record_recv: Receiver<Arc<Self::Record>>,
+        stop_recv: Receiver<Sender<()>>,
         settings: Self::Settings,
     ) -> anyhow::Result<Self>
     where
@@ -73,9 +74,10 @@ where
 
     fn run(self) -> anyhow::Result<()> {
         crossbeam::select! {
-            recv(self.recvs.stop_rx) -> _ => {
+            recv(self.recvs.stop_rx) -> finish_tx => {
                 // collect the run time meta
                 self.sink(Arc::new(R::from(Runtime::load()?)))?;
+                finish_tx?.send(())?;
             }
             recv(self.recvs.recv) -> msg => {
                 self.sink(msg?)?;


### PR DESCRIPTION
Two problems occur after the simulation finishes running:
1. The simulation doesn't shut down on its own.
2. If the simulation is stopped or completed, the records that have not yet been persisted are discarded.

It's easier to view the diff by commits.