### PR TITLE
Improved Mixnet design: Random mixnet destination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ members = [
     "tests",
     "mixnet/node",
     "mixnet/client",
+    "mixnet/protocol",
     "mixnet/topology",
 ]

--- a/mixnet/client/Cargo.toml
+++ b/mixnet/client/Cargo.toml
@@ -11,4 +11,5 @@ sphinx-packet = "0.1.0"
 nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", tag = "v1.1.22" }
 # Using an older version, since `nym-sphinx` depends on `rand` v0.7.3.
 rand = "0.7.3"
+mixnet-protocol = { path = "../protocol" }
 mixnet-topology = { path = "../topology" }

--- a/mixnet/client/Cargo.toml
+++ b/mixnet/client/Cargo.toml
@@ -13,3 +13,4 @@ nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", t
 rand = "0.7.3"
 mixnet-protocol = { path = "../protocol" }
 mixnet-topology = { path = "../topology" }
+futures = "0.3.28"

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MixnetClientConfig {
-    pub listen_addr: SocketAddr,
     pub topology: MixnetTopology,
+    // A listen address for receiving final payloads from a MixnetNode.
+    // If you want to run MixnetClient only with sender-mode, set [`None`].
+    pub listen_address: Option<SocketAddr>,
 }

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -2,6 +2,9 @@ use std::net::SocketAddr;
 
 use mixnet_topology::MixnetTopology;
 use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use crate::receiver::Receiver;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MixnetClientConfig {
@@ -12,5 +15,27 @@ pub struct MixnetClientConfig {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum MixnetClientMode {
     Sender,
-    SenderReceiver(SocketAddr),
+    SenderReceiver {
+        listen_address: SocketAddr,
+        channel_capacity: usize,
+    },
+}
+
+impl MixnetClientMode {
+    pub(crate) fn run(&self) -> Option<broadcast::Receiver<Vec<u8>>> {
+        match self {
+            Self::Sender => None,
+            Self::SenderReceiver {
+                listen_address,
+                channel_capacity,
+            } => {
+                let (tx, rx) = broadcast::channel(*channel_capacity);
+                let listen_address = *listen_address;
+
+                tokio::spawn(async move { Receiver::run(listen_address, tx).await.unwrap() });
+
+                Some(rx)
+            }
+        }
+    }
 }

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -25,8 +25,8 @@ impl MixnetClientMode {
     ) {
         match self {
             Self::Sender => (),
-            Self::SenderReceiver(listen_address) => {
-                Receiver::run(*listen_address, message_tx).await.unwrap()
+            Self::SenderReceiver(node_address) => {
+                Receiver::run(*node_address, message_tx).await.unwrap()
             }
         }
     }

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -5,8 +5,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MixnetClientConfig {
+    pub mode: MixnetClientMode,
     pub topology: MixnetTopology,
-    // A listen address for receiving final payloads from a MixnetNode.
-    // If you want to run MixnetClient only with sender-mode, set [`None`].
-    pub listen_address: Option<SocketAddr>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum MixnetClientMode {
+    Sender,
+    SenderReceiver(SocketAddr),
 }

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -2,81 +2,33 @@ pub mod config;
 mod receiver;
 mod sender;
 
-use std::{error::Error, net::SocketAddr};
+use std::error::Error;
 
 pub use config::MixnetClientConfig;
 pub use config::MixnetClientMode;
 use rand::Rng;
-use receiver::Receiver;
 use sender::Sender;
 use tokio::sync::broadcast;
 
 // A client for sending packets to Mixnet and receiving packets from Mixnet.
-pub trait MixnetClient {
-    fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>>;
-    fn subscribe(&self) -> Result<broadcast::Receiver<Vec<u8>>, Box<dyn Error>>;
-}
-
-pub fn new<R: Rng + 'static>(config: MixnetClientConfig, rng: R) -> Box<dyn MixnetClient> {
-    match config.mode {
-        MixnetClientMode::Sender => Box::new(MixnetClientSender::new(config, rng)),
-        MixnetClientMode::SenderReceiver(listen_address) => {
-            Box::new(MixnetClientSenderReceiver::new(config, listen_address, rng))
-        }
-    }
-}
-
-// A client with the sender mode
-struct MixnetClientSender<R: Rng> {
+pub struct MixnetClient<R: Rng> {
+    mode: MixnetClientMode,
     sender: Sender<R>,
 }
 
-impl<R: Rng> MixnetClientSender<R> {
-    fn new(config: MixnetClientConfig, rng: R) -> Self {
+impl<R: Rng> MixnetClient<R> {
+    pub fn new(config: MixnetClientConfig, rng: R) -> Self {
         Self {
+            mode: config.mode,
             sender: Sender::new(config.topology, rng),
         }
     }
-}
 
-impl<R: Rng> MixnetClient for MixnetClientSender<R> {
-    fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {
+    pub fn run(&self) -> Option<broadcast::Receiver<Vec<u8>>> {
+        self.mode.run()
+    }
+
+    pub fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {
         self.sender.send(msg)
-    }
-
-    fn subscribe(&self) -> Result<broadcast::Receiver<Vec<u8>>, Box<dyn Error>> {
-        Err("subscribe is not supported in sender mode".into())
-    }
-}
-
-struct MixnetClientSenderReceiver<R: Rng> {
-    sender: Sender<R>,
-    message_tx: broadcast::Sender<Vec<u8>>,
-}
-
-// A client with the sender-receiver mode
-impl<R: Rng> MixnetClientSenderReceiver<R> {
-    const CHANNEL_SIZE: usize = 100;
-
-    fn new(config: MixnetClientConfig, listen_address: SocketAddr, rng: R) -> Self {
-        let (message_tx, _) = broadcast::channel(Self::CHANNEL_SIZE);
-
-        let tx = message_tx.clone();
-        tokio::spawn(async move { Receiver::run(listen_address, tx).await.unwrap() });
-
-        Self {
-            sender: Sender::new(config.topology, rng),
-            message_tx,
-        }
-    }
-}
-
-impl<R: Rng> MixnetClient for MixnetClientSenderReceiver<R> {
-    fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {
-        self.sender.send(msg)
-    }
-
-    fn subscribe(&self) -> Result<broadcast::Receiver<Vec<u8>>, Box<dyn Error>> {
-        Ok(self.message_tx.subscribe())
     }
 }

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -6,9 +6,9 @@ use std::error::Error;
 
 pub use config::MixnetClientConfig;
 pub use config::MixnetClientMode;
+use futures::Sink;
 use rand::Rng;
 use sender::Sender;
-use tokio::sync::broadcast;
 
 // A client for sending packets to Mixnet and receiving packets from Mixnet.
 pub struct MixnetClient<R: Rng> {
@@ -24,8 +24,8 @@ impl<R: Rng> MixnetClient<R> {
         }
     }
 
-    pub fn run(&self) -> Option<broadcast::Receiver<Vec<u8>>> {
-        self.mode.run()
+    pub async fn run(&self, message_tx: impl Sink<Vec<u8>> + Clone + Unpin + Send + 'static) {
+        self.mode.run(message_tx).await
     }
 
     pub fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -2,42 +2,81 @@ pub mod config;
 mod receiver;
 mod sender;
 
-use std::error::Error;
+use std::{error::Error, net::SocketAddr};
 
 pub use config::MixnetClientConfig;
+pub use config::MixnetClientMode;
 use rand::Rng;
 use receiver::Receiver;
 use sender::Sender;
 use tokio::sync::broadcast;
 
 // A client for sending packets to Mixnet and receiving packets from Mixnet.
-pub struct MixnetClient {
-    sender: Sender,
+pub trait MixnetClient {
+    fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>>;
+    fn subscribe(&self) -> Result<broadcast::Receiver<Vec<u8>>, Box<dyn Error>>;
+}
+
+pub fn new<R: Rng + 'static>(config: MixnetClientConfig, rng: R) -> Box<dyn MixnetClient> {
+    match config.mode {
+        MixnetClientMode::Sender => Box::new(MixnetClientSender::new(config, rng)),
+        MixnetClientMode::SenderReceiver(listen_address) => {
+            Box::new(MixnetClientSenderReceiver::new(config, listen_address, rng))
+        }
+    }
+}
+
+// A client with the sender mode
+struct MixnetClientSender<R: Rng> {
+    sender: Sender<R>,
+}
+
+impl<R: Rng> MixnetClientSender<R> {
+    fn new(config: MixnetClientConfig, rng: R) -> Self {
+        Self {
+            sender: Sender::new(config.topology, rng),
+        }
+    }
+}
+
+impl<R: Rng> MixnetClient for MixnetClientSender<R> {
+    fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        self.sender.send(msg)
+    }
+
+    fn subscribe(&self) -> Result<broadcast::Receiver<Vec<u8>>, Box<dyn Error>> {
+        Err("subscribe is not supported in sender mode".into())
+    }
+}
+
+struct MixnetClientSenderReceiver<R: Rng> {
+    sender: Sender<R>,
     message_tx: broadcast::Sender<Vec<u8>>,
 }
 
-const CHANNEL_SIZE: usize = 100;
+// A client with the sender-receiver mode
+impl<R: Rng> MixnetClientSenderReceiver<R> {
+    const CHANNEL_SIZE: usize = 100;
 
-impl MixnetClient {
-    pub async fn run(config: MixnetClientConfig) -> Result<Self, Box<dyn Error>> {
-        let (message_tx, _) = broadcast::channel(CHANNEL_SIZE);
+    fn new(config: MixnetClientConfig, listen_address: SocketAddr, rng: R) -> Self {
+        let (message_tx, _) = broadcast::channel(Self::CHANNEL_SIZE);
 
-        // Run a receiver only if listen_address is specified
-        if let Some(listen_address) = config.listen_address {
-            Receiver::run(listen_address, message_tx.clone()).await?;
-        }
+        let tx = message_tx.clone();
+        tokio::spawn(async move { Receiver::run(listen_address, tx).await.unwrap() });
 
-        Ok(Self {
-            sender: Sender::new(config.topology),
+        Self {
+            sender: Sender::new(config.topology, rng),
             message_tx,
-        })
+        }
+    }
+}
+
+impl<R: Rng> MixnetClient for MixnetClientSenderReceiver<R> {
+    fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        self.sender.send(msg)
     }
 
-    pub fn send<R: Rng>(&self, msg: Vec<u8>, rng: &mut R) -> Result<(), Box<dyn Error>> {
-        self.sender.send(msg, rng)
-    }
-
-    pub fn subscribe(&self) -> broadcast::Receiver<Vec<u8>> {
-        self.message_tx.subscribe()
+    fn subscribe(&self) -> Result<broadcast::Receiver<Vec<u8>>, Box<dyn Error>> {
+        Ok(self.message_tx.subscribe())
     }
 }

--- a/mixnet/client/src/receiver.rs
+++ b/mixnet/client/src/receiver.rs
@@ -15,7 +15,7 @@ use tokio::{
     sync::broadcast,
 };
 
-// Receiver accepts TCP connections to receive incoming messages from the exit layer of Mixnet.
+// Receiver accepts TCP connections to receive incoming payloads from the Mixnet.
 pub struct Receiver;
 
 impl Receiver {

--- a/mixnet/client/src/receiver.rs
+++ b/mixnet/client/src/receiver.rs
@@ -51,7 +51,7 @@ impl Receiver {
 
     async fn handle_connection(
         mut socket: TcpStream,
-        message_tx: impl Sink<Vec<u8>> + Clone + Unpin,
+        message_tx: impl Sink<Vec<u8>> + Unpin,
         message_reconstructor: Arc<Mutex<MessageReconstructor>>,
     ) -> Result<(), Box<dyn Error>> {
         let body = Body::read(&mut socket).await?;
@@ -69,7 +69,7 @@ impl Receiver {
 
     async fn handle_payload(
         payload: Payload,
-        mut message_tx: impl Sink<Vec<u8>> + Clone + Unpin,
+        mut message_tx: impl Sink<Vec<u8>> + Unpin,
         message_reconstructor: Arc<Mutex<MessageReconstructor>>,
     ) -> Result<(), Box<dyn Error>> {
         let fragment = Fragment::try_from_bytes(&payload.recover_plaintext()?)?;

--- a/mixnet/client/src/receiver.rs
+++ b/mixnet/client/src/receiver.rs
@@ -26,30 +26,25 @@ impl Receiver {
         let listener = TcpListener::bind(listen_addr).await?;
         let message_reconstructor: Arc<Mutex<MessageReconstructor>> = Default::default();
 
-        tokio::spawn(async move {
-            loop {
-                match listener.accept().await {
-                    Ok((socket, remote_addr)) => {
-                        tracing::debug!("Accepted incoming connection from {remote_addr:?}");
+        loop {
+            match listener.accept().await {
+                Ok((socket, remote_addr)) => {
+                    tracing::debug!("Accepted incoming connection from {remote_addr:?}");
 
-                        let message_tx = message_tx.clone();
-                        let message_reconstructor = message_reconstructor.clone();
+                    let message_tx = message_tx.clone();
+                    let message_reconstructor = message_reconstructor.clone();
 
-                        tokio::spawn(async {
-                            if let Err(e) =
-                                Self::handle_connection(socket, message_tx, message_reconstructor)
-                                    .await
-                            {
-                                tracing::error!("failed to handle conn: {e}");
-                            }
-                        });
-                    }
-                    Err(e) => tracing::warn!("Failed to accept incoming connection: {e}"),
+                    tokio::spawn(async {
+                        if let Err(e) =
+                            Self::handle_connection(socket, message_tx, message_reconstructor).await
+                        {
+                            tracing::error!("failed to handle conn: {e}");
+                        }
+                    });
                 }
+                Err(e) => tracing::warn!("Failed to accept incoming connection: {e}"),
             }
-        });
-
-        Ok(())
+        }
     }
 
     async fn handle_connection(

--- a/mixnet/client/src/receiver.rs
+++ b/mixnet/client/src/receiver.rs
@@ -1,9 +1,4 @@
-use std::{
-    error::Error,
-    marker::Unpin,
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-};
+use std::{error::Error, marker::Unpin, net::SocketAddr};
 
 use futures::{Sink, SinkExt};
 use mixnet_protocol::Body;
@@ -12,57 +7,27 @@ use nym_sphinx::{
     message::{NymMessage, PaddedMessage},
     Payload,
 };
-use tokio::{
-    io::AsyncReadExt,
-    net::{TcpListener, TcpStream},
-};
+use tokio::net::TcpStream;
 
 // Receiver accepts TCP connections to receive incoming payloads from the Mixnet.
 pub struct Receiver;
 
 impl Receiver {
     pub async fn run(
-        listen_addr: SocketAddr,
-        message_tx: impl Sink<Vec<u8>> + Clone + Unpin + Send + 'static,
+        node_address: SocketAddr,
+        message_tx: impl Sink<Vec<u8>> + Unpin + Clone,
     ) -> Result<(), Box<dyn Error>> {
-        let listener = TcpListener::bind(listen_addr).await?;
-        let message_reconstructor: Arc<Mutex<MessageReconstructor>> = Default::default();
+        let mut socket = TcpStream::connect(node_address).await?;
+        let mut message_reconstructor: MessageReconstructor = Default::default();
 
         loop {
-            match listener.accept().await {
-                Ok((socket, remote_addr)) => {
-                    tracing::debug!("Accepted incoming connection from {remote_addr:?}");
-
-                    let message_tx = message_tx.clone();
-                    let message_reconstructor = message_reconstructor.clone();
-
-                    tokio::spawn(async {
-                        if let Err(e) =
-                            Self::handle_connection(socket, message_tx, message_reconstructor).await
-                        {
-                            tracing::error!("failed to handle conn: {e}");
-                        }
-                    });
+            let body = Body::read(&mut socket).await?;
+            match body {
+                Body::SphinxPacket(_) => return Err("received sphinx packet not expected".into()),
+                Body::FinalPayload(payload) => {
+                    Self::handle_payload(payload, message_tx.clone(), &mut message_reconstructor)
+                        .await?
                 }
-                Err(e) => tracing::warn!("Failed to accept incoming connection: {e}"),
-            }
-        }
-    }
-
-    async fn handle_connection(
-        mut socket: TcpStream,
-        message_tx: impl Sink<Vec<u8>> + Unpin,
-        message_reconstructor: Arc<Mutex<MessageReconstructor>>,
-    ) -> Result<(), Box<dyn Error>> {
-        let body = Body::read(&mut socket).await?;
-        match body {
-            Body::SphinxPacket(_) => Err("received sphinx packet not expected".into()),
-            Body::FinalPayload(mut reader) => {
-                let mut buf = Vec::new();
-                reader.read_to_end(&mut buf).await?;
-                let payload = Payload::from_bytes(&buf)?;
-
-                Self::handle_payload(payload, message_tx, message_reconstructor).await
             }
         }
     }
@@ -70,15 +35,11 @@ impl Receiver {
     async fn handle_payload(
         payload: Payload,
         mut message_tx: impl Sink<Vec<u8>> + Unpin,
-        message_reconstructor: Arc<Mutex<MessageReconstructor>>,
+        message_reconstructor: &mut MessageReconstructor,
     ) -> Result<(), Box<dyn Error>> {
         let fragment = Fragment::try_from_bytes(&payload.recover_plaintext()?)?;
 
-        let reconstruction_result = {
-            let mut reconstructor = message_reconstructor.lock().unwrap();
-            reconstructor.insert_new_fragment(fragment)
-        };
-
+        let reconstruction_result = message_reconstructor.insert_new_fragment(fragment);
         if let Some((padded_message, _)) = reconstruction_result {
             tracing::debug!("sending a reconstructed message to the local");
             let message = Self::remove_padding(padded_message)?;

--- a/mixnet/client/src/sender.rs
+++ b/mixnet/client/src/sender.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, net::SocketAddr};
 
-use mixnet_protocol::{write_body, BodyType};
+use mixnet_protocol::Body;
 use mixnet_topology::MixnetTopology;
 use nym_sphinx::{
     addressing::nodes::NymNodeRoutingAddress, chunking::fragment::Fragment, message::NymMessage,
@@ -90,7 +90,8 @@ impl<R: Rng> Sender<R> {
         tracing::debug!("Sending a Sphinx packet to the node: {addr:?}");
 
         let mut socket = TcpStream::connect(addr).await?;
-        write_body(&mut socket, BodyType::SphinxPacket, &packet.to_bytes()).await?;
+        let body = Body::new_sphinx(packet);
+        body.write(&mut socket).await?;
         tracing::debug!("Sent a Sphinx packet successuflly to the node: {addr:?}");
 
         Ok(())

--- a/mixnet/client/src/sender.rs
+++ b/mixnet/client/src/sender.rs
@@ -12,36 +12,32 @@ use sphinx_packet::{route, SphinxPacket, SphinxPacketBuilder};
 use tokio::net::TcpStream;
 
 // Sender splits messages into Sphinx packets and sends them to the Mixnet.
-pub struct Sender {
+pub struct Sender<R: Rng> {
     //TODO: handle topology update
     topology: MixnetTopology,
+    rng: R,
 }
 
-impl Sender {
-    pub fn new(topology: MixnetTopology) -> Self {
-        Self { topology }
+impl<R: Rng> Sender<R> {
+    pub fn new(topology: MixnetTopology, rng: R) -> Self {
+        Self { topology, rng }
     }
 
-    pub fn send<R: Rng>(
-        &self,
-        msg: Vec<u8>,
-        rng: &mut R,
-    ) -> Result<(), Box<dyn Error>> {
-        let destination = self.topology.random_destination(rng)?;
+    pub fn send(&mut self, msg: Vec<u8>) -> Result<(), Box<dyn Error>> {
+        let destination = self.topology.random_destination(&mut self.rng)?;
         let destination = Destination::new(
             DestinationAddressBytes::from_bytes(destination.address.as_bytes()),
             [0; IDENTIFIER_LENGTH], // TODO: use a proper SURBIdentifier if we need SURB
         );
 
-        Sender::pad_and_split_message(rng, msg)
+        self.pad_and_split_message(msg)
             .into_iter()
-            .map(|fragment| self.build_sphinx_packet(fragment, &destination, rng))
+            .map(|fragment| self.build_sphinx_packet(fragment, &destination))
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .for_each(|(packet, first_node)| {
                 tokio::spawn(async move {
-                    if let Err(e) = Sender::send_packet(Box::new(packet), first_node.address).await
-                    {
+                    if let Err(e) = Self::send_packet(Box::new(packet), first_node.address).await {
                         tracing::error!("failed to send packet to the first node: {e}");
                     }
                 });
@@ -50,7 +46,7 @@ impl Sender {
         Ok(())
     }
 
-    fn pad_and_split_message<R: Rng>(rng: &mut R, msg: Vec<u8>) -> Vec<Fragment> {
+    fn pad_and_split_message(&mut self, msg: Vec<u8>) -> Vec<Fragment> {
         let nym_message = NymMessage::new_plain(msg);
 
         // TODO: add PUBLIC_KEY_SIZE for encryption for the destination
@@ -60,16 +56,15 @@ impl Sender {
 
         nym_message
             .pad_to_full_packet_lengths(plaintext_size_per_packet)
-            .split_into_fragments(rng, plaintext_size_per_packet)
+            .split_into_fragments(&mut self.rng, plaintext_size_per_packet)
     }
 
-    fn build_sphinx_packet<R: Rng>(
-        &self,
+    fn build_sphinx_packet(
+        &mut self,
         fragment: Fragment,
         destination: &Destination,
-        rng: &mut R,
     ) -> Result<(sphinx_packet::SphinxPacket, route::Node), Box<dyn Error>> {
-        let route = self.topology.random_route(rng)?;
+        let route = self.topology.random_route(&mut self.rng)?;
 
         // TODO: use proper delays
         let delays: Vec<Delay> = route.iter().map(|_| Delay::new_from_nanos(0)).collect();

--- a/mixnet/node/Cargo.toml
+++ b/mixnet/node/Cargo.toml
@@ -9,4 +9,5 @@ tracing = "0.1.37"
 tokio = { version = "1.29.1", features = ["net"] }
 sphinx-packet = "0.1.0"
 nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", tag = "v1.1.22" }
+mixnet-protocol = { path = "../protocol" }
 mixnet-topology = { path = "../topology" }

--- a/mixnet/node/src/client_notifier.rs
+++ b/mixnet/node/src/client_notifier.rs
@@ -1,0 +1,47 @@
+use std::{error::Error, net::SocketAddr};
+
+use mixnet_protocol::Body;
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+};
+
+pub struct ClientNotifier {}
+
+impl ClientNotifier {
+    pub async fn run(
+        listen_address: SocketAddr,
+        mut rx: mpsc::Receiver<Body>,
+    ) -> Result<(), Box<dyn Error>> {
+        let listener = TcpListener::bind(listen_address).await?;
+        tracing::info!("Listening mixnet client connections: {listen_address}");
+
+        // Currently, handling only a single incoming connection
+        // TODO: consider handling multiple clients
+        loop {
+            match listener.accept().await {
+                Ok((socket, remote_addr)) => {
+                    tracing::debug!("Accepted incoming client connection from {remote_addr:?}");
+
+                    if let Err(e) = Self::handle_connection(socket, &mut rx).await {
+                        tracing::error!("failed to handle conn: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("Failed to accept incoming client connection: {e}"),
+            }
+        }
+    }
+
+    async fn handle_connection(
+        mut socket: TcpStream,
+        rx: &mut mpsc::Receiver<Body>,
+    ) -> Result<(), Box<dyn Error>> {
+        while let Some(body) = rx.recv().await {
+            if let Err(e) = body.write(&mut socket).await {
+                return Err(format!("error from client conn: {e}").into());
+            }
+        }
+        tracing::debug!("body receiver closed");
+        Ok(())
+    }
+}

--- a/mixnet/node/src/config.rs
+++ b/mixnet/node/src/config.rs
@@ -8,18 +8,21 @@ use sphinx_packet::crypto::PRIVATE_KEY_SIZE;
 pub struct MixnetNodeConfig {
     // A listen address for receiving Sphinx packets
     pub listen_address: SocketAddr,
+    // An listen address fro communicating with mixnet clients
+    pub client_listen_address: SocketAddr,
     // A key for decrypting Sphinx packets
     pub private_key: [u8; PRIVATE_KEY_SIZE],
-    // An address of the client with receiver-mode enabled, for sending final payloads
-    pub client_address: SocketAddr,
 }
 
 impl Default for MixnetNodeConfig {
     fn default() -> Self {
         Self {
-            listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 7777)),
+            listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7777)),
+            client_listen_address: SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(127, 0, 0, 1),
+                7778,
+            )),
             private_key: PrivateKey::new().to_bytes(),
-            client_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7778)),
         }
     }
 }

--- a/mixnet/node/src/config.rs
+++ b/mixnet/node/src/config.rs
@@ -6,8 +6,12 @@ use sphinx_packet::crypto::PRIVATE_KEY_SIZE;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MixnetNodeConfig {
+    // A listen address for receiving Sphinx packets
     pub listen_address: SocketAddr,
+    // A key for decrypting Sphinx packets
     pub private_key: [u8; PRIVATE_KEY_SIZE],
+    // An address of the client with receiver-mode enabled, for sending final payloads
+    pub client_address: SocketAddr,
 }
 
 impl Default for MixnetNodeConfig {
@@ -15,6 +19,7 @@ impl Default for MixnetNodeConfig {
         Self {
             listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 7777)),
             private_key: PrivateKey::new().to_bytes(),
+            client_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7778)),
         }
     }
 }

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -3,17 +3,14 @@ pub mod config;
 use std::{error::Error, net::SocketAddr};
 
 pub use config::MixnetNodeConfig;
-use mixnet_protocol::{write_body, BodyType};
+use mixnet_protocol::Body;
 use mixnet_topology::MixnetNodeId;
 use nym_sphinx::{
     addressing::nodes::NymNodeRoutingAddress, Delay, DestinationAddressBytes, NodeAddressBytes,
     Payload, PrivateKey, PublicKey,
 };
 use sphinx_packet::{crypto::PUBLIC_KEY_SIZE, ProcessedPacket, SphinxPacket};
-use tokio::{
-    io::AsyncReadExt,
-    net::{TcpListener, TcpStream},
-};
+use tokio::net::{TcpListener, TcpStream};
 
 // A mix node that routes packets in the Mixnet.
 pub struct MixnetNode {
@@ -63,24 +60,19 @@ impl MixnetNode {
         private_key: PrivateKey,
         client_address: SocketAddr,
     ) -> Result<(), Box<dyn Error>> {
-        match BodyType::from_u8(socket.read_u8().await?) {
-            BodyType::SphinxPacket => Self::handle_sphinx_packet(socket, private_key).await,
-            BodyType::FinalPayload => {
-                Self::handle_final_payload(socket, private_key, client_address).await
+        let body = Body::read(&mut socket).await?;
+        match body {
+            Body::SphinxPacket(packet) => Self::handle_sphinx_packet(private_key, packet).await,
+            _body @ Body::FinalPayload(_) => {
+                Self::handle_final_payload(private_key, client_address, _body).await
             }
         }
     }
 
     async fn handle_sphinx_packet(
-        mut socket: TcpStream,
         private_key: PrivateKey,
+        packet: Box<SphinxPacket>,
     ) -> Result<(), Box<dyn Error>> {
-        let mut buf = Vec::new();
-        socket.read_to_end(&mut buf).await?;
-
-        let packet = SphinxPacket::from_bytes(&buf)?;
-        tracing::debug!("received a Sphinx packet from the TCP conn");
-
         match packet.process(&private_key)? {
             ProcessedPacket::ForwardHop(packet, next_node_addr, delay) => {
                 Self::forward_packet_to_next_hop(packet, next_node_addr, delay).await
@@ -92,16 +84,14 @@ impl MixnetNode {
     }
 
     async fn handle_final_payload(
-        mut socket: TcpStream,
         _private_key: PrivateKey,
         client_address: SocketAddr,
+        body: Body<'_>,
     ) -> Result<(), Box<dyn Error>> {
         // TODO: Reuse a conn instead of establishing ad-hoc conns
         let mut client_stream = TcpStream::connect(client_address).await?;
-
         // TODO: Decrypt the final payload using the private key
-        let _ = tokio::io::copy(&mut socket, &mut client_stream).await?;
-
+        body.write(&mut client_stream).await?;
         Ok(())
     }
 
@@ -114,8 +104,7 @@ impl MixnetNode {
         tokio::time::sleep(delay.to_duration()).await;
 
         Self::forward(
-            BodyType::SphinxPacket,
-            &packet.to_bytes(),
+            Body::new_sphinx(packet),
             NymNodeRoutingAddress::try_from(next_node_addr)?,
         )
         .await
@@ -128,22 +117,17 @@ impl MixnetNode {
         tracing::debug!("Forwarding final payload to destination mixnode");
 
         Self::forward(
-            BodyType::FinalPayload,
-            payload.as_bytes(),
+            Body::new_final_owned(payload.into_bytes()),
             NymNodeRoutingAddress::try_from_bytes(&destination_addr.as_bytes())?,
         )
         .await
     }
 
-    async fn forward(
-        body_type: BodyType,
-        body: &[u8],
-        to: NymNodeRoutingAddress,
-    ) -> Result<(), Box<dyn Error>> {
+    async fn forward(body: Body<'_>, to: NymNodeRoutingAddress) -> Result<(), Box<dyn Error>> {
         let addr = SocketAddr::try_from(to)?;
 
         let mut socket = TcpStream::connect(addr).await?;
-        write_body(&mut socket, body_type, body).await?;
+        body.write(&mut socket).await?;
 
         Ok(())
     }

--- a/mixnet/protocol/Cargo.toml
+++ b/mixnet/protocol/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 tokio = "1.29.1"
+sphinx-packet = "0.1.0"
+futures = "0.3"
+tokio-util = {version  = "0.7", features = ["io", "io-util"] }

--- a/mixnet/protocol/Cargo.toml
+++ b/mixnet/protocol/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mixnet-protocol"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = "1.29.1"

--- a/mixnet/protocol/src/lib.rs
+++ b/mixnet/protocol/src/lib.rs
@@ -1,38 +1,77 @@
+use sphinx_packet::SphinxPacket;
 use std::error::Error;
+use std::io::Cursor;
 
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-pub enum BodyType {
-    SphinxPacket,
-    FinalPayload,
+pub enum Body<'a> {
+    SphinxPacket(Box<SphinxPacket>),
+    FinalPayload(Box<dyn AsyncRead + Unpin + Send + 'a>),
 }
 
-impl BodyType {
-    pub fn as_u8(&self) -> u8 {
+impl<'a> Body<'a> {
+    pub fn new_sphinx(packet: Box<SphinxPacket>) -> Self {
+        Self::SphinxPacket(packet)
+    }
+
+    pub fn new_final_owned(data: Vec<u8>) -> Self {
+        Self::FinalPayload(Box::new(Cursor::new(data)))
+    }
+
+    pub fn new_final_stream(data: impl AsyncRead + Unpin + Send + 'a) -> Self {
+        Self::FinalPayload(Box::new(data))
+    }
+
+    fn variant_as_u8(&self) -> u8 {
         match self {
-            Self::SphinxPacket => 0,
-            Self::FinalPayload => 1,
+            Self::SphinxPacket(_) => 0,
+            Self::FinalPayload(_) => 1,
         }
     }
 
-    pub fn from_u8(value: u8) -> Self {
-        match value {
-            0 => Self::SphinxPacket,
-            1 => Self::FinalPayload,
-            _ => todo!("return error"),
+    pub async fn read<R>(reader: &'a mut R) -> Result<Body<'a>, Box<dyn Error>>
+    where
+        R: AsyncRead + Unpin + Send,
+    {
+        let id = reader.read_u8().await?;
+        match id {
+            0 => Self::read_sphinx_packet(reader).await,
+            1 => Self::read_final_payload(reader).await,
+            _ => Err("Invalid body type".into()),
         }
     }
-}
 
-pub async fn write_body<'a, W>(
-    writer: &'a mut W,
-    body_type: BodyType,
-    body: &[u8],
-) -> Result<(), Box<dyn Error>>
-where
-    W: AsyncWrite + Unpin + ?Sized,
-{
-    writer.write_u8(body_type.as_u8()).await?;
-    writer.write_all(body).await?;
-    Ok(())
+    async fn read_sphinx_packet<R>(reader: &mut R) -> Result<Body<'a>, Box<dyn Error>>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).await?;
+        let packet = SphinxPacket::from_bytes(&buf)?;
+        Ok(Self::new_sphinx(Box::new(packet)))
+    }
+
+    async fn read_final_payload<R>(reader: &'a mut R) -> Result<Body<'a>, Box<dyn Error>>
+    where
+        R: AsyncRead + Unpin + Send,
+    {
+        Ok(Self::new_final_stream(reader))
+    }
+
+    pub async fn write<W>(self, writer: &mut W) -> Result<(), Box<dyn Error>>
+    where
+        W: AsyncWrite + Unpin + ?Sized,
+    {
+        let variant = self.variant_as_u8();
+        writer.write_u8(variant).await?;
+        match self {
+            Body::SphinxPacket(packet) => {
+                writer.write_all(&packet.to_bytes()).await?;
+            }
+            Body::FinalPayload(mut reader) => {
+                tokio::io::copy(&mut reader, writer).await?;
+            }
+        }
+        Ok(())
+    }
 }

--- a/mixnet/protocol/src/lib.rs
+++ b/mixnet/protocol/src/lib.rs
@@ -1,0 +1,38 @@
+use std::error::Error;
+
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+pub enum BodyType {
+    SphinxPacket,
+    FinalPayload,
+}
+
+impl BodyType {
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            Self::SphinxPacket => 0,
+            Self::FinalPayload => 1,
+        }
+    }
+
+    pub fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::SphinxPacket,
+            1 => Self::FinalPayload,
+            _ => todo!("return error"),
+        }
+    }
+}
+
+pub async fn write_body<'a, W>(
+    writer: &'a mut W,
+    body_type: BodyType,
+    body: &[u8],
+) -> Result<(), Box<dyn Error>>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    writer.write_u8(body_type.as_u8()).await?;
+    writer.write_all(body).await?;
+    Ok(())
+}

--- a/mixnet/topology/src/lib.rs
+++ b/mixnet/topology/src/lib.rs
@@ -43,6 +43,19 @@ impl MixnetTopology {
 
         Ok(route)
     }
+
+    // Choose a destination mixnet node randomly from the last layer.
+    pub fn random_destination<R: Rng>(&self, rng: &mut R) -> Result<route::Node, Box<dyn Error>> {
+        Ok(self
+            .layers
+            .last()
+            .expect("topology is not empty")
+            .random_node(rng)
+            .expect("layer is not empty")
+            .clone()
+            .try_into()
+            .unwrap())
+    }
 }
 
 impl Layer {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,6 +31,7 @@ tokio = "1"
 futures = "0.3"
 async-trait = "0.1"
 fraction = "0.13"
+tokio-util = "0.7.8"
 
 [[test]]
 name = "test_consensus_happy_path"
@@ -49,4 +50,3 @@ path = "src/tests/mixnet.rs"
 metrics = ["nomos-node/metrics"]
 waku = ["nomos-network/waku", "nomos-mempool/waku", "waku-bindings"]
 libp2p = ["nomos-network/libp2p", "nomos-mempool/libp2p", "nomos-libp2p"]
-

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -7,7 +7,8 @@ use mixnet_client::{MixnetClient, MixnetClientConfig, MixnetClientMode};
 use mixnet_node::{MixnetNode, MixnetNodeConfig};
 use mixnet_topology::{Layer, MixnetTopology, Node};
 use rand::{rngs::OsRng, RngCore};
-use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+use tokio_util::sync::PollSender;
 
 #[tokio::test]
 async fn mixnet() {
@@ -31,7 +32,7 @@ async fn mixnet() {
     assert_eq!(msg, received.as_slice());
 }
 
-async fn run_nodes_and_clients() -> (MixnetTopology, broadcast::Receiver<Vec<u8>>) {
+async fn run_nodes_and_clients() -> (MixnetTopology, mpsc::Receiver<Vec<u8>>) {
     let config1 = MixnetNodeConfig {
         listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7777)),
         client_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7778)),
@@ -87,39 +88,39 @@ async fn run_nodes_and_clients() -> (MixnetTopology, broadcast::Receiver<Vec<u8>
     // Run MixnetClient for each MixnetNode
     let client1 = MixnetClient::new(
         MixnetClientConfig {
-            mode: MixnetClientMode::SenderReceiver {
-                listen_address: config1.client_address,
-                channel_capacity: 10,
-            },
+            mode: MixnetClientMode::SenderReceiver(config1.client_address),
             topology: topology.clone(),
         },
         OsRng,
     );
-    let _ = client1.run();
+    let (client1_tx, _) = mpsc::channel::<Vec<u8>>(1);
+    tokio::spawn(async move {
+        client1.run(PollSender::new(client1_tx)).await;
+    });
 
     let client2 = MixnetClient::new(
         MixnetClientConfig {
-            mode: MixnetClientMode::SenderReceiver {
-                listen_address: config2.client_address,
-                channel_capacity: 10,
-            },
+            mode: MixnetClientMode::SenderReceiver(config2.client_address),
             topology: topology.clone(),
         },
         OsRng,
     );
-    let _ = client2.run();
+    let (client2_tx, _) = mpsc::channel::<Vec<u8>>(1);
+    tokio::spawn(async move {
+        client2.run(PollSender::new(client2_tx)).await;
+    });
 
     let client3 = MixnetClient::new(
         MixnetClientConfig {
-            mode: MixnetClientMode::SenderReceiver {
-                listen_address: config3.client_address,
-                channel_capacity: 10,
-            },
+            mode: MixnetClientMode::SenderReceiver(config3.client_address),
             topology: topology.clone(),
         },
         OsRng,
     );
-    let client3_rx = client3.run().unwrap();
+    let (client3_tx, client3_rx) = mpsc::channel::<Vec<u8>>(1);
+    tokio::spawn(async move {
+        client3.run(PollSender::new(client3_tx)).await;
+    });
 
     // Run all MixnetNodes
     tokio::spawn(async move {

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -10,30 +10,39 @@ use rand::{rngs::OsRng, RngCore};
 
 #[tokio::test]
 async fn mixnet() {
-    let topology = run_mixnodes();
-    let (client1, client2, destination) = run_clients(topology.clone()).await;
+    let (topology, destination_client) = run_nodes_and_clients().await;
 
     let mut msg = [0u8; 100 * 1024];
     rand::thread_rng().fill_bytes(&mut msg);
 
-    let res = client1.send(msg.to_vec(), destination, &mut OsRng);
+    let sender_client = MixnetClient::run(MixnetClientConfig {
+        listen_address: None, // It's not mandatory for senders to listen conns from MixnetNode
+        topology: topology.clone(),
+    })
+    .await
+    .unwrap();
+
+    let res = sender_client.send(msg.to_vec(), &mut OsRng);
     assert!(res.is_ok());
 
-    let received = client2.subscribe().recv().await.unwrap();
+    let received = destination_client.subscribe().recv().await.unwrap();
     assert_eq!(msg, received.as_slice());
 }
 
-fn run_mixnodes() -> MixnetTopology {
+async fn run_nodes_and_clients() -> (MixnetTopology, MixnetClient) {
     let config1 = MixnetNodeConfig {
         listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7777)),
+        client_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7778)),
         ..Default::default()
     };
     let config2 = MixnetNodeConfig {
-        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7778)),
+        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8777)),
+        client_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8778)),
         ..Default::default()
     };
     let config3 = MixnetNodeConfig {
-        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7779)),
+        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9777)),
+        client_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9778)),
         ..Default::default()
     };
 
@@ -73,6 +82,27 @@ fn run_mixnodes() -> MixnetTopology {
         ],
     };
 
+    // Run MixnetClient for each MixnetNode
+    let _ = MixnetClient::run(MixnetClientConfig {
+        topology: topology.clone(),
+        listen_address: Some(config1.client_address),
+    })
+    .await
+    .unwrap();
+    let _ = MixnetClient::run(MixnetClientConfig {
+        topology: topology.clone(),
+        listen_address: Some(config2.client_address),
+    })
+    .await
+    .unwrap();
+    let client3 = MixnetClient::run(MixnetClientConfig {
+        topology: topology.clone(),
+        listen_address: Some(config3.client_address),
+    })
+    .await
+    .unwrap();
+
+    // Run all MixnetNodes
     tokio::spawn(async move {
         let res = mixnode1.run().await;
         assert!(res.is_ok());
@@ -86,21 +116,8 @@ fn run_mixnodes() -> MixnetTopology {
         assert!(res.is_ok());
     });
 
-    topology
-}
-
-async fn run_clients(topology: MixnetTopology) -> (MixnetClient, MixnetClient, SocketAddr) {
-    let config1 = MixnetClientConfig {
-        listen_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8777)),
-        topology: topology.clone(),
-    };
-    let config2 = MixnetClientConfig {
-        listen_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8778)),
-        topology: topology.clone(),
-    };
-
-    let client1 = MixnetClient::run(config1.clone()).await.unwrap();
-    let client2 = MixnetClient::run(config2.clone()).await.unwrap();
-
-    (client1, client2, config2.listen_addr)
+    // According to the current implementation,
+    // the client3 (connected with the mixnode3 in the exit layer) always will be selected
+    // as a destination.
+    (topology, client3)
 }


### PR DESCRIPTION
In the previous design #302, the problem was that message senders must specify the mixnet destination (== the IP of `MixnetClient`). Please note that it's different from the message routing destination.
But, in reality, senders doesn't have any information about the IP of `MixnetClient`s available.

Instead, I improved the design like this:
- A `nomos-node` always embed a `MixnetClient` that receives Sphinx packets, reconstructs messages, and sends them to the network backend in its `nomos-node`.
   - Actually, this is the same in the previous design.
- If you want to run a `MixnetNode`, you must know at least one `MixnetClient` address.
  - In other words, `MixnetNode` operators should run their own `nomos-node` as well.
- When message senders choose 3 `MixnetNode` from `MixnetTopology`, they choose one more `MixnetNode` as a destination, randomly.
- Finallly, all message fragments (sent from a message sender) are forwarded to the destination `MixnetNode`. Then, the message is reconstructed and is broadcasted/routed to all other `nomos-node`s.
- On the other hand, as a `nomos-node` operator, it's not mandatory to run `MixnetNode`.

<img width="1317" alt="image" src="https://github.com/logos-co/nomos-node/assets/5462944/f6cbbaf3-3831-4591-8128-033eff74499e">

With this design, the message sender doesn't need to know about the mixnet destination, as Alvaro suggested. 

At the next PR, I'll show how to integrate these to the `nomos-node`.