### PR TITLE
Pick ports more randomly for integration tests

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,20 +4,14 @@ pub use nodes::NomosNode;
 // std
 use std::fmt::Debug;
 use std::net::TcpListener;
-use std::sync::Mutex;
 use std::time::Duration;
 
 //crates
 use fraction::Fraction;
-use once_cell::sync::Lazy;
-use rand::{Rng, SeedableRng};
-use rand_xoshiro::Xoshiro256PlusPlus;
-
-static RNG: Lazy<Mutex<Xoshiro256PlusPlus>> =
-    Lazy::new(|| Mutex::new(Xoshiro256PlusPlus::seed_from_u64(42)));
+use rand::{thread_rng, Rng};
 
 pub fn get_available_port() -> u16 {
-    let mut port: u16 = RNG.lock().unwrap().gen_range(8000..10000);
+    let mut port: u16 = thread_rng().gen_range(8000..10000);
     while TcpListener::bind(("127.0.0.1", port)).is_err() {
         port += 1;
     }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,21 +10,22 @@ use std::time::Duration;
 //crates
 use fraction::Fraction;
 use once_cell::sync::Lazy;
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
 static RNG: Lazy<Mutex<Xoshiro256PlusPlus>> =
     Lazy::new(|| Mutex::new(Xoshiro256PlusPlus::seed_from_u64(42)));
 
-static NET_PORT: Mutex<u16> = Mutex::new(8000);
-
 pub fn get_available_port() -> u16 {
-    let mut port = NET_PORT.lock().unwrap();
-    *port += 1;
-    while TcpListener::bind(("127.0.0.1", *port)).is_err() {
-        *port += 1;
+    let mut port = random_port();
+    while TcpListener::bind(("127.0.0.1", port)).is_err() {
+        port = random_port();
     }
-    *port
+    port
+}
+
+fn random_port() -> u16 {
+    RNG.lock().unwrap().gen_range(8000..10000)
 }
 
 #[async_trait::async_trait]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,15 +17,11 @@ static RNG: Lazy<Mutex<Xoshiro256PlusPlus>> =
     Lazy::new(|| Mutex::new(Xoshiro256PlusPlus::seed_from_u64(42)));
 
 pub fn get_available_port() -> u16 {
-    let mut port = random_port();
+    let mut port: u16 = RNG.lock().unwrap().gen_range(8000..10000);
     while TcpListener::bind(("127.0.0.1", port)).is_err() {
-        port = random_port();
+        port += 1;
     }
     port
-}
-
-fn random_port() -> u16 {
-    RNG.lock().unwrap().gen_range(8000..10000)
 }
 
 #[async_trait::async_trait]

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 // internal
-use crate::{get_available_port, Node, SpawnConfig, RNG};
+use crate::{get_available_port, Node, SpawnConfig};
 use consensus_engine::overlay::{FlatOverlaySettings, RoundRobin};
 use consensus_engine::NodeId;
 use nomos_consensus::{CarnotInfo, CarnotSettings};
@@ -22,7 +22,7 @@ use waku_bindings::{Multiaddr, PeerId};
 // crates
 use fraction::Fraction;
 use once_cell::sync::Lazy;
-use rand::Rng;
+use rand::{thread_rng, Rng};
 use reqwest::Client;
 use tempfile::NamedTempFile;
 
@@ -174,7 +174,7 @@ impl Node for NomosNode {
             } => {
                 let mut ids = vec![[0; 32]; n_participants];
                 for id in &mut ids {
-                    RNG.lock().unwrap().fill(id);
+                    thread_rng().fill(id);
                 }
                 let mut configs = ids
                     .iter()


### PR DESCRIPTION
For now, I just increased the randomness of choosing ports, even though this doesn't resolve #311 completely. Later, it woudl be better to leverage the auto port assignment (using the port `0`), but it requires lots of refactorings. 