### PR TITLE
Measure latency in mixnet tests

### DIFF
--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -109,9 +109,10 @@ impl MixnetNode {
         client_tx: mpsc::Sender<Body>,
         body: Body,
     ) -> Result<(), Box<dyn Error>> {
-        // TODO: Decrypt the final payload using the private key
+        // TODO: Decrypt the final payload using the private key, if it's encrypted
 
         // Do not wait when the channel is full or no receiver exists
+        // TODO: Consider any better way
         client_tx.try_send(body)?;
         Ok(())
     }

--- a/nodes/mixnode/src/main.rs
+++ b/nodes/mixnode/src/main.rs
@@ -11,11 +11,9 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Construct a subscriber that prints formatted traces to stdout
-    // and use that subscriber to process traces emitted after this point
+    // Install global collector configured based on RUST_LOG env var.
     // TODO: use the log service that nomos-node uses, if necessary
-    let subscriber = tracing_subscriber::FmtSubscriber::new();
-    tracing::subscriber::set_global_default(subscriber)?;
+    tracing_subscriber::fmt::init();
 
     let Args { config } = Args::parse();
     let config = serde_yaml::from_reader::<_, MixnetNodeConfig>(std::fs::File::open(config)?)?;

--- a/tests/src/tests/happy.rs
+++ b/tests/src/tests/happy.rs
@@ -68,7 +68,8 @@ async fn two_nodes_happy() {
 
 #[tokio::test]
 async fn ten_nodes_happy() {
-    let (_mixnodes, mixnet_node_configs, mixnet_topology) = MixNode::spawn_nodes(6).await;
+    //TODO: use at least 6 mixnodes after fixing https://github.com/logos-co/nomos-node/issues/329
+    let (_mixnodes, mixnet_node_configs, mixnet_topology) = MixNode::spawn_nodes(3).await;
     let nodes = NomosNode::spawn_nodes(SpawnConfig::Star {
         n_participants: 10,
         threshold: Fraction::one(),

--- a/tests/src/tests/happy.rs
+++ b/tests/src/tests/happy.rs
@@ -32,7 +32,7 @@ async fn happy_test(nodes: Vec<NomosNode>) {
         } => {}
     };
 
-    let elapsed = Instant::now().checked_duration_since(start_time).unwrap();
+    let elapsed = start_time.elapsed();
     println!("ELAPSED: {elapsed:?}");
 
     let infos = stream::iter(nodes)

--- a/tests/src/tests/happy.rs
+++ b/tests/src/tests/happy.rs
@@ -4,10 +4,13 @@ use futures::stream::{self, StreamExt};
 use std::collections::HashSet;
 use std::time::Duration;
 use tests::{MixNode, Node, NomosNode, SpawnConfig};
+use tokio::time::Instant;
 
 const TARGET_VIEW: View = View::new(20);
 
 async fn happy_test(nodes: Vec<NomosNode>) {
+    let start_time = Instant::now();
+
     let timeout = std::time::Duration::from_secs(20);
     let timeout = tokio::time::sleep(timeout);
     tokio::select! {
@@ -28,6 +31,9 @@ async fn happy_test(nodes: Vec<NomosNode>) {
         }
         } => {}
     };
+
+    let elapsed = Instant::now().checked_duration_since(start_time).unwrap();
+    println!("ELAPSED: {elapsed:?}");
 
     let infos = stream::iter(nodes)
         .then(|n| async move { n.consensus_info().await })

--- a/tests/src/tests/happy.rs
+++ b/tests/src/tests/happy.rs
@@ -68,7 +68,7 @@ async fn two_nodes_happy() {
 
 #[tokio::test]
 async fn ten_nodes_happy() {
-    let (_mixnodes, mixnet_node_configs, mixnet_topology) = MixNode::spawn_nodes(3).await;
+    let (_mixnodes, mixnet_node_configs, mixnet_topology) = MixNode::spawn_nodes(6).await;
     let nodes = NomosNode::spawn_nodes(SpawnConfig::Star {
         n_participants: 10,
         threshold: Fraction::one(),

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -9,6 +9,7 @@ use mixnet_client::{MixnetClient, MixnetClientConfig, MixnetClientError, MixnetC
 use mixnet_node::{MixnetNode, MixnetNodeConfig};
 use mixnet_topology::{Layer, MixnetTopology, Node};
 use rand::{rngs::OsRng, RngCore};
+use tests::get_available_port;
 use tokio::time::Instant;
 
 #[tokio::test]
@@ -97,18 +98,36 @@ async fn run_nodes_and_destination_client() -> (
     impl Stream<Item = Result<Vec<u8>, MixnetClientError>> + Send,
 ) {
     let config1 = MixnetNodeConfig {
-        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7777)),
-        client_listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 7778)),
+        listen_address: SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            get_available_port(),
+        )),
+        client_listen_address: SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            get_available_port(),
+        )),
         ..Default::default()
     };
     let config2 = MixnetNodeConfig {
-        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8777)),
-        client_listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8778)),
+        listen_address: SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            get_available_port(),
+        )),
+        client_listen_address: SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            get_available_port(),
+        )),
         ..Default::default()
     };
     let config3 = MixnetNodeConfig {
-        listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9777)),
-        client_listen_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9778)),
+        listen_address: SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            get_available_port(),
+        )),
+        client_listen_address: SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            get_available_port(),
+        )),
         ..Default::default()
     };
 

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -12,10 +12,23 @@ use rand::{rngs::OsRng, RngCore};
 use tokio::time::Instant;
 
 #[tokio::test]
+async fn mixnet_one_small_message() {
+    // Similar size as Nomos messages.
+    // But, this msg won't be splitted into multiple packets,
+    // since min packet size is 2KB (hardcoded in nymsphinx).
+    // https://github.com/nymtech/nym/blob/3748ab77a132143d5fd1cd75dd06334d33294815/common/nymsphinx/params/src/packet_sizes.rs#L28C10-L28C10
+    test_one_message(500).await
+}
+
+#[tokio::test]
 async fn mixnet_one_message() {
+    test_one_message(100 * 1024).await
+}
+
+async fn test_one_message(msg_size: usize) {
     let (topology, mut destination_stream) = run_nodes_and_destination_client().await;
 
-    let mut msg = [0u8; 100 * 1024];
+    let mut msg = vec![0u8; msg_size];
     rand::thread_rng().fill_bytes(&mut msg);
 
     let mut sender_client = MixnetClient::new(

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -47,7 +47,7 @@ async fn test_one_message(msg_size: usize) {
     let received = destination_stream.next().await.unwrap().unwrap();
     assert_eq!(msg, received.as_slice());
 
-    let elapsed = Instant::now().checked_duration_since(start_time).unwrap();
+    let elapsed = start_time.elapsed();
     println!("ELAPSED: {elapsed:?}");
 }
 
@@ -88,7 +88,7 @@ async fn mixnet_ten_messages() {
         assert_eq!(msg, received.as_slice());
     }
 
-    let elapsed = Instant::now().checked_duration_since(start_time).unwrap();
+    let elapsed = start_time.elapsed();
     println!("ELAPSED: {elapsed:?}");
 }
 


### PR DESCRIPTION
This is a preliminary measurement. I tried to use [Criterion](https://bheisler.github.io/criterion.rs/book/index.html) but couldn’t make compiler happy for async test functions. Instead, I’m using the naive approach for now. 

Mixnet latency with 500B message
```
$ cargo test --no-default-features --features libp2p mixnet_one_small_message -- --nocapture

     Running src/tests/mixnet.rs (target/debug/deps/test_mixnet-cd04009dfb8604f3)

running 1 test
ELAPSED: 25.08425ms
test mixnet_one_small_message ... ok
```
Mixnet latency with 100KB message
```
$ cargo test --no-default-features --features libp2p mixnet_one_message -- --nocapture

     Running src/tests/mixnet.rs (target/debug/deps/test_mixnet-cd04009dfb8604f3)

running 1 test
ELAPSED: 390.456042ms
test mixnet_one_message ... ok
```
Nomos+Mixnet latency: 20 blocks with 10 Nomos nodes and 3 mixnodes
```
$ cargo test --no-default-features --features libp2p ten_nodes_happy -- --nocapture

     Running src/tests/happy.rs (target/debug/deps/test_consensus_happy_path-49a5555fb588b413)

running 1 test
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0
waiting... 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1
waiting... 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3
waiting... 5 | 5 | 5 | 5 | 5 | 5 | 5 | 5 | 5 | 5
waiting... 7 | 7 | 7 | 7 | 7 | 7 | 7 | 7 | 7 | 7
waiting... 9 | 9 | 9 | 9 | 9 | 9 | 9 | 9 | 9 | 9
waiting... 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11
waiting... 13 | 13 | 13 | 13 | 13 | 13 | 13 | 13 | 13 | 13
waiting... 15 | 15 | 15 | 15 | 15 | 15 | 15 | 15 | 15 | 15
waiting... 17 | 17 | 17 | 17 | 17 | 17 | 17 | 17 | 17 | 17
waiting... 19 | 19 | 19 | 19 | 19 | 19 | 19 | 19 | 19 | 19
ELAPSED: 2.296275125s
test ten_nodes_happy ... ok
```
Weirdly, this is much faster than the test without mixnet (5s). I'm taking a look at why.