### PR TITLE
Revert/improve `get_available_port()` in tests

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,21 +1,25 @@
 mod nodes;
 pub use nodes::NomosNode;
+use once_cell::sync::Lazy;
 
 // std
-use std::fmt::Debug;
 use std::net::TcpListener;
 use std::time::Duration;
+use std::{fmt::Debug, sync::Mutex};
 
 //crates
 use fraction::Fraction;
 use rand::{thread_rng, Rng};
 
+static NET_PORT: Lazy<Mutex<u16>> = Lazy::new(|| Mutex::new(thread_rng().gen_range(8000..10000)));
+
 pub fn get_available_port() -> u16 {
-    let mut port: u16 = thread_rng().gen_range(8000..10000);
-    while TcpListener::bind(("127.0.0.1", port)).is_err() {
-        port += 1;
+    let mut port = NET_PORT.lock().unwrap();
+    *port += 1;
+    while TcpListener::bind(("127.0.0.1", *port)).is_err() {
+        *port += 1;
     }
-    port
+    *port
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
NOTE: This PR is for the master branch, not mixnet.

As we discussed in https://github.com/logos-co/nomos-node/pull/327#discussion_r1308091074,
- I reverted `get_available_port()` to prevent port conflicts in a single process (using mutex).
- Also, I improved it to select a starting port randomly, instead of always using `8000`. This will reduce the port conflicts in multi processes, though it's not a perfect solution.