### PR TITLE
Update resolver version in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ members = [
     "consensus-engine",
     "tests",
 ]
+resolver = "2"

--- a/nomos-services/http/src/http.rs
+++ b/nomos-services/http/src/http.rs
@@ -8,9 +8,11 @@ use std::{
 // crates
 use bytes::Bytes;
 use http::StatusCode;
+#[cfg(feature = "gql")]
+use overwatch_rs::services::relay::OutboundRelay;
 use overwatch_rs::services::{
     handle::ServiceStateHandle,
-    relay::{InboundRelay, OutboundRelay, RelayMessage},
+    relay::{InboundRelay, RelayMessage},
     state::{NoOperator, NoState},
     ServiceCore, ServiceData, ServiceId,
 };


### PR DESCRIPTION
New rust version (`1.72`) uses a new dependency resolver. We have conflict depending the version of the crates, so we can overwrite for the whole workspace to the newest one.