### PR TITLE
Move wait at network startup

### DIFF
--- a/nomos-services/consensus/src/network/adapters/libp2p.rs
+++ b/nomos-services/consensus/src/network/adapters/libp2p.rs
@@ -231,6 +231,11 @@ impl NetworkAdapter for Libp2pAdapter {
         let cache = message_cache.clone();
         let relay = network_relay.clone();
         Self::subscribe(&relay, TOPIC).await;
+        tracing::debug!("Starting up...");
+        // this wait seems to be helpful in some cases since we give the time
+        // to the network to establish connections before we start sending messages
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         // TODO: maybe we need the runtime handle here?
         tokio::spawn(async move {
             let (sender, receiver) = tokio::sync::oneshot::channel();

--- a/nomos-services/network/src/lib.rs
+++ b/nomos-services/network/src/lib.rs
@@ -83,12 +83,6 @@ where
     }
 
     async fn run(mut self) -> Result<(), overwatch_rs::DynError> {
-        tracing::debug!("Starting up...");
-        // this wait seems to be helpful in some cases for waku, where it reports
-        // to be connected to peers but does not seem to be able to send messages
-        // to them
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
         let Self {
             service_state: ServiceStateHandle {
                 mut inbound_relay, ..


### PR DESCRIPTION
We now wait after the call to 'subscribe' to give the network the time to register peers in the mesh before starting to publish messages

Should fix occurrences of  #329 in testing for the short term