### PR TITLE
Lock builds per commit and target

### DIFF
--- a/ci/Jenkinsfile.prs.linux
+++ b/ci/Jenkinsfile.prs.linux
@@ -40,7 +40,7 @@ pipeline {
 
           stage('BuildAndTest') {
             options {
-              lock("sync-features")
+              lock('sync-linux-${env.GIT_COMMIT}')
             }
             stages {
               stage('Build') {

--- a/ci/Jenkinsfile.prs.macos
+++ b/ci/Jenkinsfile.prs.macos
@@ -39,7 +39,7 @@ pipeline {
 
           stage('BuildAndTest') {
             options {
-              lock('sync-features')
+              lock('sync-macos-${env.GIT_COMMIT}')
             }
             stages {
               stage('Build') {


### PR DESCRIPTION
Previously builds for all targets had the same lock and certain steps weren't build on macos if linux didn't finish.