### PR TITLE
Fix run output fd

### DIFF
--- a/mixnet/client/Cargo.toml
+++ b/mixnet/client/Cargo.toml
@@ -13,5 +13,6 @@ nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", t
 rand = "0.7.3"
 mixnet-protocol = { path = "../protocol" }
 mixnet-topology = { path = "../topology" }
+mixnet-util = { path = "../util" }
 futures = "0.3.28"
 thiserror = "1"

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -10,7 +10,7 @@ use crate::{receiver::Receiver, MessageStream, MixnetClientError};
 pub struct MixnetClientConfig {
     pub mode: MixnetClientMode,
     pub topology: MixnetTopology,
-    pub connection_cache_size: usize,
+    pub connection_pool_size: usize,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -2,7 +2,6 @@ use std::net::SocketAddr;
 
 use futures::{stream, StreamExt};
 use mixnet_topology::MixnetTopology;
-use mixnet_util::ConnectionCache;
 use serde::{Deserialize, Serialize};
 
 use crate::{receiver::Receiver, MessageStream, MixnetClientError};
@@ -11,7 +10,7 @@ use crate::{receiver::Receiver, MessageStream, MixnetClientError};
 pub struct MixnetClientConfig {
     pub mode: MixnetClientMode,
     pub topology: MixnetTopology,
-    pub connection_cache_size: Option<usize>,
+    pub connection_cache_size: usize,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -21,14 +20,11 @@ pub enum MixnetClientMode {
 }
 
 impl MixnetClientMode {
-    pub(crate) async fn run(
-        &self,
-        cache: ConnectionCache,
-    ) -> Result<MessageStream, MixnetClientError> {
+    pub(crate) async fn run(&self) -> Result<MessageStream, MixnetClientError> {
         match self {
             Self::Sender => Ok(stream::empty().boxed()),
             Self::SenderReceiver(node_address) => {
-                Ok(Receiver::new(*node_address, cache).run().await?.boxed())
+                Ok(Receiver::new(*node_address).run().await?.boxed())
             }
         }
     }

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 pub use config::MixnetClientConfig;
 pub use config::MixnetClientMode;
 use futures::stream::BoxStream;
-use mixnet_util::ConnectionCache;
+use mixnet_util::ConnectionPool;
 use rand::Rng;
 use sender::Sender;
 use thiserror::Error;
@@ -23,7 +23,7 @@ pub type MessageStream = BoxStream<'static, Result<Vec<u8>, MixnetClientError>>;
 
 impl<R: Rng> MixnetClient<R> {
     pub fn new(config: MixnetClientConfig, rng: R) -> Self {
-        let cache = ConnectionCache::new(config.connection_cache_size);
+        let cache = ConnectionPool::new(config.connection_cache_size);
         Self {
             mode: config.mode,
             sender: Sender::new(config.topology, cache, rng),

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -23,7 +23,7 @@ pub type MessageStream = BoxStream<'static, Result<Vec<u8>, MixnetClientError>>;
 
 impl<R: Rng> MixnetClient<R> {
     pub fn new(config: MixnetClientConfig, rng: R) -> Self {
-        let cache = ConnectionPool::new(config.connection_cache_size);
+        let cache = ConnectionPool::new(config.connection_pool_size);
         Self {
             mode: config.mode,
             sender: Sender::new(config.topology, cache, rng),

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 pub use config::MixnetClientConfig;
 pub use config::MixnetClientMode;
 use futures::stream::BoxStream;
+use mixnet_util::{ConnectionCache, MAX_OPEN_FILES_LIMIT};
 use rand::Rng;
 use sender::Sender;
 use thiserror::Error;
@@ -16,20 +17,27 @@ use thiserror::Error;
 pub struct MixnetClient<R: Rng> {
     mode: MixnetClientMode,
     sender: Sender<R>,
+    cache: ConnectionCache,
 }
 
 pub type MessageStream = BoxStream<'static, Result<Vec<u8>, MixnetClientError>>;
 
 impl<R: Rng> MixnetClient<R> {
     pub fn new(config: MixnetClientConfig, rng: R) -> Self {
+        let cache = ConnectionCache::new(
+            config
+                .connection_cache_size
+                .unwrap_or(MAX_OPEN_FILES_LIMIT.unwrap_or(u8::MAX as usize)),
+        );
         Self {
             mode: config.mode,
-            sender: Sender::new(config.topology, rng),
+            sender: Sender::new(config.topology, cache.clone(), rng),
+            cache,
         }
     }
 
     pub async fn run(&self) -> Result<MessageStream, MixnetClientError> {
-        self.mode.run().await
+        self.mode.run(self.cache.clone()).await
     }
 
     pub fn send(&mut self, msg: Vec<u8>, total_delay: Duration) -> Result<(), Box<dyn Error>> {

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -34,7 +34,11 @@ impl<R: Rng> MixnetClient<R> {
         self.mode.run().await
     }
 
-    pub fn send(&mut self, msg: Vec<u8>, total_delay: Duration) -> Result<(), Box<dyn Error>> {
+    pub fn send(
+        &mut self,
+        msg: Vec<u8>,
+        total_delay: Duration,
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         self.sender.send(msg, total_delay)
     }
 }

--- a/mixnet/client/src/lib.rs
+++ b/mixnet/client/src/lib.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 pub use config::MixnetClientConfig;
 pub use config::MixnetClientMode;
 use futures::stream::BoxStream;
-use mixnet_util::{ConnectionCache, MAX_OPEN_FILES_LIMIT};
+use mixnet_util::ConnectionCache;
 use rand::Rng;
 use sender::Sender;
 use thiserror::Error;
@@ -17,27 +17,21 @@ use thiserror::Error;
 pub struct MixnetClient<R: Rng> {
     mode: MixnetClientMode,
     sender: Sender<R>,
-    cache: ConnectionCache,
 }
 
 pub type MessageStream = BoxStream<'static, Result<Vec<u8>, MixnetClientError>>;
 
 impl<R: Rng> MixnetClient<R> {
     pub fn new(config: MixnetClientConfig, rng: R) -> Self {
-        let cache = ConnectionCache::new(
-            config
-                .connection_cache_size
-                .unwrap_or(MAX_OPEN_FILES_LIMIT.unwrap_or(u8::MAX as usize)),
-        );
+        let cache = ConnectionCache::new(config.connection_cache_size);
         Self {
             mode: config.mode,
-            sender: Sender::new(config.topology, cache.clone(), rng),
-            cache,
+            sender: Sender::new(config.topology, cache, rng),
         }
     }
 
     pub async fn run(&self) -> Result<MessageStream, MixnetClientError> {
-        self.mode.run(self.cache.clone()).await
+        self.mode.run().await
     }
 
     pub fn send(&mut self, msg: Vec<u8>, total_delay: Duration) -> Result<(), Box<dyn Error>> {

--- a/mixnet/client/src/receiver.rs
+++ b/mixnet/client/src/receiver.rs
@@ -1,29 +1,51 @@
-use std::{error::Error, net::SocketAddr};
+use std::{error::Error, net::SocketAddr, sync::Arc};
 
 use futures::{stream, Stream, StreamExt};
 use mixnet_protocol::Body;
+use mixnet_util::ConnectionCache;
 use nym_sphinx::{
     chunking::{fragment::Fragment, reconstruction::MessageReconstructor},
     message::{NymMessage, PaddedMessage},
     Payload,
 };
-use tokio::net::TcpStream;
+use tokio::{net::TcpStream, sync::Mutex};
 
 use crate::MixnetClientError;
 
 // Receiver accepts TCP connections to receive incoming payloads from the Mixnet.
-pub struct Receiver;
+pub struct Receiver {
+    cache: ConnectionCache,
+    node_address: SocketAddr,
+}
 
 impl Receiver {
+    pub fn new(node_address: SocketAddr, cache: ConnectionCache) -> Self {
+        Self {
+            cache,
+            node_address,
+        }
+    }
+
     pub async fn run(
-        node_address: SocketAddr,
+        &self,
     ) -> Result<
         impl Stream<Item = Result<Vec<u8>, MixnetClientError>> + Send + 'static,
         MixnetClientError,
     > {
-        let Ok(socket) = TcpStream::connect(node_address).await else {
+        if let Some(stream) = self.cache.get(&self.node_address) {
+            return Ok(Self::message_stream(Box::pin(Self::fragment_stream(
+                stream,
+            ))));
+        }
+
+        let Ok(socket) = TcpStream::connect(self.node_address)
+            .await
+            .map(|s| Arc::new(Mutex::new(s)))
+        else {
             return Err(MixnetClientError::MixnetNodeConnectError);
         };
+
+        self.cache.insert(self.node_address, socket.clone());
 
         Ok(Self::message_stream(Box::pin(Self::fragment_stream(
             socket,
@@ -31,12 +53,17 @@ impl Receiver {
     }
 
     fn fragment_stream(
-        socket: TcpStream,
+        socket: Arc<Mutex<TcpStream>>,
     ) -> impl Stream<Item = Result<Fragment, MixnetClientError>> + Send + 'static {
-        stream::unfold(socket, |mut socket| async move {
-            let Ok(body) = Body::read(&mut socket).await else {
-                // TODO: Maybe this is a hard error and the stream is corrupted? In that case stop the stream
-                return Some((Err(MixnetClientError::MixnetNodeStreamClosed), socket));
+        stream::unfold(socket, |socket| async move {
+            let body = {
+                let mut mu = socket.lock().await;
+                let Ok(body) = Body::read(&mut *mu).await else {
+                    // TODO: Maybe this is a hard error and the stream is corrupted? In that case stop the stream
+                    drop(mu);
+                    return Some((Err(MixnetClientError::MixnetNodeStreamClosed), socket));
+                };
+                body
             };
 
             match body {

--- a/mixnet/client/src/sender.rs
+++ b/mixnet/client/src/sender.rs
@@ -28,7 +28,11 @@ impl<R: Rng> Sender<R> {
         }
     }
 
-    pub fn send(&mut self, msg: Vec<u8>, total_delay: Duration) -> Result<(), Box<dyn Error>> {
+    pub fn send(
+        &mut self,
+        msg: Vec<u8>,
+        total_delay: Duration,
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let destination = self.topology.random_destination(&mut self.rng)?;
         let destination = Destination::new(
             DestinationAddressBytes::from_bytes(destination.address.as_bytes()),
@@ -72,7 +76,8 @@ impl<R: Rng> Sender<R> {
         fragment: Fragment,
         destination: &Destination,
         total_delay: Duration,
-    ) -> Result<(sphinx_packet::SphinxPacket, route::Node), Box<dyn Error>> {
+    ) -> Result<(sphinx_packet::SphinxPacket, route::Node), Box<dyn Error + Send + Sync + 'static>>
+    {
         let route = self.topology.random_route(&mut self.rng)?;
 
         let delays: Vec<Delay> = RandomDelayIterator::new(
@@ -100,7 +105,7 @@ impl<R: Rng> Sender<R> {
         cache: &ConnectionPool,
         packet: Box<SphinxPacket>,
         addr: NodeAddressBytes,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let addr = SocketAddr::try_from(NymNodeRoutingAddress::try_from(addr)?)?;
         tracing::debug!("Sending a Sphinx packet to the node: {addr:?}");
 

--- a/mixnet/node/Cargo.toml
+++ b/mixnet/node/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1.37"
-tokio = { version = "1.29.1", features = ["net"] }
+tokio = { version = "1.32", features = ["net", "time"] }
 sphinx-packet = "0.1.0"
 nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", tag = "v1.1.22" }
 mixnet-protocol = { path = "../protocol" }
 mixnet-topology = { path = "../topology" }
 mixnet-util = { path = "../util" }
+
+[dev-dependencies]
+tokio = {version = "1.32", features =["full"]}

--- a/mixnet/node/Cargo.toml
+++ b/mixnet/node/Cargo.toml
@@ -11,3 +11,4 @@ sphinx-packet = "0.1.0"
 nym-sphinx = { package = "nym-sphinx", git = "https://github.com/nymtech/nym", tag = "v1.1.22" }
 mixnet-protocol = { path = "../protocol" }
 mixnet-topology = { path = "../topology" }
+mixnet-util = { path = "../util" }

--- a/mixnet/node/src/config.rs
+++ b/mixnet/node/src/config.rs
@@ -12,8 +12,8 @@ pub struct MixnetNodeConfig {
     pub client_listen_address: SocketAddr,
     /// A key for decrypting Sphinx packets
     pub private_key: [u8; PRIVATE_KEY_SIZE],
-    /// The size of the connection cache.
-    pub connection_cache_size: usize,
+    /// The size of the connection pool.
+    pub connection_pool_size: usize,
 }
 
 impl Default for MixnetNodeConfig {
@@ -25,7 +25,7 @@ impl Default for MixnetNodeConfig {
                 7778,
             )),
             private_key: PrivateKey::new().to_bytes(),
-            connection_cache_size: 255,
+            connection_pool_size: 255,
         }
     }
 }

--- a/mixnet/node/src/config.rs
+++ b/mixnet/node/src/config.rs
@@ -13,7 +13,7 @@ pub struct MixnetNodeConfig {
     /// A key for decrypting Sphinx packets
     pub private_key: [u8; PRIVATE_KEY_SIZE],
     /// The size of the connection cache.
-    pub connection_cache_size: Option<usize>,
+    pub connection_cache_size: usize,
 }
 
 impl Default for MixnetNodeConfig {
@@ -25,7 +25,7 @@ impl Default for MixnetNodeConfig {
                 7778,
             )),
             private_key: PrivateKey::new().to_bytes(),
-            connection_cache_size: None,
+            connection_cache_size: 255,
         }
     }
 }

--- a/mixnet/node/src/config.rs
+++ b/mixnet/node/src/config.rs
@@ -6,12 +6,14 @@ use sphinx_packet::crypto::{PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MixnetNodeConfig {
-    // A listen address for receiving Sphinx packets
+    /// A listen address for receiving Sphinx packets
     pub listen_address: SocketAddr,
-    // An listen address fro communicating with mixnet clients
+    /// An listen address fro communicating with mixnet clients
     pub client_listen_address: SocketAddr,
-    // A key for decrypting Sphinx packets
+    /// A key for decrypting Sphinx packets
     pub private_key: [u8; PRIVATE_KEY_SIZE],
+    /// The size of the connection cache.
+    pub connection_cache_size: Option<usize>,
 }
 
 impl Default for MixnetNodeConfig {
@@ -23,6 +25,7 @@ impl Default for MixnetNodeConfig {
                 7778,
             )),
             private_key: PrivateKey::new().to_bytes(),
+            connection_cache_size: None,
         }
     }
 }

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -93,7 +93,10 @@ impl MixnetNode {
         let body = Body::read(&mut socket).await?;
         match body {
             Body::SphinxPacket(packet) => {
-                cache.insert(socket.peer_addr().unwrap(), Arc::new(tokio::sync::Mutex::new(socket)));
+                cache.insert(
+                    socket.peer_addr().unwrap(),
+                    Arc::new(tokio::sync::Mutex::new(socket)),
+                );
                 Self::handle_sphinx_packet(cache, private_key, packet).await
             }
             _body @ Body::FinalPayload(_) => {

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -93,6 +93,7 @@ impl MixnetNode {
         let body = Body::read(&mut socket).await?;
         match body {
             Body::SphinxPacket(packet) => {
+                cache.insert(socket.peer_addr().unwrap(), Arc::new(tokio::sync::Mutex::new(socket)));
                 Self::handle_sphinx_packet(cache, private_key, packet).await
             }
             _body @ Body::FinalPayload(_) => {

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -172,9 +172,8 @@ impl MixnetNode {
             return Ok(());
         }
 
-        let mut socket = TcpStream::connect(addr).await?;
-        body.write(&mut socket).await?;
-        cache.insert(addr, Arc::new(tokio::sync::Mutex::new(socket)));
+        body.write(&mut *cache.get_or_init(&addr).await?.lock().await)
+            .await?;
         Ok(())
     }
 }

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -7,7 +7,7 @@ use client_notifier::ClientNotifier;
 pub use config::MixnetNodeConfig;
 use mixnet_protocol::Body;
 use mixnet_topology::MixnetNodeId;
-use mixnet_util::{ConnectionCache, MAX_OPEN_FILES_LIMIT};
+use mixnet_util::ConnectionCache;
 use nym_sphinx::{
     addressing::nodes::NymNodeRoutingAddress, Delay, DestinationAddressBytes, NodeAddressBytes,
     Payload, PrivateKey,
@@ -27,11 +27,7 @@ pub struct MixnetNode {
 
 impl MixnetNode {
     pub fn new(config: MixnetNodeConfig) -> Self {
-        let cache = ConnectionCache::new(
-            config
-                .connection_cache_size
-                .unwrap_or(MAX_OPEN_FILES_LIMIT.unwrap_or(u8::MAX as usize)),
-        );
+        let cache = ConnectionCache::new(config.connection_cache_size);
         Self { config, cache }
     }
 

--- a/mixnet/protocol/src/lib.rs
+++ b/mixnet/protocol/src/lib.rs
@@ -24,7 +24,7 @@ impl Body {
         }
     }
 
-    pub async fn read<R>(reader: &mut R) -> Result<Body, Box<dyn Error>>
+    pub async fn read<R>(reader: &mut R) -> Result<Body, Box<dyn Error + Send + Sync + 'static>>
     where
         R: AsyncRead + Unpin,
     {
@@ -36,12 +36,16 @@ impl Body {
         }
     }
 
-    fn sphinx_packet_from_bytes(data: &[u8]) -> Result<Self, Box<dyn Error>> {
+    fn sphinx_packet_from_bytes(
+        data: &[u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
         let packet = SphinxPacket::from_bytes(data)?;
         Ok(Self::new_sphinx(Box::new(packet)))
     }
 
-    async fn read_sphinx_packet<R>(reader: &mut R) -> Result<Body, Box<dyn Error>>
+    async fn read_sphinx_packet<R>(
+        reader: &mut R,
+    ) -> Result<Body, Box<dyn Error + Send + Sync + 'static>>
     where
         R: AsyncRead + Unpin,
     {
@@ -51,12 +55,16 @@ impl Body {
         Self::sphinx_packet_from_bytes(&buf)
     }
 
-    pub fn final_payload_from_bytes(data: &[u8]) -> Result<Self, Box<dyn Error>> {
+    pub fn final_payload_from_bytes(
+        data: &[u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
         let payload = Payload::from_bytes(data)?;
         Ok(Self::new_final_payload(payload))
     }
 
-    async fn read_final_payload<R>(reader: &mut R) -> Result<Body, Box<dyn Error>>
+    async fn read_final_payload<R>(
+        reader: &mut R,
+    ) -> Result<Body, Box<dyn Error + Send + Sync + 'static>>
     where
         R: AsyncRead + Unpin,
     {
@@ -67,7 +75,10 @@ impl Body {
         Self::final_payload_from_bytes(&buf)
     }
 
-    pub async fn write<W>(self, writer: &mut W) -> Result<(), Box<dyn Error>>
+    pub async fn write<W>(
+        self,
+        writer: &mut W,
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>>
     where
         W: AsyncWrite + Unpin + ?Sized,
     {

--- a/mixnet/topology/src/lib.rs
+++ b/mixnet/topology/src/lib.rs
@@ -24,7 +24,10 @@ pub struct Node {
 }
 
 impl MixnetTopology {
-    pub fn random_route<R: Rng>(&self, rng: &mut R) -> Result<Vec<route::Node>, Box<dyn Error>> {
+    pub fn random_route<R: Rng>(
+        &self,
+        rng: &mut R,
+    ) -> Result<Vec<route::Node>, Box<dyn Error + Send + Sync + 'static>> {
         let num_hops = self.layers.len();
 
         let route: Vec<route::Node> = self
@@ -45,7 +48,10 @@ impl MixnetTopology {
     }
 
     // Choose a destination mixnet node randomly from the last layer.
-    pub fn random_destination<R: Rng>(&self, rng: &mut R) -> Result<route::Node, Box<dyn Error>> {
+    pub fn random_destination<R: Rng>(
+        &self,
+        rng: &mut R,
+    ) -> Result<route::Node, Box<dyn Error + Send + Sync + 'static>> {
         Ok(self
             .layers
             .last()

--- a/mixnet/util/Cargo.toml
+++ b/mixnet/util/Cargo.toml
@@ -4,8 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lru = "0.11"
-once_cell = "1.18" # remove this dep when rust's OnceLock is stable
-rustix = { version = "0.38", features = ["process"] }
 tokio = { version = "1.32", default-features = false, features = ["sync", "net"] }
 parking_lot = { version = "0.12", features = ["send_guard"] }  

--- a/mixnet/util/Cargo.toml
+++ b/mixnet/util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mixnet-util"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lru = "0.11"
+once_cell = "1.18" # remove this dep when rust's OnceLock is stable
+rustix = { version = "0.38", features = ["process"] }
+tokio = { version = "1.32", default-features = false, features = ["sync", "net"] }
+parking_lot = { version = "0.12", features = ["send_guard"] }  

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -4,7 +4,6 @@ use parking_lot::Mutex;
 use tokio::net::TcpStream;
 
 #[derive(Clone)]
-#[repr(transparent)]
 pub struct ConnectionPool {
     pool: Arc<Mutex<HashMap<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
 }

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,0 +1,37 @@
+use std::{net::SocketAddr, num::NonZeroUsize, sync::Arc};
+
+use lru::LruCache;
+use parking_lot::Mutex;
+use tokio::net::TcpStream;
+
+/// The maximum number of open files allowed for the current process.
+pub static MAX_OPEN_FILES_LIMIT: once_cell::sync::Lazy<Option<usize>> =
+    once_cell::sync::Lazy::new(|| {
+        use rustix::process::{getrlimit, Resource};
+        // minus 1 because we need to leave one file descriptor for the listener
+        getrlimit(Resource::Nofile).maximum.map(|n| n as usize)
+    });
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct ConnectionCache {
+    lru: Arc<Mutex<LruCache<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
+}
+
+impl ConnectionCache {
+    pub fn new(size: usize) -> Self {
+        Self {
+            lru: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(size.max(1)).unwrap(),
+            ))),
+        }
+    }
+
+    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<tokio::sync::Mutex<TcpStream>>> {
+        self.lru.lock().get(addr).cloned()
+    }
+
+    pub fn insert(&self, addr: SocketAddr, stream: Arc<tokio::sync::Mutex<TcpStream>>) {
+        self.lru.lock().put(addr, stream);
+    }
+}

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,37 +1,26 @@
-use std::{net::SocketAddr, num::NonZeroUsize, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use lru::LruCache;
 use parking_lot::Mutex;
 use tokio::net::TcpStream;
-
-/// The maximum number of open files allowed for the current process.
-pub static MAX_OPEN_FILES_LIMIT: once_cell::sync::Lazy<Option<usize>> =
-    once_cell::sync::Lazy::new(|| {
-        use rustix::process::{getrlimit, Resource};
-        // minus 1 because we need to leave one file descriptor for the listener
-        getrlimit(Resource::Nofile).maximum.map(|n| n as usize)
-    });
 
 #[derive(Clone)]
 #[repr(transparent)]
 pub struct ConnectionCache {
-    lru: Arc<Mutex<LruCache<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
+    cache: Arc<Mutex<HashMap<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
 }
 
 impl ConnectionCache {
     pub fn new(size: usize) -> Self {
         Self {
-            lru: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(size.max(1)).unwrap(),
-            ))),
+            cache: Arc::new(Mutex::new(HashMap::with_capacity(size))),
         }
     }
 
     pub fn get(&self, addr: &SocketAddr) -> Option<Arc<tokio::sync::Mutex<TcpStream>>> {
-        self.lru.lock().get(addr).cloned()
+        self.cache.lock().get(addr).cloned()
     }
 
     pub fn insert(&self, addr: SocketAddr, stream: Arc<tokio::sync::Mutex<TcpStream>>) {
-        self.lru.lock().put(addr, stream);
+        self.cache.lock().insert(addr, stream);
     }
 }

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -5,22 +5,38 @@ use tokio::net::TcpStream;
 
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct ConnectionCache {
-    cache: Arc<Mutex<HashMap<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
+pub struct ConnectionPool {
+    pool: Arc<Mutex<HashMap<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
 }
 
-impl ConnectionCache {
+impl ConnectionPool {
     pub fn new(size: usize) -> Self {
         Self {
-            cache: Arc::new(Mutex::new(HashMap::with_capacity(size))),
+            pool: Arc::new(Mutex::new(HashMap::with_capacity(size))),
         }
     }
 
     pub fn get(&self, addr: &SocketAddr) -> Option<Arc<tokio::sync::Mutex<TcpStream>>> {
-        self.cache.lock().get(addr).cloned()
+        self.pool.lock().get(addr).cloned()
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    pub async fn get_or_init(
+        &self,
+        addr: &SocketAddr,
+    ) -> std::io::Result<Arc<tokio::sync::Mutex<TcpStream>>> {
+        let mut pool = self.pool.lock();
+        match pool.get(addr) {
+            Some(tcp) => Ok(tcp.clone()),
+            None => {
+                let tcp = Arc::new(tokio::sync::Mutex::new(TcpStream::connect(addr).await?));
+                pool.insert(*addr, tcp.clone());
+                Ok(tcp)
+            }
+        }
     }
 
     pub fn insert(&self, addr: SocketAddr, stream: Arc<tokio::sync::Mutex<TcpStream>>) {
-        self.cache.lock().insert(addr, stream);
+        self.pool.lock().insert(addr, stream);
     }
 }

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -26,8 +26,8 @@ impl ConnectionPool {
         addr: &SocketAddr,
     ) -> std::io::Result<Arc<tokio::sync::Mutex<TcpStream>>> {
         let mut pool = self.pool.lock();
-        match pool.get(addr) {
-            Some(tcp) => Ok(tcp.clone()),
+        match pool.get(addr).cloned() {
+            Some(tcp) => Ok(tcp),
             None => {
                 let tcp = Arc::new(tokio::sync::Mutex::new(TcpStream::connect(addr).await?));
                 pool.insert(*addr, tcp.clone());

--- a/tests/src/nodes/mixnode.rs
+++ b/tests/src/nodes/mixnode.rs
@@ -65,7 +65,7 @@ impl MixNode {
                     get_available_port(),
                 )),
                 private_key,
-                connection_cache_size: 255,
+                connection_pool_size: 255,
             };
             configs.push(config);
         }

--- a/tests/src/nodes/mixnode.rs
+++ b/tests/src/nodes/mixnode.rs
@@ -60,6 +60,7 @@ impl MixNode {
                     get_available_port(),
                 )),
                 private_key,
+                connection_cache_size: None,
             };
             configs.push(config);
         }

--- a/tests/src/nodes/mixnode.rs
+++ b/tests/src/nodes/mixnode.rs
@@ -60,7 +60,7 @@ impl MixNode {
                     get_available_port(),
                 )),
                 private_key,
-                connection_cache_size: None,
+                connection_cache_size: 255,
             };
             configs.push(config);
         }

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -264,6 +264,7 @@ fn create_node_config(
                 mixnet_client: MixnetClientConfig {
                     mode: mixnet_client_mode,
                     topology: mixnet_topology,
+                    connection_cache_size: None,
                 },
             },
         },

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -264,7 +264,7 @@ fn create_node_config(
                 mixnet_client: MixnetClientConfig {
                     mode: mixnet_client_mode,
                     topology: mixnet_topology,
-                    connection_cache_size: None,
+                    connection_cache_size: 255,
                 },
             },
         },

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -264,7 +264,7 @@ fn create_node_config(
                 mixnet_client: MixnetClientConfig {
                     mode: mixnet_client_mode,
                     topology: mixnet_topology,
-                    connection_cache_size: 255,
+                    connection_pool_size: 255,
                 },
                 mixnet_delay: Duration::ZERO..Duration::from_millis(10),
             },

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -24,7 +24,7 @@ async fn mixnet() {
         MixnetClientConfig {
             mode: MixnetClientMode::Sender,
             topology: topology.clone(),
-            connection_cache_size: 255,
+            connection_pool_size: 255,
         },
         OsRng,
     );
@@ -135,7 +135,7 @@ async fn run_nodes_and_destination_client() -> (
         MixnetClientConfig {
             mode: MixnetClientMode::SenderReceiver(config3.client_listen_address),
             topology: topology.clone(),
-            connection_cache_size: 255,
+            connection_pool_size: 255,
         },
         OsRng,
     );

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -22,6 +22,7 @@ async fn mixnet() {
         MixnetClientConfig {
             mode: MixnetClientMode::Sender,
             topology: topology.clone(),
+            connection_cache_size: 255,
         },
         OsRng,
     );
@@ -132,6 +133,7 @@ async fn run_nodes_and_destination_client() -> (
         MixnetClientConfig {
             mode: MixnetClientMode::SenderReceiver(config3.client_listen_address),
             topology: topology.clone(),
+            connection_cache_size: 255,
         },
         OsRng,
     );


### PR DESCRIPTION
This is a very simple solution. Just add a connection cache based on LRU. This solution can only make sure we will not create multiple conn for one `SocketAddr`.