### PR TITLE
Wrap tcp into dns transport to resolve hostnames

### DIFF
--- a/nomos-libp2p/Cargo.toml
+++ b/nomos-libp2p/Cargo.toml
@@ -8,6 +8,7 @@ multiaddr = "0.18"
 tokio = { version = "1", features = ["sync", "macros"] }
 futures = "0.3"
 libp2p = { version = "0.52.1", features = [
+  "dns",
   "yamux",
   "plaintext",
   "macros",

--- a/nomos-libp2p/src/lib.rs
+++ b/nomos-libp2p/src/lib.rs
@@ -10,8 +10,10 @@ use blake2::digest::{consts::U32, Digest};
 use blake2::Blake2b;
 use libp2p::gossipsub::{Message, MessageId, TopicHash};
 
+use libp2p::tcp::tokio::Tcp;
 pub use libp2p::{
     core::upgrade,
+    dns,
     gossipsub::{self, PublishError, SubscriptionError},
     identity::{self, secp256k1},
     plaintext::PlainText2Config,
@@ -75,7 +77,7 @@ impl Swarm {
         log::info!("libp2p peer_id:{}", local_peer_id);
 
         // TODO: consider using noise authentication
-        let tcp_transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true))
+        let tcp_transport = tcp::Transport::<Tcp>::new(tcp::Config::default().nodelay(true))
             .upgrade(upgrade::Version::V1Lazy)
             .authenticate(PlainText2Config {
                 local_public_key: id_keys.public(),
@@ -83,6 +85,9 @@ impl Swarm {
             .multiplex(yamux::Config::default())
             .timeout(TRANSPORT_TIMEOUT)
             .boxed();
+
+        // Wrapping TCP transport into DNS transport to resolve hostnames.
+        let tcp_transport = dns::TokioDnsConfig::system(tcp_transport)?.boxed();
 
         // TODO: consider using Signed or Anonymous.
         //       For Anonymous, a custom `message_id` function need to be set


### PR DESCRIPTION
For a more flexible multiaddrs (i.e. `/dns/localhost/tcp/3000`) to be used with libp2p, tcp needs to be wrapped into dns transport for names to be resolved into ip4 or ip6 addresses.