### PR TITLE
Use `wire` for MixnetMessage in libp2p

### DIFF
--- a/nomos-core/Cargo.toml
+++ b/nomos-core/Cargo.toml
@@ -14,14 +14,12 @@ blake2 = { version = "0.10" }
 bytes = "1.3"
 consensus-engine = { path = "../consensus-engine", features = ["serde"]}
 futures = "0.3"
-nomos-network = { path = "../nomos-services/network", optional = true }
 raptorq = { version = "1.7", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 bincode = "1.3"
 once_cell = "1.0"
 indexmap = { version = "1.9", features = ["serde"] }
-serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -31,5 +29,4 @@ tokio = { version = "1.23", features = ["macros", "rt"] }
 [features]
 default = []
 raptor = ["raptorq"]
-mock = ["nomos-network/mock", "serde_json"]
-waku = ["nomos-network/waku", "serde_json"]
+mock = []

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 tracing = "0.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tokio-stream = "0.1"
-waku-bindings = { version = "0.1.1", optional = true}
+waku-bindings = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 nomos-log = { path = "../log" }
@@ -30,6 +30,6 @@ blake2 = "0.10"
 
 [features]
 default = []
-waku = ["nomos-network/waku", "nomos-core/waku", "waku-bindings"]
+waku = ["nomos-network/waku", "waku-bindings"]
 mock = ["linked-hash-map", "nomos-network/mock", "rand", "nomos-core/mock"]
 libp2p = ["nomos-network/libp2p"]

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 tracing = "0.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tokio-stream = "0.1"
-waku-bindings = { version = "0.1.1", optional = true }
+waku-bindings = { version = "0.1.1", optional = true}
 
 [dev-dependencies]
 nomos-log = { path = "../log" }

--- a/nomos-services/mempool/src/network/adapters/mock.rs
+++ b/nomos-services/mempool/src/network/adapters/mock.rs
@@ -4,7 +4,7 @@
 use futures::{Stream, StreamExt};
 use nomos_core::tx::mock::MockTransaction;
 use nomos_network::backends::mock::{
-    EventKind, Mock, MockBackendMessage, MockContentTopic, NetworkEvent,
+    EventKind, Mock, MockBackendMessage, MockContentTopic, MockMessage, NetworkEvent,
 };
 use nomos_network::{NetworkMsg, NetworkService};
 use overwatch_rs::services::relay::OutboundRelay;
@@ -25,7 +25,7 @@ pub struct MockAdapter {
 #[async_trait::async_trait]
 impl NetworkAdapter for MockAdapter {
     type Backend = Mock;
-    type Tx = MockTransaction;
+    type Tx = MockTransaction<MockMessage>;
 
     async fn new(
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,

--- a/nomos-services/mempool/tests/mock.rs
+++ b/nomos-services/mempool/tests/mock.rs
@@ -17,7 +17,7 @@ use nomos_mempool::{
 struct MockPoolNode {
     logging: ServiceHandle<Logger>,
     network: ServiceHandle<NetworkService<Mock>>,
-    mockpool: ServiceHandle<MempoolService<MockAdapter, MockPool<MockTransaction>>>,
+    mockpool: ServiceHandle<MempoolService<MockAdapter, MockPool<MockTransaction<MockMessage>>>>,
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_mockmempool() {
     let network = app.handle().relay::<NetworkService<Mock>>();
     let mempool = app
         .handle()
-        .relay::<MempoolService<MockAdapter, MockPool<MockTransaction>>>();
+        .relay::<MempoolService<MockAdapter, MockPool<MockTransaction<MockMessage>>>>();
 
     app.spawn(async move {
         let network_outbound = network.connect().await.unwrap();

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -33,7 +33,7 @@ mixnet-client = { path = "../../mixnet/client" }
 tokio = { version = "1", features = ["full"] }
 
 [features]
-default = ["libp2p"]
+default = []
 waku = ["waku-bindings"]
 libp2p = ["nomos-libp2p", "rand"]
 mock = ["rand", "chrono"]

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -12,7 +12,6 @@ chrono = { version = "0.4", optional = true }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
 multiaddr = "0.15"
 serde = "1.0"
-serde_json = "1.0"
 sscanf = { version = "0.4", optional = true }
 sled = { version = "0.34", optional = true }
 tokio = { version = "1", features = ["sync"] }
@@ -26,6 +25,7 @@ tracing-subscriber = { version = "0.3", features = ["json"] }
 tracing-gelf = "0.7"
 futures = "0.3"
 parking_lot = "0.12"
+nomos-core = { path = "../../nomos-core" }
 nomos-libp2p = { path = "../../nomos-libp2p", optional = true }
 mixnet-client = { path = "../../mixnet/client" }
 
@@ -33,7 +33,7 @@ mixnet-client = { path = "../../mixnet/client" }
 tokio = { version = "1", features = ["full"] }
 
 [features]
-default = []
+default = ["libp2p"]
 waku = ["waku-bindings"]
 libp2p = ["nomos-libp2p", "rand"]
 mock = ["rand", "chrono"]

--- a/nomos-services/network/src/backends/libp2p.rs
+++ b/nomos-services/network/src/backends/libp2p.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 // internal
 use super::NetworkBackend;
 use mixnet_client::{MixnetClient, MixnetClientConfig};
+use nomos_core::wire;
 pub use nomos_libp2p::libp2p::gossipsub::{Message, TopicHash};
 use nomos_libp2p::{
     libp2p::{gossipsub, Multiaddr, PeerId},
@@ -71,6 +72,15 @@ pub enum Event {
 struct MixnetMessage {
     topic: Topic,
     message: Box<[u8]>,
+}
+
+impl MixnetMessage {
+    pub fn as_bytes(&self) -> Box<[u8]> {
+        wire::serialize(self).unwrap().into_boxed_slice()
+    }
+    pub fn from_bytes(data: &[u8]) -> Result<Self, wire::Error> {
+        wire::deserialize(data)
+    }
 }
 
 #[async_trait::async_trait]
@@ -145,9 +155,7 @@ impl NetworkBackend for Libp2p {
                             Command::Broadcast { topic, message } => {
                                 tracing::debug!("sending message to mixnet client");
                                 let msg = MixnetMessage { topic, message };
-                                // TODO: use `wire` instead of json, by resolving import cycles
-                                let msg = serde_json::to_vec(&msg).unwrap();
-                                log_error!(mixnet_client.send(msg, std::time::Duration::ZERO));
+                                log_error!(mixnet_client.send(msg.as_bytes().to_vec(), std::time::Duration::ZERO));
                             }
                             Command::Subscribe(topic) => {
                                 tracing::debug!("subscribing to topic: {topic}");
@@ -175,8 +183,8 @@ impl NetworkBackend for Libp2p {
                         match result {
                             Ok(msg) => {
                                 tracing::debug!("receiving message from mixnet client");
-                                let Ok(MixnetMessage { topic, message }) = serde_json::from_slice(&msg) else {
-                                    tracing::error!("failed to deserialize json received from mixnet client");
+                                let Ok(MixnetMessage { topic, message }) = MixnetMessage::from_bytes(&msg) else {
+                                    tracing::error!("failed to deserialize msg received from mixnet client");
                                     continue;
                                 };
 

--- a/nomos-services/network/src/backends/libp2p.rs
+++ b/nomos-services/network/src/backends/libp2p.rs
@@ -75,8 +75,8 @@ struct MixnetMessage {
 }
 
 impl MixnetMessage {
-    pub fn as_bytes(&self) -> Box<[u8]> {
-        wire::serialize(self).unwrap().into_boxed_slice()
+    pub fn as_bytes(&self) -> Vec<u8> {
+        wire::serialize(self).expect("Couldn't serialize MixnetMessage")
     }
     pub fn from_bytes(data: &[u8]) -> Result<Self, wire::Error> {
         wire::deserialize(data)
@@ -155,7 +155,7 @@ impl NetworkBackend for Libp2p {
                             Command::Broadcast { topic, message } => {
                                 tracing::debug!("sending message to mixnet client");
                                 let msg = MixnetMessage { topic, message };
-                                log_error!(mixnet_client.send(msg.as_bytes().to_vec(), std::time::Duration::ZERO));
+                                log_error!(mixnet_client.send(msg.as_bytes(), std::time::Duration::ZERO));
                             }
                             Command::Subscribe(topic) => {
                                 tracing::debug!("subscribing to topic: {topic}");


### PR DESCRIPTION
Replaced serde_json with wire for MixnetMessage in libp2p.

NOTE:
To resolve the cyclic package dependency, I changed `nomos-core` to not depend on `nomos-network`.
```
error: cyclic package dependency: package `nomos-core v0.1.0 (/Users/yjlee/repos/nomos-node-mix/nomos-core)` depends on itself. Cycle:
package `nomos-core v0.1.0 (/Users/yjlee/repos/nomos-node-mix/nomos-core)`
    ... which satisfies path dependency `nomos-core` (locked to 0.1.0) of package `nomos-network v0.1.0 (/Users/yjlee/repos/nomos-node-mix/nomos-services/network)`
    ... which satisfies path dependency `nomos-network` (locked to 0.1.0) of package `nomos-core v0.1.0 (/Users/yjlee/repos/nomos-node-mix/nomos-core)`
    ... which satisfies path dependency `nomos-core` (locked to 0.1.0) of package `nomos-consensus v0.1.0 (/Users/yjlee/repos/nomos-node-mix/nomos-services/consensus)`
```