### PR TITLE
Prevent mixnet tests from running forever

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -32,6 +32,7 @@ tokio = "1"
 futures = "0.3"
 async-trait = "0.1"
 fraction = "0.13"
+ntest = "0.9.0"
 
 [[test]]
 name = "test_consensus_happy_path"

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -12,6 +12,8 @@ use rand::{rngs::OsRng, RngCore};
 use tests::get_available_port;
 
 #[tokio::test]
+// Set timeout since the test won't stop even if mixnodes (spawned asynchronously) panic.
+#[ntest::timeout(5000)]
 async fn mixnet() {
     let (topology, mut destination_stream) = run_nodes_and_destination_client().await;
 


### PR DESCRIPTION
CI sometimes never stop when running the mixnet integration test, if panic happens from mixnodes due to port conflicts or any others. It's because mixnodes are spawned as async tasks. 
Here, I simply set test timeout, as we do for happy/unhappy integration tests.