### PR TITLE
using spin lock and skiplist

### DIFF
--- a/mixnet/client/src/sender.rs
+++ b/mixnet/client/src/sender.rs
@@ -108,7 +108,7 @@ impl<R: Rng> Sender<R> {
         tracing::debug!("Sending a Sphinx packet to the node: {addr:?}");
 
         let body = Body::new_sphinx(packet);
-        body.write(&mut *pool.get_or_init(&addr).await?.write())
+        body.write(pool.get_or_init(&addr).await?.get_mut())
             .await?;
 
         tracing::debug!("Sent a Sphinx packet successuflly to the node: {addr:?}");

--- a/mixnet/client/src/sender.rs
+++ b/mixnet/client/src/sender.rs
@@ -107,11 +107,9 @@ impl<R: Rng> Sender<R> {
         let addr = SocketAddr::try_from(NymNodeRoutingAddress::try_from(addr)?)?;
         tracing::debug!("Sending a Sphinx packet to the node: {addr:?}");
 
-        let mu: std::sync::Arc<tokio::sync::Mutex<tokio::net::TcpStream>> =
-            pool.get_or_init(&addr).await?;
-        let mut socket = mu.lock().await;
         let body = Body::new_sphinx(packet);
-        body.write(&mut *socket).await?;
+        body.write(&mut *pool.get_or_init(&addr).await?.write())
+            .await?;
 
         tracing::debug!("Sent a Sphinx packet successuflly to the node: {addr:?}");
 

--- a/mixnet/client/src/sender.rs
+++ b/mixnet/client/src/sender.rs
@@ -108,7 +108,7 @@ impl<R: Rng> Sender<R> {
         tracing::debug!("Sending a Sphinx packet to the node: {addr:?}");
 
         let body = Body::new_sphinx(packet);
-        body.write(pool.get_or_init(&addr).await?.get_mut())
+        body.write(&mut *pool.get_or_init(&addr).await?.write())
             .await?;
 
         tracing::debug!("Sent a Sphinx packet successuflly to the node: {addr:?}");

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -176,7 +176,7 @@ impl MixnetNode {
         to: NymNodeRoutingAddress,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let addr = SocketAddr::try_from(to)?;
-        body.write(&mut *pool.get_or_init(&addr).await?.lock().await)
+        body.write(&mut *pool.get_or_init(&addr).await?.write())
             .await?;
         Ok(())
     }

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -176,7 +176,7 @@ impl MixnetNode {
         to: NymNodeRoutingAddress,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let addr = SocketAddr::try_from(to)?;
-        body.write(pool.get_or_init(&addr).await?.get_mut())
+        body.write(&mut *pool.get_or_init(&addr).await?.write())
             .await?;
         Ok(())
     }

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -176,7 +176,7 @@ impl MixnetNode {
         to: NymNodeRoutingAddress,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let addr = SocketAddr::try_from(to)?;
-        body.write(&mut *pool.get_or_init(&addr).await?.write())
+        body.write(pool.get_or_init(&addr).await?.get_mut())
             .await?;
         Ok(())
     }

--- a/mixnet/util/Cargo.toml
+++ b/mixnet/util/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.32", default-features = false, features = ["sync", "net"] }
-parking_lot = { version = "0.12", features = ["send_guard"] }
+tokio = { version = "1.32", default-features = false, features = ["net"] }
 spin = "0.9"
 crossbeam-skiplist = "0.1"

--- a/mixnet/util/Cargo.toml
+++ b/mixnet/util/Cargo.toml
@@ -5,4 +5,6 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1.32", default-features = false, features = ["sync", "net"] }
-parking_lot = { version = "0.12", features = ["send_guard"] }  
+parking_lot = { version = "0.12", features = ["send_guard"] }
+spin = "0.9"
+crossbeam-skiplist = "0.1"

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,14 +1,46 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, cell::UnsafeCell};
 
 use crossbeam_skiplist::SkipMap;
 
 // use parking_lot::Mutex;
-use spin::RwLock;
+// use spin::RwLock;
 use tokio::net::TcpStream;
+
+pub struct StreamCell {
+    stream: UnsafeCell<TcpStream>,
+}
+
+impl StreamCell {
+    pub fn get(&self) -> &TcpStream {
+        unsafe { &*self.stream.get() }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_mut(&self) -> &mut TcpStream {
+        unsafe { &mut *self.stream.get() }
+    }
+}
+
+impl From<UnsafeCell<TcpStream>> for StreamCell {
+    fn from(stream: UnsafeCell<TcpStream>) -> Self {
+        Self { stream }
+    }
+}
+
+impl From<TcpStream> for StreamCell {
+    fn from(stream: TcpStream) -> Self {
+        Self {
+            stream: UnsafeCell::new(stream),
+        }
+    }
+}
+
+unsafe impl Send for StreamCell {}
+unsafe impl Sync for StreamCell {}
 
 #[derive(Clone)]
 pub struct ConnectionPool {
-    pool: Arc<SkipMap<SocketAddr, Arc<RwLock<TcpStream>>>>,
+    pool: Arc<SkipMap<SocketAddr, Arc<StreamCell>>>,
 }
 
 impl ConnectionPool {
@@ -18,23 +50,23 @@ impl ConnectionPool {
         }
     }
 
-    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<RwLock<TcpStream>>> {
+    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<StreamCell>> {
         self.pool.get(addr).map(|s| s.value().clone())
     }
 
     #[allow(clippy::await_holding_lock)]
-    pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<RwLock<TcpStream>>> {
+    pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<StreamCell>> {
         match self.pool.get(addr) {
             Some(ent) => Ok(ent.value().clone()),
             None => {
-                let tcp = Arc::new(RwLock::new(TcpStream::connect(addr).await?));
+                let tcp = Arc::new(StreamCell::from(TcpStream::connect(addr).await?));
                 self.insert(*addr, tcp.clone());
                 Ok(tcp)
             }
         }
     }
 
-    pub fn insert(&self, addr: SocketAddr, stream: Arc<RwLock<TcpStream>>) {
+    pub fn insert(&self, addr: SocketAddr, stream: Arc<StreamCell>) {
         self.pool.insert(addr, stream);
     }
 }

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,8 +1,6 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use crossbeam_skiplist::SkipMap;
-
-// use parking_lot::Mutex;
 use spin::RwLock;
 use tokio::net::TcpStream;
 
@@ -22,7 +20,6 @@ impl ConnectionPool {
         self.pool.get(addr).map(|s| s.value().clone())
     }
 
-    #[allow(clippy::await_holding_lock)]
     pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<RwLock<TcpStream>>> {
         match self.pool.get(addr) {
             Some(ent) => Ok(ent.value().clone()),

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,41 +1,40 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
-use parking_lot::Mutex;
+use crossbeam_skiplist::SkipMap;
+
+// use parking_lot::Mutex;
+use spin::RwLock;
 use tokio::net::TcpStream;
 
 #[derive(Clone)]
 pub struct ConnectionPool {
-    pool: Arc<Mutex<HashMap<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
+    pool: Arc<SkipMap<SocketAddr, Arc<RwLock<TcpStream>>>>,
 }
 
 impl ConnectionPool {
-    pub fn new(size: usize) -> Self {
+    pub fn new(_size: usize) -> Self {
         Self {
-            pool: Arc::new(Mutex::new(HashMap::with_capacity(size))),
+            pool: Arc::new(SkipMap::new()),
         }
     }
 
-    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<tokio::sync::Mutex<TcpStream>>> {
-        self.pool.lock().get(addr).cloned()
+    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<RwLock<TcpStream>>> {
+        self.pool.get(addr).map(|s| s.value().clone())
     }
 
     #[allow(clippy::await_holding_lock)]
-    pub async fn get_or_init(
-        &self,
-        addr: &SocketAddr,
-    ) -> std::io::Result<Arc<tokio::sync::Mutex<TcpStream>>> {
-        let mut pool = self.pool.lock();
-        match pool.get(addr).cloned() {
-            Some(tcp) => Ok(tcp),
+    pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<RwLock<TcpStream>>> {
+        match self.pool.get(addr) {
+            Some(ent) => Ok(ent.value().clone()),
             None => {
-                let tcp = Arc::new(tokio::sync::Mutex::new(TcpStream::connect(addr).await?));
-                pool.insert(*addr, tcp.clone());
+                let tcp = Arc::new(RwLock::new(TcpStream::connect(addr).await?));
+                self.insert(*addr, tcp.clone());
                 Ok(tcp)
             }
         }
     }
 
-    pub fn insert(&self, addr: SocketAddr, stream: Arc<tokio::sync::Mutex<TcpStream>>) {
-        self.pool.lock().insert(addr, stream);
+    pub fn insert(&self, addr: SocketAddr, stream: Arc<RwLock<TcpStream>>) {
+        self.pool.insert(addr, stream);
     }
 }

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,46 +1,14 @@
-use std::{net::SocketAddr, sync::Arc, cell::UnsafeCell};
+use std::{net::SocketAddr, sync::Arc};
 
 use crossbeam_skiplist::SkipMap;
 
 // use parking_lot::Mutex;
-// use spin::RwLock;
+use spin::RwLock;
 use tokio::net::TcpStream;
-
-pub struct StreamCell {
-    stream: UnsafeCell<TcpStream>,
-}
-
-impl StreamCell {
-    pub fn get(&self) -> &TcpStream {
-        unsafe { &*self.stream.get() }
-    }
-
-    #[allow(clippy::mut_from_ref)]
-    pub fn get_mut(&self) -> &mut TcpStream {
-        unsafe { &mut *self.stream.get() }
-    }
-}
-
-impl From<UnsafeCell<TcpStream>> for StreamCell {
-    fn from(stream: UnsafeCell<TcpStream>) -> Self {
-        Self { stream }
-    }
-}
-
-impl From<TcpStream> for StreamCell {
-    fn from(stream: TcpStream) -> Self {
-        Self {
-            stream: UnsafeCell::new(stream),
-        }
-    }
-}
-
-unsafe impl Send for StreamCell {}
-unsafe impl Sync for StreamCell {}
 
 #[derive(Clone)]
 pub struct ConnectionPool {
-    pool: Arc<SkipMap<SocketAddr, Arc<StreamCell>>>,
+    pool: Arc<SkipMap<SocketAddr, Arc<RwLock<TcpStream>>>>,
 }
 
 impl ConnectionPool {
@@ -50,23 +18,23 @@ impl ConnectionPool {
         }
     }
 
-    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<StreamCell>> {
+    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<RwLock<TcpStream>>> {
         self.pool.get(addr).map(|s| s.value().clone())
     }
 
     #[allow(clippy::await_holding_lock)]
-    pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<StreamCell>> {
+    pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<RwLock<TcpStream>>> {
         match self.pool.get(addr) {
             Some(ent) => Ok(ent.value().clone()),
             None => {
-                let tcp = Arc::new(StreamCell::from(TcpStream::connect(addr).await?));
+                let tcp = Arc::new(RwLock::new(TcpStream::connect(addr).await?));
                 self.insert(*addr, tcp.clone());
                 Ok(tcp)
             }
         }
     }
 
-    pub fn insert(&self, addr: SocketAddr, stream: Arc<StreamCell>) {
+    pub fn insert(&self, addr: SocketAddr, stream: Arc<RwLock<TcpStream>>) {
         self.pool.insert(addr, stream);
     }
 }


### PR DESCRIPTION
Let's discuss how to improve the performance of conn pool in this PR. This is the first try to remove expensive locks by using Skiplist and a spinlock. As we know, we do not have any data race in TcpStream, so this spin lock will not consume too many CPU cycles.