### PR TITLE
Fix MutexGuard across await

### DIFF
--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use parking_lot::Mutex;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 
 #[derive(Clone)]
 pub struct ConnectionPool {
-    pool: Arc<Mutex<HashMap<SocketAddr, Arc<tokio::sync::Mutex<TcpStream>>>>>,
+    pool: Arc<Mutex<HashMap<SocketAddr, Arc<Mutex<TcpStream>>>>>,
 }
 
 impl ConnectionPool {
@@ -15,27 +15,23 @@ impl ConnectionPool {
         }
     }
 
-    pub fn get(&self, addr: &SocketAddr) -> Option<Arc<tokio::sync::Mutex<TcpStream>>> {
-        self.pool.lock().get(addr).cloned()
+    pub async fn get(&self, addr: &SocketAddr) -> Option<Arc<Mutex<TcpStream>>> {
+        self.pool.lock().await.get(addr).cloned()
     }
 
-    #[allow(clippy::await_holding_lock)]
-    pub async fn get_or_init(
-        &self,
-        addr: &SocketAddr,
-    ) -> std::io::Result<Arc<tokio::sync::Mutex<TcpStream>>> {
-        let mut pool = self.pool.lock();
+    pub async fn get_or_init(&self, addr: &SocketAddr) -> std::io::Result<Arc<Mutex<TcpStream>>> {
+        let mut pool = self.pool.lock().await;
         match pool.get(addr).cloned() {
             Some(tcp) => Ok(tcp),
             None => {
-                let tcp = Arc::new(tokio::sync::Mutex::new(TcpStream::connect(addr).await?));
+                let tcp = Arc::new(Mutex::new(TcpStream::connect(addr).await?));
                 pool.insert(*addr, tcp.clone());
                 Ok(tcp)
             }
         }
     }
 
-    pub fn insert(&self, addr: SocketAddr, stream: Arc<tokio::sync::Mutex<TcpStream>>) {
-        self.pool.lock().insert(addr, stream);
+    pub async fn insert(&self, addr: SocketAddr, stream: Arc<Mutex<TcpStream>>) {
+        self.pool.lock().await.insert(addr, stream);
     }
 }


### PR DESCRIPTION
Holding a MutexGuard across an await point is not a good idea (see https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html).
Removing that solves the issues we had with the mixnet test without needing https://github.com/logos-co/nomos-node/pull/370