### PR TITLE
Simulations: make polars dependancy optional

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,7 +49,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable-gnu
           target: x86_64-pc-windows-gnu
           override: true
@@ -65,12 +64,6 @@ jobs:
         with:
           command: build
           args: --all --no-default-features --features ${{ matrix.feature }}
-      # Freeup some space for Windows tests
-      - name: Clean target dir (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,14 +51,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable-gnu
-          override: true
           target: x86_64-pc-windows-gnu
-      - name: Comment out simulations in Cargo.toml (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          $content = Get-Content Cargo.toml
-          $content | ForEach-Object { $_ -replace '^simulations', '#simulations' } | Set-Content Cargo.toml
-        shell: powershell
+          override: true
       # Setup Rust toolchain for other OSes
       - name: Setup Rust toolchain (Other OSes)
         if: matrix.os != 'windows-latest'
@@ -71,12 +65,6 @@ jobs:
         with:
           command: build
           args: --all --no-default-features --features ${{ matrix.feature }}
-      - uses: actions-rs/toolchain@v1
-        if: matrix.os == 'windows-latest'
-        with:
-          toolchain: stable-gnu
-          override: true
-          target: x86_64-pc-windows-gnu
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           toolchain: stable-gnu
           override: true
+          target: x86_64-pc-windows-gnu
+      - name: Comment out simulations in Cargo.toml (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          $content = Get-Content Cargo.toml
+          $content | ForEach-Object { $_ -replace '^simulations', '#simulations' } | Set-Content Cargo.toml
+        shell: powershell
       # Setup Rust toolchain for other OSes
       - name: Setup Rust toolchain (Other OSes)
         if: matrix.os != 'windows-latest'
@@ -64,6 +71,12 @@ jobs:
         with:
           command: build
           args: --all --no-default-features --features ${{ matrix.feature }}
+      - uses: actions-rs/toolchain@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          toolchain: stable-gnu
+          override: true
+          target: x86_64-pc-windows-gnu
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable-gnu
           override: true
       # Setup Rust toolchain for other OSes
@@ -65,12 +64,6 @@ jobs:
         with:
           command: build
           args: --all --no-default-features --features ${{ matrix.feature }}
-      # Freeup some space for Windows tests
-      - name: Clean target dir (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable-gnu
-          target: x86_64-pc-windows-gnu
           override: true
       # Setup Rust toolchain for other OSes
       - name: Setup Rust toolchain (Other OSes)

--- a/simulations/Cargo.toml
+++ b/simulations/Cargo.toml
@@ -28,7 +28,7 @@ nomos-core = { path = "../nomos-core" }
 nomos-consensus = { path = "../nomos-services/consensus" }
 once_cell = "1.17"
 parking_lot = "0.12"
-polars = { version = "0.27", features = ["serde", "object", "json", "csv-file", "parquet", "dtype-struct"] }
+polars = { version = "0.27", features = ["serde", "object", "json", "csv-file", "parquet", "dtype-struct"], optional = true }
 rand = { version = "0.8", features = ["small_rng"] }
 rayon = "1.7"
 scopeguard = "1"
@@ -44,3 +44,6 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 tempfile = "3.4"
+
+[features]
+polars = ["dep:polars"]

--- a/simulations/src/bin/app/main.rs
+++ b/simulations/src/bin/app/main.rs
@@ -23,9 +23,9 @@ use simulations::node::carnot::{CarnotRecord, CarnotSettings, CarnotState};
 use simulations::node::{NodeId, NodeIdExt};
 use simulations::output_processors::Record;
 use simulations::runner::{BoxedNode, SimulationRunnerHandle};
-use simulations::streaming::{
-    io::IOSubscriber, naive::NaiveSubscriber, polars::PolarsSubscriber, StreamType,
-};
+#[cfg(feature = "polars")]
+use simulations::streaming::polars::PolarsSubscriber;
+use simulations::streaming::{io::IOSubscriber, naive::NaiveSubscriber, StreamType};
 // internal
 use simulations::{runner::SimulationRunner, settings::SimulationSettings};
 mod log;
@@ -163,6 +163,7 @@ where
             let settings = stream_settings.unwrap_io();
             runner.simulate_and_subscribe::<IOSubscriber<CarnotRecord>>(settings)?
         }
+        #[cfg(feature = "polars")]
         Some(StreamType::Polars) => {
             let settings = stream_settings.unwrap_polars();
             runner.simulate_and_subscribe::<PolarsSubscriber<CarnotRecord>>(settings)?

--- a/simulations/src/bin/app/overlay_node.rs
+++ b/simulations/src/bin/app/overlay_node.rs
@@ -25,6 +25,7 @@ pub fn to_overlay_node<R: Rng>(
         simulations::streaming::StreamSettings::IO(_) => {
             simulations::streaming::SubscriberFormat::Csv
         }
+        #[cfg(feature = "polars")]
         simulations::streaming::StreamSettings::Polars(p) => p.format,
     };
     match &settings.overlay_settings {

--- a/simulations/src/node/carnot/timeout.rs
+++ b/simulations/src/node/carnot/timeout.rs
@@ -1,5 +1,8 @@
 use consensus_engine::View;
+#[cfg(feature = "polars")]
 use polars::export::ahash::HashMap;
+#[cfg(not(feature = "polars"))]
+use std::collections::HashMap;
 use std::time::Duration;
 
 pub(crate) struct TimeoutHandler {

--- a/simulations/src/streaming/mod.rs
+++ b/simulations/src/streaming/mod.rs
@@ -11,6 +11,7 @@ use crate::output_processors::{Record, RecordType, Runtime};
 
 pub mod io;
 pub mod naive;
+#[cfg(feature = "polars")]
 pub mod polars;
 pub mod runtime_subscriber;
 pub mod settings_subscriber;
@@ -83,6 +84,7 @@ pub enum StreamType {
     #[default]
     IO,
     Naive,
+    #[cfg(feature = "polars")]
     Polars,
 }
 
@@ -93,6 +95,7 @@ impl FromStr for StreamType {
         match s.trim().to_ascii_lowercase().as_str() {
             "io" => Ok(Self::IO),
             "naive" => Ok(Self::Naive),
+            #[cfg(feature = "polars")]
             "polars" => Ok(Self::Polars),
             tag => Err(format!(
                 "Invalid {tag} streaming type, only [naive, polars] are supported",
@@ -116,6 +119,7 @@ impl<'de> serde::Deserialize<'de> for StreamType {
 pub enum StreamSettings {
     Naive(naive::NaiveSettings),
     IO(io::IOStreamSettings),
+    #[cfg(feature = "polars")]
     Polars(polars::PolarsSettings),
 }
 
@@ -140,6 +144,7 @@ impl StreamSettings {
         }
     }
 
+    #[cfg(feature = "polars")]
     pub fn unwrap_polars(self) -> polars::PolarsSettings {
         match self {
             StreamSettings::Polars(settings) => settings,


### PR DESCRIPTION
Windows builds are failing, the exact reason is not obvious. 

After some investigation, the failure is not clear still, but the build fails for polars crate. As this feature is not essential to simulations, I've just made it optional and not built in ci related tests.