### PR TITLE
GH Actions: Remove codecov token

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -37,7 +37,6 @@ jobs:
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o /tmp/cov/tests.lcov;
       - uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           directory: /tmp/cov/
           name: nomos-node-codecov
           fail_ci_if_error: true


### PR DESCRIPTION
Codecov token should not be required for public repos.