### PR TITLE
Simplify mixnet topology

### DIFF
--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -42,6 +42,8 @@ impl MixnetNode {
     const CLIENT_NOTI_CHANNEL_SIZE: usize = 100;
 
     pub async fn run(self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        tracing::info!("Public key: {:?}", self.public_key());
+
         // Spawn a ClientNotifier
         let (client_tx, client_rx) = mpsc::channel(Self::CLIENT_NOTI_CHANNEL_SIZE);
         tokio::spawn(async move {

--- a/mixnet/topology/src/lib.rs
+++ b/mixnet/topology/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, error::Error, net::SocketAddr};
+use std::{error::Error, net::SocketAddr};
 
 use nym_sphinx::addressing::nodes::{NymNodeRoutingAddress, NymNodeRoutingAddressError};
 use rand::{seq::IteratorRandom, Rng};
@@ -14,7 +14,7 @@ pub struct MixnetTopology {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Layer {
-    pub nodes: HashMap<MixnetNodeId, Node>,
+    pub nodes: Vec<Node>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -66,7 +66,7 @@ impl MixnetTopology {
 
 impl Layer {
     pub fn random_node<R: Rng>(&self, rng: &mut R) -> Option<&Node> {
-        self.nodes.values().choose(rng)
+        self.nodes.iter().choose(rng)
     }
 }
 

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -19,6 +19,21 @@ network:
     discV5BootstrapNodes: []
     initial_peers: []
     relayTopics: []
+    mixnet_client:
+      mode: Sender
+      topology:
+        layers:
+         - nodes:
+            - address: 127.0.0.1:7777
+              public_key: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      connection_pool_size: 255
+    mixnet_delay:
+      start:
+        secs: 0
+        nanos: 0
+      end:
+        secs: 0
+        nanos: 0
 http:
   backend:
     address: 0.0.0.0:8080

--- a/tests/src/nodes/mixnode.rs
+++ b/tests/src/nodes/mixnode.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     process::{Child, Command, Stdio},
     time::Duration,
@@ -81,24 +80,16 @@ impl MixNode {
 
     fn build_topology(configs: Vec<MixnetNodeConfig>) -> MixnetTopology {
         // Build three empty layers first
-        let mut layers = vec![
-            Layer {
-                nodes: HashMap::new(),
-            };
-            3
-        ];
+        let mut layers = vec![Layer { nodes: Vec::new() }; 3];
         let mut layer_id = 0;
 
         // Assign nodes to each layer in round-robin
         for config in &configs {
             let public_key = config.public_key();
-            layers.get_mut(layer_id).unwrap().nodes.insert(
+            layers.get_mut(layer_id).unwrap().nodes.push(Node {
+                address: config.listen_address,
                 public_key,
-                Node {
-                    address: config.listen_address,
-                    public_key,
-                },
-            );
+            });
             layer_id = (layer_id + 1) % layers.len();
         }
 

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     time::Duration,
 };
@@ -81,31 +80,22 @@ async fn run_nodes_and_destination_client() -> (
     let topology = MixnetTopology {
         layers: vec![
             Layer {
-                nodes: HashMap::from([(
-                    mixnode1.id(),
-                    Node {
-                        address: config1.listen_address,
-                        public_key: mixnode1.public_key(),
-                    },
-                )]),
+                nodes: vec![Node {
+                    address: config1.listen_address,
+                    public_key: mixnode1.public_key(),
+                }],
             },
             Layer {
-                nodes: HashMap::from([(
-                    mixnode2.id(),
-                    Node {
-                        address: config2.listen_address,
-                        public_key: mixnode2.public_key(),
-                    },
-                )]),
+                nodes: vec![Node {
+                    address: config2.listen_address,
+                    public_key: mixnode2.public_key(),
+                }],
             },
             Layer {
-                nodes: HashMap::from([(
-                    mixnode3.id(),
-                    Node {
-                        address: config3.listen_address,
-                        public_key: mixnode3.public_key(),
-                    },
-                )]),
+                nodes: vec![Node {
+                    address: config3.listen_address,
+                    public_key: mixnode3.public_key(),
+                }],
             },
         ],
     };


### PR DESCRIPTION
The mixnet topology doesn't need to hold `HashMap<MixnetNodeId, Node>`.
`Vec<Node>` is enough.


With `HashMap` with the key type `MixnetNodeId`, it's hard to write config yaml files:
```yaml
      topology:
        layers:
        - nodes:
            ? - 190
              - 75
              - 117
              - ...
              : address: 127.0.0.1:7777
                public_key: [190, ...]
```