### PR TITLE
Adopt a sans-IO style for DaProtocol

### DIFF
--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -1,8 +1,5 @@
-// std
-use std::error::Error;
 // crates
 use bytes::Bytes;
-use futures::Stream;
 // internal
 use crate::da::attestation::Attestation;
 use crate::da::blob::Blob;
@@ -17,14 +14,24 @@ pub trait DaProtocol {
     type Attestation: Attestation;
     type Certificate: Certificate;
 
-    fn encode<T: AsRef<[u8]>>(&self, data: T) -> Box<dyn Stream<Item = Self::Blob>>;
-    fn decode<S: Stream<Item = Self::Blob>>(&self, s: S) -> Result<Bytes, Box<dyn Error>>;
+    /// Encode bytes into blobs
+    fn encode<T: AsRef<[u8]>>(&self, data: T) -> Vec<Self::Blob>;
+    /// Feed a blob for decoding.
+    /// Depending on the protocol, it may be necessary to feed multiple blobs to
+    /// recover the initial data.
+    fn recv_blob(&mut self, blob: Self::Blob);
+    /// Attempt to recover the initial data from feeded blobs.
+    /// If the protocol is not yet ready to return the data, return None.
+    fn extract(&mut self) -> Option<Bytes>;
+    /// Attest that we have received and stored a blob.
+    fn attest(&self, blob: &Self::Blob) -> Self::Attestation;
+    /// Validate that an attestation is valid for a blob.
     fn validate_attestation(&self, blob: &Self::Blob, attestation: &Self::Attestation) -> bool;
-
-    fn certificate_dispersal<S: Stream<Item = Self::Attestation>>(
-        &self,
-        attestations: S,
-    ) -> Self::Certificate;
-
+    /// Buffer attestations to produce a certificate of correct dispersal.
+    fn recv_attestation(&mut self, attestation: Self::Attestation);
+    /// Attempt to produce a certificate of correct disperal for a blob.
+    /// If the protocol is not yet ready to return the certificate, return None.
+    fn certify_dispersal(&self) -> Option<Self::Certificate>;
+    /// Validate a certificate.
     fn validate_certificate(certificate: &Self::Certificate) -> bool;
 }

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -8,6 +8,7 @@ use crate::da::certificate::Certificate;
 pub mod attestation;
 pub mod blob;
 pub mod certificate;
+pub mod full_replication;
 
 pub trait DaProtocol {
     type Blob: Blob;
@@ -31,7 +32,7 @@ pub trait DaProtocol {
     fn recv_attestation(&mut self, attestation: Self::Attestation);
     /// Attempt to produce a certificate of correct disperal for a blob.
     /// If the protocol is not yet ready to return the certificate, return None.
-    fn certify_dispersal(&self) -> Option<Self::Certificate>;
+    fn certify_dispersal(&mut self) -> Option<Self::Certificate>;
     /// Validate a certificate.
     fn validate_certificate(certificate: &Self::Certificate) -> bool;
 }

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -8,7 +8,6 @@ use crate::da::certificate::Certificate;
 pub mod attestation;
 pub mod blob;
 pub mod certificate;
-pub mod full_replication;
 
 pub trait DaProtocol {
     type Blob: Blob;
@@ -34,5 +33,5 @@ pub trait DaProtocol {
     /// If the protocol is not yet ready to return the certificate, return None.
     fn certify_dispersal(&mut self) -> Option<Self::Certificate>;
     /// Validate a certificate.
-    fn validate_certificate(certificate: &Self::Certificate) -> bool;
+    fn validate_certificate(&self, certificate: &Self::Certificate) -> bool;
 }


### PR DESCRIPTION
Remove async streams from the DaProtocol trait to avoid creating dependencies on actual I/O. The protocol it's now transformed into a state machine with an input and output buffer.

In addition, a method to create an attestation was added to the trait.