### PR TITLE
Remove failed deserialization error message

### DIFF
--- a/nomos-services/data-availability/src/network/adapters/libp2p.rs
+++ b/nomos-services/data-availability/src/network/adapters/libp2p.rs
@@ -15,7 +15,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
-use tracing::error;
+use tracing::debug;
 
 pub const NOMOS_DA_TOPIC: &str = "NomosDa";
 
@@ -47,7 +47,7 @@ where
                     match wire::deserialize::<E>(&data) {
                         Ok(msg) => Some(msg),
                         Err(e) => {
-                            error!("Unrecognized Blob message: {e}");
+                            debug!("Unrecognized message: {e}");
                             None
                         }
                     }


### PR DESCRIPTION
Firstly, a failure in deserialization for a network message is not an error especially since we're using a public channel. Secondly, that same channel is shared by different kind of messages so trying to interpret one as the other will surely lead to a unsuccessfull attempt.