### PR TITLE
Simulation branch with one committee fix

### DIFF
--- a/consensus-engine/src/overlay/branch_overlay.rs
+++ b/consensus-engine/src/overlay/branch_overlay.rs
@@ -123,8 +123,9 @@ where
         (committee_size * 2 / 3) + 1
     }
 
-    fn leader_super_majority_threshold(&self, id: NodeId) -> usize {
-        self.super_majority_threshold(id)
+    fn leader_super_majority_threshold(&self, _id: NodeId) -> usize {
+        let committee_size = self.root_committee().len();
+        (committee_size * 2 / 3) + 1
     }
 
     fn update_leader_selection<F, E>(&self, f: F) -> Result<Self, E>

--- a/consensus-engine/src/overlay/mod.rs
+++ b/consensus-engine/src/overlay/mod.rs
@@ -107,9 +107,6 @@ mod tests {
             committee_membership: FisherYatesShuffle::new(ENTROPY),
         });
 
-        let mut expected_committee = Committee::new();
-        expected_committee.extend(nodes.iter());
-
         overlay_fns_match(&tree_overlay, &branch_overlay, &nodes);
     }
 }

--- a/consensus-engine/src/overlay/mod.rs
+++ b/consensus-engine/src/overlay/mod.rs
@@ -49,3 +49,67 @@ pub trait LeaderSelection: Clone {
 pub trait CommitteeMembership: Clone {
     fn reshape_committees(&self, nodes: &mut [NodeId]);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::overlay::{FisherYatesShuffle, RoundRobin};
+
+    const ENTROPY: [u8; 32] = [0; 32];
+
+    fn overlay_fns_match(a: &impl Overlay, b: &impl Overlay, nodes: &[NodeId]) {
+        assert_eq!(a.root_committee(), b.root_committee());
+        assert_eq!(
+            a.is_member_of_child_committee(nodes[0], nodes[1]),
+            b.is_member_of_child_committee(nodes[0], nodes[1]),
+        );
+        assert_eq!(
+            a.is_member_of_root_committee(nodes[0]),
+            b.is_member_of_root_committee(nodes[0]),
+        );
+        assert_eq!(
+            a.is_member_of_leaf_committee(nodes[0]),
+            b.is_member_of_leaf_committee(nodes[0]),
+        );
+        assert_eq!(
+            a.is_child_of_root_committee(nodes[0]),
+            b.is_child_of_root_committee(nodes[0])
+        );
+        assert_eq!(a.parent_committee(nodes[0]), b.parent_committee(nodes[0]));
+        assert_eq!(a.child_committees(nodes[0]), b.child_committees(nodes[0]));
+        assert_eq!(a.leaf_committees(nodes[0]), b.leaf_committees(nodes[0]));
+        assert_eq!(a.node_committee(nodes[0]), b.node_committee(nodes[0]));
+        assert_eq!(
+            a.super_majority_threshold(nodes[0]),
+            b.super_majority_threshold(nodes[0])
+        );
+        assert_eq!(
+            a.leader_super_majority_threshold(nodes[0]),
+            b.leader_super_majority_threshold(nodes[0])
+        );
+    }
+
+    #[test]
+    fn compare_tree_branch_one_committee() {
+        let nodes: Vec<_> = (0..10).map(|i| NodeId::new([i as u8; 32])).collect();
+        let tree_overlay = TreeOverlay::new(TreeOverlaySettings {
+            nodes: nodes.clone(),
+            current_leader: nodes[0],
+            number_of_committees: 1,
+            leader: RoundRobin::new(),
+            committee_membership: FisherYatesShuffle::new(ENTROPY),
+        });
+        let branch_overlay = BranchOverlay::new(BranchOverlaySettings {
+            current_leader: nodes[0],
+            nodes: nodes.clone(),
+            branch_depth: 1,
+            leader: RoundRobin::new(),
+            committee_membership: FisherYatesShuffle::new(ENTROPY),
+        });
+
+        let mut expected_committee = Committee::new();
+        expected_committee.extend(nodes.iter());
+
+        overlay_fns_match(&tree_overlay, &branch_overlay, &nodes);
+    }
+}


### PR DESCRIPTION
During research simulation runs tree and branch overlays behave as expected, the only issue was that branch overlay timed out without incrementing the view when it contained single committee. This was not the case for flat and tree overlays.

This change fixes the problem, but to be totally sure, I'd like to ask @0xFugue to rerun all tests with this version and check if branch overlay still correlate to tree overlay results with higher committee count.