### PR TITLE
Change default network backend to libp2p

### DIFF
--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -37,6 +37,6 @@ waku-bindings = { version = "0.1.1", optional = true }
 
 
 [features]
-default = ["waku"]
+default = ["libp2p"]
 waku = ["waku-bindings", "nomos-network/waku", "nomos-mempool/waku", "nomos-consensus/waku"]
 libp2p = ["nomos-libp2p", "nomos-network/libp2p", "nomos-mempool/libp2p", "nomos-consensus/libp2p"]


### PR DESCRIPTION
We've been using it for a while and we don't plan to switch back to Waku anytime soon.