### PR TITLE
Add da service to nomos node

### DIFF
--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -25,6 +25,7 @@ nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock"] }
 nomos-http = { path = "../../nomos-services/http", features = ["http"] }
 nomos-consensus = { path = "../../nomos-services/consensus" }
 nomos-libp2p = { path = "../../nomos-libp2p", optional = true }
+nomos-da = { path = "../../nomos-services/data-availability" }
 metrics = { path = "../../nomos-services/metrics", optional = true }
 tracing-subscriber = "0.3"
 consensus-engine = { path = "../../consensus-engine" }
@@ -34,7 +35,7 @@ serde_yaml = "0.9"
 color-eyre = "0.6.0"
 serde = "1"
 waku-bindings = { version = "0.1.1", optional = true }
-
+full-replication = { path = "../../nomos-da/full-replication" }
 
 [features]
 default = ["libp2p"]

--- a/nodes/nomos-node/src/blob.rs
+++ b/nodes/nomos-node/src/blob.rs
@@ -1,1 +1,0 @@
-pub type Blob = Box<[u8]>;

--- a/nodes/nomos-node/src/config.rs
+++ b/nodes/nomos-node/src/config.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use crate::Carnot;
+#[cfg(feature = "libp2p")]
+use crate::DataAvailability;
 use clap::{Parser, ValueEnum};
 use color_eyre::eyre::{self, eyre, Result};
 use hex::FromHex;
@@ -129,6 +131,8 @@ pub struct Config {
     pub consensus: <Carnot as ServiceData>::Settings,
     #[cfg(feature = "metrics")]
     pub metrics: <MetricsService<MapMetricsBackend<MetricsData>> as ServiceData>::Settings,
+    #[cfg(feature = "libp2p")]
+    pub da: <DataAvailability as ServiceData>::Settings,
 }
 
 impl Config {

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -3,8 +3,9 @@ mod tx;
 
 use color_eyre::eyre::Result;
 use consensus_engine::overlay::{FlatOverlay, RandomBeaconState, RoundRobin};
+use full_replication::Blob;
 #[cfg(feature = "libp2p")]
-use full_replication::{AbsoluteNumber, Attestation, Blob, Certificate, FullReplication};
+use full_replication::{AbsoluteNumber, Attestation, Certificate, FullReplication};
 #[cfg(feature = "metrics")]
 use metrics::{backend::map::MapMetricsBackend, types::MetricsData, MetricsService};
 #[cfg(feature = "libp2p")]
@@ -58,6 +59,7 @@ pub type Carnot = CarnotConsensus<
     Blob,
 >;
 
+#[cfg(feature = "libp2p")]
 type DataAvailability = DataAvailabilityService<
     FullReplication<AbsoluteNumber<Attestation, Certificate>>,
     BlobCache<<Blob as nomos_core::da::blob::Blob>::Hash, Blob>,

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -83,6 +83,8 @@ fn main() -> Result<()> {
             bridges: HttpBridgeSettings { bridges },
             #[cfg(feature = "metrics")]
             metrics: config.metrics,
+            #[cfg(feature = "libp2p")]
+            da: config.da,
         },
         None,
     )

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -13,7 +13,10 @@ pub trait DaProtocol {
     type Blob: Blob;
     type Attestation: Attestation;
     type Certificate: Certificate;
+    type Settings: Clone;
 
+    // Construct a new instance
+    fn new(settings: Self::Settings) -> Self;
     /// Encode bytes into blobs
     fn encode<T: AsRef<[u8]>>(&self, data: T) -> Vec<Self::Blob>;
     /// Feed a blob for decoding.

--- a/nomos-da/full-replication/src/lib.rs
+++ b/nomos-da/full-replication/src/lib.rs
@@ -59,6 +59,11 @@ impl<A, C> AbsoluteNumber<A, C> {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Settings {
+    pub num_attestations: usize,
+}
+
 impl CertificateStrategy for AbsoluteNumber<Attestation, Certificate> {
     type Attestation = Attestation;
     type Certificate = Certificate;
@@ -79,7 +84,7 @@ impl CertificateStrategy for AbsoluteNumber<Attestation, Certificate> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, Hash, PartialEq)]
 
 pub struct Blob {
     data: Bytes,
@@ -130,6 +135,11 @@ impl DaProtocol for FullReplication<AbsoluteNumber<Attestation, Certificate>> {
     type Blob = Blob;
     type Attestation = Attestation;
     type Certificate = Certificate;
+    type Settings = Settings;
+
+    fn new(settings: Self::Settings) -> Self {
+        Self::new(AbsoluteNumber::new(settings.num_attestations))
+    }
 
     fn encode<T: AsRef<[u8]>>(&self, data: T) -> Vec<Self::Blob> {
         vec![Blob {

--- a/nomos-services/data-availability/src/backend/memory_cache.rs
+++ b/nomos-services/data-availability/src/backend/memory_cache.rs
@@ -1,12 +1,13 @@
 use crate::backend::{DaBackend, DaError};
 use moka::future::{Cache, CacheBuilder};
 use nomos_core::da::blob::Blob;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct BlobCacheSettings {
-    max_capacity: usize,
-    evicting_period: Duration,
+    pub max_capacity: usize,
+    pub evicting_period: Duration,
 }
 
 pub struct BlobCache<H, B>(Cache<H, B>);

--- a/nomos-services/data-availability/src/backend/mod.rs
+++ b/nomos-services/data-availability/src/backend/mod.rs
@@ -1,4 +1,4 @@
-mod memory_cache;
+pub mod memory_cache;
 
 use nomos_core::da::blob::Blob;
 use overwatch_rs::DynError;

--- a/nomos-services/data-availability/src/network/mod.rs
+++ b/nomos-services/data-availability/src/network/mod.rs
@@ -1,4 +1,4 @@
-mod adapters;
+pub mod adapters;
 
 // std
 // crates

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,13 +14,15 @@ overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" 
 nomos-core = { path = "../nomos-core" }
 consensus-engine = { path = "../consensus-engine", features = ["serde"] }
 nomos-mempool = { path = "../nomos-services/mempool", features = ["mock"] }
+nomos-da = { path = "../nomos-services/data-availability" }
+full-replication = { path = "../nomos-da/full-replication" }
 mixnode = { path = "../nodes/mixnode" }
 mixnet-node = { path = "../mixnet/node" }
 mixnet-client = { path = "../mixnet/client" }
 mixnet-topology = { path = "../mixnet/topology" }
 # Using older versions, since `mixnet-*` crates depend on `rand` v0.7.3.
 rand = "0.7.3"
-rand_xoshiro = "0.4"
+rand_xoshiro = "0.6"
 once_cell = "1"
 secp256k1 = { version = "0.26", features = ["rand"] }
 waku-bindings = { version = "0.1.1", optional = true }

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -292,6 +292,16 @@ fn create_node_config(
         },
         #[cfg(feature = "metrics")]
         metrics: Default::default(),
+        #[cfg(feature = "libp2p")]
+        da: nomos_da::Settings {
+            da_protocol: full_replication::Settings {
+                num_attestations: 1,
+            },
+            backend: nomos_da::backend::memory_cache::BlobCacheSettings {
+                max_capacity: usize::MAX,
+                evicting_period: Duration::from_secs(60 * 60 * 24), // 1 day
+            },
+        },
     };
     #[cfg(feature = "waku")]
     {


### PR DESCRIPTION
This PR:
* updates the data availability service to work with generic da protocols
* add the data availability service to the nomos node

Could actually split this but it's not too big and you can find the features grouped by commits anyway