### PR TITLE
CI: integrations tests libp2p

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.70.0-slim-bullseye
+FROM rust:1.72.0-slim-bullseye
 
-LABEL maintainer="augustinas@status.im"
-LABEL source="https://github.com/logos-co/nomos-research"
-LABEL description="nomos-research ci build image"
+LABEL maintainer="augustinas@status.im" \
+      source="https://github.com/logos-co/nomos-node" \
+      description="nomos-node ci build image"
 
 # Using backports for go 1.19
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' \

--- a/ci/Jenkinsfile.nightly.integration
+++ b/ci/Jenkinsfile.nightly.integration
@@ -73,10 +73,17 @@ pipeline {
 
 def runBuildAndTestsForFeature(feature, tests) {
   echo "Building node for feature: ${feature}"
-  def build_cmd = "cargo build -p nomos-node --no-default-features --features ${feature}"
+  def build_node = "cargo build -p nomos-node --no-default-features --features ${feature}"
 
-  if (sh(script: build_cmd, returnStatus: true) != 0) {
+  if (sh(script: build_node, returnStatus: true) != 0) {
     error("Build '${feature}' node failed")
+    return
+  }
+
+  def build_mixnode = "cargo build -p mixnode"
+
+  if (sh(script: build_mixnode, returnStatus: true) != 0) {
+    error("Build '${feature}' mixnode failed")
     return
   }
   


### PR DESCRIPTION
Update the docker image for ci to rust 1.72 and add mixnode build step to integration tests