### PR TITLE
CI: fix cargo clippy deprecated warnings

### DIFF
--- a/nodes/nomos-node/src/bridges/waku.rs
+++ b/nodes/nomos-node/src/bridges/waku.rs
@@ -70,7 +70,9 @@ pub(super) async fn waku_send_transaction(
                 payload,
                 WAKU_CARNOT_TX_CONTENT_TOPIC.clone(),
                 1,
-                chrono::Utc::now().timestamp_nanos() as usize,
+                chrono::Utc::now()
+                    .timestamp_nanos_opt()
+                    .expect("timestamp should be in valid range") as usize,
                 [],
                 false,
             ),

--- a/nomos-services/consensus/src/network/adapters/mock.rs
+++ b/nomos-services/consensus/src/network/adapters/mock.rs
@@ -131,7 +131,9 @@ impl NetworkAdapter for MockAdapter {
             String::from_utf8_lossy(&message.as_bytes()).to_string(),
             MOCK_APPROVAL_CONTENT_TOPIC,
             1,
-            chrono::Utc::now().timestamp_nanos() as usize,
+            chrono::Utc::now()
+                .timestamp_nanos_opt()
+                .expect("timestamp should be in valid range") as usize,
         );
         if let Err((e, _e)) = self
             .network_relay

--- a/nomos-services/consensus/src/network/adapters/waku.rs
+++ b/nomos-services/consensus/src/network/adapters/waku.rs
@@ -134,7 +134,9 @@ impl WakuAdapter {
             payload,
             content_topic,
             1,
-            chrono::Utc::now().timestamp_nanos() as usize,
+            chrono::Utc::now()
+                .timestamp_nanos_opt()
+                .expect("timestamp should be in valid range") as usize,
             [],
             false,
         );

--- a/nomos-services/network/src/backends/mock.rs
+++ b/nomos-services/network/src/backends/mock.rs
@@ -359,7 +359,10 @@ mod tests {
                         content_topic_name: "foo content".into(),
                     },
                     version: 1,
-                    timestamp: chrono::Utc::now().timestamp_nanos() as usize,
+                    timestamp: chrono::Utc::now()
+                        .timestamp_nanos_opt()
+                        .expect("timestamp should be in valid range")
+                        as usize,
                 },
             })
             .await;
@@ -376,7 +379,10 @@ mod tests {
                         content_topic_name: "bar content".into(),
                     },
                     version: 1,
-                    timestamp: chrono::Utc::now().timestamp_nanos() as usize,
+                    timestamp: chrono::Utc::now()
+                        .timestamp_nanos_opt()
+                        .expect("timestamp should be in valid range")
+                        as usize,
                 },
             })
             .await;


### PR DESCRIPTION
Fix failing jobs by updating deprecated `timestamp_nanos` method to `timestamp_nanos_opt`.