### PR TITLE
remove deprecated api

### DIFF
--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -10,7 +10,7 @@ blake2 = "0.10"
 bincode = "2.0.0-rc.2"
 bytes = "1.3"
 clap = { version = "4", features = ["derive"] }
-chrono = "0.4"
+chrono = "0.4.31"
 futures = "0.3"
 http = "0.2.9"
 hex = "0.4.3"

--- a/nodes/nomos-node/src/bridges/waku.rs
+++ b/nodes/nomos-node/src/bridges/waku.rs
@@ -70,7 +70,7 @@ pub(super) async fn waku_send_transaction(
                 payload,
                 WAKU_CARNOT_TX_CONTENT_TOPIC.clone(),
                 1,
-                chrono::Utc::now().timestamp_nanos() as usize,
+                chrono::Utc::now().timestamp_nanos_opt().unwrap() as usize,
                 [],
                 false,
             ),

--- a/nomos-services/consensus/Cargo.toml
+++ b/nomos-services/consensus/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 async-trait = "0.1"
 async-stream = "0.3"
 bytes = "1.3"
-chrono = "0.4"
+chrono = "0.4.31"
 consensus-engine = { path = "../../consensus-engine", features = ["serde"] }
 futures = "0.3"
 nomos-network = { path = "../network" }

--- a/nomos-services/consensus/src/network/adapters/mock.rs
+++ b/nomos-services/consensus/src/network/adapters/mock.rs
@@ -131,7 +131,7 @@ impl NetworkAdapter for MockAdapter {
             String::from_utf8_lossy(&message.as_bytes()).to_string(),
             MOCK_APPROVAL_CONTENT_TOPIC,
             1,
-            chrono::Utc::now().timestamp_nanos() as usize,
+            chrono::Utc::now().timestamp_nanos_opt().unwrap() as usize,
         );
         if let Err((e, _e)) = self
             .network_relay

--- a/nomos-services/consensus/src/network/adapters/waku.rs
+++ b/nomos-services/consensus/src/network/adapters/waku.rs
@@ -134,7 +134,7 @@ impl WakuAdapter {
             payload,
             content_topic,
             1,
-            chrono::Utc::now().timestamp_nanos() as usize,
+            chrono::Utc::now().timestamp_nanos_opt().unwrap() as usize,
             [],
             false,
         );

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
-chrono = "0.4"
+chrono = "0.4.31"
 futures = "0.3"
 linked-hash-map = { version = "0.5.6", optional = true }
 nomos-network = { path = "../network" }

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 bytes = "1.2"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4.31", optional = true }
 humantime-serde = { version = "1", optional = true }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", branch = "main" }
 multiaddr = "0.15"

--- a/nomos-services/network/src/backends/mock.rs
+++ b/nomos-services/network/src/backends/mock.rs
@@ -359,7 +359,7 @@ mod tests {
                         content_topic_name: "foo content".into(),
                     },
                     version: 1,
-                    timestamp: chrono::Utc::now().timestamp_nanos() as usize,
+                    timestamp: chrono::Utc::now().timestamp_nanos_opt().unwrap() as usize,
                 },
             })
             .await;
@@ -376,7 +376,7 @@ mod tests {
                         content_topic_name: "bar content".into(),
                     },
                     version: 1,
-                    timestamp: chrono::Utc::now().timestamp_nanos() as usize,
+                    timestamp: chrono::Utc::now().timestamp_nanos_opt().unwrap() as usize,
                 },
             })
             .await;

--- a/simulations/Cargo.toml
+++ b/simulations/Cargo.toml
@@ -16,7 +16,7 @@ bls-signatures = "0.14"
 csv = "1"
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3.4"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.31", features = ["serde"] }
 crc32fast = "1.3"
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 consensus-engine = { path = "../consensus-engine", features = ["simulation"] }


### PR DESCRIPTION
`timestamp_nanos` is deprecated since `chrono: 0.4.31`. 

![4261695017359_ pic](https://github.com/logos-co/nomos-node/assets/42351146/d9515771-9af2-4135-9a9a-aed1d298e3c3)
