### PR TITLE
CI: Add mixnet test to integration runs

### DIFF
--- a/ci/Jenkinsfile.nightly.integration
+++ b/ci/Jenkinsfile.nightly.integration
@@ -39,13 +39,24 @@ pipeline {
           }
         }
         stages {
-          stage('BuildAndTest') {
-            steps {
-              script {
-                /* To prevent rebuilding node for each test, tests are defined here */
-                def tests = ['ten_nodes_happy', 'two_nodes_happy', 'ten_nodes_one_down']
+          stage('Tests') {
+            options {
+              lock('sync-integration-${env.GIT_COMMIT}')
+            }
+            stages {
+              stage("BuildAndTest") {
+                steps {
+                  script {
+                    /* To prevent rebuilding node for each test, tests are defined here */
+                    def tests = ['ten_nodes_happy', 'two_nodes_happy', 'ten_nodes_one_down']
 
-                runBuildAndTestsForFeature(FEATURE, tests)
+                    if (FEATURE == 'libp2p') {
+                      tests.add('mixnet')
+                    }
+
+                    runBuildAndTestsForFeature(FEATURE, tests)
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Run test for mixnet if we're testing libp2p in nightly tests. Added same kind of locking as for PR jenkins jobs.