### PR TITLE
Refactor libp2p network backend

### DIFF
--- a/nomos-services/network/src/backends/libp2p/command.rs
+++ b/nomos-services/network/src/backends/libp2p/command.rs
@@ -1,0 +1,41 @@
+use nomos_libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Command {
+    Connect(Dial),
+    Broadcast {
+        topic: Topic,
+        message: Box<[u8]>,
+    },
+    Subscribe(Topic),
+    Unsubscribe(Topic),
+    Info {
+        reply: oneshot::Sender<Libp2pInfo>,
+    },
+    #[doc(hidden)]
+    // broadcast a message directly through gossipsub without mixnet
+    DirectBroadcastAndRetry {
+        topic: Topic,
+        message: Box<[u8]>,
+        retry_count: usize,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct Dial {
+    pub addr: Multiaddr,
+    pub retry_count: usize,
+}
+
+pub type Topic = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Libp2pInfo {
+    pub listen_addresses: Vec<Multiaddr>,
+    pub n_peers: usize,
+    pub n_connections: u32,
+    pub n_pending_connections: u32,
+}

--- a/nomos-services/network/src/backends/libp2p/config.rs
+++ b/nomos-services/network/src/backends/libp2p/config.rs
@@ -1,0 +1,57 @@
+use std::{ops::Range, time::Duration};
+
+use mixnet_client::MixnetClientConfig;
+use nomos_libp2p::{Multiaddr, SwarmConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Libp2pConfig {
+    #[serde(flatten)]
+    pub inner: SwarmConfig,
+    // Initial peers to connect to
+    #[serde(default)]
+    pub initial_peers: Vec<Multiaddr>,
+    pub mixnet_client: MixnetClientConfig,
+    #[serde(with = "humantime")]
+    pub mixnet_delay: Range<Duration>,
+}
+
+mod humantime {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::{ops::Range, time::Duration};
+
+    #[derive(Serialize, Deserialize)]
+    struct DurationRangeHelper {
+        #[serde(with = "humantime_serde")]
+        start: Duration,
+        #[serde(with = "humantime_serde")]
+        end: Duration,
+    }
+
+    pub fn serialize<S: Serializer>(
+        val: &Range<Duration>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            DurationRangeHelper {
+                start: val.start,
+                end: val.end,
+            }
+            .serialize(serializer)
+        } else {
+            val.serialize(serializer)
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Range<Duration>, D::Error> {
+        if deserializer.is_human_readable() {
+            let DurationRangeHelper { start, end } =
+                DurationRangeHelper::deserialize(deserializer)?;
+            Ok(start..end)
+        } else {
+            Range::<Duration>::deserialize(deserializer)
+        }
+    }
+}

--- a/nomos-services/network/src/backends/libp2p/mixnet.rs
+++ b/nomos-services/network/src/backends/libp2p/mixnet.rs
@@ -1,0 +1,101 @@
+use std::{ops::Range, time::Duration};
+
+use mixnet_client::MixnetClient;
+use nomos_core::wire;
+use rand::{rngs::OsRng, thread_rng, Rng};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+
+use super::{command::Topic, Command, Libp2pConfig};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MixnetMessage {
+    pub topic: Topic,
+    pub message: Box<[u8]>,
+}
+
+impl MixnetMessage {
+    pub fn as_bytes(&self) -> Vec<u8> {
+        wire::serialize(self).expect("Couldn't serialize MixnetMessage")
+    }
+    pub fn from_bytes(data: &[u8]) -> Result<Self, wire::Error> {
+        wire::deserialize(data)
+    }
+}
+
+pub fn random_delay(range: &Range<Duration>) -> Duration {
+    if range.start == range.end {
+        return range.start;
+    }
+    thread_rng().gen_range(range.start, range.end)
+}
+
+pub struct MixnetHandler {
+    client: MixnetClient<OsRng>,
+    commands_tx: mpsc::Sender<Command>,
+}
+
+impl MixnetHandler {
+    pub fn new(config: &Libp2pConfig, commands_tx: mpsc::Sender<Command>) -> Self {
+        let client = MixnetClient::new(config.mixnet_client.clone(), OsRng);
+
+        Self {
+            client,
+            commands_tx,
+        }
+    }
+
+    pub async fn run(&mut self) {
+        let Ok(mut stream) = self.client.run().await else {
+            tracing::error!("Could not quickstart mixnet stream");
+            return;
+        };
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(msg) => {
+                    tracing::debug!("receiving message from mixnet client");
+                    let Ok(MixnetMessage { topic, message }) = MixnetMessage::from_bytes(&msg)
+                        else {
+                            tracing::error!(
+                                "failed to deserialize json received from mixnet client"
+                            );
+                            continue;
+                        };
+
+                    self.commands_tx
+                        .send(Command::DirectBroadcastAndRetry {
+                            topic,
+                            message,
+                            retry_count: 0,
+                        })
+                        .await
+                        .unwrap_or_else(|_| tracing::error!("could not schedule broadcast"));
+                }
+                Err(e) => {
+                    todo!("Handle mixclient error: {e}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::random_delay;
+
+    #[test]
+    fn test_random_delay() {
+        assert_eq!(
+            random_delay(&(Duration::ZERO..Duration::ZERO)),
+            Duration::ZERO
+        );
+
+        let range = Duration::from_millis(10)..Duration::from_millis(100);
+        let delay = random_delay(&range);
+        assert!(range.start <= delay && delay < range.end);
+    }
+}

--- a/nomos-services/network/src/backends/libp2p/mod.rs
+++ b/nomos-services/network/src/backends/libp2p/mod.rs
@@ -1,32 +1,20 @@
 mod command;
 mod config;
+mod mixnet;
+mod swarm;
 
 // std
 pub use self::command::{Command, Libp2pInfo};
-use self::command::{Dial, Topic};
 pub use self::config::Libp2pConfig;
-use std::{collections::HashMap, ops::Range, time::Duration};
+use self::mixnet::MixnetHandler;
+use self::swarm::SwarmHandler;
 
 // internal
 use super::NetworkBackend;
-use mixnet_client::MixnetClient;
-use nomos_core::wire;
 pub use nomos_libp2p::libp2p::gossipsub::{Message, TopicHash};
-use nomos_libp2p::{gossipsub, libp2p::swarm::ConnectionId, BehaviourEvent, Swarm, SwarmEvent};
 // crates
 use overwatch_rs::{overwatch::handle::OverwatchHandle, services::state::NoState};
-use rand::{rngs::OsRng, thread_rng, Rng};
-use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc};
-use tokio_stream::StreamExt;
-
-macro_rules! log_error {
-    ($e:expr) => {
-        if let Err(e) = $e {
-            tracing::error!("error while processing {}: {e:?}", stringify!($e));
-        }
-    };
-}
 
 pub struct Libp2p {
     events_tx: broadcast::Sender<Event>,
@@ -38,32 +26,13 @@ pub enum EventKind {
     Message,
 }
 
-const BUFFER_SIZE: usize = 64;
-// TODO: make this configurable
-const BACKOFF: u64 = 5;
-// TODO: make this configurable
-const MAX_RETRY: usize = 3;
-
 /// Events emitted from [`NomosLibp2p`], which users can subscribe
 #[derive(Debug, Clone)]
 pub enum Event {
     Message(Message),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct MixnetMessage {
-    topic: Topic,
-    message: Box<[u8]>,
-}
-
-impl MixnetMessage {
-    pub fn as_bytes(&self) -> Vec<u8> {
-        wire::serialize(self).expect("Couldn't serialize MixnetMessage")
-    }
-    pub fn from_bytes(data: &[u8]) -> Result<Self, wire::Error> {
-        wire::deserialize(data)
-    }
-}
+const BUFFER_SIZE: usize = 64;
 
 #[async_trait::async_trait]
 impl NetworkBackend for Libp2p {
@@ -74,141 +43,20 @@ impl NetworkBackend for Libp2p {
     type NetworkEvent = Event;
 
     fn new(config: Self::Settings, overwatch_handle: OverwatchHandle) -> Self {
-        let mixnet_client = MixnetClient::new(config.mixnet_client.clone(), OsRng);
-        let (commands_tx, mut commands_rx) = tokio::sync::mpsc::channel(BUFFER_SIZE);
+        let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(BUFFER_SIZE);
         let (events_tx, _) = tokio::sync::broadcast::channel(BUFFER_SIZE);
 
-        let cmd_tx = commands_tx.clone();
+        let mut mixnet_handler = MixnetHandler::new(&config, commands_tx.clone());
         overwatch_handle.runtime().spawn(async move {
-            let Ok(mut stream) = mixnet_client.run().await else {
-                tracing::error!("Could not quickstart mixnet stream");
-                return;
-            };
-
-            while let Some(result) = stream.next().await {
-                match result {
-                    Ok(msg) => {
-                        tracing::debug!("receiving message from mixnet client");
-                        let Ok(MixnetMessage { topic, message }) = MixnetMessage::from_bytes(&msg)
-                        else {
-                            tracing::error!(
-                                "failed to deserialize json received from mixnet client"
-                            );
-                            continue;
-                        };
-
-                        cmd_tx
-                            .send(Command::DirectBroadcastAndRetry {
-                                topic,
-                                message,
-                                retry_count: 0,
-                            })
-                            .await
-                            .unwrap_or_else(|_| tracing::error!("could not schedule broadcast"));
-                    }
-                    Err(e) => {
-                        todo!("Handle mixclient error: {e}");
-                    }
-                }
-            }
+            mixnet_handler.run().await;
         });
-        let cmd_tx = commands_tx.clone();
-        let notify = events_tx.clone();
+
+        let mut swarm_handler =
+            SwarmHandler::new(&config, commands_tx.clone(), commands_rx, events_tx.clone());
         overwatch_handle.runtime().spawn(async move {
-            let mut swarm = Swarm::build(&config.inner).unwrap();
-            let mut mixnet_client = MixnetClient::new(config.mixnet_client, OsRng);
-
-            // Keep the dialing history since swarm.connect doesn't return the result synchronously
-            // TODO: Refactor: have a proper struct which holds this
-            let mut pending_dials = HashMap::<ConnectionId, Dial>::new();
-
-            for initial_peer in config.initial_peers {
-                let dial = Dial { addr: initial_peer, retry_count: 0 };
-                schedule_connect(dial, cmd_tx.clone()).await;
-            }
-
-            loop {
-                tokio::select! {
-                    Some(event) = swarm.next() => {
-                        match event {
-                            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Message {
-                                propagation_source: peer_id,
-                                message_id: id,
-                                message,
-                            })) => {
-                                tracing::debug!("Got message with id: {id} from peer: {peer_id}");
-                                log_error!(notify.send(Event::Message(message)));
-                            }
-                            SwarmEvent::ConnectionEstablished {
-                                peer_id,
-                                connection_id,
-                                endpoint,
-                               ..
-                            } => {
-                                tracing::debug!("connected to peer:{peer_id}, connection_id:{connection_id:?}");
-                                if endpoint.is_dialer() {
-                                    complete_connect(connection_id, &mut pending_dials);
-                                }
-                            }
-                            SwarmEvent::ConnectionClosed {
-                                peer_id,
-                                connection_id,
-                                cause,
-                                ..
-                            } => {
-                                tracing::debug!("connection closed from peer: {peer_id} {connection_id:?} due to {cause:?}");
-                            }
-                            SwarmEvent::OutgoingConnectionError {
-                                peer_id,
-                                connection_id,
-                                error,
-                                ..
-                            } => {
-                                tracing::error!("Failed to connect to peer: {peer_id:?} {connection_id:?} due to: {error}");
-                                retry_connect(connection_id, &mut pending_dials, cmd_tx.clone());
-                            }
-                            _ => {}
-                        }
-                    }
-                    Some(command) = commands_rx.recv() => {
-                        match command {
-                            Command::Connect(dial) => {
-                                connect(&mut swarm, dial, &mut pending_dials);
-                            }
-                            Command::Broadcast { topic, message } => {
-                                tracing::debug!("sending message to mixnet client");
-                                let msg = MixnetMessage { topic, message };
-                                let delay = random_delay(&config.mixnet_delay);
-                                log_error!(mixnet_client.send(msg.as_bytes(), delay));
-                            }
-                            Command::Subscribe(topic) => {
-                                tracing::debug!("subscribing to topic: {topic}");
-                                log_error!(swarm.subscribe(&topic));
-                            }
-                            Command::Unsubscribe(topic) => {
-                                tracing::debug!("unsubscribing to topic: {topic}");
-                                log_error!(swarm.unsubscribe(&topic));
-                            }
-                            Command::Info { reply } => {
-                                let swarm = swarm.swarm();
-                                let network_info = swarm.network_info();
-                                let counters = network_info.connection_counters();
-                                let info = Libp2pInfo {
-                                    listen_addresses: swarm.listeners().cloned().collect(),
-                                    n_peers: network_info.num_peers(),
-                                    n_connections: counters.num_connections(),
-                                    n_pending_connections: counters.num_pending(),
-                                };
-                                log_error!(reply.send(info));
-                            }
-                            Command::DirectBroadcastAndRetry { topic, message, retry_count } => {
-                               broadcast_and_retry(topic, message, retry_count, cmd_tx.clone(), &mut swarm, notify.clone()).await;
-                            }
-                        };
-                    }
-                }
-            }
+            swarm_handler.run(config.initial_peers).await;
         });
+
         Self {
             events_tx,
             commands_tx,
@@ -231,130 +79,5 @@ impl NetworkBackend for Libp2p {
                 self.events_tx.subscribe()
             }
         }
-    }
-}
-
-fn random_delay(range: &Range<Duration>) -> Duration {
-    if range.start == range.end {
-        return range.start;
-    }
-    thread_rng().gen_range(range.start, range.end)
-}
-
-async fn schedule_connect(dial: Dial, commands_tx: mpsc::Sender<Command>) {
-    commands_tx
-        .send(Command::Connect(dial))
-        .await
-        .unwrap_or_else(|_| tracing::error!("could not schedule connect"));
-}
-
-fn connect(swarm: &mut Swarm, dial: Dial, pending_dials: &mut HashMap<ConnectionId, Dial>) {
-    tracing::debug!("Connecting to {}", dial.addr);
-
-    match swarm.connect(dial.addr.clone()) {
-        Ok(connection_id) => {
-            // Dialing has been scheduled. The result will be notified as a SwarmEvent.
-            pending_dials.insert(connection_id, dial);
-        }
-        Err(e) => {
-            tracing::error!(
-                "Failed to connect to {} with unretriable error: {e}",
-                dial.addr
-            );
-        }
-    }
-}
-
-fn complete_connect(connection_id: ConnectionId, pending_dials: &mut HashMap<ConnectionId, Dial>) {
-    pending_dials.remove(&connection_id);
-}
-
-fn retry_connect(
-    connection_id: ConnectionId,
-    pending_dials: &mut HashMap<ConnectionId, Dial>,
-    commands_tx: mpsc::Sender<Command>,
-) {
-    if let Some(mut dial) = pending_dials.remove(&connection_id) {
-        dial.retry_count += 1;
-        if dial.retry_count > MAX_RETRY {
-            tracing::debug!("Max retry({MAX_RETRY}) has been reached: {dial:?}");
-            return;
-        }
-
-        let wait = exp_backoff(dial.retry_count);
-        tracing::debug!("Retry dialing in {wait:?}: {dial:?}");
-
-        tokio::spawn(async move {
-            tokio::time::sleep(wait).await;
-            schedule_connect(dial, commands_tx).await;
-        });
-    }
-}
-
-async fn broadcast_and_retry(
-    topic: Topic,
-    message: Box<[u8]>,
-    retry_count: usize,
-    commands_tx: mpsc::Sender<Command>,
-    swarm: &mut Swarm,
-    events_tx: broadcast::Sender<Event>,
-) {
-    tracing::debug!("broadcasting message to topic: {topic}");
-
-    match swarm.broadcast(&topic, message.to_vec()) {
-        Ok(id) => {
-            tracing::debug!("broadcasted message with id: {id} tp topic: {topic}");
-            // self-notification because libp2p doesn't do it
-            if swarm.is_subscribed(&topic) {
-                log_error!(events_tx.send(Event::Message(Message {
-                    source: None,
-                    data: message.into(),
-                    sequence_number: None,
-                    topic: Swarm::topic_hash(&topic),
-                })));
-            }
-        }
-        Err(gossipsub::PublishError::InsufficientPeers) if retry_count < MAX_RETRY => {
-            let wait = exp_backoff(retry_count);
-            tracing::error!("failed to broadcast message to topic due to insufficient peers, trying again in {wait:?}");
-
-            tokio::spawn(async move {
-                tokio::time::sleep(wait).await;
-                commands_tx
-                    .send(Command::DirectBroadcastAndRetry {
-                        topic,
-                        message,
-                        retry_count: retry_count + 1,
-                    })
-                    .await
-                    .unwrap_or_else(|_| tracing::error!("could not schedule retry"));
-            });
-        }
-        Err(e) => {
-            tracing::error!("failed to broadcast message to topic: {topic} {e:?}");
-        }
-    }
-}
-
-fn exp_backoff(retry: usize) -> Duration {
-    std::time::Duration::from_secs(BACKOFF.pow(retry as u32))
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use super::random_delay;
-
-    #[test]
-    fn test_random_delay() {
-        assert_eq!(
-            random_delay(&(Duration::ZERO..Duration::ZERO)),
-            Duration::ZERO
-        );
-
-        let range = Duration::from_millis(10)..Duration::from_millis(100);
-        let delay = random_delay(&range);
-        assert!(range.start <= delay && delay < range.end);
     }
 }

--- a/nomos-services/network/src/backends/libp2p/swarm.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm.rs
@@ -1,0 +1,268 @@
+use std::{collections::HashMap, ops::Range, time::Duration};
+
+use mixnet_client::MixnetClient;
+use nomos_libp2p::{
+    gossipsub::{self, Message},
+    libp2p::swarm::ConnectionId,
+    Behaviour, BehaviourEvent, Multiaddr, Swarm, SwarmEvent, THandlerErr,
+};
+use rand::rngs::OsRng;
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::StreamExt;
+
+use crate::backends::libp2p::{
+    mixnet::{random_delay, MixnetMessage},
+    Libp2pInfo,
+};
+
+use super::{
+    command::{Command, Dial, Topic},
+    Event, Libp2pConfig,
+};
+
+pub struct SwarmHandler {
+    pub swarm: Swarm,
+    pub pending_dials: HashMap<ConnectionId, Dial>,
+    pub commands_tx: mpsc::Sender<Command>,
+    pub commands_rx: mpsc::Receiver<Command>,
+    pub events_tx: broadcast::Sender<Event>,
+    pub mixnet_client: MixnetClient<OsRng>,
+    pub mixnet_delay: Range<Duration>,
+}
+
+macro_rules! log_error {
+    ($e:expr) => {
+        if let Err(e) = $e {
+            tracing::error!("error while processing {}: {e:?}", stringify!($e));
+        }
+    };
+}
+
+// TODO: make this configurable
+const BACKOFF: u64 = 5;
+// TODO: make this configurable
+const MAX_RETRY: usize = 3;
+
+impl SwarmHandler {
+    pub fn new(
+        config: &Libp2pConfig,
+        commands_tx: mpsc::Sender<Command>,
+        commands_rx: mpsc::Receiver<Command>,
+        events_tx: broadcast::Sender<Event>,
+    ) -> Self {
+        let swarm = Swarm::build(&config.inner).unwrap();
+        let mixnet_client = MixnetClient::new(config.mixnet_client.clone(), OsRng);
+
+        // Keep the dialing history since swarm.connect doesn't return the result synchronously
+        let pending_dials = HashMap::<ConnectionId, Dial>::new();
+
+        Self {
+            swarm,
+            pending_dials,
+            commands_tx,
+            commands_rx,
+            events_tx,
+            mixnet_client,
+            mixnet_delay: config.mixnet_delay.clone(),
+        }
+    }
+
+    pub async fn run(&mut self, initial_peers: Vec<Multiaddr>) {
+        for initial_peer in initial_peers {
+            let dial = Dial {
+                addr: initial_peer,
+                retry_count: 0,
+            };
+            Self::schedule_connect(dial, self.commands_tx.clone()).await;
+        }
+
+        loop {
+            tokio::select! {
+                Some(event) = self.swarm.next() => {
+                    self.handle_event(event);
+                }
+                Some(command) = self.commands_rx.recv() => {
+                    self.handle_command(command).await;
+                }
+            }
+        }
+    }
+
+    fn handle_event(&mut self, event: SwarmEvent<BehaviourEvent, THandlerErr<Behaviour>>) {
+        match event {
+            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Message {
+                propagation_source: peer_id,
+                message_id: id,
+                message,
+            })) => {
+                tracing::debug!("Got message with id: {id} from peer: {peer_id}");
+                log_error!(self.events_tx.send(Event::Message(message)));
+            }
+            SwarmEvent::ConnectionEstablished {
+                peer_id,
+                connection_id,
+                endpoint,
+                ..
+            } => {
+                tracing::debug!("connected to peer:{peer_id}, connection_id:{connection_id:?}");
+                if endpoint.is_dialer() {
+                    self.complete_connect(connection_id);
+                }
+            }
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                connection_id,
+                cause,
+                ..
+            } => {
+                tracing::debug!(
+                    "connection closed from peer: {peer_id} {connection_id:?} due to {cause:?}"
+                );
+            }
+            SwarmEvent::OutgoingConnectionError {
+                peer_id,
+                connection_id,
+                error,
+                ..
+            } => {
+                tracing::error!(
+                    "Failed to connect to peer: {peer_id:?} {connection_id:?} due to: {error}"
+                );
+                self.retry_connect(connection_id);
+            }
+            _ => {}
+        }
+    }
+
+    async fn handle_command(&mut self, command: Command) {
+        match command {
+            Command::Connect(dial) => {
+                self.connect(dial);
+            }
+            Command::Broadcast { topic, message } => {
+                tracing::debug!("sending message to mixnet client");
+                let msg = MixnetMessage { topic, message };
+                let delay = random_delay(&self.mixnet_delay);
+                log_error!(self.mixnet_client.send(msg.as_bytes(), delay));
+            }
+            Command::Subscribe(topic) => {
+                tracing::debug!("subscribing to topic: {topic}");
+                log_error!(self.swarm.subscribe(&topic));
+            }
+            Command::Unsubscribe(topic) => {
+                tracing::debug!("unsubscribing to topic: {topic}");
+                log_error!(self.swarm.unsubscribe(&topic));
+            }
+            Command::Info { reply } => {
+                let swarm = self.swarm.swarm();
+                let network_info = swarm.network_info();
+                let counters = network_info.connection_counters();
+                let info = Libp2pInfo {
+                    listen_addresses: swarm.listeners().cloned().collect(),
+                    n_peers: network_info.num_peers(),
+                    n_connections: counters.num_connections(),
+                    n_pending_connections: counters.num_pending(),
+                };
+                log_error!(reply.send(info));
+            }
+            Command::DirectBroadcastAndRetry {
+                topic,
+                message,
+                retry_count,
+            } => {
+                self.broadcast_and_retry(topic, message, retry_count).await;
+            }
+        }
+    }
+
+    async fn schedule_connect(dial: Dial, commands_tx: mpsc::Sender<Command>) {
+        commands_tx
+            .send(Command::Connect(dial))
+            .await
+            .unwrap_or_else(|_| tracing::error!("could not schedule connect"));
+    }
+
+    fn connect(&mut self, dial: Dial) {
+        tracing::debug!("Connecting to {}", dial.addr);
+
+        match self.swarm.connect(dial.addr.clone()) {
+            Ok(connection_id) => {
+                // Dialing has been scheduled. The result will be notified as a SwarmEvent.
+                self.pending_dials.insert(connection_id, dial);
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to connect to {} with unretriable error: {e}",
+                    dial.addr
+                );
+            }
+        }
+    }
+
+    fn complete_connect(&mut self, connection_id: ConnectionId) {
+        self.pending_dials.remove(&connection_id);
+    }
+
+    // TODO: Consider a common retry module for all use cases
+    fn retry_connect(&mut self, connection_id: ConnectionId) {
+        if let Some(mut dial) = self.pending_dials.remove(&connection_id) {
+            dial.retry_count += 1;
+            if dial.retry_count > MAX_RETRY {
+                tracing::debug!("Max retry({MAX_RETRY}) has been reached: {dial:?}");
+                return;
+            }
+
+            let wait = Self::exp_backoff(dial.retry_count);
+            tracing::debug!("Retry dialing in {wait:?}: {dial:?}");
+
+            let commands_tx = self.commands_tx.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(wait).await;
+                Self::schedule_connect(dial, commands_tx).await;
+            });
+        }
+    }
+
+    async fn broadcast_and_retry(&mut self, topic: Topic, message: Box<[u8]>, retry_count: usize) {
+        tracing::debug!("broadcasting message to topic: {topic}");
+
+        match self.swarm.broadcast(&topic, message.to_vec()) {
+            Ok(id) => {
+                tracing::debug!("broadcasted message with id: {id} tp topic: {topic}");
+                // self-notification because libp2p doesn't do it
+                if self.swarm.is_subscribed(&topic) {
+                    log_error!(self.events_tx.send(Event::Message(Message {
+                        source: None,
+                        data: message.into(),
+                        sequence_number: None,
+                        topic: Swarm::topic_hash(&topic),
+                    })));
+                }
+            }
+            Err(gossipsub::PublishError::InsufficientPeers) if retry_count < MAX_RETRY => {
+                let wait = Self::exp_backoff(retry_count);
+                tracing::error!("failed to broadcast message to topic due to insufficient peers, trying again in {wait:?}");
+
+                let commands_tx = self.commands_tx.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(wait).await;
+                    commands_tx
+                        .send(Command::DirectBroadcastAndRetry {
+                            topic,
+                            message,
+                            retry_count: retry_count + 1,
+                        })
+                        .await
+                        .unwrap_or_else(|_| tracing::error!("could not schedule retry"));
+                });
+            }
+            Err(e) => {
+                tracing::error!("failed to broadcast message to topic: {topic} {e:?}");
+            }
+        }
+    }
+
+    fn exp_backoff(retry: usize) -> Duration {
+        std::time::Duration::from_secs(BACKOFF.pow(retry as u32))
+    }
+}


### PR DESCRIPTION
Refactored the libp2p network backend, so that we can extend it easily.

This PR just splits a verbose `libp2p.rs` into several submodules.
- e4445033da6027d3abf0c6dc9c5c64ccad0d1d31: Move `Config` and `Command` into separate modules
- f64861521925bcaea6b3ef61cdff79bbc668bd14: Split the verbose `Libp2p::new()` into two separated modules: `SwarmHandler` and `MixnetHandler`.

At next PRs, I'm going to refine them, as written in TODO comments. Also, I'm going to add `metrics` feature for the libp2p backend.