### PR TITLE
GH: Run integration tests in all actions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,11 +28,14 @@ jobs:
           override: true
           components: llvm-tools-preview
       - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all --no-default-features --features libp2p
+      - uses: actions-rs/cargo@v1
         continue-on-error: true
       - run: |
           cargo install grcov;
-          cargo test --no-default-features --features waku -- --skip ten_nodes_happy --skip two_nodes_happy --skip ten_nodes_one_down
-          cargo test --no-default-features --features libp2p -- --skip ten_nodes_happy --skip two_nodes_happy --skip ten_nodes_one_down
+          cargo test --no-default-features --features libp2p
           mkdir /tmp/cov;
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o /tmp/cov/tests.lcov;
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --no-default-features --features ${{ matrix.feature }} -- --skip ten_nodes_happy --skip two_nodes_happy --skip ten_nodes_one_down
+          args: --all --no-default-features --features ${{ matrix.feature }}
 
   lints:
     name: Rust lints

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --no-default-features --features ${{ matrix.feature }} -- --skip ten_nodes_happy --skip two_nodes_happy --skip ten_nodes_one_down
+          args: --all --no-default-features --features ${{ matrix.feature }}
 
   lints:
     name: Rust lints


### PR DESCRIPTION
Added skipped tests in master, pr and codecov. Codecov does not use feature matrix, so only libp2p feature is built and tested, if coverage numbers doesn't suffer too much, I'd leave it as is.