### PR TITLE
Use build all before integration tests

### DIFF
--- a/ci/Jenkinsfile.nightly.integration
+++ b/ci/Jenkinsfile.nightly.integration
@@ -84,20 +84,13 @@ pipeline {
 
 def runBuildAndTestsForFeature(feature, tests) {
   echo "Building node for feature: ${feature}"
-  def build_node = "cargo build -p nomos-node --no-default-features --features ${feature}"
+  def build_node = "cargo build --all --no-default-features --features ${feature}"
 
   if (sh(script: build_node, returnStatus: true) != 0) {
     error("Build '${feature}' node failed")
     return
   }
 
-  def build_mixnode = "cargo build -p mixnode"
-
-  if (sh(script: build_mixnode, returnStatus: true) != 0) {
-    error("Build '${feature}' mixnode failed")
-    return
-  }
-  
   int iterations = params.ITERATIONS.toInteger()
   runTestCases(tests, iterations)
 }


### PR DESCRIPTION
Have all binaries in place in case integration tests need them.