### PR TITLE
Finish retry pool

### DIFF
--- a/mixnet/protocol/Cargo.toml
+++ b/mixnet/protocol/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.32", features = ["sync", "net"] }
+tokio = { version = "1.32", features = ["sync", "net", "time"] }
 sphinx-packet = "0.1.0"
 futures = "0.3"
 tokio-util = { version  = "0.7", features = ["io", "io-util"] }

--- a/mixnet/protocol/src/lib.rs
+++ b/mixnet/protocol/src/lib.rs
@@ -122,7 +122,6 @@ pub async fn retry_backoff(
     for idx in 0..max_retries {
         // backoff
         let wait = Duration::from_millis((retry_delay.as_millis() as u64).pow(idx as u32));
-
         tokio::time::sleep(wait).await;
         let mut socket = socket.lock().await;
         match body.write(&mut *socket).await {

--- a/mixnet/util/Cargo.toml
+++ b/mixnet/util/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 tokio = { version = "1.32", default-features = false, features = ["sync", "net"] }
 mixnet-protocol = { path = "../protocol" }
 crossbeam-skiplist = "0.1"
+pin-project-lite = "0.2"
+itertools = "0.11"

--- a/mixnet/util/src/lib.rs
+++ b/mixnet/util/src/lib.rs
@@ -11,6 +11,9 @@ use tokio::{
     task::JoinHandle,
 };
 
+mod retry_pool;
+pub use retry_pool::*;
+
 #[derive(Clone)]
 pub struct ConnectionPool {
     pool: Arc<Mutex<HashMap<SocketAddr, Arc<Mutex<TcpStream>>>>>,

--- a/mixnet/util/src/retry_pool.rs
+++ b/mixnet/util/src/retry_pool.rs
@@ -1,0 +1,148 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use itertools::{Either, Itertools};
+use tokio::sync::Mutex;
+
+pub struct RetryMessage<M> {
+    delay: Duration,
+    now: Instant,
+    msg: M,
+}
+
+impl<M> RetryMessage<M> {
+    pub fn into_components(self) -> (Duration, M) {
+        (self.delay, self.msg)
+    }
+}
+
+impl<M> PartialEq for RetryMessage<M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.remaining() == other.remaining()
+    }
+}
+
+impl<M> Eq for RetryMessage<M> {}
+
+impl<M> PartialOrd for RetryMessage<M> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<M> Ord for RetryMessage<M> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.remaining().cmp(&other.remaining())
+    }
+}
+
+impl<M> RetryMessage<M> {
+    pub fn new(delay: Duration, msg: M) -> Self {
+        Self {
+            delay,
+            msg,
+            now: Instant::now(),
+        }
+    }
+
+    pub fn delay(&self) -> Duration {
+        self.delay
+    }
+
+    pub fn msg(&self) -> &M {
+        &self.msg
+    }
+
+    pub fn should_retry(&self) -> bool {
+        self.now.elapsed() >= self.delay
+    }
+
+    pub fn remaining(&self) -> Duration {
+        self.delay.saturating_sub(self.now.elapsed())
+    }
+}
+
+pub enum OneOrMore<M> {
+    One((Duration, M)),
+    More(Vec<(Duration, M)>),
+}
+
+pub struct RetryPool<M> {
+    pool: Mutex<Vec<RetryMessage<M>>>,
+}
+
+impl<M> Default for RetryPool<M> {
+    fn default() -> Self {
+        Self {
+            pool: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl<M> RetryPool<M> {
+    pub fn new() -> Self {
+        Self {
+            pool: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn get(&self) -> GetFuture<M> {
+        let mut pool = self.pool.lock().await;
+
+        if pool.is_empty() {
+            return GetFuture { res: None };
+        }
+
+        let msgs = std::mem::take(&mut *pool);
+        let (mut res, mut remaining): (Vec<_>, Vec<_>) = msgs.into_iter().partition_map(|v| {
+            if v.should_retry() {
+                Either::Left(v.into_components())
+            } else {
+                Either::Right(v)
+            }
+        });
+        remaining.sort();
+        *pool = remaining;
+        match res.len() {
+            0 => GetFuture { res: None },
+            1 => GetFuture {
+                res: Some(OneOrMore::One(res.pop().unwrap())),
+            },
+            _ => GetFuture {
+                res: Some(OneOrMore::More(res)),
+            },
+        }
+    }
+
+    pub async fn insert(&self, msg: M, delay: Duration) {
+        let mut pool = self.pool.lock().await;
+        pool.push(RetryMessage::new(delay, msg));
+    }
+
+    pub async fn insert_many(&self, msgs: impl Iterator<Item = (Duration, M)>) {
+        let mut pool = self.pool.lock().await;
+        pool.extend(msgs.map(|(delay, msg)| RetryMessage::new(delay, msg)));
+    }
+}
+
+pub struct GetFuture<M> {
+    res: Option<OneOrMore<M>>,
+}
+
+impl<M> std::future::Future for GetFuture<M> {
+    type Output = OneOrMore<M>;
+
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(result) = self.res.take() {
+            Poll::Ready(result)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+// This is correct, because we never pin res field.
+impl<M> Unpin for GetFuture<M> {}


### PR DESCRIPTION
I implemented a retry pool to maintain a vector of retry messages. The `get` method of the retry pool will return a future. If no messages need to be retried, then the `GetFuture` will always be pending, so it solves the problems we have by using channels. The `GetFuture` may return multiple messages that need to be retried; it is a kind of batch-sending mechanism.