### PR TITLE
Make mempool generic

### DIFF
--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -349,7 +349,6 @@ where
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
     TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
-    BS: BlobSelect<Blob = B> + Clone + Send + Sync + 'static,
 {
     fn process_message(carnot: &Carnot<O>, msg: ConsensusMsg) {
         match msg {

--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -106,13 +106,13 @@ impl<O: Overlay, Ts, Bs> CarnotSettings<O, Ts, Bs> {
 pub struct CarnotConsensus<A, P, M, O, C, TxS, BS>
 where
     A: NetworkAdapter,
-    M: MempoolAdapter<Tx = P::Tx>,
+    M: MempoolAdapter<Item = P::Item, Key = P::Key>,
     P: MemPool,
     O: Overlay + Debug,
-    P::Tx: Transaction + Debug + 'static,
-    <P::Tx as Transaction>::Hash: Debug,
+    P::Item: Debug + 'static,
+    P::Key: Debug + 'static,
     A::Backend: 'static,
-    TxS: TxSelect<Tx = P::Tx>,
+    TxS: TxSelect<Tx = P::Item>,
     BS: BlobCertificateSelect<Certificate = C>,
 {
     service_state: ServiceStateHandle<Self>,
@@ -129,11 +129,11 @@ impl<A, P, M, O, C, TxS, BS> ServiceData for CarnotConsensus<A, P, M, O, C, TxS,
 where
     A: NetworkAdapter,
     P: MemPool,
-    P::Tx: Transaction + Debug,
-    <P::Tx as Transaction>::Hash: Debug,
-    M: MempoolAdapter<Tx = P::Tx>,
+    P::Item: Debug,
+    P::Key: Debug,
+    M: MempoolAdapter<Item = P::Item, Key = P::Key>,
     O: Overlay + Debug,
-    TxS: TxSelect<Tx = P::Tx>,
+    TxS: TxSelect<Tx = P::Item>,
     BS: BlobCertificateSelect<Certificate = C>,
 {
     const SERVICE_ID: ServiceId = "Carnot";
@@ -149,9 +149,16 @@ where
     A: NetworkAdapter + Clone + Send + Sync + 'static,
     P: MemPool + Send + Sync + 'static,
     P::Settings: Send + Sync + 'static,
-    P::Tx:
-        Debug + Clone + Eq + Hash + Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
-    <P::Tx as Transaction>::Hash: Debug + Send + Sync,
+    P::Item: Transaction
+        + Debug
+        + Clone
+        + Eq
+        + Hash
+        + Serialize
+        + serde::de::DeserializeOwned
+        + Send
+        + Sync
+        + 'static,
     C: Certificate
         + Debug
         + Clone
@@ -162,11 +169,12 @@ where
         + Send
         + Sync
         + 'static,
-    M: MempoolAdapter<Tx = P::Tx> + Send + Sync + 'static,
+    P::Key: Debug + Send + Sync,
+    M: MempoolAdapter<Item = P::Item, Key = P::Key> + Send + Sync + 'static,
     O: Overlay + Debug + Send + Sync + 'static,
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
-    TxS: TxSelect<Tx = P::Tx> + Clone + Send + Sync + 'static,
+    TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
     TxS::Settings: Send + Sync + 'static,
     BS: BlobCertificateSelect<Certificate = C> + Clone + Send + Sync + 'static,
     BS::Settings: Send + Sync + 'static,
@@ -310,9 +318,16 @@ where
     A: NetworkAdapter + Clone + Send + Sync + 'static,
     P: MemPool + Send + Sync + 'static,
     P::Settings: Send + Sync + 'static,
-    P::Tx:
-        Debug + Clone + Eq + Hash + Serialize + serde::de::DeserializeOwned + Send + Sync + 'static,
-    <P::Tx as Transaction>::Hash: Debug + Send + Sync,
+    P::Item: Transaction
+        + Debug
+        + Clone
+        + Eq
+        + Hash
+        + Serialize
+        + serde::de::DeserializeOwned
+        + Send
+        + Sync
+        + 'static,
     C: Certificate
         + Debug
         + Clone
@@ -323,12 +338,18 @@ where
         + Send
         + Sync
         + 'static,
-    M: MempoolAdapter<Tx = P::Tx> + Send + Sync + 'static,
     O: Overlay + Debug + Send + Sync + 'static,
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
-    TxS: TxSelect<Tx = P::Tx> + Clone + Send + Sync + 'static,
+    TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
     BS: BlobCertificateSelect<Certificate = C> + Clone + Send + Sync + 'static,
+    P::Key: Debug + Send + Sync,
+    M: MempoolAdapter<Item = P::Item, Key = P::Key> + Send + Sync + 'static,
+    O: Overlay + Debug + Send + Sync + 'static,
+    O::LeaderSelection: UpdateableLeaderSelection,
+    O::CommitteeMembership: UpdateableCommitteeMembership,
+    TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
+    BS: BlobSelect<Blob = B> + Clone + Send + Sync + 'static,
 {
     fn process_message(carnot: &Carnot<O>, msg: ConsensusMsg) {
         match msg {
@@ -352,11 +373,11 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn process_carnot_event(
         mut carnot: Carnot<O>,
-        event: Event<P::Tx, C>,
-        task_manager: &mut TaskManager<View, Event<P::Tx, C>>,
+        event: Event<P::Item, C>,
+        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
         adapter: A,
         private_key: PrivateKey,
-        mempool_relay: OutboundRelay<MempoolMsg<P::Tx>>,
+        mempool_relay: OutboundRelay<MempoolMsg<P::Item, P::Key>>,
         tx_selector: TxS,
         blobl_selector: BS,
         timeout: Duration,
@@ -372,7 +393,7 @@ where
                 tracing::debug!("approving proposal {:?}", block);
                 let (new_carnot, out) = carnot.approve_block(block);
                 carnot = new_carnot;
-                output = Some(Output::Send::<P::Tx, C>(out));
+                output = Some(Output::Send::<P::Item, C>(out));
             }
             Event::LocalTimeout { view } => {
                 tracing::debug!("local timeout");
@@ -442,11 +463,11 @@ where
     #[instrument(level = "debug", skip(adapter, task_manager, stream))]
     async fn process_block(
         mut carnot: Carnot<O>,
-        block: Block<P::Tx, C>,
-        mut stream: Pin<Box<dyn Stream<Item = Block<P::Tx, C>> + Send>>,
-        task_manager: &mut TaskManager<View, Event<P::Tx, C>>,
+        block: Block<P::Item, C>,
+        mut stream: Pin<Box<dyn Stream<Item = Block<P::Item, C>> + Send>>,
+        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<P::Tx, C>>) {
+    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
         tracing::debug!("received proposal {:?}", block);
         if carnot.highest_voted_view() >= block.header().view {
             tracing::debug!("already voted for view {}", block.header().view);
@@ -522,9 +543,9 @@ where
         carnot: Carnot<O>,
         timeout_qc: TimeoutQc,
         new_views: HashSet<NewView>,
-        task_manager: &mut TaskManager<View, Event<P::Tx, C>>,
+        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<P::Tx, C>>) {
+    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
         let leader_committee = [carnot.id()].into_iter().collect();
         let leader_tally_settings = CarnotTallySettings {
             threshold: carnot.leader_super_majority_threshold(),
@@ -559,9 +580,9 @@ where
     async fn receive_timeout_qc(
         carnot: Carnot<O>,
         timeout_qc: TimeoutQc,
-        task_manager: &mut TaskManager<View, Event<P::Tx, C>>,
+        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<P::Tx, C>>) {
+    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
         let mut new_state = carnot.receive_timeout_qc(timeout_qc.clone());
         let self_committee = carnot.self_committee();
         let tally_settings = CarnotTallySettings {
@@ -586,7 +607,7 @@ where
     async fn process_root_timeout(
         carnot: Carnot<O>,
         timeouts: HashSet<Timeout>,
-    ) -> (Carnot<O>, Option<Output<P::Tx, C>>) {
+    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
         // we might have received a timeout_qc sent by some other node and advanced the view
         // already, in which case we should ignore the timeout
         if carnot.current_view()
@@ -630,8 +651,8 @@ where
         qc: Qc,
         tx_selector: TxS,
         blob_selector: BS,
-        mempool_relay: OutboundRelay<MempoolMsg<P::Tx>>,
-    ) -> Option<Output<P::Tx, C>> {
+        mempool_relay: OutboundRelay<MempoolMsg<P::Item, P::Key>>,
+    ) -> Option<Output<P::Item, C>> {
         let (reply_channel, rx) = tokio::sync::oneshot::channel();
         let mut output = None;
         mempool_relay
@@ -666,7 +687,7 @@ where
     async fn process_view_change(
         carnot: Carnot<O>,
         prev_view: View,
-        task_manager: &mut TaskManager<View, Event<P::Tx, C>>,
+        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
         adapter: A,
         timeout: Duration,
     ) {
@@ -703,7 +724,7 @@ where
         }
     }
 
-    async fn gather_timeout_qc(adapter: A, view: consensus_engine::View) -> Event<P::Tx, C> {
+    async fn gather_timeout_qc(adapter: A, view: consensus_engine::View) -> Event<P::Item, C> {
         if let Some(timeout_qc) = adapter
             .timeout_qc_stream(view)
             .await
@@ -723,7 +744,7 @@ where
         committee: Committee,
         block: consensus_engine::Block,
         tally: CarnotTallySettings,
-    ) -> Event<P::Tx, C> {
+    ) -> Event<P::Item, C> {
         let tally = CarnotTally::new(tally);
         let votes_stream = adapter.votes_stream(&committee, block.view, block.id).await;
         match tally.tally(block.clone(), votes_stream).await {
@@ -740,7 +761,7 @@ where
         committee: Committee,
         timeout_qc: TimeoutQc,
         tally: CarnotTallySettings,
-    ) -> Event<P::Tx, C> {
+    ) -> Event<P::Item, C> {
         let tally = NewViewTally::new(tally);
         let stream = adapter
             .new_view_stream(&committee, timeout_qc.view().next())
@@ -762,7 +783,7 @@ where
         committee: Committee,
         view: consensus_engine::View,
         tally: CarnotTallySettings,
-    ) -> Event<P::Tx, C> {
+    ) -> Event<P::Item, C> {
         let tally = TimeoutTally::new(tally);
         let stream = adapter.timeout_stream(&committee, view).await;
         match tally.tally(view, stream).await {
@@ -774,7 +795,7 @@ where
     }
 
     #[instrument(level = "debug", skip(adapter))]
-    async fn gather_block(adapter: A, view: consensus_engine::View) -> Event<P::Tx, C> {
+    async fn gather_block(adapter: A, view: consensus_engine::View) -> Event<P::Item, C> {
         let stream = adapter
             .proposal_chunks_stream(view)
             .await

--- a/nomos-services/mempool/src/backend/mod.rs
+++ b/nomos-services/mempool/src/backend/mod.rs
@@ -2,47 +2,44 @@
 pub mod mockpool;
 
 use nomos_core::block::BlockId;
-use nomos_core::tx::Transaction;
 
 #[derive(thiserror::Error, Debug)]
 pub enum MempoolError {
-    #[error("Tx already in mempool")]
-    ExistingTx,
+    #[error("Item already in mempool")]
+    ExistingItem,
     #[error(transparent)]
     DynamicPoolError(#[from] overwatch_rs::DynError),
 }
 
 pub trait MemPool {
     type Settings: Clone;
-    type Tx: Transaction;
+    type Item;
+    type Key;
 
     /// Construct a new empty pool
     fn new(settings: Self::Settings) -> Self;
 
-    /// Add a new transaction to the mempool, for example because we received it from the network
-    fn add_tx(&mut self, tx: Self::Tx) -> Result<(), MempoolError>;
+    /// Add a new item to the mempool, for example because we received it from the network
+    fn add_item(&mut self, key: Self::Key, item: Self::Item) -> Result<(), MempoolError>;
 
-    /// Return a view over the transactions contained in the mempool.
-    /// Implementations should provide *at least* all the transactions which have not been marked as
+    /// Return a view over items contained in the mempool.
+    /// Implementations should provide *at least* all the items which have not been marked as
     /// in a block.
     /// The hint on the ancestor *can* be used by the implementation to display additional
-    /// transactions that were not included up to that point if available.
-    fn view(&self, ancestor_hint: BlockId) -> Box<dyn Iterator<Item = Self::Tx> + Send>;
+    /// items that were not included up to that point if available.
+    fn view(&self, ancestor_hint: BlockId) -> Box<dyn Iterator<Item = Self::Item> + Send>;
 
-    /// Record that a set of transactions were included in a block
-    fn mark_in_block(&mut self, txs: &[<Self::Tx as Transaction>::Hash], block: BlockId);
+    /// Record that a set of items were included in a block
+    fn mark_in_block(&mut self, items: &[Self::Key], block: BlockId);
 
     /// Returns all of the transactions for the block
     #[cfg(test)]
-    fn block_transactions(
-        &self,
-        block: BlockId,
-    ) -> Option<Box<dyn Iterator<Item = Self::Tx> + Send>>;
+    fn block_items(&self, block: BlockId) -> Option<Box<dyn Iterator<Item = Self::Item> + Send>>;
 
     /// Signal that a set of transactions can't be possibly requested anymore and can be
     /// discarded.
-    fn prune(&mut self, txs: &[<Self::Tx as Transaction>::Hash]);
+    fn prune(&mut self, items: &[Self::Key]);
 
-    fn pending_tx_count(&self) -> usize;
-    fn last_tx_timestamp(&self) -> u64;
+    fn pending_item_count(&self) -> usize;
+    fn last_item_timestamp(&self) -> u64;
 }

--- a/nomos-services/mempool/src/lib.rs
+++ b/nomos-services/mempool/src/lib.rs
@@ -11,7 +11,6 @@ use tokio::sync::oneshot::Sender;
 use crate::network::NetworkAdapter;
 use backend::MemPool;
 use nomos_core::block::BlockId;
-use nomos_core::tx::Transaction;
 use nomos_network::NetworkService;
 use overwatch_rs::services::{
     handle::ServiceStateHandle,
@@ -22,11 +21,11 @@ use overwatch_rs::services::{
 
 pub struct MempoolService<N, P>
 where
-    N: NetworkAdapter<Tx = P::Tx>,
+    N: NetworkAdapter<Item = P::Item, Key = P::Key>,
     P: MemPool,
     P::Settings: Clone,
-    P::Tx: Debug + 'static,
-    <P::Tx as Transaction>::Hash: Debug,
+    P::Item: Debug + 'static,
+    P::Key: Debug + 'static,
 {
     service_state: ServiceStateHandle<Self>,
     network_relay: Relay<NetworkService<N::Backend>>,
@@ -34,29 +33,30 @@ where
 }
 
 pub struct MempoolMetrics {
-    pub pending_txs: usize,
-    pub last_tx_timestamp: u64,
+    pub pending_items: usize,
+    pub last_item_timestamp: u64,
 }
 
-pub enum MempoolMsg<Tx: Transaction> {
-    AddTx {
-        tx: Tx,
+pub enum MempoolMsg<Item, Key> {
+    Add {
+        item: Item,
+        key: Key,
         reply_channel: Sender<Result<(), ()>>,
     },
     View {
         ancestor_hint: BlockId,
-        reply_channel: Sender<Box<dyn Iterator<Item = Tx> + Send>>,
+        reply_channel: Sender<Box<dyn Iterator<Item = Item> + Send>>,
     },
     Prune {
-        ids: Vec<Tx::Hash>,
+        ids: Vec<Key>,
     },
     #[cfg(test)]
-    BlockTransaction {
+    BlockItems {
         block: BlockId,
-        reply_channel: Sender<Option<Box<dyn Iterator<Item = Tx> + Send>>>,
+        reply_channel: Sender<Option<Box<dyn Iterator<Item = Item> + Send>>>,
     },
     MarkInBlock {
-        ids: Vec<Tx::Hash>,
+        ids: Vec<Key>,
         block: BlockId,
     },
     Metrics {
@@ -64,16 +64,17 @@ pub enum MempoolMsg<Tx: Transaction> {
     },
 }
 
-impl<Tx: Transaction + Debug> Debug for MempoolMsg<Tx>
+impl<Item, Key> Debug for MempoolMsg<Item, Key>
 where
-    Tx::Hash: Debug,
+    Item: Debug,
+    Key: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             Self::View { ancestor_hint, .. } => {
                 write!(f, "MempoolMsg::View {{ ancestor_hint: {ancestor_hint:?}}}")
             }
-            Self::AddTx { tx, .. } => write!(f, "MempoolMsg::AddTx{{tx: {tx:?}}}"),
+            Self::Add { item, .. } => write!(f, "MempoolMsg::Add{{item: {item:?}}}"),
             Self::Prune { ids } => write!(f, "MempoolMsg::Prune{{ids: {ids:?}}}"),
             Self::MarkInBlock { ids, block } => {
                 write!(
@@ -82,29 +83,29 @@ where
                 )
             }
             #[cfg(test)]
-            Self::BlockTransaction { block, .. } => {
-                write!(f, "MempoolMsg::BlockTransaction{{block: {block:?}}}")
+            Self::BlockItem { block, .. } => {
+                write!(f, "MempoolMsg::BlockItem{{block: {block:?}}}")
             }
             Self::Metrics { .. } => write!(f, "MempoolMsg::Metrics"),
         }
     }
 }
 
-impl<Tx: Transaction + 'static> RelayMessage for MempoolMsg<Tx> {}
+impl<Item: 'static, Key: 'static> RelayMessage for MempoolMsg<Item, Key> {}
 
 impl<N, P> ServiceData for MempoolService<N, P>
 where
-    N: NetworkAdapter<Tx = P::Tx>,
+    N: NetworkAdapter<Item = P::Item, Key = P::Key>,
     P: MemPool,
     P::Settings: Clone,
-    P::Tx: Debug + 'static,
-    <P::Tx as Transaction>::Hash: Debug,
+    P::Item: Debug + 'static,
+    P::Key: Debug + 'static,
 {
     const SERVICE_ID: ServiceId = "Mempool";
-    type Settings = P::Settings;
+    type Settings = Settings<P::Settings, N::Settings>;
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State>;
-    type Message = MempoolMsg<<P as MemPool>::Tx>;
+    type Message = MempoolMsg<<P as MemPool>::Item, <P as MemPool>::Key>;
 }
 
 #[async_trait::async_trait]
@@ -112,9 +113,10 @@ impl<N, P> ServiceCore for MempoolService<N, P>
 where
     P: MemPool + Send + 'static,
     P::Settings: Clone + Send + Sync + 'static,
-    P::Tx: Transaction + Clone + Debug + Send + Sync + 'static,
-    <P::Tx as Transaction>::Hash: Debug + Send + Sync + 'static,
-    N: NetworkAdapter<Tx = P::Tx> + Send + Sync + 'static,
+    N::Settings: Clone + Send + Sync + 'static,
+    P::Item: Clone + Debug + Send + Sync + 'static,
+    P::Key: Debug + Send + Sync + 'static,
+    N: NetworkAdapter<Item = P::Item, Key = P::Key> + Send + Sync + 'static,
 {
     fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
         let network_relay = service_state.overwatch_handle.relay();
@@ -145,8 +147,8 @@ where
             tokio::select! {
                 Some(msg) = service_state.inbound_relay.recv() => {
                     match msg {
-                        MempoolMsg::AddTx { tx, reply_channel } => {
-                            match pool.add_tx(tx.clone()) {
+                        MempoolMsg::Add { item, key, reply_channel } => {
+                            match pool.add_item(key, item) {
                                 Ok(_id) => {
                                     if let Err(e) = reply_channel.send(Ok(())) {
                                         tracing::debug!("Failed to send reply to AddTx: {:?}", e);
@@ -167,15 +169,15 @@ where
                         }
                         #[cfg(test)]
                         MempoolMsg::BlockTransaction { block, reply_channel } => {
-                            reply_channel.send(pool.block_transactions(block)).unwrap_or_else(|_| {
-                                tracing::debug!("could not send back block transactions")
+                            reply_channel.send(pool.block_items(block)).unwrap_or_else(|_| {
+                                tracing::debug!("could not send back block items")
                             });
                         }
                         MempoolMsg::Prune { ids } => { pool.prune(&ids); },
                         MempoolMsg::Metrics { reply_channel } => {
                             let metrics = MempoolMetrics {
-                                pending_txs: pool.pending_tx_count(),
-                                last_tx_timestamp: pool.last_tx_timestamp(),
+                                pending_items: pool.pending_item_count(),
+                                last_item_timestamp: pool.last_item_timestamp(),
                             };
                             reply_channel.send(metrics).unwrap_or_else(|_| {
                                 tracing::debug!("could not send back mempool metrics")
@@ -183,9 +185,9 @@ where
                         }
                     }
                 }
-                Some(tx) = network_txs.next() => {
-                    pool.add_tx(tx).unwrap_or_else(|e| {
-                        tracing::debug!("could not add tx to the pool due to: {}", e)
+                Some((key, item )) = network_items.next() => {
+                    pool.add_item(key, item).unwrap_or_else(|e| {
+                        tracing::debug!("could not add item to the pool due to: {}", e)
                     });
                 }
             }

--- a/nomos-services/mempool/src/lib.rs
+++ b/nomos-services/mempool/src/lib.rs
@@ -83,7 +83,7 @@ where
                 )
             }
             #[cfg(test)]
-            Self::BlockItem { block, .. } => {
+            Self::BlockItems { block, .. } => {
                 write!(f, "MempoolMsg::BlockItem{{block: {block:?}}}")
             }
             Self::Metrics { .. } => write!(f, "MempoolMsg::Metrics"),
@@ -173,7 +173,7 @@ where
                             pool.mark_in_block(&ids, block);
                         }
                         #[cfg(test)]
-                        MempoolMsg::BlockTransaction { block, reply_channel } => {
+                        MempoolMsg::BlockItems { block, reply_channel } => {
                             reply_channel.send(pool.block_items(block)).unwrap_or_else(|_| {
                                 tracing::debug!("could not send back block items")
                             });

--- a/nomos-services/mempool/src/network/adapters/libp2p.rs
+++ b/nomos-services/mempool/src/network/adapters/libp2p.rs
@@ -15,7 +15,7 @@ pub const CARNOT_TX_TOPIC: &str = "CarnotTx";
 
 pub struct Libp2pAdapter<Item, Key> {
     network_relay: OutboundRelay<<NetworkService<Libp2p> as ServiceData>::Message>,
-    _tx: PhantomData<Tx>,
+    settings: Settings<Key, Item>,
 }
 
 #[async_trait::async_trait]
@@ -25,10 +25,12 @@ where
     Key: Clone + Send + Sync + 'static,
 {
     type Backend = Libp2p;
+    type Settings = Settings<Key, Item>;
     type Item = Item;
     type Key = Key;
 
     async fn new(
+        settings: Self::Settings,
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
     ) -> Self {
         network_relay
@@ -71,4 +73,10 @@ where
             },
         )))
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct Settings<K, V> {
+    pub topic: String,
+    pub id: fn(&V) -> K,
 }

--- a/nomos-services/mempool/src/network/adapters/libp2p.rs
+++ b/nomos-services/mempool/src/network/adapters/libp2p.rs
@@ -1,14 +1,9 @@
-// std
-use std::marker::PhantomData;
 // crates
 use futures::Stream;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
-use tracing::log::error;
-
 // internal
-use crate::network::messages::TransactionMsg;
 use crate::network::NetworkAdapter;
 use nomos_core::wire;
 use nomos_network::backends::libp2p::{Command, Event, EventKind, Libp2p, Message, TopicHash};
@@ -18,18 +13,20 @@ use overwatch_rs::services::ServiceData;
 
 pub const CARNOT_TX_TOPIC: &str = "CarnotTx";
 
-pub struct Libp2pAdapter<Tx> {
+pub struct Libp2pAdapter<Item, Key> {
     network_relay: OutboundRelay<<NetworkService<Libp2p> as ServiceData>::Message>,
     _tx: PhantomData<Tx>,
 }
 
 #[async_trait::async_trait]
-impl<Tx> NetworkAdapter for Libp2pAdapter<Tx>
+impl<Item, Key> NetworkAdapter for Libp2pAdapter<Item, Key>
 where
-    Tx: DeserializeOwned + Serialize + Send + Sync + 'static,
+    Item: DeserializeOwned + Serialize + Send + Sync + 'static + Clone,
+    Key: Clone + Send + Sync + 'static,
 {
     type Backend = Libp2p;
-    type Tx = Tx;
+    type Item = Item;
+    type Key = Key;
 
     async fn new(
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
@@ -42,11 +39,14 @@ where
             .expect("Network backend should be ready");
         Self {
             network_relay,
-            _tx: PhantomData,
+            settings,
         }
     }
-    async fn transactions_stream(&self) -> Box<dyn Stream<Item = Self::Tx> + Unpin + Send> {
-        let topic_hash = TopicHash::from_raw(CARNOT_TX_TOPIC);
+    async fn transactions_stream(
+        &self,
+    ) -> Box<dyn Stream<Item = (Self::Key, Self::Item)> + Unpin + Send> {
+        let topic_hash = TopicHash::from_raw(self.settings.topic.clone());
+        let id = self.settings.id;
         let (sender, receiver) = tokio::sync::oneshot::channel();
         self.network_relay
             .send(NetworkMsg::Subscribe {
@@ -59,10 +59,10 @@ where
         Box::new(Box::pin(BroadcastStream::new(receiver).filter_map(
             move |message| match message {
                 Ok(Event::Message(Message { data, topic, .. })) if topic == topic_hash => {
-                    match wire::deserialize::<TransactionMsg<Tx>>(&data) {
-                        Ok(msg) => Some(msg.tx),
+                    match wire::deserialize::<Item>(&data) {
+                        Ok(item) => Some((id(&item), item)),
                         Err(e) => {
-                            error!("Unrecognized Tx message: {e}");
+                            tracing::debug!("Unrecognized message: {e}");
                             None
                         }
                     }

--- a/nomos-services/mempool/src/network/adapters/mock.rs
+++ b/nomos-services/mempool/src/network/adapters/mock.rs
@@ -25,10 +25,12 @@ pub struct MockAdapter {
 #[async_trait::async_trait]
 impl NetworkAdapter for MockAdapter {
     type Backend = Mock;
+    type Settings = ();
     type Item = MockTransaction<MockMessage>;
     type Key = MockTxId;
 
     async fn new(
+        _settings: Self::Settings,
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
     ) -> Self {
         // send message to boot the network producer

--- a/nomos-services/mempool/src/network/adapters/mock.rs
+++ b/nomos-services/mempool/src/network/adapters/mock.rs
@@ -2,7 +2,7 @@
 
 // crates
 use futures::{Stream, StreamExt};
-use nomos_core::tx::mock::MockTransaction;
+use nomos_core::tx::mock::{MockTransaction, MockTxId};
 use nomos_network::backends::mock::{
     EventKind, Mock, MockBackendMessage, MockContentTopic, MockMessage, NetworkEvent,
 };
@@ -25,7 +25,8 @@ pub struct MockAdapter {
 #[async_trait::async_trait]
 impl NetworkAdapter for MockAdapter {
     type Backend = Mock;
-    type Tx = MockTransaction<MockMessage>;
+    type Item = MockTransaction<MockMessage>;
+    type Key = MockTxId;
 
     async fn new(
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
@@ -57,7 +58,9 @@ impl NetworkAdapter for MockAdapter {
         Self { network_relay }
     }
 
-    async fn transactions_stream(&self) -> Box<dyn Stream<Item = Self::Tx> + Unpin + Send> {
+    async fn transactions_stream(
+        &self,
+    ) -> Box<dyn Stream<Item = (Self::Key, Self::Item)> + Unpin + Send> {
         let (sender, receiver) = tokio::sync::oneshot::channel();
         if let Err((_, e)) = self
             .network_relay
@@ -77,7 +80,8 @@ impl NetworkAdapter for MockAdapter {
                     Ok(NetworkEvent::RawMessage(message)) => {
                         tracing::info!("Received message: {:?}", message.payload());
                         if message.content_topic().eq(&MOCK_TX_CONTENT_TOPIC) {
-                            Some(MockTransaction::new(message))
+                            let tx = MockTransaction::new(message);
+                            Some((tx.id(), tx))
                         } else {
                             None
                         }

--- a/nomos-services/mempool/src/network/adapters/waku.rs
+++ b/nomos-services/mempool/src/network/adapters/waku.rs
@@ -57,7 +57,9 @@ where
         }
     }
 
-    async fn transactions_stream(&self) -> Box<dyn Stream<Item = (Self::Key, Self::Item)> + Unpin + Send> {
+    async fn transactions_stream(
+        &self,
+    ) -> Box<dyn Stream<Item = (Self::Key, Self::Item)> + Unpin + Send> {
         let (sender, receiver) = tokio::sync::oneshot::channel();
         if let Err((_, _e)) = self
             .network_relay

--- a/nomos-services/mempool/src/network/adapters/waku.rs
+++ b/nomos-services/mempool/src/network/adapters/waku.rs
@@ -33,11 +33,13 @@ where
     Item: DeserializeOwned + Serialize + Send + Sync + 'static,
 {
     type Backend = Waku;
+    type Settings = ();
     type Item = Item;
     // TODO: implement real key
     type Key = ();
 
     async fn new(
+        _settings: Self::Settings,
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
     ) -> Self {
         // Subscribe to the carnot pubsub topic

--- a/nomos-services/mempool/src/network/mod.rs
+++ b/nomos-services/mempool/src/network/mod.rs
@@ -14,9 +14,12 @@ use overwatch_rs::services::ServiceData;
 #[async_trait::async_trait]
 pub trait NetworkAdapter {
     type Backend: NetworkBackend + 'static;
+    type Settings: Clone;
+
     type Item: Send + Sync + 'static;
     type Key: Send + Sync + 'static;
     async fn new(
+        settings: Self::Settings,
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
     ) -> Self;
     async fn transactions_stream(

--- a/nomos-services/mempool/src/network/mod.rs
+++ b/nomos-services/mempool/src/network/mod.rs
@@ -14,9 +14,12 @@ use overwatch_rs::services::ServiceData;
 #[async_trait::async_trait]
 pub trait NetworkAdapter {
     type Backend: NetworkBackend + 'static;
-    type Tx: Send + Sync + 'static;
+    type Item: Send + Sync + 'static;
+    type Key: Send + Sync + 'static;
     async fn new(
         network_relay: OutboundRelay<<NetworkService<Self::Backend> as ServiceData>::Message>,
     ) -> Self;
-    async fn transactions_stream(&self) -> Box<dyn Stream<Item = Self::Tx> + Unpin + Send>;
+    async fn transactions_stream(
+        &self,
+    ) -> Box<dyn Stream<Item = (Self::Key, Self::Item)> + Unpin + Send>;
 }

--- a/nomos-services/mempool/tests/mock.rs
+++ b/nomos-services/mempool/tests/mock.rs
@@ -13,7 +13,7 @@ use overwatch_rs::{overwatch::OverwatchRunner, services::handle::ServiceHandle};
 use nomos_mempool::{
     backend::mockpool::MockPool,
     network::adapters::mock::{MockAdapter, MOCK_TX_CONTENT_TOPIC},
-    MempoolMsg, MempoolService, Settings
+    MempoolMsg, MempoolService, Settings,
 };
 
 #[derive(Services)]


### PR DESCRIPTION
Make the mempool generic with respect to the item and remove
mentions of specific transaction formats/traits. This will allow
us to reuse the same code for both coordination layer transactions
and certificates, or in general, whatever items need to be included
in a block.