### PR TITLE
Add the `metrics` recording feature for libp2p

### DIFF
--- a/nomos-libp2p/Cargo.toml
+++ b/nomos-libp2p/Cargo.toml
@@ -24,8 +24,12 @@ hex = "0.4.3"
 log = "0.4.19"
 thiserror = "1.0.40"
 tracing = "0.1"
+prometheus-client = { version = "0.21.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"
 serde_json = "1.0.99"
 tokio = { version = "1", features = ["time"] }
+
+[features]
+metrics = ["libp2p/metrics", "prometheus-client"]

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -37,4 +37,5 @@ tokio = { version = "1", features = ["full"] }
 default = []
 waku = ["waku-bindings"]
 libp2p = ["nomos-libp2p", "rand", "humantime-serde"]
+metrics = ["nomos-libp2p/metrics"]
 mock = ["rand", "chrono"]


### PR DESCRIPTION
Using [libp2p_metrics](https://github.com/libp2p/rust-libp2p/tree/master/misc/metrics), we can gather metrics by recording libp2p events. For example, we can record how many messages are sent/received to/from certain peers. This would be useful for https://github.com/logos-co/nomos-node/issues/391 in the future.

TODO: expose libp2p metrics to the [metrics service](https://github.com/logos-co/nomos-node/tree/master/nomos-services/metrics).

