### PR TITLE
GH: Waku windows build configuration

### DIFF
--- a/.github/actions/mingw-env/action.yml
+++ b/.github/actions/mingw-env/action.yml
@@ -11,6 +11,11 @@ runs:
         msystem: mingw64
         update: true
         pacboy: binutils
+    - name: Configure CC and CXX for GNU
+      shell: pwsh
+      run: |
+        "CC=x86_64-w64-mingw32-gcc" >> $env.GITHUB_ENV
+        "CXX=x86_64-w64-mingw32-g++" >> $env.GITHUB_ENV
     - name: Configure environment
       shell: pwsh
       run: |

--- a/.github/actions/mingw-env/action.yml
+++ b/.github/actions/mingw-env/action.yml
@@ -1,0 +1,17 @@
+# Adapting https://github.com/microsoft/windows-rs/blob/master/.github/actions/fix-environment/action.yml
+# for waku windows builds to use desired binutils version.
+name: Fix environment
+description: GitHub VMs aren't configured correctly
+runs:
+  using: "composite"
+  steps:
+    - name: Update binutils (Windows)
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        update: true
+        pacboy: binutils
+    - name: Configure environment
+      shell: pwsh
+      run: |
+        "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,14 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      # Setup latest binutils for Windows
+      - name: Update binutils (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+          pacboy: binutils
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,14 +61,10 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      # Setup latest binutils for Windows
-      - name: Update binutils (Windows)
+      # Setup build environment (Windows)
+      - name: Setup build environment (Windows)
         if: matrix.os == 'windows-latest'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: mingw64
-          update: true
-          pacboy: binutils
+        uses: ./.github/actions/mingw-env
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,13 +44,13 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v3 # we need go to build go-waku
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       # Setup Rust toolchain with GNU for Windows
       - name: Setup Rust with GNU toolchain (Windows)
         if: matrix.os == 'windows-latest'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.1-gnu
+          toolchain: stable-gnu
           target: x86_64-pc-windows-gnu
           override: true
       # Setup Rust toolchain for other OSes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable-gnu
+          toolchain: 1.71.1-gnu
           target: x86_64-pc-windows-gnu
           override: true
       # Setup Rust toolchain for other OSes


### PR DESCRIPTION
Compilation on windows for waku features fails with  “corrupt .drectve”. The issue is similar to one described here: https://github.com/rust-lang/rust/issues/112368