### PR TITLE
Handle mixnet invalid fragment error

### DIFF
--- a/mixnet/client/src/error.rs
+++ b/mixnet/client/src/error.rs
@@ -11,6 +11,8 @@ pub enum MixnetClientError {
     UnexpectedStreamBody,
     #[error("invalid payload")]
     InvalidPayload,
+    #[error("invalid fragment")]
+    InvalidFragment,
     #[error("invalid routing address: {0}")]
     InvalidRoutingAddress(#[from] NymNodeRoutingAddressError),
     #[error("{0}")]

--- a/mixnet/client/src/receiver.rs
+++ b/mixnet/client/src/receiver.rs
@@ -90,7 +90,7 @@ impl Receiver {
             match next {
                 Ok(fragment) => {
                     if let Some(message) =
-                        Self::try_reconstruct_message(fragment, message_reconstructor)
+                        Self::try_reconstruct_message(fragment, message_reconstructor)?
                     {
                         return Ok(message);
                     }
@@ -108,14 +108,14 @@ impl Receiver {
     fn try_reconstruct_message(
         fragment: Fragment,
         message_reconstructor: &mut MessageReconstructor,
-    ) -> Option<Vec<u8>> {
+    ) -> Result<Option<Vec<u8>>> {
         let reconstruction_result = message_reconstructor.insert_new_fragment(fragment);
         match reconstruction_result {
             Some((padded_message, _)) => {
-                let message = Self::remove_padding(padded_message).unwrap();
-                Some(message)
+                let message = Self::remove_padding(padded_message)?;
+                Ok(Some(message))
             }
-            None => None,
+            None => Ok(None),
         }
     }
 
@@ -126,7 +126,7 @@ impl Receiver {
 
         match padded_message.remove_padding(dummy_num_mix_hops)? {
             NymMessage::Plain(msg) => Ok(msg),
-            _ => todo!("return error"),
+            _ => Err(MixnetClientError::InvalidFragment),
         }
     }
 }


### PR DESCRIPTION
Resolved the `todo!(..)` by returning a concrete error.

NEXT: Define the proper behaviour of the upper-most layer in error cases. We may need to recreate the stream or ignore invalid payloads/fragments https://github.com/logos-co/nomos-node/blob/2e46763475dc009f5ab4febf61e0857ba53ef3e5/nomos-services/network/src/backends/libp2p/mixnet.rs#L75-L75