### PR TITLE
Add `send` method to mempool network adapter

### DIFF
--- a/nodes/nomos-node/src/bridges/libp2p.rs
+++ b/nodes/nomos-node/src/bridges/libp2p.rs
@@ -3,11 +3,9 @@
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 // internal
-use nomos_core::wire;
 use nomos_http::http::HttpResponse;
 use nomos_network::backends::libp2p::{Command, Libp2p};
 use nomos_network::NetworkMsg;
-use nomos_node::Tx;
 use overwatch_rs::services::relay::OutboundRelay;
 
 pub(super) async fn handle_libp2p_info_req(
@@ -23,22 +21,6 @@ pub(super) async fn handle_libp2p_info_req(
 
     let info = receiver.await.unwrap();
     res_tx.send(Ok(serde_json::to_vec(&info)?.into())).await?;
-
-    Ok(())
-}
-
-pub(super) async fn libp2p_send_transaction(
-    network_relay: OutboundRelay<NetworkMsg<Libp2p>>,
-    tx: Tx,
-) -> Result<(), overwatch_rs::DynError> {
-    let payload = wire::serialize(&tx).expect("Tx serialization failed");
-    network_relay
-        .send(NetworkMsg::Process(Command::Broadcast {
-            topic: nomos_mempool::network::adapters::libp2p::CARNOT_TX_TOPIC.to_string(),
-            message: payload.into_boxed_slice(),
-        }))
-        .await
-        .map_err(|(e, _)| e)?;
 
     Ok(())
 }

--- a/nodes/nomos-node/src/bridges/mod.rs
+++ b/nodes/nomos-node/src/bridges/mod.rs
@@ -88,9 +88,7 @@ where
             res_tx, payload, ..
         }) = http_request_channel.recv().await
         {
-            if let Err(e) =
-                handle_mempool_add_tx_req(&handle, &mempool_channel, res_tx, payload).await
-            {
+            if let Err(e) = handle_mempool_add_tx_req(&mempool_channel, res_tx, payload).await {
                 error!(e);
             }
         }
@@ -141,7 +139,6 @@ async fn handle_mempool_metrics_req(
 }
 
 pub(super) async fn handle_mempool_add_tx_req(
-    handle: &overwatch_rs::overwatch::handle::OverwatchHandle,
     mempool_channel: &OutboundRelay<MempoolMsg<Tx, <Tx as Transaction>::Hash>>,
     res_tx: Sender<HttpResponse>,
     payload: Option<Bytes>,
@@ -162,12 +159,7 @@ pub(super) async fn handle_mempool_add_tx_req(
             .map_err(|(e, _)| e)?;
 
         match receiver.await {
-            Ok(Ok(())) => {
-                // broadcast transaction to peers
-                let network_relay = handle.relay::<NetworkService<Libp2p>>().connect().await?;
-                libp2p_send_transaction(network_relay, tx).await?;
-                Ok(res_tx.send(Ok(b"".to_vec().into())).await?)
-            }
+            Ok(Ok(())) => Ok(res_tx.send(Ok(b"".to_vec().into())).await?),
             Ok(Err(())) => Ok(res_tx
                 .send(Err((
                     StatusCode::CONFLICT,

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tokio-stream = "0.1"
 waku-bindings = { version = "0.1.1", optional = true}
+chrono = "0.4"
 
 [dev-dependencies]
 nomos-log = { path = "../log" }

--- a/nomos-services/mempool/src/lib.rs
+++ b/nomos-services/mempool/src/lib.rs
@@ -155,7 +155,7 @@ where
                         MempoolMsg::Add { item, key, reply_channel } => {
                             match pool.add_item(key, item.clone()) {
                                 Ok(_id) => {
-                                    // Broadcast the transaction to the network
+                                    // Broadcast the item to the network
                                     let net = network_relay.clone();
                                     let settings = service_state.settings_reader.get_updated_settings().network;
                                     // move sending to a new task so local operations can complete in the meantime

--- a/nomos-services/mempool/src/network/adapters/mock.rs
+++ b/nomos-services/mempool/src/network/adapters/mock.rs
@@ -93,4 +93,17 @@ impl NetworkAdapter for MockAdapter {
             },
         )))
     }
+
+    async fn send(&self, msg: Self::Item) {
+        if let Err((e, _)) = self
+            .network_relay
+            .send(NetworkMsg::Process(MockBackendMessage::Broadcast {
+                topic: MOCK_PUB_SUB_TOPIC.into(),
+                msg: msg.message().clone(),
+            }))
+            .await
+        {
+            tracing::error!("failed to send item to topic: {e}");
+        }
+    }
 }

--- a/nomos-services/mempool/src/network/mod.rs
+++ b/nomos-services/mempool/src/network/mod.rs
@@ -25,4 +25,6 @@ pub trait NetworkAdapter {
     async fn transactions_stream(
         &self,
     ) -> Box<dyn Stream<Item = (Self::Key, Self::Item)> + Unpin + Send>;
+
+    async fn send(&self, item: Self::Item);
 }


### PR DESCRIPTION
Centralize responsabilities for mempool-network interface in the adapter trait.