### PR TITLE
Add a second mempool for DA certificates

### DIFF
--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -10,7 +10,10 @@ use metrics::{backend::map::MapMetricsBackend, types::MetricsData, MetricsServic
 use nomos_consensus::network::adapters::libp2p::Libp2pAdapter as ConsensusLibp2pAdapter;
 
 use nomos_consensus::CarnotConsensus;
-use nomos_core::tx::Transaction;
+use nomos_core::{
+    da::{blob, certificate},
+    tx::Transaction,
+};
 use nomos_da::{
     backend::memory_cache::BlobCache, network::adapters::libp2p::Libp2pAdapter as DaLibp2pAdapter,
     DataAvailabilityService,
@@ -20,8 +23,10 @@ use nomos_http::bridge::HttpBridgeService;
 use nomos_http::http::HttpService;
 use nomos_log::Logger;
 use nomos_mempool::network::adapters::libp2p::Libp2pAdapter as MempoolLibp2pAdapter;
-use nomos_mempool::Transaction as TxDiscriminant;
-use nomos_mempool::{backend::mockpool::MockPool, MempoolService};
+use nomos_mempool::{
+    backend::mockpool::MockPool, Certificate as CertDiscriminant, MempoolService,
+    Transaction as TxDiscriminant,
+};
 use nomos_network::backends::libp2p::Libp2p;
 
 use nomos_network::NetworkService;
@@ -35,14 +40,20 @@ use nomos_core::{
 };
 pub use tx::Tx;
 
+pub const CL_TOPIC: &str = "cl";
+pub const DA_TOPIC: &str = "da";
 const MB16: usize = 1024 * 1024 * 16;
 
 pub type Carnot = CarnotConsensus<
     ConsensusLibp2pAdapter,
     MockPool<Tx, <Tx as Transaction>::Hash>,
     MempoolLibp2pAdapter<Tx, <Tx as Transaction>::Hash>,
+    MockPool<Certificate, <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash>,
+    MempoolLibp2pAdapter<
+        Certificate,
+        <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash,
+    >,
     FlatOverlay<RoundRobin, RandomBeaconState>,
-    Certificate,
     FillSizeWithTx<MB16, Tx>,
     FillSizeWithBlobsCertificate<MB16, Certificate>,
 >;
@@ -53,17 +64,20 @@ type DataAvailability = DataAvailabilityService<
     DaLibp2pAdapter<Blob, Attestation>,
 >;
 
-type Mempool = MempoolService<
-    MempoolLibp2pAdapter<Tx, <Tx as Transaction>::Hash>,
-    MockPool<Tx, <Tx as Transaction>::Hash>,
-    TxDiscriminant,
->;
+type Mempool<K, V, D> = MempoolService<MempoolLibp2pAdapter<K, V>, MockPool<K, V>, D>;
 
 #[derive(Services)]
 pub struct Nomos {
     logging: ServiceHandle<Logger>,
     network: ServiceHandle<NetworkService<Libp2p>>,
-    mockpool: ServiceHandle<Mempool>,
+    cl_mempool: ServiceHandle<Mempool<Tx, <Tx as Transaction>::Hash, TxDiscriminant>>,
+    da_mempool: ServiceHandle<
+        Mempool<
+            Certificate,
+            <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash,
+            CertDiscriminant,
+        >,
+    >,
     consensus: ServiceHandle<Carnot>,
     http: ServiceHandle<HttpService<AxumBackend>>,
     bridges: ServiceHandle<HttpBridgeService>,

--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -484,6 +484,7 @@ where
         carnot
     }
 
+    #[allow(clippy::type_complexity)]
     #[instrument(level = "debug", skip(adapter, task_manager, stream))]
     async fn process_block(
         mut carnot: Carnot<O>,
@@ -562,6 +563,7 @@ where
         (carnot, None)
     }
 
+    #[allow(clippy::type_complexity)]
     #[instrument(level = "debug", skip(task_manager, adapter))]
     async fn approve_new_view(
         carnot: Carnot<O>,
@@ -600,6 +602,7 @@ where
         (new_carnot, Some(Output::Send(out)))
     }
 
+    #[allow(clippy::type_complexity)]
     #[instrument(level = "debug", skip(task_manager, adapter))]
     async fn receive_timeout_qc(
         carnot: Carnot<O>,
@@ -627,6 +630,7 @@ where
         (new_state, None)
     }
 
+    #[allow(clippy::type_complexity)]
     #[instrument(level = "debug")]
     async fn process_root_timeout(
         carnot: Carnot<O>,

--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -41,8 +41,8 @@ use nomos_core::da::certificate::{BlobCertificateSelect, Certificate};
 use nomos_core::tx::{Transaction, TxSelect};
 use nomos_core::vote::Tally;
 use nomos_mempool::{
-    backend::MemPool, network::NetworkAdapter as MempoolAdapter, MempoolMsg, MempoolService,
-    Transaction as TxDiscriminant,
+    backend::MemPool, network::NetworkAdapter as MempoolAdapter, Certificate as CertDiscriminant,
+    MempoolMsg, MempoolService, Transaction as TxDiscriminant,
 };
 use nomos_network::NetworkService;
 use overwatch_rs::services::relay::{OutboundRelay, Relay, RelayMessage};
@@ -104,39 +104,46 @@ impl<O: Overlay, Ts, Bs> CarnotSettings<O, Ts, Bs> {
     }
 }
 
-pub struct CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
+pub struct CarnotConsensus<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS>
 where
     A: NetworkAdapter,
     ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key>,
     ClPool: MemPool,
+    DaPool: MemPool,
+    DaPoolAdapter: MempoolAdapter<Item = DaPool::Item, Key = DaPool::Key>,
     O: Overlay + Debug,
     ClPool::Item: Debug + 'static,
     ClPool::Key: Debug + 'static,
+    DaPool::Item: Debug + 'static,
+    DaPool::Key: Debug + 'static,
     A::Backend: 'static,
     TxS: TxSelect<Tx = ClPool::Item>,
-    BS: BlobCertificateSelect<Certificate = C>,
+    BS: BlobCertificateSelect<Certificate = DaPool::Item>,
 {
     service_state: ServiceStateHandle<Self>,
     // underlying networking backend. We need this so we can relay and check the types properly
     // when implementing ServiceCore for CarnotConsensus
     network_relay: Relay<NetworkService<A::Backend>>,
     cl_mempool_relay: Relay<MempoolService<ClPoolAdapter, ClPool, TxDiscriminant>>,
+    da_mempool_relay: Relay<MempoolService<DaPoolAdapter, DaPool, CertDiscriminant>>,
     _overlay: std::marker::PhantomData<O>,
-    // this need to be substituted by some kind DA bo
-    _blob_certificate: std::marker::PhantomData<C>,
 }
 
-impl<A, ClPool, ClPoolAdapter, O, C, TxS, BS> ServiceData
-    for CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
+impl<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS> ServiceData
+    for CarnotConsensus<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS>
 where
     A: NetworkAdapter,
     ClPool: MemPool,
     ClPool::Item: Debug,
     ClPool::Key: Debug,
+    DaPool: MemPool,
+    DaPool::Item: Debug,
+    DaPool::Key: Debug,
     ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key>,
+    DaPoolAdapter: MempoolAdapter<Item = DaPool::Item, Key = DaPool::Key>,
     O: Overlay + Debug,
     TxS: TxSelect<Tx = ClPool::Item>,
-    BS: BlobCertificateSelect<Certificate = C>,
+    BS: BlobCertificateSelect<Certificate = DaPool::Item>,
 {
     const SERVICE_ID: ServiceId = "Carnot";
     type Settings = CarnotSettings<O, TxS::Settings, BS::Settings>;
@@ -146,12 +153,14 @@ where
 }
 
 #[async_trait::async_trait]
-impl<A, ClPool, ClPoolAdapter, O, C, TxS, BS> ServiceCore
-    for CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
+impl<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS> ServiceCore
+    for CarnotConsensus<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS>
 where
     A: NetworkAdapter + Clone + Send + Sync + 'static,
     ClPool: MemPool + Send + Sync + 'static,
     ClPool::Settings: Send + Sync + 'static,
+    DaPool: MemPool + Send + Sync + 'static,
+    DaPool::Settings: Send + Sync + 'static,
     ClPool::Item: Transaction
         + Debug
         + Clone
@@ -162,7 +171,7 @@ where
         + Send
         + Sync
         + 'static,
-    C: Certificate
+    DaPool::Item: Certificate
         + Debug
         + Clone
         + Eq
@@ -173,24 +182,27 @@ where
         + Sync
         + 'static,
     ClPool::Key: Debug + Send + Sync,
+    DaPool::Key: Debug + Send + Sync,
     ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key> + Send + Sync + 'static,
+    DaPoolAdapter: MempoolAdapter<Item = DaPool::Item, Key = DaPool::Key> + Send + Sync + 'static,
     O: Overlay + Debug + Send + Sync + 'static,
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
     TxS: TxSelect<Tx = ClPool::Item> + Clone + Send + Sync + 'static,
     TxS::Settings: Send + Sync + 'static,
-    BS: BlobCertificateSelect<Certificate = C> + Clone + Send + Sync + 'static,
+    BS: BlobCertificateSelect<Certificate = DaPool::Item> + Clone + Send + Sync + 'static,
     BS::Settings: Send + Sync + 'static,
 {
     fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
         let network_relay = service_state.overwatch_handle.relay();
         let cl_mempool_relay = service_state.overwatch_handle.relay();
+        let da_mempool_relay = service_state.overwatch_handle.relay();
         Ok(Self {
             service_state,
             network_relay,
             _overlay: Default::default(),
-            _blob_certificate: Default::default(),
             cl_mempool_relay,
+            da_mempool_relay,
         })
     }
 
@@ -203,6 +215,12 @@ where
 
         let cl_mempool_relay: OutboundRelay<_> = self
             .cl_mempool_relay
+            .connect()
+            .await
+            .expect("Relay connection with MemPoolService should succeed");
+
+        let da_mempool_relay: OutboundRelay<_> = self
+            .da_mempool_relay
             .connect()
             .await
             .expect("Relay connection with MemPoolService should succeed");
@@ -290,6 +308,7 @@ where
                             adapter.clone(),
                             private_key,
                             cl_mempool_relay.clone(),
+                            da_mempool_relay.clone(),
                             tx_selector.clone(),
                             blob_selector.clone(),
                             timeout,
@@ -316,12 +335,14 @@ enum Output<Tx: Clone + Eq + Hash, BlobCertificate: Clone + Eq + Hash> {
     },
 }
 
-impl<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
-    CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
+impl<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS>
+    CarnotConsensus<A, ClPool, ClPoolAdapter, DaPool, DaPoolAdapter, O, TxS, BS>
 where
     A: NetworkAdapter + Clone + Send + Sync + 'static,
     ClPool: MemPool + Send + Sync + 'static,
     ClPool::Settings: Send + Sync + 'static,
+    DaPool: MemPool + Send + Sync + 'static,
+    DaPool::Settings: Send + Sync + 'static,
     ClPool::Item: Transaction
         + Debug
         + Clone
@@ -332,7 +353,7 @@ where
         + Send
         + Sync
         + 'static,
-    C: Certificate
+    DaPool::Item: Certificate
         + Debug
         + Clone
         + Eq
@@ -346,13 +367,11 @@ where
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
     TxS: TxSelect<Tx = ClPool::Item> + Clone + Send + Sync + 'static,
-    BS: BlobCertificateSelect<Certificate = C> + Clone + Send + Sync + 'static,
+    BS: BlobCertificateSelect<Certificate = DaPool::Item> + Clone + Send + Sync + 'static,
     ClPool::Key: Debug + Send + Sync,
+    DaPool::Key: Debug + Send + Sync,
     ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key> + Send + Sync + 'static,
-    O: Overlay + Debug + Send + Sync + 'static,
-    O::LeaderSelection: UpdateableLeaderSelection,
-    O::CommitteeMembership: UpdateableCommitteeMembership,
-    TxS: TxSelect<Tx = ClPool::Item> + Clone + Send + Sync + 'static,
+    DaPoolAdapter: MempoolAdapter<Item = DaPool::Item, Key = DaPool::Key> + Send + Sync + 'static,
 {
     fn process_message(carnot: &Carnot<O>, msg: ConsensusMsg) {
         match msg {
@@ -376,11 +395,12 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn process_carnot_event(
         mut carnot: Carnot<O>,
-        event: Event<ClPool::Item, C>,
-        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
+        event: Event<ClPool::Item, DaPool::Item>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, DaPool::Item>>,
         adapter: A,
         private_key: PrivateKey,
         cl_mempool_relay: OutboundRelay<MempoolMsg<ClPool::Item, ClPool::Key>>,
+        da_mempool_relay: OutboundRelay<MempoolMsg<DaPool::Item, DaPool::Key>>,
         tx_selector: TxS,
         blobl_selector: BS,
         timeout: Duration,
@@ -396,7 +416,7 @@ where
                 tracing::debug!("approving proposal {:?}", block);
                 let (new_carnot, out) = carnot.approve_block(block);
                 carnot = new_carnot;
-                output = Some(Output::Send::<ClPool::Item, C>(out));
+                output = Some(Output::Send::<ClPool::Item, DaPool::Item>(out));
             }
             Event::LocalTimeout { view } => {
                 tracing::debug!("local timeout");
@@ -438,6 +458,7 @@ where
                     tx_selector.clone(),
                     blobl_selector.clone(),
                     cl_mempool_relay,
+                    da_mempool_relay,
                 )
                 .await;
             }
@@ -466,11 +487,11 @@ where
     #[instrument(level = "debug", skip(adapter, task_manager, stream))]
     async fn process_block(
         mut carnot: Carnot<O>,
-        block: Block<ClPool::Item, C>,
-        mut stream: Pin<Box<dyn Stream<Item = Block<ClPool::Item, C>> + Send>>,
-        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
+        block: Block<ClPool::Item, DaPool::Item>,
+        mut stream: Pin<Box<dyn Stream<Item = Block<ClPool::Item, DaPool::Item>> + Send>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, DaPool::Item>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, DaPool::Item>>) {
         tracing::debug!("received proposal {:?}", block);
         if carnot.highest_voted_view() >= block.header().view {
             tracing::debug!("already voted for view {}", block.header().view);
@@ -546,9 +567,9 @@ where
         carnot: Carnot<O>,
         timeout_qc: TimeoutQc,
         new_views: HashSet<NewView>,
-        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, DaPool::Item>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, DaPool::Item>>) {
         let leader_committee = [carnot.id()].into_iter().collect();
         let leader_tally_settings = CarnotTallySettings {
             threshold: carnot.leader_super_majority_threshold(),
@@ -583,9 +604,9 @@ where
     async fn receive_timeout_qc(
         carnot: Carnot<O>,
         timeout_qc: TimeoutQc,
-        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, DaPool::Item>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, DaPool::Item>>) {
         let mut new_state = carnot.receive_timeout_qc(timeout_qc.clone());
         let self_committee = carnot.self_committee();
         let tally_settings = CarnotTallySettings {
@@ -610,7 +631,7 @@ where
     async fn process_root_timeout(
         carnot: Carnot<O>,
         timeouts: HashSet<Timeout>,
-    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, DaPool::Item>>) {
         // we might have received a timeout_qc sent by some other node and advanced the view
         // already, in which case we should ignore the timeout
         if carnot.current_view()
@@ -646,7 +667,13 @@ where
 
     #[instrument(
         level = "debug",
-        skip(cl_mempool_relay, private_key, tx_selector, blob_selector)
+        skip(
+            cl_mempool_relay,
+            da_mempool_relay,
+            private_key,
+            tx_selector,
+            blob_selector
+        )
     )]
     async fn propose_block(
         id: NodeId,
@@ -655,34 +682,30 @@ where
         tx_selector: TxS,
         blob_selector: BS,
         cl_mempool_relay: OutboundRelay<MempoolMsg<ClPool::Item, ClPool::Key>>,
-    ) -> Option<Output<ClPool::Item, C>> {
-        let (reply_channel, rx) = tokio::sync::oneshot::channel();
+        da_mempool_relay: OutboundRelay<MempoolMsg<DaPool::Item, DaPool::Key>>,
+    ) -> Option<Output<ClPool::Item, DaPool::Item>> {
         let mut output = None;
-        cl_mempool_relay
-            .send(MempoolMsg::View {
-                ancestor_hint: BlockId::zeros(),
-                reply_channel,
-            })
-            .await
-            .unwrap_or_else(|(e, _)| eprintln!("Could not get transactions from mempool {e}"));
+        let cl_txs = get_mempool_contents(cl_mempool_relay);
+        let da_certs = get_mempool_contents(da_mempool_relay);
 
-        match rx.await {
-            Ok(txs) => {
+        match futures::join!(cl_txs, da_certs) {
+            (Ok(cl_txs), Ok(da_certs)) => {
                 let beacon = RandomBeaconState::generate_happy(qc.view(), &private_key);
                 let Ok(proposal) = BlockBuilder::new(tx_selector, blob_selector)
                     .with_view(qc.view().next())
                     .with_parent_qc(qc)
                     .with_proposer(id)
                     .with_beacon_state(beacon)
-                    .with_transactions(txs)
-                    .with_blobs_certificates([].into_iter())
+                    .with_transactions(cl_txs)
+                    .with_blobs_certificates(da_certs)
                     .build()
                 else {
                     panic!("Proposal block should always succeed to be built")
                 };
                 output = Some(Output::BroadcastProposal { proposal });
             }
-            Err(e) => tracing::error!("Could not fetch txs {e}"),
+            (Err(_), _) => tracing::error!("Could not fetch block cl transactions"),
+            (_, Err(_)) => tracing::error!("Could not fetch block da certificates"),
         }
         output
     }
@@ -690,7 +713,7 @@ where
     async fn process_view_change(
         carnot: Carnot<O>,
         prev_view: View,
-        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, DaPool::Item>>,
         adapter: A,
         timeout: Duration,
     ) {
@@ -727,7 +750,10 @@ where
         }
     }
 
-    async fn gather_timeout_qc(adapter: A, view: consensus_engine::View) -> Event<ClPool::Item, C> {
+    async fn gather_timeout_qc(
+        adapter: A,
+        view: consensus_engine::View,
+    ) -> Event<ClPool::Item, DaPool::Item> {
         if let Some(timeout_qc) = adapter
             .timeout_qc_stream(view)
             .await
@@ -747,7 +773,7 @@ where
         committee: Committee,
         block: consensus_engine::Block,
         tally: CarnotTallySettings,
-    ) -> Event<ClPool::Item, C> {
+    ) -> Event<ClPool::Item, DaPool::Item> {
         let tally = CarnotTally::new(tally);
         let votes_stream = adapter.votes_stream(&committee, block.view, block.id).await;
         match tally.tally(block.clone(), votes_stream).await {
@@ -764,7 +790,7 @@ where
         committee: Committee,
         timeout_qc: TimeoutQc,
         tally: CarnotTallySettings,
-    ) -> Event<ClPool::Item, C> {
+    ) -> Event<ClPool::Item, DaPool::Item> {
         let tally = NewViewTally::new(tally);
         let stream = adapter
             .new_view_stream(&committee, timeout_qc.view().next())
@@ -786,7 +812,7 @@ where
         committee: Committee,
         view: consensus_engine::View,
         tally: CarnotTallySettings,
-    ) -> Event<ClPool::Item, C> {
+    ) -> Event<ClPool::Item, DaPool::Item> {
         let tally = TimeoutTally::new(tally);
         let stream = adapter.timeout_stream(&committee, view).await;
         match tally.tally(view, stream).await {
@@ -798,7 +824,10 @@ where
     }
 
     #[instrument(level = "debug", skip(adapter))]
-    async fn gather_block(adapter: A, view: consensus_engine::View) -> Event<ClPool::Item, C> {
+    async fn gather_block(
+        adapter: A,
+        view: consensus_engine::View,
+    ) -> Event<ClPool::Item, DaPool::Item> {
         let stream = adapter
             .proposal_chunks_stream(view)
             .await
@@ -1018,4 +1047,20 @@ mod tests {
         let deserialized: CarnotInfo = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, info);
     }
+}
+
+async fn get_mempool_contents<Item, Key>(
+    mempool: OutboundRelay<MempoolMsg<Item, Key>>,
+) -> Result<Box<dyn Iterator<Item = Item> + Send>, tokio::sync::oneshot::error::RecvError> {
+    let (reply_channel, rx) = tokio::sync::oneshot::channel();
+
+    mempool
+        .send(MempoolMsg::View {
+            ancestor_hint: BlockId::zeros(),
+            reply_channel,
+        })
+        .await
+        .unwrap_or_else(|(e, _)| eprintln!("Could not get transactions from mempool {e}"));
+
+    rx.await
 }

--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -104,37 +104,38 @@ impl<O: Overlay, Ts, Bs> CarnotSettings<O, Ts, Bs> {
     }
 }
 
-pub struct CarnotConsensus<A, P, M, O, C, TxS, BS>
+pub struct CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
 where
     A: NetworkAdapter,
-    M: MempoolAdapter<Item = P::Item, Key = P::Key>,
-    P: MemPool,
+    ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key>,
+    ClPool: MemPool,
     O: Overlay + Debug,
-    P::Item: Debug + 'static,
-    P::Key: Debug + 'static,
+    ClPool::Item: Debug + 'static,
+    ClPool::Key: Debug + 'static,
     A::Backend: 'static,
-    TxS: TxSelect<Tx = P::Item>,
+    TxS: TxSelect<Tx = ClPool::Item>,
     BS: BlobCertificateSelect<Certificate = C>,
 {
     service_state: ServiceStateHandle<Self>,
     // underlying networking backend. We need this so we can relay and check the types properly
     // when implementing ServiceCore for CarnotConsensus
     network_relay: Relay<NetworkService<A::Backend>>,
-    mempool_relay: Relay<MempoolService<M, P, TxDiscriminant>>,
+    cl_mempool_relay: Relay<MempoolService<ClPoolAdapter, ClPool, TxDiscriminant>>,
     _overlay: std::marker::PhantomData<O>,
     // this need to be substituted by some kind DA bo
     _blob_certificate: std::marker::PhantomData<C>,
 }
 
-impl<A, P, M, O, C, TxS, BS> ServiceData for CarnotConsensus<A, P, M, O, C, TxS, BS>
+impl<A, ClPool, ClPoolAdapter, O, C, TxS, BS> ServiceData
+    for CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
 where
     A: NetworkAdapter,
-    P: MemPool,
-    P::Item: Debug,
-    P::Key: Debug,
-    M: MempoolAdapter<Item = P::Item, Key = P::Key>,
+    ClPool: MemPool,
+    ClPool::Item: Debug,
+    ClPool::Key: Debug,
+    ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key>,
     O: Overlay + Debug,
-    TxS: TxSelect<Tx = P::Item>,
+    TxS: TxSelect<Tx = ClPool::Item>,
     BS: BlobCertificateSelect<Certificate = C>,
 {
     const SERVICE_ID: ServiceId = "Carnot";
@@ -145,12 +146,13 @@ where
 }
 
 #[async_trait::async_trait]
-impl<A, P, M, O, C, TxS, BS> ServiceCore for CarnotConsensus<A, P, M, O, C, TxS, BS>
+impl<A, ClPool, ClPoolAdapter, O, C, TxS, BS> ServiceCore
+    for CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
 where
     A: NetworkAdapter + Clone + Send + Sync + 'static,
-    P: MemPool + Send + Sync + 'static,
-    P::Settings: Send + Sync + 'static,
-    P::Item: Transaction
+    ClPool: MemPool + Send + Sync + 'static,
+    ClPool::Settings: Send + Sync + 'static,
+    ClPool::Item: Transaction
         + Debug
         + Clone
         + Eq
@@ -170,25 +172,25 @@ where
         + Send
         + Sync
         + 'static,
-    P::Key: Debug + Send + Sync,
-    M: MempoolAdapter<Item = P::Item, Key = P::Key> + Send + Sync + 'static,
+    ClPool::Key: Debug + Send + Sync,
+    ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key> + Send + Sync + 'static,
     O: Overlay + Debug + Send + Sync + 'static,
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
-    TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
+    TxS: TxSelect<Tx = ClPool::Item> + Clone + Send + Sync + 'static,
     TxS::Settings: Send + Sync + 'static,
     BS: BlobCertificateSelect<Certificate = C> + Clone + Send + Sync + 'static,
     BS::Settings: Send + Sync + 'static,
 {
     fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
         let network_relay = service_state.overwatch_handle.relay();
-        let mempool_relay = service_state.overwatch_handle.relay();
+        let cl_mempool_relay = service_state.overwatch_handle.relay();
         Ok(Self {
             service_state,
             network_relay,
             _overlay: Default::default(),
             _blob_certificate: Default::default(),
-            mempool_relay,
+            cl_mempool_relay,
         })
     }
 
@@ -199,8 +201,8 @@ where
             .await
             .expect("Relay connection with NetworkService should succeed");
 
-        let mempool_relay: OutboundRelay<_> = self
-            .mempool_relay
+        let cl_mempool_relay: OutboundRelay<_> = self
+            .cl_mempool_relay
             .connect()
             .await
             .expect("Relay connection with MemPoolService should succeed");
@@ -287,7 +289,7 @@ where
                             &mut task_manager,
                             adapter.clone(),
                             private_key,
-                            mempool_relay.clone(),
+                            cl_mempool_relay.clone(),
                             tx_selector.clone(),
                             blob_selector.clone(),
                             timeout,
@@ -314,12 +316,13 @@ enum Output<Tx: Clone + Eq + Hash, BlobCertificate: Clone + Eq + Hash> {
     },
 }
 
-impl<A, P, M, O, C, TxS, BS> CarnotConsensus<A, P, M, O, C, TxS, BS>
+impl<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
+    CarnotConsensus<A, ClPool, ClPoolAdapter, O, C, TxS, BS>
 where
     A: NetworkAdapter + Clone + Send + Sync + 'static,
-    P: MemPool + Send + Sync + 'static,
-    P::Settings: Send + Sync + 'static,
-    P::Item: Transaction
+    ClPool: MemPool + Send + Sync + 'static,
+    ClPool::Settings: Send + Sync + 'static,
+    ClPool::Item: Transaction
         + Debug
         + Clone
         + Eq
@@ -342,14 +345,14 @@ where
     O: Overlay + Debug + Send + Sync + 'static,
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
-    TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
+    TxS: TxSelect<Tx = ClPool::Item> + Clone + Send + Sync + 'static,
     BS: BlobCertificateSelect<Certificate = C> + Clone + Send + Sync + 'static,
-    P::Key: Debug + Send + Sync,
-    M: MempoolAdapter<Item = P::Item, Key = P::Key> + Send + Sync + 'static,
+    ClPool::Key: Debug + Send + Sync,
+    ClPoolAdapter: MempoolAdapter<Item = ClPool::Item, Key = ClPool::Key> + Send + Sync + 'static,
     O: Overlay + Debug + Send + Sync + 'static,
     O::LeaderSelection: UpdateableLeaderSelection,
     O::CommitteeMembership: UpdateableCommitteeMembership,
-    TxS: TxSelect<Tx = P::Item> + Clone + Send + Sync + 'static,
+    TxS: TxSelect<Tx = ClPool::Item> + Clone + Send + Sync + 'static,
 {
     fn process_message(carnot: &Carnot<O>, msg: ConsensusMsg) {
         match msg {
@@ -373,11 +376,11 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn process_carnot_event(
         mut carnot: Carnot<O>,
-        event: Event<P::Item, C>,
-        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
+        event: Event<ClPool::Item, C>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
         adapter: A,
         private_key: PrivateKey,
-        mempool_relay: OutboundRelay<MempoolMsg<P::Item, P::Key>>,
+        cl_mempool_relay: OutboundRelay<MempoolMsg<ClPool::Item, ClPool::Key>>,
         tx_selector: TxS,
         blobl_selector: BS,
         timeout: Duration,
@@ -393,7 +396,7 @@ where
                 tracing::debug!("approving proposal {:?}", block);
                 let (new_carnot, out) = carnot.approve_block(block);
                 carnot = new_carnot;
-                output = Some(Output::Send::<P::Item, C>(out));
+                output = Some(Output::Send::<ClPool::Item, C>(out));
             }
             Event::LocalTimeout { view } => {
                 tracing::debug!("local timeout");
@@ -434,7 +437,7 @@ where
                     qc,
                     tx_selector.clone(),
                     blobl_selector.clone(),
-                    mempool_relay,
+                    cl_mempool_relay,
                 )
                 .await;
             }
@@ -463,11 +466,11 @@ where
     #[instrument(level = "debug", skip(adapter, task_manager, stream))]
     async fn process_block(
         mut carnot: Carnot<O>,
-        block: Block<P::Item, C>,
-        mut stream: Pin<Box<dyn Stream<Item = Block<P::Item, C>> + Send>>,
-        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
+        block: Block<ClPool::Item, C>,
+        mut stream: Pin<Box<dyn Stream<Item = Block<ClPool::Item, C>> + Send>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
         tracing::debug!("received proposal {:?}", block);
         if carnot.highest_voted_view() >= block.header().view {
             tracing::debug!("already voted for view {}", block.header().view);
@@ -543,9 +546,9 @@ where
         carnot: Carnot<O>,
         timeout_qc: TimeoutQc,
         new_views: HashSet<NewView>,
-        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
         let leader_committee = [carnot.id()].into_iter().collect();
         let leader_tally_settings = CarnotTallySettings {
             threshold: carnot.leader_super_majority_threshold(),
@@ -580,9 +583,9 @@ where
     async fn receive_timeout_qc(
         carnot: Carnot<O>,
         timeout_qc: TimeoutQc,
-        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
         adapter: A,
-    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
         let mut new_state = carnot.receive_timeout_qc(timeout_qc.clone());
         let self_committee = carnot.self_committee();
         let tally_settings = CarnotTallySettings {
@@ -607,7 +610,7 @@ where
     async fn process_root_timeout(
         carnot: Carnot<O>,
         timeouts: HashSet<Timeout>,
-    ) -> (Carnot<O>, Option<Output<P::Item, C>>) {
+    ) -> (Carnot<O>, Option<Output<ClPool::Item, C>>) {
         // we might have received a timeout_qc sent by some other node and advanced the view
         // already, in which case we should ignore the timeout
         if carnot.current_view()
@@ -643,7 +646,7 @@ where
 
     #[instrument(
         level = "debug",
-        skip(mempool_relay, private_key, tx_selector, blob_selector)
+        skip(cl_mempool_relay, private_key, tx_selector, blob_selector)
     )]
     async fn propose_block(
         id: NodeId,
@@ -651,11 +654,11 @@ where
         qc: Qc,
         tx_selector: TxS,
         blob_selector: BS,
-        mempool_relay: OutboundRelay<MempoolMsg<P::Item, P::Key>>,
-    ) -> Option<Output<P::Item, C>> {
+        cl_mempool_relay: OutboundRelay<MempoolMsg<ClPool::Item, ClPool::Key>>,
+    ) -> Option<Output<ClPool::Item, C>> {
         let (reply_channel, rx) = tokio::sync::oneshot::channel();
         let mut output = None;
-        mempool_relay
+        cl_mempool_relay
             .send(MempoolMsg::View {
                 ancestor_hint: BlockId::zeros(),
                 reply_channel,
@@ -687,7 +690,7 @@ where
     async fn process_view_change(
         carnot: Carnot<O>,
         prev_view: View,
-        task_manager: &mut TaskManager<View, Event<P::Item, C>>,
+        task_manager: &mut TaskManager<View, Event<ClPool::Item, C>>,
         adapter: A,
         timeout: Duration,
     ) {
@@ -724,7 +727,7 @@ where
         }
     }
 
-    async fn gather_timeout_qc(adapter: A, view: consensus_engine::View) -> Event<P::Item, C> {
+    async fn gather_timeout_qc(adapter: A, view: consensus_engine::View) -> Event<ClPool::Item, C> {
         if let Some(timeout_qc) = adapter
             .timeout_qc_stream(view)
             .await
@@ -744,7 +747,7 @@ where
         committee: Committee,
         block: consensus_engine::Block,
         tally: CarnotTallySettings,
-    ) -> Event<P::Item, C> {
+    ) -> Event<ClPool::Item, C> {
         let tally = CarnotTally::new(tally);
         let votes_stream = adapter.votes_stream(&committee, block.view, block.id).await;
         match tally.tally(block.clone(), votes_stream).await {
@@ -761,7 +764,7 @@ where
         committee: Committee,
         timeout_qc: TimeoutQc,
         tally: CarnotTallySettings,
-    ) -> Event<P::Item, C> {
+    ) -> Event<ClPool::Item, C> {
         let tally = NewViewTally::new(tally);
         let stream = adapter
             .new_view_stream(&committee, timeout_qc.view().next())
@@ -783,7 +786,7 @@ where
         committee: Committee,
         view: consensus_engine::View,
         tally: CarnotTallySettings,
-    ) -> Event<P::Item, C> {
+    ) -> Event<ClPool::Item, C> {
         let tally = TimeoutTally::new(tally);
         let stream = adapter.timeout_stream(&committee, view).await;
         match tally.tally(view, stream).await {
@@ -795,7 +798,7 @@ where
     }
 
     #[instrument(level = "debug", skip(adapter))]
-    async fn gather_block(adapter: A, view: consensus_engine::View) -> Event<P::Item, C> {
+    async fn gather_block(adapter: A, view: consensus_engine::View) -> Event<ClPool::Item, C> {
         let stream = adapter
             .proposal_chunks_stream(view)
             .await


### PR DESCRIPTION
Add a separate mempool for DA certificates. This approach was chosen over a single shared mempool to allow for greater customization.

Also adds the relevant endpoint to add certificates and inspect metrics