### PR TITLE
Fix clippy and check warnings on released rust 1.73

### DIFF
--- a/consensus-engine/src/overlay/random_beacon.rs
+++ b/consensus-engine/src/overlay/random_beacon.rs
@@ -4,7 +4,7 @@ use bls_signatures::{PrivateKey, PublicKey, Serialize, Signature};
 use rand::{seq::SliceRandom, SeedableRng};
 use serde::{Deserialize, Serialize as SerdeSerialize};
 use sha2::{Digest, Sha256};
-use std::ops::Deref;
+
 use thiserror::Error;
 
 use super::LeaderSelection;
@@ -96,7 +96,7 @@ fn view_to_bytes(view: View) -> Box<[u8]> {
 // for now, just use something that works
 fn choice(state: &RandomBeaconState, nodes: &[NodeId]) -> NodeId {
     let mut seed = [0; 32];
-    seed.copy_from_slice(&state.entropy().deref()[..32]);
+    seed.copy_from_slice(&state.entropy()[..32]);
     let mut rng = rand_chacha::ChaChaRng::from_seed(seed);
     *nodes.choose(&mut rng).unwrap()
 }
@@ -110,7 +110,7 @@ impl LeaderSelection for RandomBeaconState {
 impl CommitteeMembership for RandomBeaconState {
     fn reshape_committees(&self, nodes: &mut [NodeId]) {
         let mut seed = [0; 32];
-        seed.copy_from_slice(&self.entropy().deref()[..32]);
+        seed.copy_from_slice(&self.entropy()[..32]);
         FisherYatesShuffle::shuffle(nodes, seed);
     }
 }

--- a/consensus-engine/tests/fuzz/ref_state.rs
+++ b/consensus-engine/tests/fuzz/ref_state.rs
@@ -154,7 +154,7 @@ impl ReferenceStateMachine for RefState {
             }
             Transition::ApproveNewViewWithLatestTimeoutQc(timeout_qc, _) => {
                 let new_view = RefState::new_view_from(timeout_qc);
-                state.chain.entry(new_view).or_insert(ViewEntry::new());
+                state.chain.entry(new_view).or_default();
                 state.highest_voted_view = new_view;
             }
         }
@@ -407,10 +407,6 @@ impl RefState {
 }
 
 impl ViewEntry {
-    fn new() -> ViewEntry {
-        Default::default()
-    }
-
     fn is_empty(&self) -> bool {
         self.blocks.is_empty() && self.timeout_qcs.is_empty()
     }

--- a/nomos-da/full-replication/Cargo.toml
+++ b/nomos-da/full-replication/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 blake2 = { version = "0.10" }
-bytes = { versino = "1.3", features = ["serde"] }
+bytes = { version = "1.3", features = ["serde"] }
 nomos-core = { path = "../../nomos-core" }
 serde = { version = "1.0", features = ["derive"] }

--- a/nomos-services/consensus/src/network/adapters/mock.rs
+++ b/nomos-services/consensus/src/network/adapters/mock.rs
@@ -88,10 +88,12 @@ impl NetworkAdapter for MockAdapter {
         self.send(message, &Committee::default()).await
     }
 
+    #[allow(clippy::diverging_sub_expression)]
     async fn timeout_stream(&self, _committee: &Committee, _view: View) -> BoxedStream<TimeoutMsg> {
         todo!()
     }
 
+    #[allow(clippy::diverging_sub_expression)]
     async fn timeout_qc_stream(&self, _view: View) -> BoxedStream<TimeoutQcMsg> {
         todo!()
     }
@@ -122,6 +124,7 @@ impl NetworkAdapter for MockAdapter {
         )))
     }
 
+    #[allow(clippy::diverging_sub_expression)]
     async fn new_view_stream(&self, _: &Committee, _view: View) -> BoxedStream<NewViewMsg> {
         todo!()
     }

--- a/nomos-services/metrics/src/lib.rs
+++ b/nomos-services/metrics/src/lib.rs
@@ -108,7 +108,7 @@ impl<Backend: MetricsBackend> ServiceData for MetricsService<Backend> {
 
 impl<Backend: MetricsBackend> MetricsService<Backend> {
     async fn handle_load(
-        backend: &mut Backend,
+        backend: &Backend,
         service_id: &OwnedServiceId,
         reply_channel: tokio::sync::oneshot::Sender<Option<Backend::MetricsData>>,
     ) {
@@ -153,7 +153,7 @@ impl<Backend: MetricsBackend + Send + Sync + 'static> ServiceCore for MetricsSer
                     service_id,
                     reply_channel,
                 } => {
-                    MetricsService::handle_load(&mut backend, &service_id, reply_channel).await;
+                    MetricsService::handle_load(&backend, &service_id, reply_channel).await;
                 }
                 MetricsMessage::Update { service_id, data } => {
                     MetricsService::handle_update(&mut backend, &service_id, data).await;

--- a/nomos-services/network/src/backends/mock.rs
+++ b/nomos-services/network/src/backends/mock.rs
@@ -266,7 +266,7 @@ impl NetworkBackend for Mock {
                     .lock()
                     .unwrap()
                     .entry(topic)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(msg.clone());
                 let _ = self.message_event.send(NetworkEvent::RawMessage(msg));
             }

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -17,6 +17,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time"] }
+tempfile = "3"
 
 [features]
 default = []

--- a/nomos-services/storage/src/backends/sled.rs
+++ b/nomos-services/storage/src/backends/sled.rs
@@ -123,21 +123,19 @@ mod test {
         let sled_settings = SledBackendSettings {
             db_path: temp_path.path().to_path_buf(),
         };
-        let key = "foo";
-        let value = "bar";
 
         let mut sled_db: SledBackend<NoStorageSerde> = SledBackend::new(sled_settings)?;
         let result = sled_db
             .execute(Box::new(move |tx| {
-                let key = key;
-                let value = value;
+                let key = "foo";
+                let value = "bar";
                 tx.insert(key, value)?;
                 let result = tx.get(key)?;
                 tx.remove(key)?;
                 Ok(result.map(|ivec| ivec.to_vec().into()))
             }))
             .await??;
-        assert_eq!(result, Some(value.as_bytes().into()));
+        assert_eq!(result, Some("bar".as_bytes().into()));
 
         Ok(())
     }

--- a/tests/src/tests/mixnet.rs
+++ b/tests/src/tests/mixnet.rs
@@ -75,9 +75,9 @@ async fn run_nodes_and_destination_client() -> (
         ..Default::default()
     };
 
-    let mixnode1 = MixnetNode::new(config1.clone());
-    let mixnode2 = MixnetNode::new(config2.clone());
-    let mixnode3 = MixnetNode::new(config3.clone());
+    let mixnode1 = MixnetNode::new(config1);
+    let mixnode2 = MixnetNode::new(config2);
+    let mixnode3 = MixnetNode::new(config3);
 
     let topology = MixnetTopology {
         layers: vec![


### PR DESCRIPTION
As Rust release 1.73, there are new clippy rules which make our CI always fail.