### PR TITLE
Add default for `MixnetClientConfig::connection_pool_size`

### DIFF
--- a/mixnet/client/Cargo.toml
+++ b/mixnet/client/Cargo.toml
@@ -16,3 +16,6 @@ mixnet-topology = { path = "../topology" }
 mixnet-util = { path = "../util" }
 futures = "0.3.28"
 thiserror = "1"
+
+[dev-dependencies]
+serde_yaml = "0.9.25"

--- a/mixnet/client/src/config.rs
+++ b/mixnet/client/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{receiver::Receiver, MessageStream, MixnetClientError};
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct MixnetClientConfig {
     pub mode: MixnetClientMode,
     pub topology: MixnetTopology,
@@ -43,7 +43,7 @@ impl MixnetClientConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum MixnetClientMode {
     Sender,
     SenderReceiver(SocketAddr),

--- a/mixnet/topology/src/lib.rs
+++ b/mixnet/topology/src/lib.rs
@@ -9,17 +9,17 @@ pub type MixnetNodeId = [u8; PUBLIC_KEY_SIZE];
 
 pub type Result<T> = core::result::Result<T, NymNodeRoutingAddressError>;
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct MixnetTopology {
     pub layers: Vec<Layer>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Layer {
     pub nodes: Vec<Node>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Node {
     #[serde(with = "addr_serde")]
     pub address: SocketAddr,

--- a/mixnet/topology/src/lib.rs
+++ b/mixnet/topology/src/lib.rs
@@ -9,17 +9,17 @@ pub type MixnetNodeId = [u8; PUBLIC_KEY_SIZE];
 
 pub type Result<T> = core::result::Result<T, NymNodeRoutingAddressError>;
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct MixnetTopology {
     pub layers: Vec<Layer>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Layer {
     pub nodes: Vec<Node>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Node {
     #[serde(with = "addr_serde")]
     pub address: SocketAddr,


### PR DESCRIPTION
Closes #459 

@zeegomo 
As @al8n mentioned in https://github.com/logos-co/nomos-node/issues/459#issuecomment-1764760768, the default value of `max_retries` and `retry_delay` have been already defined, so that the default values can be used if nothing is set in the yaml. 
In addition to it, I defined the default of `connection_pool_size` as well.
I'm not sure if this is what you intended. Please let me know if you need something more.