### PR TITLE
Human serde committeeid

### DIFF
--- a/consensus-engine/src/types/committee.rs
+++ b/consensus-engine/src/types/committee.rs
@@ -3,8 +3,24 @@ use std::collections::BTreeSet;
 use crate::NodeId;
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommitteeId(pub(crate) [u8; 32]);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for CommitteeId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        nomos_utils::serde::serialize_bytes_array(self.0, serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Deserialize<'de> for CommitteeId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        nomos_utils::serde::deserialize_bytes_array(deserializer).map(Self)
+    }
+}
 
 impl CommitteeId {
     pub const fn new(val: [u8; 32]) -> Self {

--- a/nomos-utils/src/lib.rs
+++ b/nomos-utils/src/lib.rs
@@ -25,7 +25,7 @@ pub mod serde {
         deserializer: D,
     ) -> Result<[u8; N], D::Error> {
         use serde::Deserialize;
-        let s = <&[u8]>::deserialize(deserializer)?;
+        let s = String::deserialize(deserializer)?;
         let mut output = [0u8; N];
         const_hex::decode_to_slice(s, &mut output)
             .map(|_| output)

--- a/nomos-utils/src/lib.rs
+++ b/nomos-utils/src/lib.rs
@@ -25,9 +25,10 @@ pub mod serde {
         deserializer: D,
     ) -> Result<[u8; N], D::Error> {
         use serde::Deserialize;
-        let s = String::deserialize(deserializer)?;
+        use std::borrow::Cow;
+        let s: Cow<str> = Cow::deserialize(deserializer)?;
         let mut output = [0u8; N];
-        const_hex::decode_to_slice(s, &mut output)
+        const_hex::decode_to_slice(s.as_ref(), &mut output)
             .map(|_| output)
             .map_err(<D::Error as serde::de::Error>::custom)
     }


### PR DESCRIPTION
Added committee id ser/de, it's needed for simulation topology info.
Also YAML doesn't support deserializing to bytes (https://github.com/dtolnay/serde-yaml/blob/master/tests/test_error.rs#L123), that's why if it's trying to deser a human readable variant, it'll deserialize to string first. 