### PR TITLE
Allow deprecated type in Swarm

### DIFF
--- a/nomos-libp2p/src/lib.rs
+++ b/nomos-libp2p/src/lib.rs
@@ -12,7 +12,7 @@ pub use libp2p;
 use blake2::digest::{consts::U32, Digest};
 use blake2::Blake2b;
 use libp2p::gossipsub::{Message, MessageId, TopicHash};
-
+#[allow(deprecated)]
 pub use libp2p::{
     core::upgrade,
     dns,
@@ -151,6 +151,7 @@ impl Swarm {
 }
 
 impl futures::Stream for Swarm {
+    #[allow(deprecated)]
     type Item = SwarmEvent<BehaviourEvent, THandlerErr<Behaviour>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/nomos-services/network/src/backends/libp2p/swarm.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, ops::Range, time::Duration};
 
 use mixnet_client::MixnetClient;
+#[allow(deprecated)]
 use nomos_libp2p::{
     gossipsub::{self, Message},
     libp2p::swarm::ConnectionId,
@@ -88,6 +89,7 @@ impl SwarmHandler {
         }
     }
 
+    #[allow(deprecated)]
     fn handle_event(&mut self, event: SwarmEvent<BehaviourEvent, THandlerErr<Behaviour>>) {
         match event {
             SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Message {


### PR DESCRIPTION
We have to use the type of the upstream dependency