### PR TITLE
test: set consensus timeout for integration tests conservatively

### DIFF
--- a/tests/src/tests/happy.rs
+++ b/tests/src/tests/happy.rs
@@ -78,11 +78,7 @@ async fn happy_test(nodes: &[NomosNode]) {
 async fn two_nodes_happy() {
     let (_mixnodes, mixnet_config) = MixNode::spawn_nodes(2).await;
     let nodes = NomosNode::spawn_nodes(SpawnConfig::Chain {
-        consensus: ConsensusConfig {
-            n_participants: 2,
-            threshold: Fraction::one(),
-            timeout: Duration::from_secs(10),
-        },
+        consensus: get_consensus_config(2),
         mixnet: mixnet_config,
     })
     .await;
@@ -93,11 +89,7 @@ async fn two_nodes_happy() {
 async fn ten_nodes_happy() {
     let (_mixnodes, mixnet_config) = MixNode::spawn_nodes(3).await;
     let nodes = NomosNode::spawn_nodes(SpawnConfig::Chain {
-        consensus: ConsensusConfig {
-            n_participants: 10,
-            threshold: Fraction::one(),
-            timeout: Duration::from_secs(10),
-        },
+        consensus: get_consensus_config(10),
         mixnet: mixnet_config,
     })
     .await;
@@ -108,11 +100,7 @@ async fn ten_nodes_happy() {
 async fn test_get_block() {
     let (_mixnodes, mixnet_config) = MixNode::spawn_nodes(3).await;
     let nodes = NomosNode::spawn_nodes(SpawnConfig::Chain {
-        consensus: ConsensusConfig {
-            n_participants: 2,
-            threshold: Fraction::one(),
-            timeout: Duration::from_secs(10),
-        },
+        consensus: get_consensus_config(2),
         mixnet: mixnet_config,
     })
     .await;
@@ -126,4 +114,14 @@ async fn test_get_block() {
     })
     .await
     .unwrap();
+}
+
+fn get_consensus_config(n_participants: usize) -> ConsensusConfig {
+    ConsensusConfig {
+        n_participants,
+        threshold: Fraction::one(),
+        // Since it takes 1+ secs to start each nomos-node,
+        // set the timeout conservatively.
+        timeout: Duration::from_millis(n_participants as u64 * 2500),
+    }
 }


### PR DESCRIPTION
I've found that the first nomos-node sometimes invoke local_timeout, because the consensus timeout is set to 10s, even though it takes 1+ secs for each nomos-node to be started. 

For happy tests, we need to see the consensus timeout conservatively, so that timeout doesn't happen at the bootstrap stage.

This will solve the CI failure in the master branch and https://github.com/logos-co/nomos-node/pull/445#issuecomment-1770471151.