### PR TITLE
Stop using msg hash as a libp2p msg ID

### DIFF
--- a/nomos-libp2p/Cargo.toml
+++ b/nomos-libp2p/Cargo.toml
@@ -18,7 +18,6 @@ libp2p = { version = "0.52.4", features = [
   "tokio",
   "secp256k1",
 ] }
-blake2 = { version = "0.10" }
 serde = { version = "1.0.166", features = ["derive"] }
 hex = "0.4.3"
 log = "0.4.19"


### PR DESCRIPTION
## Background
I've seen the following error from one of the nomos-nodes when running the demo app #495, even though the app works well.
```
2023-10-31T07:37:25.924036Z  WARN libp2p_gossipsub::behaviour: Not publishing a message that has already been published. Msg-id c9babb739f010ce091741e38afb4414f1c1db42b5c263df38eba6b235a596d65
2023-10-31T07:37:25.924072Z ERROR nomos_network::backends::libp2p::swarm: failed to broadcast message to topic: NomosDa Duplicate
```
We use a message hash as a libp2p message ID. And, libp2p doesn't publish a message with ID that has been already published. Also, libp2p [ignores](https://github.com/libp2p/rust-libp2p/blob/51070dae6395821c5ab45014b7208f15975c9101/protocols/gossipsub/src/behaviour.rs#L1817) messages that have been recently received. 
https://github.com/logos-co/nomos-node/blob/7dce530d13e54ce939d3752d941287b7fff124e5/nomos-libp2p/src/lib.rs#L162
It's okay in most cases. But, in DA (especially with FullReplication), some messages may not be published:
- because we don't set the [`Attestation.voter`](https://github.com/logos-co/nomos-node/blob/libp2p-msg-id/nomos-da/full-replication/src/lib.rs#L210-L210).
- because messages are published by some of the nomos-nodes that listen messages from the mixnet exit layer.

Nevertheless, DA with FullReplication has worked well because we've set the `num_attestations = 1`: https://github.com/logos-co/nomos-node/blob/449547bc57db2e17b9147deeded715caf301bace/nomos-cli/src/da/disseminate.rs#L242-L242

## Fix

Although everything works well now, I think we need to fix this behavior to prevent hard-to-debug errors in the future.

The easiest way would be setting the `Attestation.voter` properly. But, first of all, I think we don't need to use a message hash as a message ID. Even if upper layers want to publish the same message multiple times deliberately, I think the network layer shouldn't refuse it.

Instead of using message hash, it's enough to use the [default message ID function](https://github.com/libp2p/rust-libp2p/blob/51070dae6395821c5ab45014b7208f15975c9101/protocols/gossipsub/src/config.rs#L641) (that concatenates source peer id with sequence number).