### PR TITLE
Store logs from failed CI as artifacts

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           command: test
           args: --all --no-default-features --features ${{ matrix.feature }}
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: integration-test-artifacts
+          path: tests/.tmp*
 
   lints:
     name: Rust lints

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,6 +35,11 @@ jobs:
           cargo test --no-default-features --features libp2p
           mkdir /tmp/cov;
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o /tmp/cov/tests.lcov;
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: integration-test-artifacts
+          path: tests/.tmp*
       - uses: codecov/codecov-action@v3
         with:
           directory: /tmp/cov/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ store.*
 sim_config.json
 *.txt
 .env
+
+# Integration test temp dirs
+tests/.tmp*

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -58,7 +58,11 @@ impl NomosNode {
     pub async fn spawn(mut config: Config) -> Self {
         // Waku stores the messages in a db file in the current dir, we need a different
         // directory for each node to avoid conflicts
-        let dir = tempfile::tempdir().unwrap();
+        //
+        // NOTE: It's easier to use the current location instead of OS-default tempfile location
+        // because Github Actions can easily access files in the current location using wildcard
+        // to upload them as artifacts.
+        let dir = tempfile::TempDir::new_in(std::env::current_dir().unwrap()).unwrap();
         let mut file = NamedTempFile::new().unwrap();
         let config_path = file.path().to_owned();
 


### PR DESCRIPTION
Closes #507

If CI fails, integration test artifacts (logs, etc...) are uploaded to Github Actions. 

The uploaded artifacts can be found at the bottom of the `Summary` page of each action.
<img width="581" alt="image" src="https://github.com/logos-co/nomos-node/assets/5462944/72d2c14d-e9ca-4d53-bd80-978fdf017ea0">

Currently, we upload artifacts without compressing them (since it's simpler and doesn't cost), but they're automatically compressed as a zip when you download them.