### PR TITLE
Limit GetBlocks response size

### DIFF
--- a/nomos-services/consensus/src/lib.rs
+++ b/nomos-services/consensus/src/lib.rs
@@ -55,6 +55,9 @@ use overwatch_rs::services::{
 };
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+// Limit the number of blocks returned by GetBlocks
+// Approx 64KB of data
+const BLOCKS_LIMIT: usize = 512;
 
 fn default_timeout() -> Duration {
     DEFAULT_TIMEOUT
@@ -441,7 +444,8 @@ where
 
                 while let Some(block) = blocks.get(&cur) {
                     res.push(block.clone());
-                    if cur == to || cur == carnot.genesis_block().id {
+                    // limit the response size
+                    if cur == to || cur == carnot.genesis_block().id || res.len() >= BLOCKS_LIMIT {
                         break;
                     }
                     cur = block.parent();


### PR DESCRIPTION
Put a hard limit of 1024 blocks in the response returned by GetBlocks to avoid slowing things down. This number was chosen rather arbitrarily. We might want to do some more fine tuning.

Even with the new api, a client could request a very long sequence of blocks (for example because it might be starting up after the chain has been running for a lot of time already) and we don't want that to block a node.
Specifically for the catching up phase, we might want to design a better protocol, but for the moment polling this API multiple times should do it.