### PR TITLE
Prometheus metrics service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "nomos-core",
     "nomos-libp2p",
     "nomos-services/api",
+    "nomos-metrics",
     "nomos-services/log",
     "nomos-services/metrics",
     "nomos-services/network",

--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -24,6 +24,7 @@ nomos-network = { path = "../../nomos-services/network", features = ["libp2p"] }
 nomos-api = { path = "../../nomos-services/api" }
 nomos-log = { path = "../../nomos-services/log" }
 nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock", "libp2p"] }
+nomos-metrics = { path = "../../nomos-metrics" }
 nomos-http = { path = "../../nomos-services/http", features = ["http"] }
 carnot-consensus = { path = "../../nomos-services/carnot-consensus", features = ["libp2p"] }
 nomos-storage = { path = "../../nomos-services/storage", features = ["sled"] }

--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -23,7 +23,7 @@ nomos-core = { path = "../../nomos-core" }
 nomos-network = { path = "../../nomos-services/network", features = ["libp2p"] }
 nomos-api = { path = "../../nomos-services/api" }
 nomos-log = { path = "../../nomos-services/log" }
-nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock", "libp2p"] }
+nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock", "libp2p", "metrics"] }
 nomos-metrics = { path = "../../nomos-metrics" }
 nomos-http = { path = "../../nomos-services/http", features = ["http"] }
 carnot-consensus = { path = "../../nomos-services/carnot-consensus", features = ["libp2p"] }

--- a/nodes/nomos-node/src/api.rs
+++ b/nodes/nomos-node/src/api.rs
@@ -123,6 +123,7 @@ where
             .route("/storage/block", routing::post(block::<S, T>))
             .route("/mempool/add/tx", routing::post(add_tx::<T>))
             .route("/mempool/add/cert", routing::post(add_cert))
+            .route("/metrics", routing::get(get_metrics))
             .with_state(handle);
 
         Server::bind(&self.settings.address)
@@ -335,6 +336,31 @@ where
     )
 )]
 async fn add_cert(
+    State(handle): State<OverwatchHandle>,
+    Json(cert): Json<Certificate>,
+) -> Response {
+    make_request_and_return_response!(mempool::add::<
+        Libp2p,
+        Libp2pAdapter<Certificate, <Blob as blob::Blob>::Hash>,
+        nomos_mempool::Certificate,
+        Certificate,
+        <Blob as blob::Blob>::Hash,
+    >(
+        &handle,
+        cert,
+        nomos_core::da::certificate::Certificate::hash
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/metrics",
+    responses(
+        (status = 200, description = "Get all metrics"),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
+async fn get_metrics(
     State(handle): State<OverwatchHandle>,
     Json(cert): Json<Certificate>,
 ) -> Response {

--- a/nodes/nomos-node/src/config.rs
+++ b/nodes/nomos-node/src/config.rs
@@ -115,6 +115,12 @@ pub struct DaArgs {
     da_voter: Option<String>,
 }
 
+#[derive(Parser, Debug, Clone)]
+pub struct MetricsArgs {
+    #[clap(long = "with-metrics", env = "WITH_METRICS")]
+    pub with_metrics: bool,
+}
+
 #[derive(Deserialize, Debug, Clone, Serialize)]
 pub struct Config {
     pub log: <Logger as ServiceData>::Settings,

--- a/nodes/nomos-node/src/config.rs
+++ b/nodes/nomos-node/src/config.rs
@@ -10,8 +10,6 @@ use crate::{Carnot, Tx, Wire, MB16};
 use clap::{Parser, ValueEnum};
 use color_eyre::eyre::{self, eyre, Result};
 use hex::FromHex;
-#[cfg(feature = "metrics")]
-use metrics::{backend::map::MapMetricsBackend, types::MetricsData, MetricsService};
 use nomos_api::ApiService;
 use nomos_libp2p::{secp256k1::SecretKey, Multiaddr};
 use nomos_log::{Logger, LoggerBackend, LoggerFormat};
@@ -127,8 +125,6 @@ pub struct Config {
     pub network: <NetworkService<Libp2p> as ServiceData>::Settings,
     pub http: <ApiService<AxumBackend<Tx, Wire, MB16>> as ServiceData>::Settings,
     pub consensus: <Carnot as ServiceData>::Settings,
-    #[cfg(feature = "metrics")]
-    pub metrics: <MetricsService<MapMetricsBackend<MetricsData>> as ServiceData>::Settings,
     pub da: <DataAvailability as ServiceData>::Settings,
 }
 

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -35,7 +35,9 @@ use nomos_storage::{
     StorageService,
 };
 
-pub use config::{Config, ConsensusArgs, DaArgs, HttpArgs, LogArgs, NetworkArgs, OverlayArgs};
+pub use config::{
+    Config, ConsensusArgs, DaArgs, HttpArgs, LogArgs, MetricsArgs, NetworkArgs, OverlayArgs,
+};
 use nomos_core::{
     da::certificate::select::FillSize as FillSizeWithBlobsCertificate,
     tx::select::FillSize as FillSizeWithTx,

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -29,6 +29,7 @@ use nomos_mempool::{
     backend::mockpool::MockPool, Certificate as CertDiscriminant, MempoolService,
     Transaction as TxDiscriminant,
 };
+use nomos_metrics::Metrics;
 use nomos_network::backends::libp2p::Libp2p;
 use nomos_storage::{
     backends::{sled::SledBackend, StorageSerde},
@@ -91,10 +92,9 @@ pub struct Nomos {
     >,
     consensus: ServiceHandle<Carnot>,
     http: ServiceHandle<ApiService<AxumBackend<Tx, Wire, MB16>>>,
-    #[cfg(feature = "metrics")]
-    metrics: ServiceHandle<MetricsService<MapMetricsBackend<MetricsData>>>,
     da: ServiceHandle<DataAvailability>,
     storage: ServiceHandle<StorageService<SledBackend<Wire>>>,
+    metrics: ServiceHandle<Metrics>,
     system_sig: ServiceHandle<SystemSig>,
 }
 

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -29,6 +29,7 @@ use nomos_mempool::{
     backend::mockpool::MockPool, Certificate as CertDiscriminant, MempoolService,
     Transaction as TxDiscriminant,
 };
+#[cfg(feature = "metrics")]
 use nomos_metrics::Metrics;
 use nomos_network::backends::libp2p::Libp2p;
 use nomos_storage::{
@@ -94,6 +95,7 @@ pub struct Nomos {
     http: ServiceHandle<ApiService<AxumBackend<Tx, Wire, MB16>>>,
     da: ServiceHandle<DataAvailability>,
     storage: ServiceHandle<StorageService<SledBackend<Wire>>>,
+    #[cfg(feature = "metrics")]
     metrics: ServiceHandle<Metrics>,
     system_sig: ServiceHandle<SystemSig>,
 }

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
         .update_overlay(overlay_args)?
         .update_network(network_args)?;
 
-    let metrics = metrics_args.with_metrics.then(NomosRegistry::default);
+    let registry = metrics_args.with_metrics.then(NomosRegistry::default);
 
     let app = OverwatchRunner::<Nomos>::run(
         NomosServiceSettings {
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
                     topic: String::from(nomos_node::CL_TOPIC),
                     id: <Tx as Transaction>::hash,
                 },
-                metrics: metrics.clone(),
+                registry: registry.clone(),
             },
             da_mempool: nomos_mempool::Settings {
                 backend: (),
@@ -86,10 +86,10 @@ fn main() -> Result<()> {
                     topic: String::from(nomos_node::DA_TOPIC),
                     id: cert_id,
                 },
-                metrics: metrics.clone(),
+                registry: registry.clone(),
             },
             consensus: config.consensus,
-            metrics: MetricsSettings { registry: metrics },
+            metrics: MetricsSettings { registry },
             da: config.da,
             storage: nomos_storage::backends::sled::SledBackendSettings {
                 db_path: std::path::PathBuf::from(DEFAULT_DB_PATH),

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -1,5 +1,5 @@
 use full_replication::{Blob, Certificate};
-use nomos_metrics::NomosRegistry;
+use nomos_metrics::{MetricsSettings, NomosRegistry};
 use nomos_node::{
     Config, ConsensusArgs, DaArgs, HttpArgs, LogArgs, MetricsArgs, NetworkArgs, Nomos,
     NomosServiceSettings, OverlayArgs, Tx,
@@ -86,11 +86,10 @@ fn main() -> Result<()> {
                     topic: String::from(nomos_node::DA_TOPIC),
                     id: cert_id,
                 },
-                metrics,
+                metrics: metrics.clone(),
             },
             consensus: config.consensus,
-            #[cfg(feature = "metrics")]
-            metrics: config.metrics,
+            metrics: MetricsSettings { registry: metrics },
             da: config.da,
             storage: nomos_storage::backends::sled::SledBackendSettings {
                 db_path: std::path::PathBuf::from(DEFAULT_DB_PATH),

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -66,13 +66,13 @@ fn main() -> Result<()> {
         .update_overlay(overlay_args)?
         .update_network(network_args)?;
 
-    let registry = if cfg!(feature = "metrics") {
-        metrics_args
-            .with_metrics
-            .then(nomos_metrics::NomosRegistry::default)
-    } else {
-        None
-    };
+    let registry = cfg!(feature = "metrics")
+        .then(|| {
+            metrics_args
+                .with_metrics
+                .then(nomos_metrics::NomosRegistry::default)
+        })
+        .flatten();
 
     let app = OverwatchRunner::<Nomos>::run(
         NomosServiceSettings {

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -71,6 +71,7 @@ fn main() -> Result<()> {
                     topic: String::from(nomos_node::CL_TOPIC),
                     id: <Tx as Transaction>::hash,
                 },
+                metrics: None,
             },
             da_mempool: nomos_mempool::Settings {
                 backend: (),
@@ -78,6 +79,7 @@ fn main() -> Result<()> {
                     topic: String::from(nomos_node::DA_TOPIC),
                     id: cert_id,
                 },
+                metrics: None,
             },
             consensus: config.consensus,
             #[cfg(feature = "metrics")]

--- a/nomos-metrics/Cargo.toml
+++ b/nomos-metrics/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1"
 futures = "0.3"
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "ac28d01" }
-tracing = "0.1"
-serde = { version = "1", features = ["derive"] }
 prometheus-client = "0.22.0"
+tracing = "0.1"
+tokio = { version = "1", features = ["sync", "macros"] }
+serde = { version = "1", features = ["derive"] }

--- a/nomos-metrics/Cargo.toml
+++ b/nomos-metrics/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nomos-metrics"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1"
+futures = "0.3"
+overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
+overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "ac28d01" }
+tracing = "0.1"
+serde = { version = "1", features = ["derive"] }
+prometheus-client = "0.22.0"

--- a/nomos-metrics/src/lib.rs
+++ b/nomos-metrics/src/lib.rs
@@ -83,7 +83,7 @@ impl ServiceCore for Metrics {
                         let reg = registry.lock().unwrap();
                         // If encoding fails, we need to stop trying process subsequent metrics gather
                         // requests. If it succeds, encode method returns empty unit type.
-                        _ = encode(&mut buf, &reg).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+                        _ = encode(&mut buf, &reg).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                     }
 
                     reply_channel

--- a/nomos-metrics/src/lib.rs
+++ b/nomos-metrics/src/lib.rs
@@ -27,9 +27,9 @@ pub struct Metrics {
     registry: NomosRegistry,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MetricsSettings {
-    registry: Option<NomosRegistry>,
+    pub registry: Option<NomosRegistry>,
 }
 
 pub struct GatherResult {}

--- a/nomos-metrics/src/lib.rs
+++ b/nomos-metrics/src/lib.rs
@@ -1,0 +1,9 @@
+use prometheus_client::registry::Registry;
+use std::sync::{Arc, Mutex};
+
+pub use prometheus_client::{self, *};
+
+// A wrapper for prometheus_client Registry.
+// Lock is only used during services initialization.
+pub type NomosRegistry = Arc<Mutex<Registry>>;
+

--- a/nomos-metrics/src/lib.rs
+++ b/nomos-metrics/src/lib.rs
@@ -32,12 +32,8 @@ pub struct MetricsSettings {
     pub registry: Option<NomosRegistry>,
 }
 
-pub struct GatherResult {}
-
 pub enum MetricsMsg {
-    Gather {
-        reply_channel: Sender<String>
-    },
+    Gather { reply_channel: Sender<String> },
 }
 
 impl RelayMessage for MetricsMsg {}

--- a/nomos-metrics/src/lib.rs
+++ b/nomos-metrics/src/lib.rs
@@ -1,9 +1,123 @@
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
-
 pub use prometheus_client::{self, *};
 
+// std
+use std::fmt::{Debug, Error, Formatter};
+use std::sync::{Arc, Mutex};
+// crates
+use futures::StreamExt;
+use overwatch_rs::services::life_cycle::LifecycleMessage;
+use overwatch_rs::services::{
+    handle::ServiceStateHandle,
+    relay::RelayMessage,
+    state::{NoOperator, NoState},
+    ServiceCore, ServiceData,
+};
+use prometheus_client::encoding::text::encode;
+use prometheus_client::registry::Registry;
+use tokio::sync::oneshot::Sender;
+use tracing::error;
+// internal
+
 // A wrapper for prometheus_client Registry.
-// Lock is only used during services initialization.
+// Lock is only used during services initialization and prometheus pull query.
 pub type NomosRegistry = Arc<Mutex<Registry>>;
 
+pub struct Metrics {
+    service_state: ServiceStateHandle<Self>,
+    registry: NomosRegistry,
+}
+
+#[derive(Clone)]
+pub struct MetricsSettings {
+    registry: Option<NomosRegistry>,
+}
+
+pub struct GatherResult {}
+
+pub enum MetricsMsg {
+    Gather {
+        reply_channel: Sender<String>
+    },
+}
+
+impl RelayMessage for MetricsMsg {}
+
+impl Debug for MetricsMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        match self {
+            Self::Gather { .. } => {
+                write!(f, "MetricsMsg::Gather")
+            }
+        }
+    }
+}
+
+impl ServiceData for Metrics {
+    const SERVICE_ID: &'static str = "Metrics";
+    type Settings = MetricsSettings;
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = MetricsMsg;
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for Metrics {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
+        let config = service_state.settings_reader.get_updated_settings();
+
+        Ok(Self {
+            service_state,
+            registry: config.registry.ok_or("No registry provided")?,
+        })
+    }
+
+    async fn run(self) -> Result<(), overwatch_rs::DynError> {
+        let Self {
+            mut service_state,
+            registry,
+        } = self;
+        let mut lifecycle_stream = service_state.lifecycle_handle.message_stream();
+        loop {
+            tokio::select! {
+                Some(msg) = service_state.inbound_relay.recv() => {
+                    let MetricsMsg::Gather{reply_channel} = msg;
+
+                    let mut buf = String::new();
+                    {
+                        let reg = registry.lock().unwrap();
+                        // If encoding fails, we need to stop trying process subsequent metrics gather
+                        // requests. If it succeds, encode method returns empty unit type.
+                        _ = encode(&mut buf, &reg).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+                    }
+
+                    reply_channel
+                        .send(buf)
+                        .unwrap_or_else(|_| tracing::debug!("could not send back metrics"));
+                }
+                Some(msg) = lifecycle_stream.next() =>  {
+                    if Self::should_stop_service(msg).await {
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Metrics {
+    async fn should_stop_service(message: LifecycleMessage) -> bool {
+        match message {
+            LifecycleMessage::Shutdown(sender) => {
+                if sender.send(()).is_err() {
+                    error!(
+                        "Error sending successful shutdown signal from service {}",
+                        Self::SERVICE_ID
+                    );
+                }
+                true
+            }
+            LifecycleMessage::Kill => true,
+        }
+    }
+}

--- a/nomos-services/api/Cargo.toml
+++ b/nomos-services/api/Cargo.toml
@@ -19,6 +19,7 @@ carnot-consensus = { path = "../carnot-consensus" }
 nomos-network = { path = "../../nomos-services/network" }
 nomos-da = { path = "../../nomos-services/data-availability" }
 nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock", "libp2p", "openapi"] }
+nomos-metrics = { path = "../../nomos-metrics" }
 nomos-storage = { path = "../../nomos-services/storage", features = ["sled"] }
 nomos-libp2p = { path = "../../nomos-libp2p" }
 full-replication = { path = "../../nomos-da/full-replication" }

--- a/nomos-services/api/src/http/metrics.rs
+++ b/nomos-services/api/src/http/metrics.rs
@@ -1,0 +1,18 @@
+use nomos_metrics::{Metrics, MetricsMsg};
+use tokio::sync::oneshot;
+
+pub async fn gather(
+    handle: &overwatch_rs::overwatch::handle::OverwatchHandle,
+) -> Result<String, super::DynError> {
+    let relay = handle.relay::<Metrics>().connect().await?;
+    let (sender, receiver) = oneshot::channel();
+
+    relay
+        .send(MetricsMsg::Gather {
+            reply_channel: sender,
+        })
+        .await
+        .map_err(|(e, _)| e)?;
+
+    Ok(receiver.await?)
+}

--- a/nomos-services/api/src/http/mod.rs
+++ b/nomos-services/api/src/http/mod.rs
@@ -4,4 +4,5 @@ pub mod consensus;
 pub mod da;
 pub mod libp2p;
 pub mod mempool;
+pub mod metrics;
 pub mod storage;

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1"
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 futures = "0.3"
 linked-hash-map = { version = "0.5.6", optional = true }
+nomos-metrics = { path = "../../nomos-metrics" }
 nomos-network = { path = "../network" }
 nomos-core = { path = "../../nomos-core" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -35,6 +35,7 @@ blake2 = "0.10"
 default = []
 mock = ["linked-hash-map", "nomos-network/mock", "rand", "nomos-core/mock"]
 libp2p = ["nomos-network/libp2p"]
+metrics = []
 
 # enable to help generate OpenAPI
 openapi = ["dep:utoipa", "serde_json"]

--- a/nomos-services/mempool/src/lib.rs
+++ b/nomos-services/mempool/src/lib.rs
@@ -167,7 +167,7 @@ where
         let network_relay = service_state.overwatch_handle.relay();
         let settings = service_state.settings_reader.get_updated_settings();
         let metrics = settings
-            .metrics
+            .registry
             .map(|reg| Metrics::new(reg, service_state.id()));
         Ok(Self {
             service_state,
@@ -328,5 +328,5 @@ where
 pub struct Settings<B, N> {
     pub backend: B,
     pub network: N,
-    pub metrics: Option<NomosRegistry>,
+    pub registry: Option<NomosRegistry>,
 }

--- a/nomos-services/mempool/src/metrics.rs
+++ b/nomos-services/mempool/src/metrics.rs
@@ -53,7 +53,7 @@ impl Metrics {
         let messages = Family::default();
         sub_registry.register(
             "messages",
-            "Messages emitted by the relay Mempool",
+            "Messages emitted by the Mempool",
             messages.clone(),
         );
 

--- a/nomos-services/mempool/src/metrics.rs
+++ b/nomos-services/mempool/src/metrics.rs
@@ -1,0 +1,80 @@
+use std::fmt::Debug;
+
+use nomos_metrics::prometheus_client::{
+    self, encoding::EncodeLabelSet, encoding::EncodeLabelValue,
+};
+use nomos_metrics::NomosRegistry;
+
+use nomos_metrics::metrics::{counter::Counter, family::Family};
+use overwatch_rs::services::ServiceId;
+
+use crate::MempoolMsg;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
+enum MempoolMsgType {
+    Add,
+    View,
+    Prune,
+    MarkInBlock,
+}
+
+impl<I, K> From<&MempoolMsg<I, K>> for MempoolMsgType
+where
+    I: 'static + Debug,
+    K: 'static + Debug,
+{
+    fn from(event: &MempoolMsg<I, K>) -> Self {
+        match event {
+            MempoolMsg::Add { .. } => MempoolMsgType::Add,
+            MempoolMsg::View { .. } => MempoolMsgType::View,
+            MempoolMsg::Prune { .. } => MempoolMsgType::Prune,
+            MempoolMsg::MarkInBlock { .. } => MempoolMsgType::MarkInBlock,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct MessageLabels {
+    label: MempoolMsgType,
+}
+
+pub(crate) struct Metrics {
+    messages: Family<MessageLabels, Counter>,
+}
+
+impl Metrics {
+    pub(crate) fn new(registry: NomosRegistry, discriminant: ServiceId) -> Self {
+        let mut registry = registry
+            .lock()
+            .expect("should've acquired the lock for registry");
+        let sub_registry = registry.sub_registry_with_prefix(discriminant);
+
+        let messages = Family::default();
+        sub_registry.register(
+            "messages",
+            "Messages emitted by the relay Mempool",
+            messages.clone(),
+        );
+
+        Self { messages }
+    }
+
+    pub(crate) fn record<I, K>(&self, msg: &MempoolMsg<I, K>)
+    where
+        I: 'static + Debug,
+        K: 'static + Debug,
+    {
+        match msg {
+            MempoolMsg::Add { .. }
+            | MempoolMsg::View { .. }
+            | MempoolMsg::Prune { .. }
+            | MempoolMsg::MarkInBlock { .. } => {
+                self.messages
+                    .get_or_create(&MessageLabels { label: msg.into() })
+                    .inc();
+            }
+            _ => {}
+        }
+    }
+}

--- a/nomos-services/mempool/src/metrics.rs
+++ b/nomos-services/mempool/src/metrics.rs
@@ -1,13 +1,13 @@
+// std
 use std::fmt::Debug;
-
-use nomos_metrics::prometheus_client::{
-    self, encoding::EncodeLabelSet, encoding::EncodeLabelValue,
+// crates
+use nomos_metrics::{
+    metrics::{counter::Counter, family::Family},
+    prometheus_client::{self, encoding::EncodeLabelSet, encoding::EncodeLabelValue},
+    NomosRegistry,
 };
-use nomos_metrics::NomosRegistry;
-
-use nomos_metrics::metrics::{counter::Counter, family::Family};
 use overwatch_rs::services::ServiceId;
-
+// internal
 use crate::MempoolMsg;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]

--- a/nomos-services/mempool/tests/mock.rs
+++ b/nomos-services/mempool/tests/mock.rs
@@ -64,6 +64,7 @@ fn test_mockmempool() {
             mockpool: Settings {
                 backend: (),
                 network: (),
+                registry: None,
             },
             logging: LoggerSettings::default(),
         },


### PR DESCRIPTION
Implementation of nomos metrics service using [prometheus_client](https://github.com/prometheus/client_rust). Before adding more features and metrics the concept validation is needed.

Similar to the tracing crate, nomos metrics service does not own the "main" registry that is used by all other service to put their metrics in. The main registry is created before initializing the node and passed to services to register them selves.

Nomos metrics service is responsible for accessing the registry whenever remote prometheus server queries new metrics (via nomos-api).

Every service that wants to publish metrics need to register them selves during the initialization. After this point individual services are responsible how they collects the metrics. The easiest approach is to track service messages by type, but more advanced metrics can by added.

If this approach looks viable, then current `MempoolMsg::Metrics` message could be renamed and moved under "{cl, da}/stats".

This implementation is currently located in `root directory/nomos-metrics` but should eventually replace `nomos-services/metrics`. Old implementation is left for readablity and would be removed.

Example respose when querying `localhost:8080/metrics`:
```bash
curl localhost:8080/metrics
# HELP mempool-cl_messages Messages emitted by the Mempool.
# TYPE mempool-cl_messages counter
# HELP mempool-da_messages Messages emitted by the Mempool.
# TYPE mempool-da_messages counter
# EOF
```