### PR TITLE
Fix nomos-cli api

### DIFF
--- a/nomos-cli/src/api/da.rs
+++ b/nomos-cli/src/api/da.rs
@@ -10,8 +10,7 @@ pub async fn get_blobs(
     const BLOBS_PATH: &str = "da/blobs";
     CLIENT
         .post(node.join(BLOBS_PATH).unwrap())
-        .header("Content-Type", "application/json")
-        .body(serde_json::to_string(&ids).unwrap())
+        .json(&ids)
         .send()
         .await?
         .json()

--- a/nomos-cli/src/api/mempool.rs
+++ b/nomos-cli/src/api/mempool.rs
@@ -9,8 +9,7 @@ where
     const NODE_CERT_PATH: &str = "mempool/add/cert";
     CLIENT
         .post(node.join(NODE_CERT_PATH).unwrap())
-        .header("Content-Type", "application/json")
-        .body(serde_json::to_string(cert).unwrap())
+        .json(cert)
         .send()
         .await
 }

--- a/nomos-cli/src/api/storage.rs
+++ b/nomos-cli/src/api/storage.rs
@@ -10,12 +10,11 @@ pub async fn get_block_contents(
     block: &BlockId,
 ) -> Result<Option<Block<Tx, Certificate>>, reqwest::Error> {
     const BLOCK_PATH: &str = "storage/block";
-    let block = CLIENT
+    CLIENT
         .post(node.join(BLOCK_PATH).unwrap())
-        .body(serde_json::to_string(block).unwrap())
+        .json(block)
         .send()
         .await?
         .json()
-        .await?;
-    Ok(block)
+        .await
 }


### PR DESCRIPTION
Use reqwest's `json` method instead of manually serializing body into json so that we don't have to set the content type ourselves (and sometimes forget)