### PR TITLE
Fix mixnode HOL blocking

### DIFF
--- a/mixnet/node/src/config.rs
+++ b/mixnet/node/src/config.rs
@@ -18,9 +18,6 @@ pub struct MixnetNodeConfig {
     /// The size of the connection pool.
     #[serde(default = "MixnetNodeConfig::default_connection_pool_size")]
     pub connection_pool_size: usize,
-    /// The maximum number of retries.
-    #[serde(default = "MixnetNodeConfig::default_max_retries")]
-    pub max_retries: usize,
     /// The retry delay between retries.
     #[serde(default = "MixnetNodeConfig::default_retry_delay")]
     pub retry_delay: Duration,
@@ -36,7 +33,6 @@ impl Default for MixnetNodeConfig {
             )),
             private_key: PrivateKey::new().to_bytes(),
             connection_pool_size: 255,
-            max_retries: 3,
             retry_delay: Duration::from_secs(5),
         }
     }
@@ -45,10 +41,6 @@ impl Default for MixnetNodeConfig {
 impl MixnetNodeConfig {
     const fn default_connection_pool_size() -> usize {
         255
-    }
-
-    const fn default_max_retries() -> usize {
-        3
     }
 
     const fn default_retry_delay() -> Duration {

--- a/mixnet/node/src/forward_scheduler.rs
+++ b/mixnet/node/src/forward_scheduler.rs
@@ -1,0 +1,61 @@
+use std::collections::{hash_map::Entry, HashMap};
+use std::net::SocketAddr;
+
+use mixnet_protocol::Body;
+use tokio::sync::mpsc;
+
+use crate::{forwarder::Forwarder, MixnetNodeConfig};
+
+pub struct ForwardScheduler {
+    config: MixnetNodeConfig,
+    rx: mpsc::UnboundedReceiver<Packet>,
+    forwarders: HashMap<SocketAddr, Forwarder>,
+}
+
+impl ForwardScheduler {
+    pub fn new(rx: mpsc::UnboundedReceiver<Packet>, config: MixnetNodeConfig) -> Self {
+        Self {
+            config,
+            rx,
+            forwarders: HashMap::with_capacity(config.connection_pool_size),
+        }
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                packet = self.rx.recv() => {
+                    if let Some(packet) = packet {
+                        self.schedule(packet, self.config).await;
+                    } else {
+                        unreachable!("Packet channel should not be closed, because PacketForwarder is also holding the send half");
+                    }
+                },
+                _ = tokio::signal::ctrl_c() => {
+                    tracing::info!("Shutting down packet forwarder task...");
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn schedule(&mut self, packet: Packet, config: MixnetNodeConfig) {
+        if let Entry::Vacant(entry) = self.forwarders.entry(packet.target) {
+            entry.insert(Forwarder::new(packet.target, config));
+        }
+
+        let forwarder = self.forwarders.get_mut(&packet.target).unwrap();
+        forwarder.schedule(packet.body);
+    }
+}
+
+pub struct Packet {
+    target: SocketAddr,
+    body: Body,
+}
+
+impl Packet {
+    pub fn new(target: SocketAddr, body: Body) -> Self {
+        Self { target, body }
+    }
+}

--- a/mixnet/node/src/forward_scheduler.rs
+++ b/mixnet/node/src/forward_scheduler.rs
@@ -6,6 +6,11 @@ use tokio::sync::mpsc;
 
 use crate::{forwarder::Forwarder, MixnetNodeConfig};
 
+/// [`ForwardScheduler`] receives all packets processed by [`InboundHandler`]s,
+/// and tosses them to corresponding [`Forwarder`]s.
+///
+/// Because [`ForwardScheduler`] is a single component where all packets are gathered to,
+/// it must be as light as possible.
 pub struct ForwardScheduler {
     config: MixnetNodeConfig,
     rx: mpsc::UnboundedReceiver<Packet>,

--- a/mixnet/node/src/forwarder.rs
+++ b/mixnet/node/src/forwarder.rs
@@ -1,0 +1,79 @@
+use std::net::SocketAddr;
+
+use mixnet_protocol::{Body, ProtocolError};
+use tokio::{net::TcpStream, sync::mpsc};
+
+use crate::MixnetNodeConfig;
+
+pub struct Forwarder {
+    tx: mpsc::UnboundedSender<Body>,
+}
+
+impl Forwarder {
+    pub fn new(addr: SocketAddr, config: MixnetNodeConfig) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let tx_ = tx.clone();
+        tokio::spawn(async move {
+            Forwarder::run(addr, rx, tx_, config).await;
+        });
+
+        Self { tx }
+    }
+
+    async fn run(
+        addr: SocketAddr,
+        mut rx: mpsc::UnboundedReceiver<Body>,
+        mut tx: mpsc::UnboundedSender<Body>,
+        config: MixnetNodeConfig,
+    ) {
+        loop {
+            match Forwarder::connect_and_forward(addr, &mut rx, &mut tx).await {
+                Ok(_) => {
+                    tracing::debug!("closing the forwarder: {addr}");
+                    return;
+                }
+                Err(e) => {
+                    tracing::error!("retrying: failed to connect and forward to {addr}: {e}");
+                    tokio::time::sleep(config.retry_delay).await;
+                }
+            }
+        }
+    }
+
+    async fn connect_and_forward(
+        addr: SocketAddr,
+        rx: &mut mpsc::UnboundedReceiver<Body>,
+        tx: &mut mpsc::UnboundedSender<Body>,
+    ) -> core::result::Result<(), ProtocolError> {
+        match TcpStream::connect(addr).await {
+            Ok(mut conn) => {
+                while let Some(body) = rx.recv().await {
+                    if let Err(e) = body.write(&mut conn).await {
+                        match e {
+                            ProtocolError::IO(_) => {
+                                tx.send(body).expect("the receiver half is always open");
+                                return Err(e);
+                            }
+                            _ => {
+                                tracing::error!("ignoring: failed to forward body to {addr}: {e}",);
+                            }
+                        }
+                    } else {
+                        tracing::debug!("forwarded body to {addr}");
+                    }
+                }
+
+                // the sender half has been closed.
+                Ok(())
+            }
+            Err(e) => Err(ProtocolError::from(e)),
+        }
+    }
+
+    pub fn schedule(&mut self, body: Body) {
+        self.tx
+            .send(body)
+            .expect("the receiver half is always open");
+    }
+}

--- a/mixnet/node/src/forwarder.rs
+++ b/mixnet/node/src/forwarder.rs
@@ -5,6 +5,8 @@ use tokio::{net::TcpStream, sync::mpsc};
 
 use crate::MixnetNodeConfig;
 
+/// [`Forwarder`] holds a TCP connection to another mix node,
+/// and forwards all incoming packets to it.
 pub struct Forwarder {
     tx: mpsc::UnboundedSender<Body>,
 }

--- a/mixnet/node/src/inbound_handler.rs
+++ b/mixnet/node/src/inbound_handler.rs
@@ -10,6 +10,9 @@ use tokio::{net::TcpStream, sync::mpsc};
 
 use crate::{forward_scheduler::Packet, MixnetNodeConfig, Result};
 
+/// [`InboundHandler`] spawns a task for each body coming from a TCP connection.
+/// Each task decapsulates/delays/sends a body to the [`ForwardScheduler`].
+/// It is recommended to spawn a [`InboundHandler`] per TCP connection.
 #[derive(Clone)]
 pub struct InboundHandler {
     config: MixnetNodeConfig,

--- a/mixnet/node/src/inbound_handler.rs
+++ b/mixnet/node/src/inbound_handler.rs
@@ -1,0 +1,113 @@
+use std::net::SocketAddr;
+
+use mixnet_protocol::{Body, ProtocolError};
+use nym_sphinx::{
+    addressing::nodes::NymNodeRoutingAddress, Delay, DestinationAddressBytes, NodeAddressBytes,
+    PrivateKey,
+};
+use sphinx_packet::{ProcessedPacket, SphinxPacket};
+use tokio::{net::TcpStream, sync::mpsc};
+
+use crate::{forward_scheduler::Packet, MixnetNodeConfig, Result};
+
+#[derive(Clone)]
+pub struct InboundHandler {
+    config: MixnetNodeConfig,
+    client_tx: mpsc::Sender<Body>,
+    packet_tx: mpsc::UnboundedSender<Packet>,
+}
+
+impl InboundHandler {
+    pub fn new(
+        config: MixnetNodeConfig,
+        client_tx: mpsc::Sender<Body>,
+        packet_tx: mpsc::UnboundedSender<Packet>,
+    ) -> Self {
+        Self {
+            config,
+            client_tx,
+            packet_tx,
+        }
+    }
+
+    pub async fn handle_connection(&self, mut socket: TcpStream) -> Result<()> {
+        loop {
+            let body = Body::read(&mut socket).await?;
+            let this = self.clone();
+            tokio::spawn(async move {
+                if let Err(e) = this.handle_body(body).await {
+                    tracing::error!("failed to handle body: {e}");
+                }
+            });
+        }
+    }
+
+    async fn handle_body(&self, body: Body) -> Result<()> {
+        match body {
+            Body::SphinxPacket(packet) => self.handle_sphinx_packet(packet).await,
+            Body::FinalPayload(payload) => {
+                self.forward_body_to_client_notifier(Body::FinalPayload(payload))
+                    .await
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    async fn handle_sphinx_packet(&self, packet: Box<SphinxPacket>) -> Result<()> {
+        match packet
+            .process(&PrivateKey::from(self.config.private_key))
+            .map_err(ProtocolError::InvalidSphinxPacket)?
+        {
+            ProcessedPacket::ForwardHop(packet, next_node_addr, delay) => {
+                self.forward_packet_to_next_hop(Body::SphinxPacket(packet), next_node_addr, delay)
+                    .await
+            }
+            ProcessedPacket::FinalHop(destination_addr, _, payload) => {
+                self.forward_payload_to_destination(Body::FinalPayload(payload), destination_addr)
+                    .await
+            }
+        }
+    }
+
+    async fn forward_body_to_client_notifier(&self, body: Body) -> Result<()> {
+        // TODO: Decrypt the final payload using the private key, if it's encrypted
+
+        // Do not wait when the channel is full or no receiver exists
+        self.client_tx.try_send(body)?;
+        Ok(())
+    }
+
+    async fn forward_packet_to_next_hop(
+        &self,
+        packet: Body,
+        next_node_addr: NodeAddressBytes,
+        delay: Delay,
+    ) -> Result<()> {
+        tracing::debug!("Delaying the packet for {delay:?}");
+        tokio::time::sleep(delay.to_duration()).await;
+
+        self.forward(packet, NymNodeRoutingAddress::try_from(next_node_addr)?)
+            .await
+    }
+
+    async fn forward_payload_to_destination(
+        &self,
+        payload: Body,
+        destination_addr: DestinationAddressBytes,
+    ) -> Result<()> {
+        tracing::debug!("Forwarding final payload to destination mixnode");
+
+        self.forward(
+            payload,
+            NymNodeRoutingAddress::try_from_bytes(&destination_addr.as_bytes())?,
+        )
+        .await
+    }
+
+    async fn forward(&self, body: Body, to: NymNodeRoutingAddress) -> Result<()> {
+        let addr = SocketAddr::from(to);
+
+        self.packet_tx.send(Packet::new(addr, body))?;
+        Ok(())
+    }
+}

--- a/mixnet/node/src/lib.rs
+++ b/mixnet/node/src/lib.rs
@@ -1,24 +1,21 @@
 mod client_notifier;
 pub mod config;
-
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    net::SocketAddr,
-};
+mod forward_scheduler;
+mod forwarder;
+mod inbound_handler;
 
 use client_notifier::ClientNotifier;
 pub use config::MixnetNodeConfig;
 use mixnet_protocol::{Body, ProtocolError};
 use mixnet_topology::MixnetNodeId;
-use nym_sphinx::{
-    addressing::nodes::{NymNodeRoutingAddress, NymNodeRoutingAddressError},
-    Delay, DestinationAddressBytes, NodeAddressBytes, PrivateKey,
-};
+use nym_sphinx::addressing::nodes::NymNodeRoutingAddressError;
 pub use sphinx_packet::crypto::PRIVATE_KEY_SIZE;
-use sphinx_packet::{crypto::PUBLIC_KEY_SIZE, ProcessedPacket, SphinxPacket};
-use tokio::{
-    net::{TcpListener, TcpStream},
-    sync::mpsc,
+use sphinx_packet::crypto::PUBLIC_KEY_SIZE;
+use tokio::{net::TcpListener, sync::mpsc};
+
+use crate::{
+    forward_scheduler::{ForwardScheduler, Packet},
+    inbound_handler::InboundHandler,
 };
 
 pub type Result<T> = core::result::Result<T, MixnetNodeError>;
@@ -86,11 +83,7 @@ impl MixnetNode {
             packet_forwarder.run().await;
         });
 
-        let inbound_handler = InboundHandler {
-            config: self.config,
-            client_tx,
-            packet_tx: tx,
-        };
+        let inbound_handler = InboundHandler::new(self.config, client_tx, tx);
 
         loop {
             tokio::select! {
@@ -115,222 +108,5 @@ impl MixnetNode {
                 }
             }
         }
-    }
-}
-
-#[derive(Clone)]
-struct InboundHandler {
-    config: MixnetNodeConfig,
-    client_tx: mpsc::Sender<Body>,
-    packet_tx: mpsc::UnboundedSender<Packet>,
-}
-
-impl InboundHandler {
-    async fn handle_connection(&self, mut socket: TcpStream) -> Result<()> {
-        loop {
-            let body = Body::read(&mut socket).await?;
-            let this = self.clone();
-            tokio::spawn(async move {
-                if let Err(e) = this.handle_body(body).await {
-                    tracing::error!("failed to handle body: {e}");
-                }
-            });
-        }
-    }
-
-    async fn handle_body(&self, body: Body) -> Result<()> {
-        match body {
-            Body::SphinxPacket(packet) => self.handle_sphinx_packet(packet).await,
-            Body::FinalPayload(payload) => {
-                self.forward_body_to_client_notifier(Body::FinalPayload(payload))
-                    .await
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    async fn handle_sphinx_packet(&self, packet: Box<SphinxPacket>) -> Result<()> {
-        match packet
-            .process(&PrivateKey::from(self.config.private_key))
-            .map_err(ProtocolError::InvalidSphinxPacket)?
-        {
-            ProcessedPacket::ForwardHop(packet, next_node_addr, delay) => {
-                self.forward_packet_to_next_hop(Body::SphinxPacket(packet), next_node_addr, delay)
-                    .await
-            }
-            ProcessedPacket::FinalHop(destination_addr, _, payload) => {
-                self.forward_payload_to_destination(Body::FinalPayload(payload), destination_addr)
-                    .await
-            }
-        }
-    }
-
-    async fn forward_body_to_client_notifier(&self, body: Body) -> Result<()> {
-        // TODO: Decrypt the final payload using the private key, if it's encrypted
-
-        // Do not wait when the channel is full or no receiver exists
-        self.client_tx.try_send(body)?;
-        Ok(())
-    }
-
-    async fn forward_packet_to_next_hop(
-        &self,
-        packet: Body,
-        next_node_addr: NodeAddressBytes,
-        delay: Delay,
-    ) -> Result<()> {
-        tracing::debug!("Delaying the packet for {delay:?}");
-        tokio::time::sleep(delay.to_duration()).await;
-
-        self.forward(packet, NymNodeRoutingAddress::try_from(next_node_addr)?)
-            .await
-    }
-
-    async fn forward_payload_to_destination(
-        &self,
-        payload: Body,
-        destination_addr: DestinationAddressBytes,
-    ) -> Result<()> {
-        tracing::debug!("Forwarding final payload to destination mixnode");
-
-        self.forward(
-            payload,
-            NymNodeRoutingAddress::try_from_bytes(&destination_addr.as_bytes())?,
-        )
-        .await
-    }
-
-    async fn forward(&self, body: Body, to: NymNodeRoutingAddress) -> Result<()> {
-        let addr = SocketAddr::from(to);
-
-        self.packet_tx.send(Packet::new(addr, body))?;
-        Ok(())
-    }
-}
-
-struct ForwardScheduler {
-    config: MixnetNodeConfig,
-    rx: mpsc::UnboundedReceiver<Packet>,
-    forwarders: HashMap<SocketAddr, Forwarder>,
-}
-
-impl ForwardScheduler {
-    pub fn new(rx: mpsc::UnboundedReceiver<Packet>, config: MixnetNodeConfig) -> Self {
-        Self {
-            config,
-            rx,
-            forwarders: HashMap::with_capacity(config.connection_pool_size),
-        }
-    }
-
-    pub async fn run(mut self) {
-        loop {
-            tokio::select! {
-                packet = self.rx.recv() => {
-                    if let Some(packet) = packet {
-                        self.schedule(packet, self.config).await;
-                    } else {
-                        unreachable!("Packet channel should not be closed, because PacketForwarder is also holding the send half");
-                    }
-                },
-                _ = tokio::signal::ctrl_c() => {
-                    tracing::info!("Shutting down packet forwarder task...");
-                    return;
-                }
-            }
-        }
-    }
-
-    async fn schedule(&mut self, packet: Packet, config: MixnetNodeConfig) {
-        if let Entry::Vacant(entry) = self.forwarders.entry(packet.target) {
-            entry.insert(Forwarder::new(packet.target, config));
-        }
-
-        let forwarder = self.forwarders.get_mut(&packet.target).unwrap();
-        forwarder.schedule(packet.body);
-    }
-}
-
-struct Forwarder {
-    tx: mpsc::UnboundedSender<Body>,
-}
-
-impl Forwarder {
-    fn new(addr: SocketAddr, config: MixnetNodeConfig) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
-
-        let tx_ = tx.clone();
-        tokio::spawn(async move {
-            Forwarder::run(addr, rx, tx_, config).await;
-        });
-
-        Self { tx }
-    }
-
-    async fn run(
-        addr: SocketAddr,
-        mut rx: mpsc::UnboundedReceiver<Body>,
-        mut tx: mpsc::UnboundedSender<Body>,
-        config: MixnetNodeConfig,
-    ) {
-        loop {
-            match Forwarder::connect_and_forward(addr, &mut rx, &mut tx).await {
-                Ok(_) => {
-                    tracing::debug!("closing the forwarder: {addr}");
-                    return;
-                }
-                Err(e) => {
-                    tracing::error!("retrying: failed to connect and forward to {addr}: {e}");
-                    tokio::time::sleep(config.retry_delay).await;
-                }
-            }
-        }
-    }
-
-    async fn connect_and_forward(
-        addr: SocketAddr,
-        rx: &mut mpsc::UnboundedReceiver<Body>,
-        tx: &mut mpsc::UnboundedSender<Body>,
-    ) -> core::result::Result<(), ProtocolError> {
-        match TcpStream::connect(addr).await {
-            Ok(mut conn) => {
-                while let Some(body) = rx.recv().await {
-                    if let Err(e) = body.write(&mut conn).await {
-                        match e {
-                            ProtocolError::IO(_) => {
-                                tx.send(body).expect("the receiver half is always open");
-                                return Err(e);
-                            }
-                            _ => {
-                                tracing::error!("ignoring: failed to forward body to {addr}: {e}",);
-                            }
-                        }
-                    } else {
-                        tracing::debug!("forwarded body to {addr}");
-                    }
-                }
-
-                // the sender half has been closed.
-                Ok(())
-            }
-            Err(e) => Err(ProtocolError::from(e)),
-        }
-    }
-
-    pub fn schedule(&mut self, body: Body) {
-        self.tx
-            .send(body)
-            .expect("the receiver half is always open");
-    }
-}
-
-pub struct Packet {
-    target: SocketAddr,
-    body: Body,
-}
-
-impl Packet {
-    fn new(target: SocketAddr, body: Body) -> Self {
-        Self { target, body }
     }
 }


### PR DESCRIPTION
Closes #526 

- b7a5ac732bd39fcf15a4f0ce91998972bfe8bb6d: fixed the mixnode HOL blocking issue where the mixnode process is blocked if only one of packets is not forwarded in the reasonable amount of time.
  - Instead of having a single task who forwards all packets sequentially, spawn a separate task for each destination connection. IIRC, this is the way that we had previously discussed, but we missed to implemented it.
- f4a40b9539208a4266711f7c0018d0ba5e5c5992: refactored into sub-files.
- 8c1d959634d3a7ad4afca6fdd370350b9040f102: comments (sorry for putting this commit at the last).

TODO: https://github.com/logos-co/nomos-node/issues/529