### PR TITLE
Unbox select traits

### DIFF
--- a/nomos-core/src/da/certificate/mod.rs
+++ b/nomos-core/src/da/certificate/mod.rs
@@ -20,5 +20,5 @@ pub trait BlobCertificateSelect {
     fn select_blob_from<'i, I: Iterator<Item = Self::Certificate> + 'i>(
         &self,
         certificates: I,
-    ) -> Box<dyn Iterator<Item = Self::Certificate> + 'i>;
+    ) -> impl Iterator<Item = Self::Certificate> + 'i;
 }

--- a/nomos-core/src/da/certificate/select.rs
+++ b/nomos-core/src/da/certificate/select.rs
@@ -30,7 +30,7 @@ impl<const SIZE: usize, C: Certificate> BlobCertificateSelect for FillSize<SIZE,
     fn select_blob_from<'i, I: Iterator<Item = Self::Certificate> + 'i>(
         &self,
         certificates: I,
-    ) -> Box<dyn Iterator<Item = Self::Certificate> + 'i> {
+    ) -> impl Iterator<Item = Self::Certificate> + 'i {
         utils::select::select_from_till_fill_size::<SIZE, Self::Certificate>(
             |blob| blob.as_bytes().len(),
             certificates,

--- a/nomos-core/src/tx/mod.rs
+++ b/nomos-core/src/tx/mod.rs
@@ -28,5 +28,5 @@ pub trait TxSelect {
     fn select_tx_from<'i, I: Iterator<Item = Self::Tx> + 'i>(
         &self,
         txs: I,
-    ) -> Box<dyn Iterator<Item = Self::Tx> + 'i>;
+    ) -> impl Iterator<Item = Self::Tx> + 'i;
 }

--- a/nomos-core/src/tx/select.rs
+++ b/nomos-core/src/tx/select.rs
@@ -30,7 +30,7 @@ impl<const SIZE: usize, Tx: Transaction> TxSelect for FillSize<SIZE, Tx> {
     fn select_tx_from<'i, I: Iterator<Item = Self::Tx> + 'i>(
         &self,
         txs: I,
-    ) -> Box<dyn Iterator<Item = Self::Tx> + 'i> {
+    ) -> impl Iterator<Item = Self::Tx> + 'i {
         utils::select::select_from_till_fill_size::<SIZE, Self::Tx>(|tx| tx.as_bytes().len(), txs)
     }
 }

--- a/nomos-core/src/utils/select.rs
+++ b/nomos-core/src/utils/select.rs
@@ -1,10 +1,10 @@
 pub fn select_from_till_fill_size<'i, const SIZE: usize, T>(
     mut measure: impl FnMut(&T) -> usize + 'i,
     items: impl Iterator<Item = T> + 'i,
-) -> Box<dyn Iterator<Item = T> + 'i> {
+) -> impl Iterator<Item = T> + 'i {
     let mut current_size = 0usize;
-    Box::new(items.take_while(move |item: &T| {
+    items.take_while(move |item: &T| {
         current_size += measure(item);
         current_size <= SIZE
-    }))
+    })
 }


### PR DESCRIPTION
After rust 1.75 we can start migrating and use `impl Foo` in return positions in traits. I've been playing around with it a bit. Simple ones are easy to migrate. Once it hits lifetimes, adding `Send`  or using `Stream` makes things a bit more complicated. For now as initial brick we have this.