### PR TITLE
Testnet config update for nomos.tech

### DIFF
--- a/compose.static.yml
+++ b/compose.static.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: testnet/Dockerfile
     ports:
       - "3000:3000/tcp"
-      - "18080:8080/tcp"
+      - "18080:18080/tcp"
     volumes:
       - ./testnet:/etc/nomos
     depends_on:
@@ -37,7 +37,7 @@ services:
       - mix-node-2
     ports:
       - "3001:3000/tcp"
-      - "18081:8080/tcp"
+      - "18081:18080/tcp"
     environment:
       - LIBP2P_REPLICAS=3
       - ETCDCTL_ENDPOINTS=${DOCKER_COMPOSE_ETCDCTL_ENDPOINTS:-etcd:2379}
@@ -63,7 +63,7 @@ services:
       - mix-node-2
     ports:
       - "3002:3000/tcp"
-      - "18082:8080/tcp"
+      - "18082:18080/tcp"
     environment:
       - LIBP2P_REPLICAS=3
       - ETCDCTL_ENDPOINTS=${DOCKER_COMPOSE_ETCDCTL_ENDPOINTS:-etcd:2379}
@@ -89,7 +89,7 @@ services:
       - mix-node-2
     ports:
       - "3003:3000/tcp"
-      - "18083:8080/tcp"
+      - "18083:18080/tcp"
     environment:
       - LIBP2P_REPLICAS=3
       - ETCDCTL_ENDPOINTS=${DOCKER_COMPOSE_ETCDCTL_ENDPOINTS:-etcd:2379}

--- a/testnet/bootstrap_config.yaml
+++ b/testnet/bootstrap_config.yaml
@@ -73,7 +73,7 @@ da:
     voter: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     num_attestations: 1
   backend:
-    max_capacity: 10
+    max_capacity: 10000
     evicting_period: 
       secs: 3600
       nanos: 0

--- a/testnet/bootstrap_config.yaml
+++ b/testnet/bootstrap_config.yaml
@@ -65,7 +65,7 @@ network:
 
 http:
   backend_settings:
-    address: 0.0.0.0:8080
+    address: 0.0.0.0:18080
     cors_origins: []
 
 da:

--- a/testnet/libp2p_config.yaml
+++ b/testnet/libp2p_config.yaml
@@ -73,7 +73,7 @@ da:
     voter: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     num_attestations: 1
   backend:
-    max_capacity: 10
+    max_capacity: 10000
     evicting_period: 
       secs: 3600
       nanos: 0

--- a/testnet/libp2p_config.yaml
+++ b/testnet/libp2p_config.yaml
@@ -65,7 +65,7 @@ network:
 
 http:
   backend_settings:
-    address: 0.0.0.0:8080
+    address: 0.0.0.0:18080
     cors_origins: []
 
 da:


### PR DESCRIPTION
To avoid configuring firewall rules for multiple port ranges, nomos http ports are set in the same range for containers and host.
In addition DA storage limit was increased.