### PR TITLE
Receive blocks blobs in parallel

### DIFF
--- a/nomos-cli/config.yaml
+++ b/nomos-cli/config.yaml
@@ -1,3 +1,45 @@
 backend:
-  host: "127.0.0.1"
-  port: 8000
+  host: 0.0.0.0
+  port: 3019
+  log_level: "fatal"
+  # Node key needs to be unique for every client.
+  node_key: "0000000000000000000000000000000000000000000000000000000000001444"
+  discV5BootstrapNodes: []
+  initial_peers: ["/dns/testnet.nomos.tech/tcp/3000"]
+  relayTopics: []
+  # Mixclient configuration to communicate with mixnodes.
+  # The libp2p network backend always requires this mixclient configuration
+  # (cannot be disabled for now).
+  mixnet_client:
+    # A mixclient mode. For details, see the documentation of the "mixnet" crate.
+    # - Sender
+    # - !SenderReceiver [mixnode_client_listen_address]
+    mode: Sender
+    # A mixnet topology, which contains the information of all mixnodes in the mixnet.
+    # (The topology is static for now.)
+    topology:
+      # Each mixnet layer consists of a list of mixnodes.
+      layers:
+       - nodes:
+          - address: testnet.nomos.tech:7707  # A listen address of the mixnode
+            public_key: "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715"
+       - nodes:
+          - address: testnet.nomos.tech:7717  # A listen address of the mixnode
+            public_key: "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715"
+
+       - nodes:
+          - address: testnet.nomos.tech:7727  # A listen address of the mixnode
+            public_key: "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715"
+
+    # A max number of connections that will stay connected to mixnodes in the first mixnet layer.
+    connection_pool_size: 255
+    max_retries: 5
+    retry_delay:
+      secs: 1
+      nanos: 0
+  # A range of total delay that will be set to each Sphinx packets
+  # sent to the mixnet for timing obfuscation.
+  # Panics if start > end.
+  mixnet_delay:
+    start: "0ms"
+    end: "0ms"


### PR DESCRIPTION
This change allows demo app to receive blobs of multiple blocks in parallel, thus making demo app instantaneous (compared to previous version) even on a very fast nomos network.

I encourage you to test it on `testnet.nomos.tech`.
To connect, compile the project and run `./target/debug/nomos-cli chat --network-config nomos-cli/config.yaml --node http://testnet.nomos.tech:18080`

Note: **Be sure to change `nomos-cli/config.yaml` `node_key` to something different in case multiple clients connect to the network**

Note: Try sending unique messages (e.g. don't send "hi"), there are some limitations in DA at the moment.

Note: Long messages gets disseminated, but for some reason won't show up in the chat.
