### PR TITLE
bump rayon version to make cargo work

### DIFF
--- a/simulations/Cargo.toml
+++ b/simulations/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.17"
 parking_lot = "0.12"
 polars = { version = "0.27", features = ["serde", "object", "json", "csv-file", "parquet", "dtype-struct"], optional = true }
 rand = { version = "0.8", features = ["small_rng"] }
-rayon = "1.7"
+rayon = "1.8"
 scopeguard = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_with = "2.3"


### PR DESCRIPTION
Cargo fails to work because of version conflicts.

<img width="1332" alt="image" src="https://github.com/logos-co/nomos-node/assets/42351146/eaadf440-00d3-4cf7-bba1-cc605f1e833b">
