### PR TITLE
Prune blocks for consensus

### DIFF
--- a/consensus/carnot-engine/src/types/view.rs
+++ b/consensus/carnot-engine/src/types/view.rs
@@ -43,6 +43,10 @@ impl View {
     pub const fn prev(&self) -> Self {
         Self(self.0 - 1)
     }
+
+    pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
+    }
 }
 
 impl From<i64> for View {

--- a/nomos-cli/src/api/consensus.rs
+++ b/nomos-cli/src/api/consensus.rs
@@ -13,6 +13,16 @@ pub async fn carnot_info(node: &Url) -> Result<CarnotInfo, reqwest::Error> {
         .await
 }
 
+pub async fn carnot_prune(node: &Url) -> Result<(), reqwest::Error> {
+    const NODE_CARNOT_PRUNE_PATH: &str = "carnot/prune";
+    CLIENT
+        .get(node.join(NODE_CARNOT_PRUNE_PATH).unwrap())
+        .send()
+        .await?
+        .json::<()>()
+        .await
+}
+
 pub async fn get_blocks_info(
     node: &Url,
     from: Option<BlockId>,

--- a/nomos-cli/src/api/consensus.rs
+++ b/nomos-cli/src/api/consensus.rs
@@ -13,10 +13,11 @@ pub async fn carnot_info(node: &Url) -> Result<CarnotInfo, reqwest::Error> {
         .await
 }
 
-pub async fn carnot_prune(node: &Url) -> Result<(), reqwest::Error> {
+pub async fn carnot_prune(node: &Url, offset: i64) -> Result<(), reqwest::Error> {
     const NODE_CARNOT_PRUNE_PATH: &str = "carnot/prune";
-    CLIENT
-        .get(node.join(NODE_CARNOT_PRUNE_PATH).unwrap())
+    let mut req = CLIENT.get(node.join(NODE_CARNOT_PRUNE_PATH).unwrap());
+    req = req.query(&[("kind", "end")]);
+    req.query(&[("offset", offset)])
         .send()
         .await?
         .json::<()>()

--- a/nomos-cli/src/cmds/chat/mod.rs
+++ b/nomos-cli/src/cmds/chat/mod.rs
@@ -245,7 +245,7 @@ async fn check_for_messages(sender: Sender<Vec<ChatMessage>>, node: Url) {
         let n = node.clone();
         tokio::spawn(async move {
             // We do not care the prune result
-            let _ = carnot_prune(&n).await;
+            let _ = carnot_prune(&n, 3).await;
         });
     }
 }

--- a/nomos-services/carnot-consensus/src/network/adapters/mock.rs
+++ b/nomos-services/carnot-consensus/src/network/adapters/mock.rs
@@ -13,7 +13,7 @@ use crate::network::{
     messages::{ProposalMsg, VoteMsg},
     BoxedStream, NetworkAdapter,
 };
-use consensus_engine::{BlockId, Committee, View};
+use carnot_engine::{BlockId, Committee, View};
 
 const MOCK_PUB_SUB_TOPIC: &str = "MockPubSubTopic";
 const MOCK_BLOCK_CONTENT_TOPIC: MockContentTopic = MockContentTopic::new("MockSim", 1, "MockBlock");


### PR DESCRIPTION
- Add `ConsensusMsg::Prune`
- Add a HTTP API for pruning old blocks