### PR TITLE
Disseminate app file input

### DIFF
--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -9,11 +9,11 @@ use reqwest::Url;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Default)]
 pub struct Disseminate {
     // TODO: accept bytes
     #[clap(short, long)]
-    pub data: String,
+    pub data: Option<String>,
     /// Path to the network config file
     #[clap(short, long)]
     pub network_config: PathBuf,
@@ -30,6 +30,9 @@ pub struct Disseminate {
     /// File to write the certificate to, if present.
     #[clap(long)]
     pub output: Option<PathBuf>,
+    /// File to disseminate
+    #[clap(short, long)]
+    pub file: Option<PathBuf>,
 }
 
 impl Disseminate {
@@ -41,7 +44,15 @@ impl Disseminate {
             <NetworkService<Libp2p> as ServiceData>::Settings,
         >(std::fs::File::open(&self.network_config)?)?;
         let (status_updates, rx) = std::sync::mpsc::channel();
-        let bytes: Box<[u8]> = self.data.clone().as_bytes().into();
+        let bytes: Box<[u8]> = match (&self.data, &self.file) {
+            (Some(data), None) => data.clone().as_bytes().into(),
+            (None, Some(file_path)) => {
+                let file_bytes = std::fs::read(file_path)?;
+                file_bytes.into_boxed_slice()
+            }
+            (Some(_), Some(_)) => return Err("Cannot specify both data and file".into()),
+            (None, None) => return Err("Either data or file must be specified".into()),
+        };
         let timeout = Duration::from_secs(self.timeout);
         let da_protocol = self.da_protocol.clone();
         let node_addr = self.node_addr.clone();

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -205,7 +205,7 @@ impl ServiceCore for DisseminateService {
 // protocols, but only the one chosen will be used.
 // We can enforce only sensible combinations of protocol/settings
 // are specified by using special clap directives
-#[derive(Clone, Debug, Args)]
+#[derive(Clone, Debug, Args, Default)]
 pub struct DaProtocolChoice {
     #[clap(long, default_value = "full-replication")]
     pub da_protocol: Protocol,
@@ -227,14 +227,15 @@ impl TryFrom<DaProtocolChoice> for FullReplication<AbsoluteNumber<Attestation, C
     }
 }
 
-#[derive(Clone, Debug, Args)]
+#[derive(Clone, Debug, Args, Default)]
 pub struct ProtocolSettings {
     #[clap(flatten)]
     pub full_replication: FullReplicationSettings,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, ValueEnum, Default)]
 pub enum Protocol {
+    #[default]
     FullReplication,
 }
 


### PR DESCRIPTION
To use dissemination app as a bot for chat demo, there needs to be a way to send any binary data to the DA storage.
Nomos chat is encoding ChatMessage with bincode, now dissemination app will be able to send preencoded messages as a bot in the testnet.