### PR TITLE
Nomos chat app non interactive

### DIFF
--- a/nomos-cli/src/cmds/chat/mod.rs
+++ b/nomos-cli/src/cmds/chat/mod.rs
@@ -67,7 +67,7 @@ pub struct NomosChat {
     #[clap(long, requires("message"))]
     pub author: Option<String>,
     /// Message for non interactive message formation
-    #[clap(long)]
+    #[clap(long, requires("author"))]
     pub message: Option<String>,
 }
 

--- a/nomos-cli/src/cmds/chat/mod.rs
+++ b/nomos-cli/src/cmds/chat/mod.rs
@@ -63,6 +63,12 @@ pub struct NomosChat {
     /// The node to connect to to fetch blocks and blobs
     #[clap(long)]
     pub node: Url,
+    /// Author for non interactive message formation
+    #[clap(long, requires("message"))]
+    pub author: Option<String>,
+    /// Message for non interactive message formation
+    #[clap(long)]
+    pub message: Option<String>,
 }
 
 pub struct App {
@@ -86,12 +92,6 @@ impl NomosChat {
             <NetworkService<Libp2p> as ServiceData>::Settings,
         >(std::fs::File::open(&self.network_config)?)?;
         let da_protocol = self.da_protocol.clone();
-        // setup terminal
-        enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-        let backend = CrosstermBackend::new(stdout);
-        let mut terminal = Terminal::new(backend)?;
 
         let node_addr = Some(self.node.clone());
 
@@ -125,6 +125,21 @@ impl NomosChat {
             .wait_finished()
         });
 
+        if let Some(author) = self.author.as_ref() {
+            let message = self
+                .message
+                .as_ref()
+                .expect("Should be available if author is set");
+            return run_once(author, message, payload_sender);
+        }
+
+        // setup terminal
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend)?;
+
         let app = App {
             input: Input::default(),
             username: None,
@@ -152,6 +167,24 @@ impl NomosChat {
 
         Ok(())
     }
+}
+
+fn run_once(
+    author: &str,
+    message: &str,
+    payload_sender: UnboundedSender<Box<[u8]>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    payload_sender.send(
+        wire::serialize(&ChatMessage {
+            author: author.to_string(),
+            message: message.to_string(),
+            _nonce: rand::random(),
+        })
+        .unwrap()
+        .into(),
+    )?;
+
+    Ok(())
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) {


### PR DESCRIPTION
Add params to nomos cli app to send chat message and exit the application. This will be used alongside the dissemination app to produce constant traffic in the testnet.

For chat app to decode messages, they need to be in ChatMessage struct, encoded with bincode. Bincode has no external cli tool to encode independantly, so either we need to write that tool, that we would be able to use from scripts, or we use chatapp to do encoding to ChatMessage directly, because it's specific to it.

Dissemination app will still be used for big data blob uploads to the testnet.