### PR TITLE
Add testnet cli_config and volume

### DIFF
--- a/compose.static.yml
+++ b/compose.static.yml
@@ -176,8 +176,8 @@ services:
     env_file:
       - ./testnet/monitoring/grafana/plugins.env
     volumes:
-      - ./testnet/monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini
-        ./testnet/monitoring/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./testnet/monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini:z
+      - ./testnet/monitoring/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:z
     ports:
       - 9091:3000
     restart: on-failure

--- a/compose.static.yml
+++ b/compose.static.yml
@@ -144,6 +144,8 @@ services:
     build:
       context: .
       dockerfile: testnet/Dockerfile
+    volumes:
+      - ./testnet:/etc/nomos
     entrypoint: /etc/nomos/scripts/run_nomos_bot.sh
 
   etcd:

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -2,10 +2,6 @@
 
 FROM rust:1.75.0-slim-bullseye AS builder
 
-# Using backports for go 1.19
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' \
-    >> /etc/apt/sources.list
-
 # Dependecies for publishing documentation.
 RUN apt-get update && apt-get install -yq \
     git clang etcd-client libssl-dev pkg-config
@@ -17,7 +13,7 @@ RUN cargo build --release --all --features metrics
 
 # NODE IMAGE ----------------------------------------------------------
 
-FROM bitnami/minideb:latest
+FROM bitnami/minideb:bullseye
 
 LABEL maintainer="augustinas@status.im" \
       source="https://github.com/logos-co/nomos-node" \
@@ -31,6 +27,5 @@ COPY --from=builder /nomos/target/release/nomos-cli /usr/bin/nomos-cli
 COPY --from=builder /nomos/target/release/mixnode /usr/bin/mixnode
 COPY --from=builder /usr/bin/etcdctl /usr/bin/etcdctl
 COPY nodes/nomos-node/config.yaml /etc/nomos/config.yaml
-RUN install_packages python3 python3-etcd3
 
 ENTRYPOINT ["/usr/bin/nomos-node"]

--- a/testnet/cli_config.yaml
+++ b/testnet/cli_config.yaml
@@ -1,0 +1,44 @@
+backend:
+  host: 0.0.0.0
+  port: 4007
+  log_level: "fatal"
+  node_key: "0000000000000000000000000000000000000000000000000000000000000667"
+  discV5BootstrapNodes: []
+  initial_peers: ["/dns/bootstrap/tcp/3000"]
+  relayTopics: []
+  # Mixclient configuration to communicate with mixnodes.
+  # The libp2p network backend always requires this mixclient configuration
+  # (cannot be disabled for now).
+  mixnet_client:
+    # A mixclient mode. For details, see the documentation of the "mixnet" crate.
+    # - Sender
+    # - !SenderReceiver [mixnode_client_listen_address]
+    mode: Sender
+    # A mixnet topology, which contains the information of all mixnodes in the mixnet.
+    # (The topology is static for now.)
+    topology:
+      # Each mixnet layer consists of a list of mixnodes.
+      layers:
+       - nodes:
+          - address: mix-node-0:7707  # A listen address of the mixnode
+            public_key: "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715"
+       - nodes:
+          - address: mix-node-1:7717  # A listen address of the mixnode
+            public_key: "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715"
+
+       - nodes:
+          - address: mix-node-2:7727  # A listen address of the mixnode
+            public_key: "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715"
+
+    # A max number of connections that will stay connected to mixnodes in the first mixnet layer.
+    connection_pool_size: 255
+    max_retries: 5
+    retry_delay:
+      secs: 1
+      nanos: 0
+  # A range of total delay that will be set to each Sphinx packets
+  # sent to the mixnet for timing obfuscation.
+  # Panics if start > end.
+  mixnet_delay:
+    start: "0ms"
+    end: "0ms"

--- a/testnet/scripts/run_nomos_bot.sh
+++ b/testnet/scripts/run_nomos_bot.sh
@@ -4,6 +4,6 @@ echo "I am a container ${HOSTNAME} bot"
 
 while true
 do
-    /usr/bin/nomos-cli chat --author nomos-ghost --message "$(date +%H:%M:%S) ~ ping" --network-config /etc/nomos/cli_config.yml --node-addr http://bootstrap:18080
+    /usr/bin/nomos-cli chat --author nomos-ghost --message "$(date +%H:%M:%S) ~ ping" --network-config /etc/nomos/cli_config.yaml --node http://bootstrap:18080
     sleep 10
 done


### PR DESCRIPTION
Three fixes were requried after the grafana and nomos bot addition:
- Grafana failed to start because of configuration file mode (644), setting it explicitly should help;
- Nomos chat bot cli params were incorrect, and the configuration filename misspelled;
- Nomos chat requires openssl libs, and because "build" image was using different debian version, the "exec" image had dependencies in different place with different versions.