### PR TITLE
Use QUIC for libp2p

### DIFF
--- a/nomos-libp2p/Cargo.toml
+++ b/nomos-libp2p/Cargo.toml
@@ -7,15 +7,12 @@ edition = "2021"
 multiaddr = "0.18"
 tokio = { version = "1", features = ["sync", "macros"] }
 futures = "0.3"
-libp2p = { version = "0.52.4", features = [
+libp2p = { version = "0.53.2", features = [
   "dns",
-  "yamux",
-  "plaintext",
   "macros",
   "gossipsub",
-  "identify",
-  "tcp",
   "tokio",
+  "quic",
   "secp256k1",
 ] }
 blake2 = { version = "0.10" }

--- a/nomos-services/network/src/backends/libp2p/swarm.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, time::Duration};
 use nomos_libp2p::{
     gossipsub::{self, Message},
     libp2p::swarm::ConnectionId,
-    Behaviour, BehaviourEvent, Multiaddr, Swarm, SwarmEvent, THandlerErr,
+    BehaviourEvent, Multiaddr, Swarm, SwarmEvent,
 };
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::StreamExt;
@@ -79,8 +79,7 @@ impl SwarmHandler {
         }
     }
 
-    #[allow(deprecated)]
-    fn handle_event(&mut self, event: SwarmEvent<BehaviourEvent, THandlerErr<Behaviour>>) {
+    fn handle_event(&mut self, event: SwarmEvent<BehaviourEvent>) {
         match event {
             SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Message {
                 propagation_source: peer_id,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -39,6 +39,7 @@ pub fn adjust_timeout(d: Duration) -> Duration {
 pub trait Node: Sized {
     type ConsensusInfo: Debug + Clone + PartialEq;
     async fn spawn_nodes(config: SpawnConfig) -> Vec<Self>;
+    fn node_configs(config: SpawnConfig) -> Vec<nomos_node::Config>;
     async fn consensus_info(&self) -> Self::ConsensusInfo;
     fn stop(&mut self);
 }

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -10,7 +10,7 @@ use carnot_engine::overlay::{RandomBeaconState, RoundRobin, TreeOverlay, TreeOve
 use carnot_engine::{BlockId, NodeId, Overlay};
 use full_replication::Certificate;
 use nomos_core::block::Block;
-use nomos_libp2p::{multiaddr, Multiaddr};
+use nomos_libp2p::{Multiaddr, Swarm};
 use nomos_log::{LoggerBackend, LoggerFormat};
 use nomos_mempool::MempoolMetrics;
 use nomos_network::backends::libp2p::Libp2pConfig;
@@ -334,7 +334,10 @@ fn create_node_config(
 }
 
 fn node_address(config: &Config) -> Multiaddr {
-    multiaddr!(Ip4([127, 0, 0, 1]), Tcp(config.network.backend.inner.port))
+    Swarm::multiaddr(
+        std::net::Ipv4Addr::new(127, 0, 0, 1),
+        config.network.backend.inner.port,
+    )
 }
 
 pub enum Pool {


### PR DESCRIPTION
This PR will be merged to the PR #569, not `master`.

I replaced TCP with QUIC in the `nomos-libp2p` crate, which will be used by the `mixnet` network backend.
Plus, I bumped libp2p to the latest version that contains the libp2p `stream` protocol, which is necessary for mixnet communication.

DA integration tests will be failed because of the difference between TCP and QUIC when connections are closed. I'll open another PR to modify tests for QUIC environment.