### PR TITLE
Fix integration tests for QUIC environment

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -39,6 +39,7 @@ pub fn adjust_timeout(d: Duration) -> Duration {
 pub trait Node: Sized {
     type ConsensusInfo: Debug + Clone + PartialEq;
     async fn spawn_nodes(config: SpawnConfig) -> Vec<Self>;
+    fn node_configs(config: SpawnConfig) -> Vec<nomos_node::Config>;
     async fn consensus_info(&self) -> Self::ConsensusInfo;
     fn stop(&mut self);
 }

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -198,6 +198,8 @@ impl NomosNode {
 impl Node for NomosNode {
     type ConsensusInfo = CarnotInfo;
 
+    /// Spawn nodes sequentially.
+    /// After one node is spawned successfully, the next node is spawned.
     async fn spawn_nodes(config: SpawnConfig) -> Vec<Self> {
         let mut nodes = Vec::new();
         for conf in Self::node_configs(config) {

--- a/tests/src/nodes/nomos.rs
+++ b/tests/src/nodes/nomos.rs
@@ -199,34 +199,42 @@ impl Node for NomosNode {
     type ConsensusInfo = CarnotInfo;
 
     async fn spawn_nodes(config: SpawnConfig) -> Vec<Self> {
+        let mut nodes = Vec::new();
+        for conf in Self::node_configs(config) {
+            nodes.push(Self::spawn(conf).await);
+        }
+        nodes
+    }
+
+    fn node_configs(config: SpawnConfig) -> Vec<nomos_node::Config> {
         match config {
             SpawnConfig::Star { consensus } => {
                 let (next_leader_config, configs) = create_node_configs(consensus);
 
                 let first_node_addr = node_address(&next_leader_config);
-                let mut nodes = vec![Self::spawn(next_leader_config).await];
+                let mut node_configs = vec![next_leader_config];
                 for mut conf in configs {
                     conf.network
                         .backend
                         .initial_peers
                         .push(first_node_addr.clone());
 
-                    nodes.push(Self::spawn(conf).await);
+                    node_configs.push(conf);
                 }
-                nodes
+                node_configs
             }
             SpawnConfig::Chain { consensus } => {
                 let (next_leader_config, configs) = create_node_configs(consensus);
 
                 let mut prev_node_addr = node_address(&next_leader_config);
-                let mut nodes = vec![Self::spawn(next_leader_config).await];
+                let mut node_configs = vec![next_leader_config];
                 for mut conf in configs {
                     conf.network.backend.initial_peers.push(prev_node_addr);
                     prev_node_addr = node_address(&conf);
 
-                    nodes.push(Self::spawn(conf).await);
+                    node_configs.push(conf);
                 }
-                nodes
+                node_configs
             }
         }
     }


### PR DESCRIPTION
This PR will be merged to the PR #580.

When using QUIC (as changed in #580), DA integration tests fail because of the difference between TCP and QUIC.
The tests spawn two nomos-nodes and shutdown the second node in order to run the DA CLI with the same config that the second node used.
When two nodes were spawned, the first node accepted a connection with the libp2p `PeerId` of the second node. And, the connection is not automatically disconnected when the second node is shutdown because it's not TCP.
So, if the DA CLI is started with the same `PeerId` and tries to connect to the first node, the first node rejects the connection because it already has the previous connection for the `PeedId`.

Of course, we can make the DA CLI use a different `PeerId`. But instead, I modified the tests to spawn only the first node (to not spawn the second node). I think it's much simpler and safer.