### PR TITLE
DA Api Metadata

### DIFF
--- a/nomos-cli/src/cmds/chat/mod.rs
+++ b/nomos-cli/src/cmds/chat/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use clap::Args;
 use full_replication::{
-    AbsoluteNumber, Attestation, Certificate, FullReplication, Settings as DaSettings,
+    AbsoluteNumber, Attestation, Certificate, FullReplication, Metadata, Settings as DaSettings,
 };
 use futures::{stream, StreamExt};
 use nomos_core::{da::DaProtocol, header::HeaderId, wire};
@@ -79,7 +79,7 @@ pub struct App {
     message_status: Option<Status>,
     message_in_flight: bool,
     last_updated: Instant,
-    payload_sender: UnboundedSender<Box<[u8]>>,
+    payload_sender: UnboundedSender<(Metadata, Box<[u8]>)>,
     status_updates: Receiver<Status>,
     node: Url,
     logs: Arc<sync::Mutex<Vec<u8>>>,
@@ -173,9 +173,10 @@ impl NomosChat {
 fn run_once(
     author: &str,
     message: &str,
-    payload_sender: UnboundedSender<Box<[u8]>>,
+    payload_sender: UnboundedSender<(Metadata, Box<[u8]>)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    payload_sender.send(
+    payload_sender.send((
+        Metadata::default(),
         wire::serialize(&ChatMessage {
             author: author.to_string(),
             message: message.to_string(),
@@ -183,7 +184,7 @@ fn run_once(
         })
         .unwrap()
         .into(),
-    )?;
+    ))?;
 
     Ok(())
 }
@@ -222,7 +223,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) {
                         if !app.message_in_flight && !app.input.value().is_empty() {
                             app.message_in_flight = true;
                             app.payload_sender
-                                .send(
+                                .send((
+                                    Metadata::default(), // TODO: track index and pass app_id
                                     wire::serialize(&ChatMessage {
                                         author: app.username.clone().unwrap(),
                                         message: app.input.value().into(),
@@ -230,7 +232,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) {
                                     })
                                     .unwrap()
                                     .into(),
-                                )
+                                ))
                                 .unwrap();
                         }
                     }

--- a/nomos-cli/src/cmds/chat/mod.rs
+++ b/nomos-cli/src/cmds/chat/mod.rs
@@ -8,7 +8,8 @@ use crate::{
     api::consensus::get_blocks_info,
     da::{
         disseminate::{
-            DaProtocolChoice, DisseminateApp, DisseminateAppServiceSettings, Settings, Status,
+            DaProtocolChoice, DisseminateApp, DisseminateAppServiceSettings, Payload, Settings,
+            Status,
         },
         retrieve::get_block_blobs,
     },
@@ -79,7 +80,7 @@ pub struct App {
     message_status: Option<Status>,
     message_in_flight: bool,
     last_updated: Instant,
-    payload_sender: UnboundedSender<(Metadata, Box<[u8]>)>,
+    payload_sender: UnboundedSender<Payload>,
     status_updates: Receiver<Status>,
     node: Url,
     logs: Arc<sync::Mutex<Vec<u8>>>,
@@ -173,7 +174,7 @@ impl NomosChat {
 fn run_once(
     author: &str,
     message: &str,
-    payload_sender: UnboundedSender<(Metadata, Box<[u8]>)>,
+    payload_sender: UnboundedSender<Payload>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     payload_sender.send((
         Metadata::default(),

--- a/nomos-cli/src/cmds/chat/ui.rs
+++ b/nomos-cli/src/cmds/chat/ui.rs
@@ -129,6 +129,7 @@ fn render_messages(f: &mut Frame, app: &App, rect: Rect) {
                  author,
                  message,
                  _nonce,
+                 ..
              }| {
                 let content = if author == app.username.as_ref().unwrap() {
                     static MARGIN: usize = 2;

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -2,6 +2,7 @@ use crate::da::disseminate::{
     DaProtocolChoice, DisseminateApp, DisseminateAppServiceSettings, Settings, Status,
 };
 use clap::Args;
+use full_replication::Metadata;
 use nomos_log::{LoggerBackend, LoggerSettings};
 use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
 use nomos_network::NetworkService;
@@ -59,7 +60,7 @@ impl Disseminate {
         let node_addr = self.node_addr.clone();
         let output = self.output.clone();
         let (payload_sender, payload_rx) = tokio::sync::mpsc::unbounded_channel();
-        payload_sender.send(bytes).unwrap();
+        payload_sender.send((Metadata::default(), bytes)).unwrap(); // TODO: pass index and app_id
         std::thread::spawn(move || {
             OverwatchRunner::<DisseminateApp>::run(
                 DisseminateAppServiceSettings {

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -30,6 +30,8 @@ use std::{
 };
 use tokio::sync::{mpsc::UnboundedReceiver, Mutex};
 
+pub type Payload = (Metadata, Box<[u8]>);
+
 pub async fn disseminate_and_wait<D, B, N, A, C>(
     mut da: D,
     data: Box<[u8]>,
@@ -124,7 +126,7 @@ pub struct DisseminateApp {
 #[derive(Clone, Debug)]
 pub struct Settings {
     // This is wrapped in an Arc just to make the struct Clone
-    pub payload: Arc<Mutex<UnboundedReceiver<(Metadata, Box<[u8]>)>>>,
+    pub payload: Arc<Mutex<UnboundedReceiver<Payload>>>,
     pub timeout: Duration,
     pub da_protocol: DaProtocolChoice,
     pub status_updates: Sender<Status>,

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -1,9 +1,11 @@
 use crate::api::mempool::send_certificate;
 use clap::{Args, ValueEnum};
-use full_replication::{AbsoluteNumber, Attestation, Certificate, FullReplication, Voter};
+use full_replication::{
+    AbsoluteNumber, Attestation, Certificate, FullReplication, Metadata, Voter,
+};
 use futures::StreamExt;
 use hex::FromHex;
-use nomos_core::{da::DaProtocol, wire};
+use nomos_core::{da::certificate, da::DaProtocol, wire};
 use nomos_da::network::{adapters::libp2p::Libp2pAdapter as DaNetworkAdapter, NetworkAdapter};
 use nomos_log::Logger;
 use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
@@ -31,6 +33,7 @@ use tokio::sync::{mpsc::UnboundedReceiver, Mutex};
 pub async fn disseminate_and_wait<D, B, N, A, C>(
     mut da: D,
     data: Box<[u8]>,
+    metadata: C::Extension,
     adapter: N,
     status_updates: Sender<Status>,
     node_addr: Option<&Url>,
@@ -39,7 +42,8 @@ pub async fn disseminate_and_wait<D, B, N, A, C>(
 where
     D: DaProtocol<Blob = B, Attestation = A, Certificate = C>,
     N: NetworkAdapter<Blob = B, Attestation = A> + Send + Sync,
-    C: Serialize,
+    C: Serialize + certificate::Certificate,
+    C::Extension: Clone,
 {
     // 1) Building blob
     status_updates.send(Status::Encoding)?;
@@ -55,7 +59,7 @@ where
     status_updates.send(Status::WaitingAttestations)?;
     let mut attestations = adapter.attestation_stream().await;
     let cert: C = loop {
-        da.recv_attestation(attestations.next().await.unwrap());
+        da.recv_attestation(attestations.next().await.unwrap(), metadata.clone());
 
         if let Some(certificate) = da.certify_dispersal() {
             status_updates.send(Status::CreatingCert)?;
@@ -120,7 +124,7 @@ pub struct DisseminateApp {
 #[derive(Clone, Debug)]
 pub struct Settings {
     // This is wrapped in an Arc just to make the struct Clone
-    pub payload: Arc<Mutex<UnboundedReceiver<Box<[u8]>>>>,
+    pub payload: Arc<Mutex<UnboundedReceiver<(Metadata, Box<[u8]>)>>>,
     pub timeout: Duration,
     pub da_protocol: DaProtocolChoice,
     pub status_updates: Sender<Status>,
@@ -166,12 +170,13 @@ impl ServiceCore for DisseminateService {
             .await
             .expect("Relay connection with NetworkService should succeed");
 
-        while let Some(data) = payload.lock().await.recv().await {
+        while let Some((metadata, data)) = payload.lock().await.recv().await {
             match tokio::time::timeout(
                 timeout,
                 disseminate_and_wait(
                     da_protocol.clone(),
                     data,
+                    metadata,
                     DaNetworkAdapter::new(network_relay.clone()).await,
                     status_updates.clone(),
                     node_addr.as_ref(),

--- a/nomos-core/src/da/certificate/mod.rs
+++ b/nomos-core/src/da/certificate/mod.rs
@@ -6,9 +6,11 @@ use std::hash::Hash;
 
 pub trait Certificate {
     type Blob: Blob;
+    type Extension;
     type Hash: Hash + Eq + Clone;
     fn blob(&self) -> <Self::Blob as Blob>::Hash;
     fn hash(&self) -> Self::Hash;
+    fn extension(&self) -> Self::Extension;
     fn as_bytes(&self) -> Bytes;
 }
 
@@ -25,8 +27,12 @@ pub trait BlobCertificateSelect {
 
 pub trait CertificateStrategy {
     type Attestation;
-    type Certificate;
+    type Certificate: Certificate;
 
     fn can_build(&self, attestations: &[Self::Attestation]) -> bool;
-    fn build(&self, attestations: Vec<Self::Attestation>) -> Self::Certificate;
+    fn build(
+        &self,
+        attestations: Vec<Self::Attestation>,
+        extension: <Self::Certificate as Certificate>::Extension,
+    ) -> Self::Certificate;
 }

--- a/nomos-core/src/da/certificate/mod.rs
+++ b/nomos-core/src/da/certificate/mod.rs
@@ -22,3 +22,11 @@ pub trait BlobCertificateSelect {
         certificates: I,
     ) -> impl Iterator<Item = Self::Certificate> + 'i;
 }
+
+pub trait CertificateStrategy {
+    type Attestation;
+    type Certificate;
+
+    fn can_build(&self, attestations: &[Self::Attestation]) -> bool;
+    fn build(&self, attestations: Vec<Self::Attestation>) -> Self::Certificate;
+}

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -31,7 +31,11 @@ pub trait DaProtocol {
     /// Validate that an attestation is valid for a blob.
     fn validate_attestation(&self, blob: &Self::Blob, attestation: &Self::Attestation) -> bool;
     /// Buffer attestations to produce a certificate of correct dispersal.
-    fn recv_attestation(&mut self, attestation: Self::Attestation);
+    fn recv_attestation(
+        &mut self,
+        attestation: Self::Attestation,
+        ext: <Self::Certificate as Certificate>::Extension,
+    );
     /// Attempt to produce a certificate of correct disperal for a blob.
     /// If the protocol is not yet ready to return the certificate, return None.
     fn certify_dispersal(&mut self) -> Option<Self::Certificate>;

--- a/nomos-da/full-replication/src/lib.rs
+++ b/nomos-da/full-replication/src/lib.rs
@@ -2,7 +2,8 @@
 use nomos_core::da::{
     attestation::{self, Attestation as _},
     blob::{self, BlobHasher},
-    certificate, DaProtocol,
+    certificate::{self, CertificateStrategy},
+    DaProtocol,
 };
 // std
 use std::collections::HashSet;
@@ -41,15 +42,6 @@ impl<S> FullReplication<S> {
             output_certificate_buf: Vec::new(),
         }
     }
-}
-
-// TODO: maybe abstract in a general library?
-trait CertificateStrategy {
-    type Attestation: attestation::Attestation;
-    type Certificate: certificate::Certificate;
-
-    fn can_build(&self, attestations: &[Self::Attestation]) -> bool;
-    fn build(&self, attestations: Vec<Self::Attestation>) -> Certificate;
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Added `Extension` to DA Certificate.

In FullReplication DaProtocol this is used to store metadata containing `app_id` and `index` for the disseminated data.

The Nomos zone would need to track for which `app_id` the received attestation was for. It should also control the order the data using `index`. After receiving sufficient number of attestations from da nodes, Nomos Zone would add `metadata` as the Certificate extention field and send it to the mempool. 

Block Producer would use Certificate and related extention data to form the CertificateID and put it into the block together with the related extension (in FullReplication case metadata).