### PR TITLE
Expose 18080 for HTTP API in Testnet

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: testnet/Dockerfile
     ports:
       - "3000:3000/tcp"
-      - "8080:8080/tcp"
+      - "18080:18080/tcp"
     volumes:
       - ./testnet:/etc/nomos
     environment:

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -47,13 +47,13 @@ docker compose logs -f {bootstrap,libp2p-node,mixnode,etcd}
 
 ## Using testnet
 
-Bootstrap node is accessible from the host via `3000` and `8080` ports. To expose other nomos nodes, please update `libp2p-node` service in the `compose.yml` file with this configuration:
+Bootstrap node is accessible from the host via `3000` and `18080` ports. To expose other nomos nodes, please update `libp2p-node` service in the `compose.yml` file with this configuration:
 
 ```bash
   libp2p-node:
     ports:
     - "3001-3010:3000" # Use range depending on the number of nomos node replicas.
-    - "8081-8190:8080"
+    - "18081-18190:18080"
 ```
 
 After running `docker compose up`, the randomly assigned ports can be viewed with `ps` command:


### PR DESCRIPTION
I found that nodes in the testnet settings listen on [`0.0.0.0:18080`](https://github.com/logos-co/nomos-node/blob/bab83fe2b814d7c45043871e3c2cdf95758204f0/testnet/bootstrap_config.yaml#L68) for HTTP API, but the `compose.yml` is exporting [8080](https://github.com/logos-co/nomos-node/blob/e51865fe3303b54cc2b66cb1fb090a0989c4c91f/compose.yml#L9) instead of 18080. I think we need to change `compose.yml` to expose 18080 because all other configs (`compose.static.yml` and `prometheus-config.yml`) are using 18080. Please correct me if I'm wrong.