### PR TITLE
Added `mixnet` compilation feature

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        feature: [libp2p]
+        feature: [libp2p, mixnet]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false # all OSes should be tested even if one fails (default: true)
       matrix:
-        feature: [libp2p]
+        feature: [libp2p, mixnet]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,13 +70,15 @@ jobs:
           command: build
           args: --all --no-default-features --features ${{ matrix.feature }}
       - name: Cargo test (Other OSes)
-        if: matrix.os != 'windows-latest'
+        # TODO: enable tests for mixnet
+        if: matrix.os != 'windows-latest' && matrix.feature != 'mixnet'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all --no-default-features --features ${{ matrix.feature }}
       - name: Cargo test (Windows)
-        if: matrix.os == 'windows-latest'
+        # TODO: enable tests for mixnet
+        if: matrix.os == 'windows-latest' && matrix.feature != 'mixnet'
         uses: actions-rs/cargo@v1
         env:
           # Because Windows runners in Github Actions tend to be slow.
@@ -95,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        feature: [libp2p]
+        feature: [libp2p, mixnet]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -20,16 +20,19 @@ overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "ac28d
 tracing = "0.1"
 multiaddr = "0.18"
 nomos-core = { path = "../../nomos-core" }
-nomos-network = { path = "../../nomos-services/network", features = ["libp2p"] }
+nomos-network = { path = "../../nomos-services/network" }
 nomos-api = { path = "../../nomos-services/api" }
 nomos-log = { path = "../../nomos-services/log" }
-nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock", "libp2p", "metrics"] }
+nomos-mempool = { path = "../../nomos-services/mempool", features = [
+  "mock",
+  "metrics",
+] }
 nomos-metrics = { path = "../../nomos-metrics" }
 nomos-http = { path = "../../nomos-services/http", features = ["http"] }
-carnot-consensus = { path = "../../nomos-services/carnot-consensus", features = ["libp2p"] }
+carnot-consensus = { path = "../../nomos-services/carnot-consensus" }
 nomos-storage = { path = "../../nomos-services/storage", features = ["sled"] }
 nomos-libp2p = { path = "../../nomos-libp2p" }
-nomos-da = { path = "../../nomos-services/data-availability", features = ["libp2p"] }
+nomos-da = { path = "../../nomos-services/data-availability" }
 nomos-system-sig = { path = "../../nomos-services/system-sig" }
 metrics = { path = "../../nomos-services/metrics", optional = true }
 tracing-subscriber = "0.3"
@@ -47,3 +50,18 @@ utoipa-swagger-ui = { version = "4.0" }
 axum = { version = "0.6" }
 hyper = { version = "0.14", features = ["full"] }
 tower-http = { version = "0.4", features = ["cors", "trace"] }
+
+[features]
+default = []
+libp2p = [
+  "nomos-network/libp2p",
+  "nomos-mempool/libp2p",
+  "nomos-da/libp2p",
+  "carnot-consensus/libp2p",
+]
+mixnet = [
+  "nomos-network/mixnet",
+  "nomos-mempool/mixnet",
+  "nomos-da/mixnet",
+  "carnot-consensus/mixnet",
+]

--- a/nodes/nomos-node/src/api.rs
+++ b/nodes/nomos-node/src/api.rs
@@ -22,8 +22,13 @@ use utoipa_swagger_ui::SwaggerUi;
 use carnot_engine::BlockId;
 use full_replication::{Blob, Certificate};
 use nomos_core::{da::blob, tx::Transaction};
-use nomos_mempool::{network::adapters::libp2p::Libp2pAdapter, openapi::Status, MempoolMetrics};
-use nomos_network::backends::libp2p::Libp2p;
+use nomos_mempool::{
+    network::adapters::p2p::P2pAdapter as MempoolNetworkAdapter, openapi::Status, MempoolMetrics,
+};
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as NetworkBackend;
 use nomos_storage::backends::StorageSerde;
 
 use nomos_api::{
@@ -322,8 +327,8 @@ where
     <Tx as Transaction>::Hash: std::cmp::Ord + Debug + Send + Sync + 'static,
 {
     make_request_and_return_response!(mempool::add::<
-        Libp2p,
-        Libp2pAdapter<Tx, <Tx as Transaction>::Hash>,
+        NetworkBackend,
+        MempoolNetworkAdapter<Tx, <Tx as Transaction>::Hash>,
         nomos_mempool::Transaction,
         Tx,
         <Tx as Transaction>::Hash,
@@ -343,8 +348,8 @@ async fn add_cert(
     Json(cert): Json<Certificate>,
 ) -> Response {
     make_request_and_return_response!(mempool::add::<
-        Libp2p,
-        Libp2pAdapter<Certificate, <Blob as blob::Blob>::Hash>,
+        NetworkBackend,
+        MempoolNetworkAdapter<Certificate, <Blob as blob::Blob>::Hash>,
         nomos_mempool::Certificate,
         Certificate,
         <Blob as blob::Blob>::Hash,

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -2,7 +2,7 @@ pub mod api;
 mod config;
 mod tx;
 
-use carnot_consensus::network::adapters::libp2p::Libp2pAdapter as ConsensusLibp2pAdapter;
+use carnot_consensus::network::adapters::p2p::P2pAdapter as ConsensusNetworkAdapter;
 use carnot_engine::overlay::{RandomBeaconState, RoundRobin, TreeOverlay};
 use color_eyre::eyre::Result;
 use full_replication::Certificate;
@@ -21,11 +21,11 @@ use nomos_core::{
     wire,
 };
 use nomos_da::{
-    backend::memory_cache::BlobCache, network::adapters::libp2p::Libp2pAdapter as DaLibp2pAdapter,
+    backend::memory_cache::BlobCache, network::adapters::p2p::P2pAdapter as DaNetworkAdapter,
     DataAvailabilityService,
 };
 use nomos_log::Logger;
-use nomos_mempool::network::adapters::libp2p::Libp2pAdapter as MempoolLibp2pAdapter;
+use nomos_mempool::network::adapters::p2p::P2pAdapter as MempoolNetworkAdapter;
 use nomos_mempool::{
     backend::mockpool::MockPool, Certificate as CertDiscriminant, MempoolService,
     Transaction as TxDiscriminant,
@@ -58,15 +58,15 @@ pub const DA_TOPIC: &str = "da";
 const MB16: usize = 1024 * 1024 * 16;
 
 pub type Carnot = CarnotConsensus<
-    ConsensusLibp2pAdapter,
+    ConsensusNetworkAdapter,
     MockPool<BlockId, Tx, <Tx as Transaction>::Hash>,
-    MempoolLibp2pAdapter<Tx, <Tx as Transaction>::Hash>,
+    MempoolNetworkAdapter<Tx, <Tx as Transaction>::Hash>,
     MockPool<
         BlockId,
         Certificate,
         <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash,
     >,
-    MempoolLibp2pAdapter<
+    MempoolNetworkAdapter<
         Certificate,
         <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash,
     >,
@@ -79,10 +79,10 @@ pub type Carnot = CarnotConsensus<
 pub type DataAvailability = DataAvailabilityService<
     FullReplication<AbsoluteNumber<Attestation, Certificate>>,
     BlobCache<<Blob as nomos_core::da::blob::Blob>::Hash, Blob>,
-    DaLibp2pAdapter<Blob, Attestation>,
+    DaNetworkAdapter<Blob, Attestation>,
 >;
 
-type Mempool<K, V, D> = MempoolService<MempoolLibp2pAdapter<K, V>, MockPool<BlockId, K, V>, D>;
+type Mempool<K, V, D> = MempoolService<MempoolNetworkAdapter<K, V>, MockPool<BlockId, K, V>, D>;
 
 #[derive(Services)]
 pub struct Nomos {

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -13,7 +13,7 @@ use nomos_core::{
     tx::Transaction,
 };
 
-use nomos_mempool::network::adapters::libp2p::Settings as AdapterSettings;
+use nomos_mempool::network::adapters::p2p::Settings as AdapterSettings;
 
 use overwatch_rs::overwatch::*;
 

--- a/nomos-cli/Cargo.toml
+++ b/nomos-cli/Cargo.toml
@@ -11,18 +11,18 @@ fraction = "0.13"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 async-trait = "0.1"
-clap = {version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 carnot-engine = { path = "../consensus/carnot-engine" }
 serde_yaml = "0.9"
 futures = "0.3"
 tokio = { version = "1", features = ["sync"] }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "ac28d01" }
-nomos-network = { path = "../nomos-services/network", features = ["libp2p"] }
-nomos-da = { path = "../nomos-services/data-availability", features = ["libp2p"] }
+nomos-network = { path = "../nomos-services/network" }
+nomos-da = { path = "../nomos-services/data-availability" }
 carnot-consensus = { path = "../nomos-services/carnot-consensus" }
 nomos-log = { path = "../nomos-services/log" }
-nomos-libp2p = { path = "../nomos-libp2p"}
+nomos-libp2p = { path = "../nomos-libp2p" }
 nomos-core = { path = "../nomos-core" }
 nomos-node = { path = "../nodes/nomos-node" }
 full-replication = { path = "../nomos-da/full-replication" }
@@ -37,3 +37,8 @@ ratatui = "0.24"
 tui-input = "0.8"
 ansi-to-tui = "3"
 rand = "0.8"
+
+[features]
+default = []
+libp2p = ["nomos-network/libp2p", "nomos-da/libp2p"]
+mixnet = ["nomos-network/mixnet", "nomos-da/mixnet"]

--- a/nomos-cli/src/cmds/chat/mod.rs
+++ b/nomos-cli/src/cmds/chat/mod.rs
@@ -20,7 +20,11 @@ use full_replication::{
 use futures::{stream, StreamExt};
 use nomos_core::{block::BlockId, da::DaProtocol, wire};
 use nomos_log::{LoggerBackend, LoggerSettings, SharedWriter};
-use nomos_network::{backends::libp2p::Libp2p, NetworkService};
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as NetworkBackend;
+use nomos_network::NetworkService;
 use overwatch_rs::{overwatch::OverwatchRunner, services::ServiceData};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -89,7 +93,7 @@ impl NomosChat {
     pub fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         let network = serde_yaml::from_reader::<
             _,
-            <NetworkService<Libp2p> as ServiceData>::Settings,
+            <NetworkService<NetworkBackend> as ServiceData>::Settings,
         >(std::fs::File::open(&self.network_config)?)?;
         let da_protocol = self.da_protocol.clone();
 

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -3,7 +3,11 @@ use crate::da::disseminate::{
 };
 use clap::Args;
 use nomos_log::{LoggerBackend, LoggerSettings};
-use nomos_network::{backends::libp2p::Libp2p, NetworkService};
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as NetworkBackend;
+use nomos_network::NetworkService;
 use overwatch_rs::{overwatch::OverwatchRunner, services::ServiceData};
 use reqwest::Url;
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -41,7 +45,7 @@ impl Disseminate {
             .expect("setting tracing default failed");
         let network = serde_yaml::from_reader::<
             _,
-            <NetworkService<Libp2p> as ServiceData>::Settings,
+            <NetworkService<NetworkBackend> as ServiceData>::Settings,
         >(std::fs::File::open(&self.network_config)?)?;
         let (status_updates, rx) = std::sync::mpsc::channel();
 

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -4,9 +4,13 @@ use full_replication::{AbsoluteNumber, Attestation, Certificate, FullReplication
 use futures::StreamExt;
 use hex::FromHex;
 use nomos_core::{da::DaProtocol, wire};
-use nomos_da::network::{adapters::libp2p::Libp2pAdapter, NetworkAdapter};
+use nomos_da::network::{adapters::p2p::P2pAdapter as DaNetworkAdapter, NetworkAdapter};
 use nomos_log::Logger;
-use nomos_network::{backends::libp2p::Libp2p, NetworkService};
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as NetworkBackend;
+use nomos_network::NetworkService;
 use overwatch_derive::*;
 use overwatch_rs::{
     services::{
@@ -111,7 +115,7 @@ impl std::fmt::Display for Status {
 // an overwatch app
 #[derive(Services)]
 pub struct DisseminateApp {
-    network: ServiceHandle<NetworkService<Libp2p>>,
+    network: ServiceHandle<NetworkService<NetworkBackend>>,
     send_blob: ServiceHandle<DisseminateService>,
     logger: ServiceHandle<Logger>,
 }
@@ -160,7 +164,7 @@ impl ServiceCore for DisseminateService {
 
         let network_relay = service_state
             .overwatch_handle
-            .relay::<NetworkService<Libp2p>>()
+            .relay::<NetworkService<NetworkBackend>>()
             .connect()
             .await
             .expect("Relay connection with NetworkService should succeed");
@@ -171,7 +175,7 @@ impl ServiceCore for DisseminateService {
                 disseminate_and_wait(
                     da_protocol.clone(),
                     data,
-                    Libp2pAdapter::new(network_relay.clone()).await,
+                    DaNetworkAdapter::new(network_relay.clone()).await,
                     status_updates.clone(),
                     node_addr.as_ref(),
                     output.as_ref(),

--- a/nomos-services/api/Cargo.toml
+++ b/nomos-services/api/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [features]
 default = ["axum"]
 axum = ["dep:axum", "dep:hyper", "dep:tower-http", "utoipa-swagger-ui/axum"]
+libp2p = ["nomos-mempool/libp2p"]
+mixnet = ["nomos-mempool/mixnet"]
 
 [dependencies]
 async-trait = "0.1"
@@ -18,7 +20,10 @@ nomos-core = { path = "../../nomos-core" }
 carnot-consensus = { path = "../carnot-consensus" }
 nomos-network = { path = "../../nomos-services/network" }
 nomos-da = { path = "../../nomos-services/data-availability" }
-nomos-mempool = { path = "../../nomos-services/mempool", features = ["mock", "libp2p", "openapi"] }
+nomos-mempool = { path = "../../nomos-services/mempool", features = [
+  "mock",
+  "openapi",
+] }
 nomos-metrics = { path = "../../nomos-metrics" }
 nomos-storage = { path = "../../nomos-services/storage", features = ["sled"] }
 nomos-libp2p = { path = "../../nomos-libp2p" }

--- a/nomos-services/api/src/http/cl.rs
+++ b/nomos-services/api/src/http/cl.rs
@@ -4,7 +4,7 @@ use nomos_core::block::BlockId;
 use nomos_core::tx::Transaction;
 use nomos_mempool::{
     backend::mockpool::MockPool,
-    network::adapters::libp2p::Libp2pAdapter,
+    network::adapters::p2p::P2pAdapter as MempoolNetworkAdapter,
     openapi::{MempoolMetrics, Status},
     MempoolMsg, MempoolService, Transaction as TxDiscriminant,
 };
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
 type ClMempoolService<T> = MempoolService<
-    Libp2pAdapter<T, <T as Transaction>::Hash>,
+    MempoolNetworkAdapter<T, <T as Transaction>::Hash>,
     MockPool<BlockId, T, <T as Transaction>::Hash>,
     TxDiscriminant,
 >;

--- a/nomos-services/api/src/http/consensus.rs
+++ b/nomos-services/api/src/http/consensus.rs
@@ -5,8 +5,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::oneshot;
 
 use carnot_consensus::{
-    network::adapters::libp2p::Libp2pAdapter as ConsensusLibp2pAdapter, CarnotConsensus,
-    CarnotInfo, ConsensusMsg,
+    network::adapters::p2p::P2pAdapter as ConsensusNetworkAdapter, CarnotConsensus, CarnotInfo,
+    ConsensusMsg,
 };
 use carnot_engine::{
     overlay::{RandomBeaconState, RoundRobin, TreeOverlay},
@@ -21,20 +21,20 @@ use nomos_core::{
     tx::{select::FillSize as FillSizeWithTx, Transaction},
 };
 use nomos_mempool::{
-    backend::mockpool::MockPool, network::adapters::libp2p::Libp2pAdapter as MempoolLibp2pAdapter,
+    backend::mockpool::MockPool, network::adapters::p2p::P2pAdapter as MempoolNetworkAdapter,
 };
 use nomos_storage::backends::{sled::SledBackend, StorageSerde};
 
 pub type Carnot<Tx, SS, const SIZE: usize> = CarnotConsensus<
-    ConsensusLibp2pAdapter,
+    ConsensusNetworkAdapter,
     MockPool<BlockId, Tx, <Tx as Transaction>::Hash>,
-    MempoolLibp2pAdapter<Tx, <Tx as Transaction>::Hash>,
+    MempoolNetworkAdapter<Tx, <Tx as Transaction>::Hash>,
     MockPool<
         BlockId,
         Certificate,
         <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash,
     >,
-    MempoolLibp2pAdapter<
+    MempoolNetworkAdapter<
         Certificate,
         <<Certificate as certificate::Certificate>::Blob as blob::Blob>::Hash,
     >,

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -2,19 +2,19 @@ use full_replication::{AbsoluteNumber, Attestation, Blob, Certificate, FullRepli
 use nomos_core::block::BlockId;
 use nomos_core::da::blob;
 use nomos_da::{
-    backend::memory_cache::BlobCache, network::adapters::libp2p::Libp2pAdapter as DaLibp2pAdapter,
+    backend::memory_cache::BlobCache, network::adapters::p2p::P2pAdapter as DaNetworkAdapter,
     DaMsg, DataAvailabilityService,
 };
 use nomos_mempool::{
     backend::mockpool::MockPool,
-    network::adapters::libp2p::Libp2pAdapter,
+    network::adapters::p2p::P2pAdapter as MempoolNetworkAdapter,
     openapi::{MempoolMetrics, Status},
     Certificate as CertDiscriminant, MempoolMsg, MempoolService,
 };
 use tokio::sync::oneshot;
 
 pub type DaMempoolService = MempoolService<
-    Libp2pAdapter<Certificate, <Blob as blob::Blob>::Hash>,
+    MempoolNetworkAdapter<Certificate, <Blob as blob::Blob>::Hash>,
     MockPool<BlockId, Certificate, <Blob as blob::Blob>::Hash>,
     CertDiscriminant,
 >;
@@ -22,7 +22,7 @@ pub type DaMempoolService = MempoolService<
 pub type DataAvailability = DataAvailabilityService<
     FullReplication<AbsoluteNumber<Attestation, Certificate>>,
     BlobCache<<Blob as nomos_core::da::blob::Blob>::Hash, Blob>,
-    DaLibp2pAdapter<Blob, Attestation>,
+    DaNetworkAdapter<Blob, Attestation>,
 >;
 
 pub async fn da_mempool_metrics(

--- a/nomos-services/carnot-consensus/Cargo.toml
+++ b/nomos-services/carnot-consensus/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { version = "1", optional = true }
 default = []
 mock = ["nomos-network/mock"]
 libp2p = ["nomos-network/libp2p", "nomos-libp2p"]
+mixnet = ["nomos-network/mixnet", "nomos-libp2p"]
 openapi = ["dep:utoipa", "serde_json"]
 
 [dev-dependencies]

--- a/nomos-services/carnot-consensus/src/network/adapters/mod.rs
+++ b/nomos-services/carnot-consensus/src/network/adapters/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "libp2p")]
-pub mod libp2p;
 #[cfg(feature = "mock")]
 pub mod mock;
+#[cfg(any(feature = "libp2p", feature = "mixnet"))]
+pub mod p2p;

--- a/nomos-services/data-availability/Cargo.toml
+++ b/nomos-services/data-availability/Cargo.toml
@@ -19,3 +19,4 @@ tokio-stream = "0.1"
 
 [features]
 libp2p = ["nomos-network/libp2p"]
+mixnet = ["nomos-network/mixnet"]

--- a/nomos-services/data-availability/src/network/adapters/mod.rs
+++ b/nomos-services/data-availability/src/network/adapters/mod.rs
@@ -1,2 +1,2 @@
-#[cfg(feature = "libp2p")]
-pub mod libp2p;
+#[cfg(any(feature = "libp2p", feature = "mixnet"))]
+pub mod p2p;

--- a/nomos-services/data-availability/src/network/adapters/p2p.rs
+++ b/nomos-services/data-availability/src/network/adapters/p2p.rs
@@ -7,7 +7,11 @@ use std::marker::PhantomData;
 // internal
 use crate::network::NetworkAdapter;
 use nomos_core::wire;
-use nomos_network::backends::libp2p::{Command, Event, EventKind, Libp2p, Message, TopicHash};
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as Backend;
+use nomos_network::backends::libp2p::{Command, Event, EventKind, Message, TopicHash};
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as Backend;
 use nomos_network::{NetworkMsg, NetworkService};
 use overwatch_rs::services::relay::OutboundRelay;
 use overwatch_rs::services::ServiceData;
@@ -19,13 +23,13 @@ use tracing::debug;
 
 pub const NOMOS_DA_TOPIC: &str = "NomosDa";
 
-pub struct Libp2pAdapter<B, A> {
-    network_relay: OutboundRelay<<NetworkService<Libp2p> as ServiceData>::Message>,
+pub struct P2pAdapter<B, A> {
+    network_relay: OutboundRelay<<NetworkService<Backend> as ServiceData>::Message>,
     _blob: PhantomData<B>,
     _attestation: PhantomData<A>,
 }
 
-impl<B, A> Libp2pAdapter<B, A>
+impl<B, A> P2pAdapter<B, A>
 where
     B: Serialize + DeserializeOwned + Send + Sync + 'static,
     A: Serialize + DeserializeOwned + Send + Sync + 'static,
@@ -70,12 +74,12 @@ where
 }
 
 #[async_trait::async_trait]
-impl<B, A> NetworkAdapter for Libp2pAdapter<B, A>
+impl<B, A> NetworkAdapter for P2pAdapter<B, A>
 where
     B: Serialize + DeserializeOwned + Send + Sync + 'static,
     A: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-    type Backend = Libp2p;
+    type Backend = Backend;
     type Blob = B;
     type Attestation = A;
 

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -35,6 +35,7 @@ blake2 = "0.10"
 default = []
 mock = ["linked-hash-map", "nomos-network/mock", "rand", "nomos-core/mock"]
 libp2p = ["nomos-network/libp2p"]
+mixnet = ["nomos-network/mixnet"]
 metrics = []
 
 # enable to help generate OpenAPI

--- a/nomos-services/mempool/src/network/adapters/mod.rs
+++ b/nomos-services/mempool/src/network/adapters/mod.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "libp2p")]
-pub mod libp2p;
+#[cfg(any(feature = "libp2p", feature = "mixnet"))]
+pub mod p2p;
 
 #[cfg(feature = "mock")]
 pub mod mock;

--- a/nomos-services/mempool/src/network/adapters/p2p.rs
+++ b/nomos-services/mempool/src/network/adapters/p2p.rs
@@ -6,23 +6,27 @@ use tokio_stream::StreamExt;
 // internal
 use crate::network::NetworkAdapter;
 use nomos_core::wire;
-use nomos_network::backends::libp2p::{Command, Event, EventKind, Libp2p, Message, TopicHash};
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as Backend;
+use nomos_network::backends::libp2p::{Command, Event, EventKind, Message, TopicHash};
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as Backend;
 use nomos_network::{NetworkMsg, NetworkService};
 use overwatch_rs::services::relay::OutboundRelay;
 use overwatch_rs::services::ServiceData;
 
-pub struct Libp2pAdapter<Item, Key> {
-    network_relay: OutboundRelay<<NetworkService<Libp2p> as ServiceData>::Message>,
+pub struct P2pAdapter<Item, Key> {
+    network_relay: OutboundRelay<<NetworkService<Backend> as ServiceData>::Message>,
     settings: Settings<Key, Item>,
 }
 
 #[async_trait::async_trait]
-impl<Item, Key> NetworkAdapter for Libp2pAdapter<Item, Key>
+impl<Item, Key> NetworkAdapter for P2pAdapter<Item, Key>
 where
     Item: DeserializeOwned + Serialize + Send + Sync + 'static + Clone,
     Key: Clone + Send + Sync + 'static,
 {
-    type Backend = Libp2p;
+    type Backend = Backend;
     type Settings = Settings<Key, Item>;
     type Item = Item;
     type Key = Key;

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -33,5 +33,6 @@ tokio = { version = "1", features = ["full"] }
 [features]
 default = []
 libp2p = ["nomos-libp2p", "rand", "humantime-serde"]
+mixnet = ["nomos-libp2p", "rand", "humantime-serde"]
 mock = ["rand", "chrono"]
 openapi = ["dep:utoipa", "serde_json"]

--- a/nomos-services/network/src/backends/libp2p/swarm.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm.rs
@@ -290,6 +290,7 @@ impl SwarmHandler {
         std::time::Duration::from_secs(BACKOFF.pow(retry as u32))
     }
 
+    #[allow(dead_code)]
     pub fn incoming_streams(&mut self, protocol: StreamProtocol) -> IncomingStreams {
         self.stream_control.accept(protocol).unwrap()
     }

--- a/nomos-services/network/src/backends/mixnet/mod.rs
+++ b/nomos-services/network/src/backends/mixnet/mod.rs
@@ -35,7 +35,7 @@ pub struct MixnetNetworkBackend {
     mixclient_message_queue: MessageQueue,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MixnetConfig {
     libp2p_config: Libp2pConfig,
     mixclient_config: MixClientConfig,

--- a/nomos-services/network/src/backends/mod.rs
+++ b/nomos-services/network/src/backends/mod.rs
@@ -2,9 +2,10 @@ use super::*;
 use overwatch_rs::{overwatch::handle::OverwatchHandle, services::state::ServiceState};
 use tokio::sync::broadcast::Receiver;
 
-#[cfg(feature = "libp2p")]
+#[cfg(any(feature = "libp2p", feature = "mixnet"))]
 pub mod libp2p;
 
+#[cfg(feature = "mixnet")]
 pub mod mixnet;
 
 #[cfg(feature = "mock")]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,14 +7,14 @@ publish = false
 [dependencies]
 nomos-node = { path = "../nodes/nomos-node", default-features = false }
 carnot-consensus = { path = "../nomos-services/carnot-consensus" }
-nomos-network = { path = "../nomos-services/network", features = ["libp2p"]}
+nomos-network = { path = "../nomos-services/network" }
 mixnet = { path = "../mixnet" }
 nomos-log = { path = "../nomos-services/log" }
 nomos-api = { path = "../nomos-services/api" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 nomos-core = { path = "../nomos-core" }
 carnot-engine = { path = "../consensus/carnot-engine", features = ["serde"] }
-nomos-mempool = { path = "../nomos-services/mempool", features = ["mock", "libp2p"] }
+nomos-mempool = { path = "../nomos-services/mempool", features = ["mock"] }
 nomos-da = { path = "../nomos-services/data-availability" }
 full-replication = { path = "../nomos-da/full-replication" }
 rand = "0.8"
@@ -48,4 +48,6 @@ path = "src/tests/cli.rs"
 
 
 [features]
+libp2p = ["nomos-network/libp2p", "nomos-mempool/libp2p"]
+mixnet = ["nomos-network/mixnet", "nomos-mempool/mixnet"]
 metrics = ["nomos-node/metrics"]


### PR DESCRIPTION
Added the `mixnet` compilation feature to enable the mixnet network backend instead of the libp2p network backend.

Because the external API of the mixnet network backend is exactly the same as the libp2p network backend, we can reuse the existing network adapter of consensus, mempool, and DA without any modification. The one thing I changed is selecting a proper network backend using conditional compilation.

I didn't modify the integration test for mixnet yet. I'll do it in the PR #597.