### PR TITLE
Add mixnet integration test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,15 +70,13 @@ jobs:
           command: build
           args: --all --no-default-features --features ${{ matrix.feature }}
       - name: Cargo test (Other OSes)
-        # TODO: enable tests for mixnet
-        if: matrix.os != 'windows-latest' && matrix.feature != 'mixnet'
+        if: matrix.os != 'windows-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all --no-default-features --features ${{ matrix.feature }}
       - name: Cargo test (Windows)
-        # TODO: enable tests for mixnet
-        if: matrix.os == 'windows-latest' && matrix.feature != 'mixnet'
+        if: matrix.os == 'windows-latest'
         uses: actions-rs/cargo@v1
         env:
           # Because Windows runners in Github Actions tend to be slow.

--- a/mixnet/src/crypto.rs
+++ b/mixnet/src/crypto.rs
@@ -1,0 +1,6 @@
+use sphinx_packet::crypto::{PrivateKey, PublicKey, PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE};
+
+/// Converts a mixnode private key to a public key
+pub fn public_key_from(private_key: [u8; PRIVATE_KEY_SIZE]) -> [u8; PUBLIC_KEY_SIZE] {
+    *PublicKey::from(&PrivateKey::from(private_key)).as_bytes()
+}

--- a/mixnet/src/lib.rs
+++ b/mixnet/src/lib.rs
@@ -6,6 +6,8 @@
 pub mod address;
 /// Mix client
 pub mod client;
+/// Mixnet cryptography
+pub mod crypto;
 /// Mixnet errors
 pub mod error;
 mod fragment;

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -32,7 +32,10 @@ use nomos_mempool::{
 };
 #[cfg(feature = "metrics")]
 use nomos_metrics::Metrics;
-use nomos_network::backends::libp2p::Libp2p;
+#[cfg(feature = "libp2p")]
+use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
+#[cfg(feature = "mixnet")]
+use nomos_network::backends::mixnet::MixnetNetworkBackend as NetworkBackend;
 use nomos_storage::{
     backends::{sled::SledBackend, StorageSerde},
     StorageService,
@@ -87,7 +90,7 @@ type Mempool<K, V, D> = MempoolService<MempoolNetworkAdapter<K, V>, MockPool<Hea
 #[derive(Services)]
 pub struct Nomos {
     logging: ServiceHandle<Logger>,
-    network: ServiceHandle<NetworkService<Libp2p>>,
+    network: ServiceHandle<NetworkService<NetworkBackend>>,
     cl_mempool: ServiceHandle<Mempool<Tx, <Tx as Transaction>::Hash, TxDiscriminant>>,
     da_mempool: ServiceHandle<
         Mempool<

--- a/tests/src/tests/cli.rs
+++ b/tests/src/tests/cli.rs
@@ -7,7 +7,7 @@ use nomos_cli::{
 use nomos_core::da::{blob::Blob as _, DaProtocol};
 use std::{io::Write, time::Duration};
 use tempfile::NamedTempFile;
-use tests::{adjust_timeout, get_available_port, nodes::nomos::Pool, Node, NomosNode, SpawnConfig};
+use tests::{adjust_timeout, nodes::nomos::Pool, Node, NomosNode, SpawnConfig};
 
 const CLI_BIN: &str = "../target/debug/nomos-cli";
 
@@ -36,13 +36,9 @@ async fn disseminate(config: &mut Disseminate) {
     let node_configs = NomosNode::node_configs(SpawnConfig::chain_happy(2));
     let first_node = NomosNode::spawn(node_configs[0].clone()).await;
 
-    let mut network_config = node_configs[1].network.clone();
-    // use a new port because the old port is sometimes not closed immediately
-    network_config.backend.inner.port = get_available_port();
-
     let mut file = NamedTempFile::new().unwrap();
     let config_path = file.path().to_owned();
-    serde_yaml::to_writer(&mut file, &network_config).unwrap();
+    serde_yaml::to_writer(&mut file, &node_configs[1].network).unwrap();
     let da_protocol = DaProtocolChoice {
         da_protocol: Protocol::FullReplication,
         settings: ProtocolSettings {

--- a/tests/src/tests/happy.rs
+++ b/tests/src/tests/happy.rs
@@ -14,7 +14,7 @@ struct Info {
 }
 
 async fn happy_test(nodes: &[NomosNode]) {
-    let timeout = adjust_timeout(Duration::from_secs(30));
+    let timeout = adjust_timeout(Duration::from_secs(60));
     let timeout = tokio::time::sleep(timeout);
     tokio::select! {
         _ = timeout => panic!("timed out waiting for nodes to reach view {}", TARGET_VIEW),


### PR DESCRIPTION
Now we can run integration tests with the mixnet mode. 
Please note that we're going to provide only the mixnet mode in production, but we maintain the libp2p mode as well for easy developments for the time being.

UPDATE:
This PR contains something looks unnatural. I improved the entire code base by PR https://github.com/logos-co/nomos-node/pull/615. I recommend you to review that PR first.

