### PR TITLE
refactor: define struct for Libp2p Mixnet extension

### DIFF
--- a/mixnet/src/node.rs
+++ b/mixnet/src/node.rs
@@ -17,7 +17,6 @@ pub struct MixNode {
 }
 
 struct MixNodeRunner {
-    _config: MixNodeConfig,
     encryption_private_key: PrivateKey,
     poisson: Poisson,
     packet_queue: mpsc::Receiver<PacketBody>,
@@ -50,7 +49,6 @@ impl MixNode {
         let (output_tx, output_rx) = mpsc::unbounded_channel();
 
         let mixnode_runner = MixNodeRunner {
-            _config: config,
             encryption_private_key,
             poisson,
             packet_queue: packet_rx,


### PR DESCRIPTION
I meant to do this in my initial implementation but forgot it. Sorry for your inconvenience. 
I just defined a `Mixnet` struct that is used as an extension for libp2p backend, and moved all related function into it.
The reason of this refactoring is for implementing mixnet metrics soon.