### PR TITLE
Add missing error check: `LedgerError::ParentNotFound`

### DIFF
--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -503,7 +503,8 @@ where
 
                 cryptarchia = new_state;
             }
-            Err(Error::Consensus(cryptarchia_engine::Error::ParentMissing(parent))) => {
+            Err(Error::Ledger(cryptarchia_ledger::LedgerError::ParentNotFound(parent)))
+            | Err(Error::Consensus(cryptarchia_engine::Error::ParentMissing(parent))) => {
                 tracing::debug!("missing parent {:?}", parent);
                 // TODO: request parent block
             }


### PR DESCRIPTION
I found this when running the fuzz test in #629. If the parent of the block being processed is missing, we may encounter `LedgerError::ParentNotFound` as well as `cryptarchia_engine::Error::ParentMissing`. Although the real error handling logic is not implemented yet, I think both errors need to be checked for future implementations.