### PR TITLE
Remove duplicate error log in network service

### DIFF
--- a/nomos-services/network/src/backends/libp2p/swarm.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm.rs
@@ -210,10 +210,6 @@ impl SwarmHandler {
                 self.pending_dials.insert(connection_id, dial);
             }
             Err(e) => {
-                tracing::error!(
-                    "Failed to connect to {} with unretriable error: {e}",
-                    dial.addr
-                );
                 if let Err(err) = dial.result_sender.send(Err(e)) {
                     tracing::warn!("failed to send the Err result of dialing: {err:?}");
                 }


### PR DESCRIPTION
This is a very simple PR.

Because we're already printing a log with a proper log level according to the error type in the [upper layer](https://github.com/logos-co/nomos-node/blob/fae4c994d70a32453fb16f38245329ecc31ad519/nomos-services/network/src/backends/libp2p/mixnet.rs#L158-L158), we can remove the duplicate log in the `swarm.rs`. That log is actually very annoying because one of these error types always happen when a node A is trying to dial to itself for creating a p2p stream (to send mix packets). That type of log doesn't need to be printed with the ERROR level because it's ignored in the upper layer.

p.s. We may be able to improve the logic to not try to dial if the peer address is mine, but I couldn't find any sophisticated way to check if the address is mine.