### PR TITLE
Reuse evaluations when computing proofs

### DIFF
--- a/nomos-da/kzgrs-backend/src/verifier.rs
+++ b/nomos-da/kzgrs-backend/src/verifier.rs
@@ -179,7 +179,7 @@ mod test {
             bytes_to_polynomial::<BYTES_PER_FIELD_ELEMENT>(column.as_bytes().as_slice(), *DOMAIN)
                 .unwrap();
         let column_commitment = commit_polynomial(&column_poly, &GLOBAL_PARAMETERS).unwrap();
-        let (_, aggregated_poly) = bytes_to_polynomial::<
+        let (aggregated_evals, aggregated_poly) = bytes_to_polynomial::<
             { DaEncoderParams::MAX_BLS12_381_ENCODING_CHUNK_SIZE },
         >(
             hash_column_and_commitment::<{ DaEncoderParams::MAX_BLS12_381_ENCODING_CHUNK_SIZE }>(
@@ -192,8 +192,14 @@ mod test {
         .unwrap();
         let aggregated_commitment =
             commit_polynomial(&aggregated_poly, &GLOBAL_PARAMETERS).unwrap();
-        let column_proof =
-            generate_element_proof(0, &aggregated_poly, &GLOBAL_PARAMETERS, *DOMAIN).unwrap();
+        let column_proof = generate_element_proof(
+            0,
+            &aggregated_poly,
+            &aggregated_evals,
+            &GLOBAL_PARAMETERS,
+            *DOMAIN,
+        )
+        .unwrap();
         assert!(DaVerifier::verify_column(
             &column,
             &column_commitment,

--- a/nomos-da/kzgrs/Cargo.toml
+++ b/nomos-da/kzgrs/Cargo.toml
@@ -18,3 +18,10 @@ num-bigint = "0.4.4"
 thiserror = "1.0.58"
 num-traits = "0.2.18"
 rand = "0.8.5"
+
+[dev-dependencies]
+divan = "0.1"
+
+[[bench]]
+name = "kzg"
+harness = false

--- a/nomos-da/kzgrs/benches/kzg.rs
+++ b/nomos-da/kzgrs/benches/kzg.rs
@@ -1,0 +1,92 @@
+use ark_bls12_381::{Bls12_381, Fr};
+use ark_poly::univariate::DensePolynomial;
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_poly_commit::kzg10::{UniversalParams, KZG10};
+use divan::counter::ItemsCount;
+use divan::{black_box, counter::BytesCount, AllocProfiler, Bencher};
+use kzgrs::{Evaluations, Polynomial};
+use once_cell::sync::Lazy;
+use rand::RngCore;
+
+use kzgrs::{common::bytes_to_polynomial_unchecked, kzg::*};
+
+fn main() {
+    divan::main()
+}
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+const SIZES: &[usize] = &[1usize, 2, 3, 4, 5, 6, 7, 8];
+
+static GLOBAL_PARAMETERS: Lazy<UniversalParams<Bls12_381>> = Lazy::new(|| {
+    let mut rng = rand::thread_rng();
+    KZG10::<Bls12_381, DensePolynomial<Fr>>::setup(1024, true, &mut rng).unwrap()
+});
+
+static DOMAIN: Lazy<GeneralEvaluationDomain<Fr>> =
+    Lazy::new(|| GeneralEvaluationDomain::new(1024).unwrap());
+
+fn rand_data_elements(elements_count: usize, chunk_size: usize) -> Vec<u8> {
+    let mut buff = vec![0u8; elements_count * chunk_size];
+    rand::thread_rng().fill_bytes(&mut buff);
+    buff
+}
+
+const CHUNK_SIZE: usize = 31;
+
+#[allow(non_snake_case)]
+#[divan::bench(args = [10, 100, 1000])]
+fn commit_polynomial_with_element_count(bencher: Bencher, element_count: usize) {
+    let size = bencher
+        .with_inputs(|| {
+            let data = rand_data_elements(element_count, CHUNK_SIZE);
+            bytes_to_polynomial_unchecked::<CHUNK_SIZE>(&data, *DOMAIN)
+        })
+        .input_counter(move |(_evals, poly)| BytesCount::new(element_count * CHUNK_SIZE))
+        .bench_refs(|(_evals, poly)| black_box(commit_polynomial(poly, &GLOBAL_PARAMETERS)));
+}
+
+#[allow(non_snake_case)]
+#[divan::bench]
+fn compute_single_proof(bencher: Bencher) {
+    let size = bencher
+        .with_inputs(|| {
+            let data = rand_data_elements(10, CHUNK_SIZE);
+            bytes_to_polynomial_unchecked::<CHUNK_SIZE>(&data, *DOMAIN)
+        })
+        .input_counter(|_| ItemsCount::new(1usize))
+        .bench_refs(|(evals, poly)| {
+            black_box(generate_element_proof(
+                7,
+                poly,
+                evals,
+                &GLOBAL_PARAMETERS,
+                *DOMAIN,
+            ))
+        });
+}
+
+#[allow(non_snake_case)]
+#[divan::bench]
+fn verify_single_proof(bencher: Bencher) {
+    let size = bencher
+        .with_inputs(|| {
+            let data = rand_data_elements(10, CHUNK_SIZE);
+            let (eval, poly) = bytes_to_polynomial_unchecked::<CHUNK_SIZE>(&data, *DOMAIN);
+            let commitment = commit_polynomial(&poly, &GLOBAL_PARAMETERS).unwrap();
+            let proof =
+                generate_element_proof(0, &poly, &eval, &GLOBAL_PARAMETERS, *DOMAIN).unwrap();
+            (0usize, eval.evals[0], commitment, proof)
+        })
+        .input_counter(|_| ItemsCount::new(1usize))
+        .bench_refs(|(index, elemnent, commitment, proof)| {
+            black_box(verify_element_proof(
+                index.clone(),
+                elemnent,
+                commitment,
+                proof,
+                *DOMAIN,
+                &GLOBAL_PARAMETERS,
+            ))
+        });
+}

--- a/nomos-da/kzgrs/src/kzg.rs
+++ b/nomos-da/kzgrs/src/kzg.rs
@@ -104,10 +104,10 @@ mod test {
         let mut rng = thread_rng();
         bytes.try_fill(&mut rng).unwrap();
         let evaluations = bytes_to_evaluations::<31>(&bytes, *DOMAIN).evals;
-        let (_, poly) = bytes_to_polynomial::<31>(&bytes, *DOMAIN).unwrap();
+        let (eval, poly) = bytes_to_polynomial::<31>(&bytes, *DOMAIN).unwrap();
         let commitment = commit_polynomial(&poly, &GLOBAL_PARAMETERS).unwrap();
         let proofs: Vec<_> = (0..10)
-            .map(|i| generate_element_proof(i, &poly, &GLOBAL_PARAMETERS, *DOMAIN).unwrap())
+            .map(|i| generate_element_proof(i, &poly, &eval, &GLOBAL_PARAMETERS, *DOMAIN).unwrap())
             .collect();
         for (i, (element, proof)) in evaluations.iter().zip(proofs.iter()).enumerate() {
             // verifying works

--- a/nomos-da/kzgrs/src/kzg.rs
+++ b/nomos-da/kzgrs/src/kzg.rs
@@ -3,7 +3,7 @@ use crate::Evaluations;
 use ark_bls12_381::{Bls12_381, Fr};
 use ark_ec::pairing::Pairing;
 use ark_poly::univariate::DensePolynomial;
-use ark_poly::{DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain, Polynomial};
+use ark_poly::{DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
 use ark_poly_commit::kzg10::{Commitment, Powers, Proof, UniversalParams, KZG10};
 use num_traits::One;
 use std::borrow::Cow;

--- a/nomos-da/kzgrs/src/kzg.rs
+++ b/nomos-da/kzgrs/src/kzg.rs
@@ -1,4 +1,5 @@
 use crate::common::KzgRsError;
+use crate::Evaluations;
 use ark_bls12_381::{Bls12_381, Fr};
 use ark_ec::pairing::Pairing;
 use ark_poly::univariate::DensePolynomial;
@@ -27,11 +28,14 @@ pub fn commit_polynomial(
 pub fn generate_element_proof(
     element_index: usize,
     polynomial: &DensePolynomial<Fr>,
+    evaluations: &Evaluations,
     global_parameters: &UniversalParams<Bls12_381>,
     domain: GeneralEvaluationDomain<Fr>,
 ) -> Result<Proof<Bls12_381>, KzgRsError> {
     let u = domain.element(element_index);
-    let v = polynomial.evaluate(&u);
+    // Instead of evaluating over the polynomial, we can reuse the evaluation points from the rs encoding
+    // let v = polynomial.evaluate(&u);
+    let v = evaluations.evals[element_index];
     let f_x_v = polynomial + &DensePolynomial::<Fr>::from_coefficients_vec(vec![-v]);
     let x_u = DensePolynomial::<Fr>::from_coefficients_vec(vec![-u, Fr::one()]);
     let witness_polynomial: DensePolynomial<_> = &f_x_v / &x_u;


### PR DESCRIPTION
Reuse precomputed evaluations instead of evaluating the polynomial for each proof