### PR TITLE
DA Encoded Data to Blobs

### DIFF
--- a/nomos-da/kzgrs-backend/src/verifier.rs
+++ b/nomos-da/kzgrs-backend/src/verifier.rs
@@ -19,12 +19,12 @@ use kzgrs::{
 
 #[derive(Clone)]
 pub struct DaBlob {
-    column: Column,
-    column_commitment: Commitment,
-    aggregated_column_commitment: Commitment,
-    aggregated_column_proof: Proof,
-    rows_commitments: Vec<Commitment>,
-    rows_proofs: Vec<Proof>,
+    pub column: Column,
+    pub column_commitment: Commitment,
+    pub aggregated_column_commitment: Commitment,
+    pub aggregated_column_proof: Proof,
+    pub rows_commitments: Vec<Commitment>,
+    pub rows_proofs: Vec<Proof>,
 }
 
 impl DaBlob {


### PR DESCRIPTION
A method to transform encoded data to blobs for dispersal, rust representation of a `_prepare_data` in nomos-spec:
https://github.com/logos-co/nomos-specs/blob/9390d481ba332923e6406bc9edcb008b814867aa/da/dispersal.py#L27-L46