### PR TITLE
Add execution constraints to coverage.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ name: Codecov
 
 jobs:
   test:
-    name: Test
+    name: Test with Coverage
     env:
       RUSTFLAGS: -C instrument-coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make codecov only run on PRs that target `master`. There are some PRs whose `upload to codecov` is silently failing. After a brief investigation, I think this is due to the free tier 250 monthly upload limit. Sticking to using codecov only in PRs that target `master` might be enough to stay under the limit.

Alternatively (or in addition), these two actions could be very handy:
- https://github.com/marketplace/actions/go-beautiful-html-coverage
- https://github.com/marketplace/actions/code-coverage-report-difference (if grcov could export to the go coverage format, or convert it some other way)
