### PR TITLE
Make coverage workflow name clearer.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ name: Codecov
 
 jobs:
   test:
-    name: Test
+    name: Test with Coverage
     env:
       RUSTFLAGS: -C instrument-coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
A dummy PR to check the rule in https://github.com/logos-co/nomos-node/pull/653 is applied.