### PR TITLE
Feature flag to toggle tracing

### DIFF
--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -51,5 +51,7 @@ tower-http = { version = "0.4", features = ["cors", "trace"] }
 time = "0.3"
 
 [features]
+default = ["tracing"]
 mixnet = ["nomos-network/mixnet"]
 metrics = []
+tracing = []

--- a/nodes/nomos-node/src/lib.rs
+++ b/nodes/nomos-node/src/lib.rs
@@ -10,6 +10,7 @@ use bytes::Bytes;
 pub use config::{Config, CryptarchiaArgs, HttpArgs, LogArgs, MetricsArgs, NetworkArgs};
 use nomos_api::ApiService;
 use nomos_core::{da::certificate, header::HeaderId, tx::Transaction, wire};
+#[cfg(feature = "tracing")]
 use nomos_log::Logger;
 use nomos_mempool::da::verify::fullreplication::DaVerificationProvider as MempoolVerificationProvider;
 use nomos_mempool::network::adapters::libp2p::Libp2pAdapter as MempoolNetworkAdapter;
@@ -74,6 +75,7 @@ pub type DaMempool = DaMempoolService<
 
 #[derive(Services)]
 pub struct Nomos {
+    #[cfg(feature = "tracing")]
     logging: ServiceHandle<Logger>,
     network: ServiceHandle<NetworkService<NetworkBackend>>,
     cl_mempool: ServiceHandle<TxMempool>,

--- a/nodes/nomos-node/src/main.rs
+++ b/nodes/nomos-node/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> Result<()> {
     let app = OverwatchRunner::<Nomos>::run(
         NomosServiceSettings {
             network: config.network,
+            #[cfg(feature = "tracing")]
             logging: config.log,
             http: config.http,
             cl_mempool: nomos_mempool::TxMempoolSettings {


### PR DESCRIPTION
To build a node without tracing use `cargo build -p nomos-node --no-default-features`.
Node already has the ability to disable logging with `None` option for the LoggingBackend.