### PR TITLE
Da: cache toeplitz1

### DIFF
--- a/nomos-da/kzgrs-backend/benches/encoder.rs
+++ b/nomos-da/kzgrs-backend/benches/encoder.rs
@@ -1,6 +1,7 @@
 use divan::counter::BytesCount;
 use divan::Bencher;
 use kzgrs_backend::encoder::{DaEncoder, DaEncoderParams};
+use once_cell::sync::{Lazy, OnceCell};
 use rand::RngCore;
 use std::hint::black_box;
 
@@ -8,8 +9,11 @@ fn main() {
     divan::main()
 }
 
-const PARAMS: DaEncoderParams = DaEncoderParams::default_with(4096);
-const ENCODER: DaEncoder = DaEncoder::new(PARAMS);
+static ENCODER: Lazy<DaEncoder> = Lazy::new(|| {
+    let params = DaEncoderParams::new(4096, true);
+    DaEncoder::new(params)
+});
+
 const KB: usize = 1024;
 
 pub fn rand_data(elements_count: usize) -> Vec<u8> {

--- a/nomos-da/kzgrs-backend/benches/encoder.rs
+++ b/nomos-da/kzgrs-backend/benches/encoder.rs
@@ -1,7 +1,7 @@
 use divan::counter::BytesCount;
 use divan::Bencher;
 use kzgrs_backend::encoder::{DaEncoder, DaEncoderParams};
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::Lazy;
 use rand::RngCore;
 use std::hint::black_box;
 

--- a/nomos-da/kzgrs/src/fk20.rs
+++ b/nomos-da/kzgrs/src/fk20.rs
@@ -78,6 +78,7 @@ pub fn fk20_batch_generate_elements_proofs(
         .collect()
 }
 
+#[derive(Clone)]
 pub struct Toeplitz1Cache(Vec<G1Projective>);
 
 impl Toeplitz1Cache {


### PR DESCRIPTION
Toeplitz part 1 can be cached as it just depends on the global parameters. From benches it improves performance in around a *40%* for the proofs computations.