### PR TITLE
fix missing build settings for libp2p nodes

### DIFF
--- a/compose.static.yml
+++ b/compose.static.yml
@@ -23,6 +23,9 @@ services:
 
   libp2p-node-1:
     container_name: libp2p_node_1
+    build:
+      context: .
+      dockerfile: testnet/Dockerfile
     image: nomos:latest
     volumes:
       - ./testnet:/etc/nomos
@@ -45,6 +48,9 @@ services:
 
   libp2p-node-2:
     container_name: libp2p_node_2
+    build:
+      context: .
+      dockerfile: testnet/Dockerfile
     image: nomos:latest
     volumes:
       - ./testnet:/etc/nomos
@@ -67,6 +73,9 @@ services:
 
   libp2p-node-3:
     container_name: libp2p_node_3
+    build:
+      context: .
+      dockerfile: testnet/Dockerfile
     image: nomos:latest
     volumes:
       - ./testnet:/etc/nomos
@@ -89,6 +98,9 @@ services:
 
   chatbot:
     container_name: chatbot
+    build:
+      context: .
+      dockerfile: testnet/Dockerfile
     image: nomos:latest
     volumes:
       - ./testnet:/etc/nomos


### PR DESCRIPTION
Otherwise we get:
```
ERROR: for libp2p-node-1  pull access denied for nomos, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
ERROR: for libp2p-node-2  pull access denied for nomos, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
ERROR: for libp2p-node-3  pull access denied for nomos, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
ERROR: for chatbot  pull access denied for nomos, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
ERROR: pull access denied for nomos, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```
Required for:
* https://github.com/status-im/infra-misc/pull/294