### PR TITLE
Just use openssl.dev, no binaries for nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ pkgs.mkShell {
     rust-bin.stable."1.79.0".default
     clang_14
     llvmPackages_14.libclang
-    openssl
+    openssl.dev
   ];
   shellHook = ''
     export LIBCLANG_PATH="${pkgs.llvmPackages_14.libclang.lib}/lib";


### PR DESCRIPTION
Apparently it works with the .dev version of the package, we avoid bringing up the binaries I think.