### PR TITLE
CI: Rust 1.80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD IMAGE ---------------------------------------------------------
 
-FROM rust:1.79.0-slim-bullseye AS builder
+FROM rust:1.80.0-slim-bullseye AS builder
 
 WORKDIR /nomos
 COPY . . 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79.0-slim-bullseye
+FROM rust:1.80.0-slim-bullseye
 
 LABEL maintainer="augustinas@status.im" \
       source="https://github.com/logos-co/nomos-node" \

--- a/nomos-core/src/header/cryptarchia.rs
+++ b/nomos-core/src/header/cryptarchia.rs
@@ -5,6 +5,7 @@ use cryptarchia_engine::Slot;
 use cryptarchia_ledger::LeaderProof;
 use serde::{Deserialize, Serialize};
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq, Copy)]
 pub struct Nonce([u8; 32]);
 

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@
     overlays = [
       (import (fetchGit {
         url = "https://github.com/oxalica/rust-overlay.git";
-        rev = "419e7fae2731f41dd9b3e34dfe8802be68558b92";
+        rev = "8b81b8ed00b20fd57b24adcb390bd96ea81ecd90";
       }))
     ];
    }
@@ -17,7 +17,7 @@ pkgs.mkShell {
 
   buildInputs = with pkgs; [
     pkg-config
-    rust-bin.stable."1.79.0".default
+    rust-bin.stable."1.80.0".default
     clang_14
     llvmPackages_14.libclang
     openssl.dev

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD IMAGE ---------------------------------------------------------
 
-FROM rust:1.79.0-slim-bullseye AS builder
+FROM rust:1.80.0-slim-bullseye AS builder
 
 WORKDIR /nomos
 COPY . . 


### PR DESCRIPTION
Added a `allow[dead_code]` for `Nonce` in consensus for Clippy.
Unused methods in da libp2p will be handled in a separate PRs.