### PR TITLE
DA: Dispersal in Cli App with mock backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ members = [
     "nomos-services/data-availability/verifier",
     "nomos-services/data-availability/tests",
     "nomos-da/full-replication",
-    # TODO: add it again and reimplement full replication
-    #    "nomos-cli",
+    "nomos-cli",
     "nomos-utils",
     "nodes/nomos-node",
     "mixnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "nomos-services/metrics",
     "nomos-services/system-sig",
     "nomos-services/data-availability/indexer",
+    "nomos-services/data-availability/network",
     "nomos-services/data-availability/verifier",
     "nomos-services/data-availability/tests",
     "nomos-da/full-replication",

--- a/nomos-cli/Cargo.toml
+++ b/nomos-cli/Cargo.toml
@@ -19,12 +19,13 @@ overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" 
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "ac28d01" }
 nomos-network = { path = "../nomos-services/network", features = ["libp2p"] }
 cryptarchia-consensus = { path = "../nomos-services/cryptarchia-consensus" }
+kzgrs-backend = { path = "../nomos-da/kzgrs-backend" }
 nomos-log = { path = "../nomos-services/log" }
 nomos-libp2p = { path = "../nomos-libp2p" }
 nomos-core = { path = "../nomos-core" }
 nomos-node = { path = "../nodes/nomos-node" }
 full-replication = { path = "../nomos-da/full-replication" }
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/nomos-cli/Cargo.toml
+++ b/nomos-cli/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3"
 tokio = { version = "1", features = ["sync"] }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "ac28d01" }
-nomos-network = { path = "../nomos-services/network", features = ["libp2p"] }
+nomos-da-network-service = { path = "../nomos-services/data-availability/network" }
 cryptarchia-consensus = { path = "../nomos-services/cryptarchia-consensus" }
 kzgrs-backend = { path = "../nomos-da/kzgrs-backend" }
 nomos-log = { path = "../nomos-services/log" }

--- a/nomos-cli/src/api/mempool.rs
+++ b/nomos-cli/src/api/mempool.rs
@@ -2,14 +2,14 @@ use super::CLIENT;
 use reqwest::{Error, Response, Url};
 use serde::Serialize;
 
-pub async fn send_certificate<C>(node: &Url, cert: &C) -> Result<Response, Error>
+pub async fn send_blob_info<I>(node: &Url, info: &I) -> Result<Response, Error>
 where
-    C: Serialize,
+    I: Serialize,
 {
     const NODE_CERT_PATH: &str = "mempool/add/cert";
     CLIENT
         .post(node.join(NODE_CERT_PATH).unwrap())
-        .json(cert)
+        .json(info)
         .send()
         .await
 }

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -18,9 +18,6 @@ pub struct Disseminate {
     /// Path to the network config file
     #[clap(short, long)]
     pub network_config: PathBuf,
-    /// The data availability protocol to use. Defaults to full replication.
-    // #[clap(flatten)]
-    // pub da_protocol: DaProtocolChoice,
     /// Timeout in seconds. Defaults to 120 seconds.
     #[clap(short, long, default_value = "120")]
     pub timeout: u64,

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -1,4 +1,6 @@
-use crate::da::disseminate::{DisseminateApp, DisseminateAppServiceSettings, Settings, Status};
+use crate::da::disseminate::{
+    DisseminateApp, DisseminateAppServiceSettings, KzgrsSettings, Settings, Status,
+};
 use clap::Args;
 use nomos_da_network_service::backends::mock::executor::MockExecutorBackend as NetworkBackend;
 use nomos_da_network_service::NetworkService;
@@ -64,6 +66,7 @@ impl Disseminate {
                     send_blob: Settings {
                         payload: Arc::new(Mutex::new(payload_rx)),
                         timeout,
+                        kzgrs_settings: KzgrsSettings::default(),
                         status_updates,
                         node_addr,
                         output,

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -1,6 +1,4 @@
-use crate::da::disseminate::{
-    DaProtocolChoice, DisseminateApp, DisseminateAppServiceSettings, Settings, Status,
-};
+use crate::da::disseminate::{DisseminateApp, DisseminateAppServiceSettings, Settings, Status};
 use clap::Args;
 use nomos_log::{LoggerBackend, LoggerSettings};
 use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
@@ -19,8 +17,8 @@ pub struct Disseminate {
     #[clap(short, long)]
     pub network_config: PathBuf,
     /// The data availability protocol to use. Defaults to full replication.
-    #[clap(flatten)]
-    pub da_protocol: DaProtocolChoice,
+    // #[clap(flatten)]
+    // pub da_protocol: DaProtocolChoice,
     /// Timeout in seconds. Defaults to 120 seconds.
     #[clap(short, long, default_value = "120")]
     pub timeout: u64,
@@ -55,7 +53,6 @@ impl Disseminate {
         };
 
         let timeout = Duration::from_secs(self.timeout);
-        let da_protocol = self.da_protocol.clone();
         let node_addr = self.node_addr.clone();
         let output = self.output.clone();
         let (payload_sender, payload_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -67,7 +64,6 @@ impl Disseminate {
                     send_blob: Settings {
                         payload: Arc::new(Mutex::new(payload_rx)),
                         timeout,
-                        da_protocol,
                         status_updates,
                         node_addr,
                         output,

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -1,8 +1,8 @@
 use crate::da::disseminate::{DisseminateApp, DisseminateAppServiceSettings, Settings, Status};
 use clap::Args;
+use nomos_da_network_service::backends::mock::executor::MockExecutorBackend as NetworkBackend;
+use nomos_da_network_service::NetworkService;
 use nomos_log::{LoggerBackend, LoggerSettings};
-use nomos_network::backends::libp2p::Libp2p as NetworkBackend;
-use nomos_network::NetworkService;
 use overwatch_rs::{overwatch::OverwatchRunner, services::ServiceData};
 use reqwest::Url;
 use std::{path::PathBuf, sync::Arc, time::Duration};

--- a/nomos-cli/src/cmds/mod.rs
+++ b/nomos-cli/src/cmds/mod.rs
@@ -1,22 +1,22 @@
 use clap::Subcommand;
 
 // pub mod chat;
-// pub mod disseminate;
+pub mod disseminate;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    // /// Send a blob to the network and collect attestations to create a DA proof
-    // Disseminate(disseminate::Disseminate),
+    /// Send a blob to the network and collect attestations to create a DA proof
+    Disseminate(disseminate::Disseminate),
     // /// (Almost) Instant messaging protocol on top of the Nomos network
     // Chat(chat::NomosChat),
 }
 
 impl Command {
     pub fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
-        // match self {
-        //     Command::Disseminate(cmd) => cmd.run(),
-        //     Command::Chat(cmd) => cmd.run(),
-        // }
+        match self {
+            Command::Disseminate(cmd) => cmd.run(),
+            // Command::Chat(cmd) => cmd.run(),
+        }?;
         Ok(())
     }
 }

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use kzgrs_backend::{
-    common::build_attestation_message,
+    common::build_blob_id,
     dispersal::{BlobInfo, Metadata},
     encoder::EncodedData as KzgEncodedData,
 };
@@ -52,7 +52,7 @@ where
     // 1) Building blob
     status_updates.send(Status::Encoding)?;
     let encoded_data = encoder.encode(&data).map_err(Box::new)?;
-    let blob_hash = build_attestation_message(
+    let blob_hash = build_blob_id(
         &encoded_data.aggregated_column_commitment,
         &encoded_data.row_commitments,
     );

--- a/nomos-cli/src/da/mod.rs
+++ b/nomos-cli/src/da/mod.rs
@@ -1,2 +1,3 @@
 pub mod disseminate;
+pub mod network;
 // pub mod retrieve;

--- a/nomos-cli/src/da/mod.rs
+++ b/nomos-cli/src/da/mod.rs
@@ -1,2 +1,2 @@
 pub mod disseminate;
-pub mod retrieve;
+// pub mod retrieve;

--- a/nomos-cli/src/da/network/adapters/mock.rs
+++ b/nomos-cli/src/da/network/adapters/mock.rs
@@ -1,0 +1,27 @@
+use kzgrs_backend::encoder::EncodedData as KzgEncodedData;
+use nomos_core::da::DaDispersal;
+use nomos_da_network_service::{backends::mock::executor::MockExecutorBackend, NetworkService};
+use overwatch_rs::{
+    services::{relay::OutboundRelay, ServiceData},
+    DynError,
+};
+type Relay<T> = OutboundRelay<<NetworkService<T> as ServiceData>::Message>;
+
+pub struct MockExecutorDispersalAdapter {
+    network_relay: Relay<MockExecutorBackend>,
+}
+
+impl MockExecutorDispersalAdapter {
+    pub fn new(network_relay: Relay<MockExecutorBackend>) -> Self {
+        Self { network_relay }
+    }
+}
+
+impl DaDispersal for MockExecutorDispersalAdapter {
+    type EncodedData = KzgEncodedData;
+    type Error = DynError;
+
+    fn disperse(&self, encoded_data: Self::EncodedData) -> Result<(), Self::Error> {
+        todo!()
+    }
+}

--- a/nomos-cli/src/da/network/adapters/mock.rs
+++ b/nomos-cli/src/da/network/adapters/mock.rs
@@ -1,11 +1,30 @@
-use kzgrs_backend::encoder::EncodedData as KzgEncodedData;
+use std::fmt;
+
+use kzgrs_backend::{common::blob::DaBlob, encoder::EncodedData as KzgEncodedData};
 use nomos_core::da::DaDispersal;
-use nomos_da_network_service::{backends::mock::executor::MockExecutorBackend, NetworkService};
-use overwatch_rs::{
-    services::{relay::OutboundRelay, ServiceData},
-    DynError,
+use nomos_da_network_service::{
+    backends::mock::executor::{Command, MockExecutorBackend},
+    DaNetworkMsg, NetworkService,
 };
+use overwatch_rs::services::{relay::OutboundRelay, ServiceData};
 type Relay<T> = OutboundRelay<<NetworkService<T> as ServiceData>::Message>;
+
+#[derive(Debug)]
+pub struct DispersalError(String);
+
+impl fmt::Display for DispersalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for DispersalError {}
+
+impl From<String> for DispersalError {
+    fn from(s: String) -> Self {
+        DispersalError(s)
+    }
+}
 
 pub struct MockExecutorDispersalAdapter {
     network_relay: Relay<MockExecutorBackend>,
@@ -17,11 +36,34 @@ impl MockExecutorDispersalAdapter {
     }
 }
 
+#[async_trait::async_trait]
 impl DaDispersal for MockExecutorDispersalAdapter {
     type EncodedData = KzgEncodedData;
-    type Error = DynError;
+    type Error = DispersalError;
 
-    fn disperse(&self, encoded_data: Self::EncodedData) -> Result<(), Self::Error> {
-        todo!()
+    async fn disperse(&self, encoded_data: Self::EncodedData) -> Result<(), Self::Error> {
+        for (i, column) in encoded_data.extended_data.columns().enumerate() {
+            let blob = DaBlob {
+                column: column.clone(),
+                column_commitment: encoded_data.column_commitments[i],
+                aggregated_column_commitment: encoded_data.aggregated_column_commitment,
+                aggregated_column_proof: encoded_data.aggregated_column_proofs[i],
+                rows_commitments: encoded_data.row_commitments.clone(),
+                rows_proofs: encoded_data
+                    .rows_proofs
+                    .iter()
+                    .map(|proofs| proofs.get(i).cloned().unwrap())
+                    .collect(),
+            };
+
+            self.network_relay
+                .send(DaNetworkMsg::Process(Command::Disperse {
+                    blob,
+                    subnetwork_id: i as u32,
+                }))
+                .await
+                .map_err(|(e, _)| e.to_string())?
+        }
+        Ok(())
     }
 }

--- a/nomos-cli/src/da/network/adapters/mod.rs
+++ b/nomos-cli/src/da/network/adapters/mod.rs
@@ -1,0 +1,1 @@
+pub mod mock;

--- a/nomos-cli/src/da/network/mod.rs
+++ b/nomos-cli/src/da/network/mod.rs
@@ -1,0 +1,1 @@
+pub mod adapters;

--- a/nomos-cli/src/da/retrieve.rs
+++ b/nomos-cli/src/da/retrieve.rs
@@ -1,10 +1,9 @@
 use full_replication::Blob;
-use nomos_core::da::certificate::Certificate;
 use nomos_core::header::HeaderId;
 use reqwest::Url;
 use thiserror::Error;
 
-use crate::api::{da::get_blobs, storage::get_block_contents};
+use crate::api::storage::get_block_contents;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/nomos-cli/src/lib.rs
+++ b/nomos-cli/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod api;
 pub mod cmds;
-// pub mod da;
+pub mod da;
 
 use clap::Parser;
 use cmds::Command;

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -17,11 +17,12 @@ pub trait DaVerifier {
     fn verify(&self, blob: &Self::DaBlob) -> Result<(), Self::Error>;
 }
 
+#[async_trait::async_trait]
 pub trait DaDispersal {
     type EncodedData;
     type Error;
 
-    fn disperse(&self, encoded_data: Self::EncodedData) -> Result<(), Self::Error>;
+    async fn disperse(&self, encoded_data: Self::EncodedData) -> Result<(), Self::Error>;
 }
 
 pub trait Signer {

--- a/nomos-da/kzgrs-backend/src/common/blob.rs
+++ b/nomos-da/kzgrs-backend/src/common/blob.rs
@@ -5,7 +5,7 @@ use nomos_core::da::blob;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 // internal
-use super::build_attestation_message;
+use super::build_blob_id;
 use crate::common::Column;
 use crate::common::Commitment;
 use crate::common::{
@@ -44,7 +44,7 @@ pub struct DaBlob {
 
 impl DaBlob {
     pub fn id(&self) -> Vec<u8> {
-        build_attestation_message(&self.aggregated_column_commitment, &self.rows_commitments).into()
+        build_blob_id(&self.aggregated_column_commitment, &self.rows_commitments).into()
     }
 
     pub fn column_id(&self) -> Vec<u8> {
@@ -58,6 +58,6 @@ impl blob::Blob for DaBlob {
     type BlobId = Vec<u8>;
 
     fn id(&self) -> Self::BlobId {
-        build_attestation_message(&self.aggregated_column_commitment, &self.rows_commitments).into()
+        build_blob_id(&self.aggregated_column_commitment, &self.rows_commitments).into()
     }
 }

--- a/nomos-da/kzgrs-backend/src/common/mod.rs
+++ b/nomos-da/kzgrs-backend/src/common/mod.rs
@@ -153,7 +153,7 @@ pub fn hash_column_and_commitment<const HASH_SIZE: usize>(
         .unwrap_or_else(|_| panic!("Size is guaranteed by constant {HASH_SIZE:?}"))
 }
 
-pub fn build_attestation_message(
+pub fn build_blob_id(
     aggregated_column_commitment: &Commitment,
     rows_commitments: &[Commitment],
 ) -> [u8; 32] {

--- a/nomos-da/kzgrs-backend/src/dispersal.rs
+++ b/nomos-da/kzgrs-backend/src/dispersal.rs
@@ -11,6 +11,12 @@ pub struct BlobInfo {
     metadata: Metadata,
 }
 
+impl BlobInfo {
+    pub fn new(id: [u8; 32], metadata: Metadata) -> Self {
+        Self { id, metadata }
+    }
+}
+
 impl blob::info::DispersedBlobInfo for BlobInfo {
     type BlobId = [u8; 32];
 
@@ -48,6 +54,10 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    pub fn new(app_id: [u8; 32], index: Index) -> Self {
+        Self { app_id, index }
+    }
+
     pub fn size(&self) -> usize {
         std::mem::size_of_val(&self.app_id) + std::mem::size_of_val(&self.index)
     }

--- a/nomos-services/data-availability/network/Cargo.toml
+++ b/nomos-services/data-availability/network/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nomos-da-network-service"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1"
+futures = "0.3"
+kzgrs-backend = { path = "../../../nomos-da/kzgrs-backend" }
+overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "sync"] }
+tokio-stream = "0.1"
+tracing = "0.1"

--- a/nomos-services/data-availability/network/src/backends/mock/executor.rs
+++ b/nomos-services/data-availability/network/src/backends/mock/executor.rs
@@ -1,4 +1,4 @@
-use kzgrs_backend::common::blob::DaBlob;
+use kzgrs_backend::common::{blob::DaBlob, build_attestation_message};
 use overwatch_rs::{overwatch::handle::OverwatchHandle, services::state::NoState};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{
@@ -21,7 +21,10 @@ pub enum EventKind {
 // Assuming that behaviour will wrap the nomos_da_message types.
 #[derive(Debug, Clone)]
 pub enum DisperseMessage {
-    DispersalSuccess,
+    DispersalSuccess {
+        blob_id: [u8; 32],
+        subnetwork_id: u32,
+    },
 }
 
 // A subset of sample protocol messages that will come over the wire.
@@ -51,9 +54,9 @@ pub enum Command {
 
 #[derive(Clone)]
 pub struct MockExecutorBackend {
-    config: MockConfig,
+    _config: MockConfig,
+    _commands_tx: mpsc::Sender<Command>,
     events_tx: broadcast::Sender<Event>,
-    commands_tx: mpsc::Sender<Command>,
 }
 
 #[async_trait::async_trait]
@@ -64,12 +67,12 @@ impl NetworkBackend for MockExecutorBackend {
     type EventKind = EventKind;
     type NetworkEvent = Event;
 
-    fn new(config: Self::Settings, _: OverwatchHandle) -> Self {
-        let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(BUFFER_SIZE);
+    fn new(_config: Self::Settings, _: OverwatchHandle) -> Self {
+        let (_commands_tx, _) = tokio::sync::mpsc::channel(BUFFER_SIZE);
         let (events_tx, _) = tokio::sync::broadcast::channel(BUFFER_SIZE);
         Self {
-            config,
-            commands_tx,
+            _config,
+            _commands_tx,
             events_tx,
         }
     }
@@ -79,7 +82,19 @@ impl NetworkBackend for MockExecutorBackend {
             Command::Disperse {
                 blob,
                 subnetwork_id,
-            } => todo!(),
+            } => {
+                let blob_id = build_attestation_message(
+                    &blob.aggregated_column_commitment,
+                    &blob.rows_commitments,
+                );
+
+                let success_message = DisperseMessage::DispersalSuccess {
+                    blob_id,
+                    subnetwork_id,
+                };
+
+                let _ = self.events_tx.send(Event::Disperse(success_message));
+            }
         }
     }
 

--- a/nomos-services/data-availability/network/src/backends/mock/executor.rs
+++ b/nomos-services/data-availability/network/src/backends/mock/executor.rs
@@ -1,4 +1,4 @@
-use kzgrs_backend::common::{blob::DaBlob, build_attestation_message};
+use kzgrs_backend::common::{blob::DaBlob, build_blob_id};
 use overwatch_rs::{overwatch::handle::OverwatchHandle, services::state::NoState};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{
@@ -83,10 +83,8 @@ impl NetworkBackend for MockExecutorBackend {
                 blob,
                 subnetwork_id,
             } => {
-                let blob_id = build_attestation_message(
-                    &blob.aggregated_column_commitment,
-                    &blob.rows_commitments,
-                );
+                let blob_id =
+                    build_blob_id(&blob.aggregated_column_commitment, &blob.rows_commitments);
 
                 let success_message = DisperseMessage::DispersalSuccess {
                     blob_id,

--- a/nomos-services/data-availability/network/src/backends/mock/executor.rs
+++ b/nomos-services/data-availability/network/src/backends/mock/executor.rs
@@ -1,0 +1,91 @@
+use kzgrs_backend::common::blob::DaBlob;
+use overwatch_rs::{overwatch::handle::OverwatchHandle, services::state::NoState};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{
+    broadcast::{self, Receiver},
+    mpsc,
+};
+
+use crate::backends::NetworkBackend;
+
+const BUFFER_SIZE: usize = 64;
+
+#[derive(Debug)]
+pub enum EventKind {
+    Dispersal,
+    Sample,
+}
+
+// A subset of dispersal protocol messages that will come over the wire.
+// Imitates the message that will come from libp2p behaviour.
+// Assuming that behaviour will wrap the nomos_da_message types.
+#[derive(Debug, Clone)]
+pub enum DisperseMessage {
+    DispersalSuccess,
+}
+
+// A subset of sample protocol messages that will come over the wire.
+// Imitates the message that will come from libp2p behaviour
+// Assuming that behaviour will wrap the nomos_da_message types.
+#[derive(Debug, Clone)]
+pub enum SampleMessage {
+    SampleSuccess {
+        blob: Box<DaBlob>,
+        subnetwork_id: u32,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum Event {
+    Disperse(DisperseMessage),
+    Sample(SampleMessage),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MockConfig {}
+
+#[derive(Debug)]
+pub enum Command {
+    Disperse { blob: DaBlob, subnetwork_id: u32 },
+}
+
+#[derive(Clone)]
+pub struct MockExecutorBackend {
+    config: MockConfig,
+    events_tx: broadcast::Sender<Event>,
+    commands_tx: mpsc::Sender<Command>,
+}
+
+#[async_trait::async_trait]
+impl NetworkBackend for MockExecutorBackend {
+    type Settings = MockConfig;
+    type State = NoState<MockConfig>;
+    type Message = Command;
+    type EventKind = EventKind;
+    type NetworkEvent = Event;
+
+    fn new(config: Self::Settings, _: OverwatchHandle) -> Self {
+        let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(BUFFER_SIZE);
+        let (events_tx, _) = tokio::sync::broadcast::channel(BUFFER_SIZE);
+        Self {
+            config,
+            commands_tx,
+            events_tx,
+        }
+    }
+
+    async fn process(&self, msg: Self::Message) {
+        match msg {
+            Command::Disperse {
+                blob,
+                subnetwork_id,
+            } => todo!(),
+        }
+    }
+
+    async fn subscribe(&mut self, kind: Self::EventKind) -> Receiver<Self::NetworkEvent> {
+        match kind {
+            EventKind::Dispersal | EventKind::Sample => self.events_tx.subscribe(),
+        }
+    }
+}

--- a/nomos-services/data-availability/network/src/backends/mock/mod.rs
+++ b/nomos-services/data-availability/network/src/backends/mock/mod.rs
@@ -1,0 +1,1 @@
+pub mod executor;

--- a/nomos-services/data-availability/network/src/backends/mod.rs
+++ b/nomos-services/data-availability/network/src/backends/mod.rs
@@ -1,0 +1,18 @@
+pub mod mock;
+
+use super::*;
+use overwatch_rs::{overwatch::handle::OverwatchHandle, services::state::ServiceState};
+use tokio::sync::broadcast::Receiver;
+
+#[async_trait::async_trait]
+pub trait NetworkBackend {
+    type Settings: Clone + Debug + Send + Sync + 'static;
+    type State: ServiceState<Settings = Self::Settings> + Clone + Send + Sync;
+    type Message: Debug + Send + Sync + 'static;
+    type EventKind: Debug + Send + Sync + 'static;
+    type NetworkEvent: Debug + Send + Sync + 'static;
+
+    fn new(config: Self::Settings, overwatch_handle: OverwatchHandle) -> Self;
+    async fn process(&self, msg: Self::Message);
+    async fn subscribe(&mut self, event: Self::EventKind) -> Receiver<Self::NetworkEvent>;
+}

--- a/nomos-services/data-availability/network/src/lib.rs
+++ b/nomos-services/data-availability/network/src/lib.rs
@@ -1,0 +1,178 @@
+pub mod backends;
+
+// std
+use std::fmt::{self, Debug};
+// crates
+use async_trait::async_trait;
+use backends::NetworkBackend;
+use futures::StreamExt;
+use overwatch_rs::services::life_cycle::LifecycleMessage;
+use overwatch_rs::services::{
+    handle::ServiceStateHandle,
+    relay::RelayMessage,
+    state::{NoOperator, ServiceState},
+    ServiceCore, ServiceData, ServiceId,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use tokio::sync::oneshot;
+use tracing::error;
+// internal
+
+pub enum DaNetworkMsg<B: NetworkBackend> {
+    Process(B::Message),
+    Subscribe {
+        kind: B::EventKind,
+        sender: oneshot::Sender<broadcast::Receiver<B::NetworkEvent>>,
+    },
+}
+
+impl<B: NetworkBackend> Debug for DaNetworkMsg<B> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Process(msg) => write!(fmt, "DaNetworkMsg::Process({msg:?})"),
+            Self::Subscribe { kind, sender } => write!(
+                fmt,
+                "DaNetworkMsg::Subscribe{{ kind: {kind:?}, sender: {sender:?}}}"
+            ),
+        }
+    }
+}
+
+impl<T: NetworkBackend + 'static> RelayMessage for DaNetworkMsg<T> {}
+
+#[derive(Serialize, Deserialize)]
+pub struct NetworkConfig<B: NetworkBackend> {
+    pub backend: B::Settings,
+}
+
+impl<B: NetworkBackend> Debug for NetworkConfig<B> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "NetworkConfig {{ backend: {:?}}}", self.backend)
+    }
+}
+
+pub struct NetworkService<B: NetworkBackend + 'static> {
+    backend: B,
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct NetworkState<B: NetworkBackend> {
+    _backend: B::State,
+}
+
+impl<B: NetworkBackend + 'static> ServiceData for NetworkService<B> {
+    const SERVICE_ID: ServiceId = "DaNetwork";
+    type Settings = NetworkConfig<B>;
+    type State = NetworkState<B>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = DaNetworkMsg<B>;
+}
+
+#[async_trait]
+impl<B> ServiceCore for NetworkService<B>
+where
+    B: NetworkBackend + Send + 'static,
+    B::State: Send + Sync,
+{
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, overwatch_rs::DynError> {
+        Ok(Self {
+            backend: <B as NetworkBackend>::new(
+                service_state.settings_reader.get_updated_settings().backend,
+                service_state.overwatch_handle.clone(),
+            ),
+            service_state,
+        })
+    }
+
+    async fn run(mut self) -> Result<(), overwatch_rs::DynError> {
+        let Self {
+            service_state:
+                ServiceStateHandle {
+                    mut inbound_relay,
+                    lifecycle_handle,
+                    ..
+                },
+            mut backend,
+        } = self;
+        let mut lifecycle_stream = lifecycle_handle.message_stream();
+        loop {
+            tokio::select! {
+                Some(msg) = inbound_relay.recv() => {
+                    Self::handle_network_service_message(msg, &mut backend).await;
+                }
+                Some(msg) = lifecycle_stream.next() => {
+                    if Self::should_stop_service(msg).await {
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<B> NetworkService<B>
+where
+    B: NetworkBackend + Send + 'static,
+    B::State: Send + Sync,
+{
+    async fn handle_network_service_message(msg: DaNetworkMsg<B>, backend: &mut B) {
+        match msg {
+            DaNetworkMsg::Process(msg) => {
+                // split sending in two steps to help the compiler understand we do not
+                // need to hold an instance of &I (which is not send) across an await point
+                let _send = backend.process(msg);
+                _send.await
+            }
+            DaNetworkMsg::Subscribe { kind, sender } => sender
+                .send(backend.subscribe(kind).await)
+                .unwrap_or_else(|_| {
+                    tracing::warn!(
+                        "client hung up before a subscription handle could be established"
+                    )
+                }),
+        }
+    }
+
+    async fn should_stop_service(msg: LifecycleMessage) -> bool {
+        match msg {
+            LifecycleMessage::Kill => true,
+            LifecycleMessage::Shutdown(signal_sender) => {
+                // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
+                if signal_sender.send(()).is_err() {
+                    error!(
+                        "Error sending successful shutdown signal from service {}",
+                        Self::SERVICE_ID
+                    );
+                }
+                true
+            }
+        }
+    }
+}
+
+impl<B: NetworkBackend> Clone for NetworkConfig<B> {
+    fn clone(&self) -> Self {
+        NetworkConfig {
+            backend: self.backend.clone(),
+        }
+    }
+}
+
+impl<B: NetworkBackend> Clone for NetworkState<B> {
+    fn clone(&self) -> Self {
+        NetworkState {
+            _backend: self._backend.clone(),
+        }
+    }
+}
+
+impl<B: NetworkBackend> ServiceState for NetworkState<B> {
+    type Settings = NetworkConfig<B>;
+    type Error = <B::State as ServiceState>::Error;
+
+    fn from_settings(settings: &Self::Settings) -> Result<Self, Self::Error> {
+        B::State::from_settings(&settings.backend).map(|_backend| Self { _backend })
+    }
+}


### PR DESCRIPTION
Dispersal command with simplified da network backend mock for executor.

This version has simplified configuration for the cli, with a plan to improve it in subsequent pull requests with more options for different da network backends (libp2p or mock).

Full replication option was removed as an option in the dispersal cli app.