### PR TITLE
DA: Store and load multiple columns for the same blob in a single node

### DIFF
--- a/nodes/nomos-node/src/api.rs
+++ b/nodes/nomos-node/src/api.rs
@@ -75,6 +75,7 @@ where
     A: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     B: Blob + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     <B as Blob>::BlobId: AsRef<[u8]> + Send + Sync + 'static,
+    <B as Blob>::ColumnIndex: AsRef<[u8]> + Send + Sync + 'static,
     C: DispersedBlobInfo<BlobId = [u8; 32]>
         + Clone
         + Debug
@@ -327,6 +328,7 @@ where
     A: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     B: Blob + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     <B as Blob>::BlobId: AsRef<[u8]> + Send + Sync + 'static,
+    <B as Blob>::ColumnIndex: AsRef<[u8]> + Send + Sync + 'static,
     VB: VerifierBackend + CoreDaVerifier<DaBlob = B>,
     <VB as VerifierBackend>::Settings: Clone,
     <VB as CoreDaVerifier>::Error: Error,

--- a/nomos-core/src/da/blob/mod.rs
+++ b/nomos-core/src/da/blob/mod.rs
@@ -4,8 +4,10 @@ pub mod select;
 
 pub trait Blob {
     type BlobId;
+    type ColumnIndex;
 
     fn id(&self) -> Self::BlobId;
+    fn column_idx(&self) -> Self::ColumnIndex;
 }
 
 pub trait BlobSelect {

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -1,9 +1,9 @@
+pub mod blob;
+
 // crates
 // internal
-
 use blob::Blob;
 
-pub mod blob;
 pub type BlobId = [u8; 32];
 
 pub trait DaEncoder {

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -1,6 +1,8 @@
 // crates
 // internal
 
+use blob::Blob;
+
 pub mod blob;
 pub type BlobId = [u8; 32];
 
@@ -12,7 +14,7 @@ pub trait DaEncoder {
 }
 
 pub trait DaVerifier {
-    type DaBlob;
+    type DaBlob: Blob;
     type Error;
 
     fn verify(&self, blob: &Self::DaBlob) -> Result<(), Self::Error>;

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -2,7 +2,7 @@
 // internal
 
 pub mod blob;
-pub type BlobId = u32;
+pub type BlobId = [u8; 32];
 
 pub trait DaEncoder {
     type EncodedData;

--- a/nomos-core/src/da/mod.rs
+++ b/nomos-core/src/da/mod.rs
@@ -2,6 +2,7 @@
 // internal
 
 pub mod blob;
+pub type BlobId = u32;
 
 pub trait DaEncoder {
     type EncodedData;

--- a/nomos-da/kzgrs-backend/src/common/blob.rs
+++ b/nomos-da/kzgrs-backend/src/common/blob.rs
@@ -57,9 +57,14 @@ impl DaBlob {
 }
 
 impl blob::Blob for DaBlob {
-    type BlobId = Vec<u8>;
+    type BlobId = [u8; 32];
+    type ColumnIndex = [u8; 2];
 
     fn id(&self) -> Self::BlobId {
-        build_blob_id(&self.aggregated_column_commitment, &self.rows_commitments).into()
+        build_blob_id(&self.aggregated_column_commitment, &self.rows_commitments)
+    }
+
+    fn column_idx(&self) -> Self::ColumnIndex {
+        self.column_idx.to_be_bytes()
     }
 }

--- a/nomos-da/storage/src/fs/mod.rs
+++ b/nomos-da/storage/src/fs/mod.rs
@@ -35,13 +35,16 @@ pub async fn load_blob(base_dir: PathBuf, blob_id: &[u8]) -> Option<Bytes> {
 
 pub async fn write_blob(
     base_dir: PathBuf,
-    blob_idx: &[u8],
+    blob_id: &[u8],
+    column_idx: &[u8],
     data: &[u8],
 ) -> Result<(), std::io::Error> {
-    let blob_idx = hex::encode(blob_idx);
+    let blob_id = hex::encode(blob_id);
+    let column_file = hex::encode(column_idx);
 
     let mut path = base_dir;
-    path.push(blob_idx);
+    path.push(blob_id);
+    path.push(column_file);
 
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;

--- a/nomos-da/storage/src/fs/mod.rs
+++ b/nomos-da/storage/src/fs/mod.rs
@@ -35,13 +35,13 @@ pub async fn load_blob(base_dir: PathBuf, blob_id: &[u8]) -> Option<Bytes> {
 
 pub async fn write_blob(
     base_dir: PathBuf,
-    blob_id: &[u8],
+    blob_idx: &[u8],
     data: &[u8],
 ) -> Result<(), std::io::Error> {
-    let blob_id = hex::encode(blob_id);
+    let blob_idx = hex::encode(blob_idx);
 
     let mut path = base_dir;
-    path.push(blob_id);
+    path.push(blob_idx);
 
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;

--- a/nomos-da/storage/src/fs/mod.rs
+++ b/nomos-da/storage/src/fs/mod.rs
@@ -3,34 +3,48 @@ use std::path::PathBuf;
 // crates
 use bytes::Bytes;
 use tokio::{
-    fs::{File, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::{AsyncReadExt, AsyncWriteExt},
 };
 // internal
 
 // TODO: Rocksdb has a feature called BlobDB that handles largo blob storing, but further
 // investigation needs to be done to see if rust wrapper supports it.
-pub async fn load_blob(base_dir: PathBuf, blob_id: &[u8]) -> Option<Bytes> {
+pub async fn load_blob(base_dir: PathBuf, blob_id: &[u8]) -> Vec<Bytes> {
     let blob_id = hex::encode(blob_id);
 
     let mut path = base_dir;
     path.push(blob_id);
 
-    let mut file = match File::open(path).await {
-        Ok(file) => file,
+    let mut blobs = Vec::new();
+
+    let mut column_files = match fs::read_dir(&path).await {
+        Ok(entries) => entries,
         Err(e) => {
-            tracing::error!("Failed to open file: {}", e);
-            return None;
+            tracing::error!("Failed to read directory: {}", e);
+            return blobs;
         }
     };
 
-    let mut contents = vec![];
-    if let Err(e) = file.read_to_end(&mut contents).await {
-        tracing::error!("Failed to read file: {}", e);
-        return None;
+    while let Some(entry) = column_files.next_entry().await.ok().flatten() {
+        let mut file = match File::open(entry.path()).await {
+            Ok(file) => file,
+            Err(e) => {
+                tracing::error!("Failed to open file: {}", e);
+                continue;
+            }
+        };
+
+        let mut contents = vec![];
+        if let Err(e) = file.read_to_end(&mut contents).await {
+            tracing::error!("Failed to read file: {}", e);
+            continue;
+        }
+
+        blobs.push(Bytes::from(contents));
     }
 
-    Some(Bytes::from(contents))
+    blobs
 }
 
 pub async fn write_blob(

--- a/nomos-da/storage/src/rocksdb/mod.rs
+++ b/nomos-da/storage/src/rocksdb/mod.rs
@@ -1,7 +1,7 @@
 use bytes::{Bytes, BytesMut};
 
 pub const DA_VID_KEY_PREFIX: &str = "da/vid/";
-pub const DA_ATTESTED_KEY_PREFIX: &str = "da/attested/";
+pub const DA_VERIFIED_KEY_PREFIX: &str = "da/verified/";
 
 pub fn key_bytes(prefix: &str, id: impl AsRef<[u8]>) -> Bytes {
     let mut buffer = BytesMut::new();

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -77,7 +77,7 @@ pub async fn get_range<Tx, C, V, SS, const SIZE: usize>(
     handle: &OverwatchHandle,
     app_id: <V as Metadata>::AppId,
     range: Range<<V as Metadata>::Index>,
-) -> Result<Vec<(<V as Metadata>::Index, Option<Bytes>)>, DynError>
+) -> Result<Vec<(<V as Metadata>::Index, Vec<Bytes>)>, DynError>
 where
     Tx: Transaction
         + Eq

--- a/nomos-services/api/src/http/da.rs
+++ b/nomos-services/api/src/http/da.rs
@@ -54,6 +54,7 @@ where
     A: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     B: Blob + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     <B as Blob>::BlobId: AsRef<[u8]> + Send + Sync + 'static,
+    <B as Blob>::ColumnIndex: AsRef<[u8]> + Send + Sync + 'static,
     VB: VerifierBackend + CoreDaVerifier<DaBlob = B>,
     <VB as VerifierBackend>::Settings: Clone,
     <VB as CoreDaVerifier>::Error: Error,

--- a/nomos-services/data-availability/indexer/src/lib.rs
+++ b/nomos-services/data-availability/indexer/src/lib.rs
@@ -74,7 +74,7 @@ pub enum DaMsg<B, V: Metadata> {
     GetRange {
         app_id: <V as Metadata>::AppId,
         range: Range<<V as Metadata>::Index>,
-        reply_channel: Sender<Vec<(<V as Metadata>::Index, Option<B>)>>,
+        reply_channel: Sender<Vec<(<V as Metadata>::Index, Vec<B>)>>,
     },
 }
 

--- a/nomos-services/data-availability/indexer/src/storage/adapters/rocksdb.rs
+++ b/nomos-services/data-availability/indexer/src/storage/adapters/rocksdb.rs
@@ -3,9 +3,12 @@ use std::{marker::PhantomData, ops::Range};
 
 use bytes::Bytes;
 use futures::{stream::FuturesUnordered, Stream};
-use nomos_core::da::blob::{
-    info::DispersedBlobInfo,
-    metadata::{Metadata, Next},
+use nomos_core::da::{
+    blob::{
+        info::DispersedBlobInfo,
+        metadata::{Metadata, Next},
+    },
+    BlobId,
 };
 use nomos_da_storage::fs::load_blob;
 use nomos_da_storage::rocksdb::{key_bytes, DA_VERIFIED_KEY_PREFIX, DA_VID_KEY_PREFIX};
@@ -34,7 +37,7 @@ where
 impl<S, B> DaStorageAdapter for RocksAdapter<S, B>
 where
     S: StorageSerde + Send + Sync + 'static,
-    B: DispersedBlobInfo<BlobId = [u8; 32]> + Metadata + Send + Sync,
+    B: DispersedBlobInfo<BlobId = BlobId> + Metadata + Send + Sync,
     B::Index: AsRef<[u8]> + Next + Clone + PartialOrd + Send + Sync + 'static,
     B::AppId: AsRef<[u8]> + Clone + Send + Sync + 'static,
 {

--- a/nomos-services/data-availability/indexer/src/storage/adapters/rocksdb.rs
+++ b/nomos-services/data-availability/indexer/src/storage/adapters/rocksdb.rs
@@ -8,7 +8,7 @@ use nomos_core::da::blob::{
     metadata::{Metadata, Next},
 };
 use nomos_da_storage::fs::load_blob;
-use nomos_da_storage::rocksdb::{key_bytes, DA_ATTESTED_KEY_PREFIX, DA_VID_KEY_PREFIX};
+use nomos_da_storage::rocksdb::{key_bytes, DA_VERIFIED_KEY_PREFIX, DA_VID_KEY_PREFIX};
 use nomos_storage::{
     backends::{rocksdb::RocksBackend, StorageSerde},
     StorageMsg, StorageService,
@@ -58,7 +58,7 @@ where
         let (app_id, idx) = info.metadata();
 
         // Check if Info in a block is something that the node've seen before.
-        let attested_key = key_bytes(DA_ATTESTED_KEY_PREFIX, info.blob_id());
+        let attested_key = key_bytes(DA_VERIFIED_KEY_PREFIX, info.blob_id());
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
 
         self.storage_relay

--- a/nomos-services/data-availability/indexer/src/storage/mod.rs
+++ b/nomos-services/data-availability/indexer/src/storage/mod.rs
@@ -28,5 +28,5 @@ pub trait DaStorageAdapter {
         &self,
         app_id: <Self::Info as Metadata>::AppId,
         range: Range<<Self::Info as Metadata>::Index>,
-    ) -> Box<dyn Stream<Item = (<Self::Info as Metadata>::Index, Option<Self::Blob>)> + Unpin + Send>;
+    ) -> Box<dyn Stream<Item = (<Self::Info as Metadata>::Index, Vec<Self::Blob>)> + Unpin + Send>;
 }

--- a/nomos-services/data-availability/tests/src/indexer_integration.rs
+++ b/nomos-services/data-availability/tests/src/indexer_integration.rs
@@ -17,6 +17,7 @@ use nomos_core::tx::Transaction;
 use nomos_da_indexer::storage::adapters::rocksdb::RocksAdapterSettings;
 use nomos_da_indexer::IndexerSettings;
 use nomos_da_storage::fs::write_blob;
+use nomos_da_storage::rocksdb::DA_VERIFIED_KEY_PREFIX;
 use nomos_libp2p::{Multiaddr, SwarmConfig};
 use nomos_mempool::network::adapters::libp2p::Settings as AdapterSettings;
 use nomos_mempool::{DaMempoolSettings, TxMempoolSettings};
@@ -31,6 +32,7 @@ use rand::{thread_rng, Rng};
 use tempfile::{NamedTempFile, TempDir};
 use time::OffsetDateTime;
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+
 // internal
 use crate::common::*;
 
@@ -222,7 +224,7 @@ fn test_indexer() {
             });
 
         // Mock attested blob by writting directly into the da storage.
-        let mut attested_key = Vec::from(b"da/attested/" as &[u8]);
+        let mut attested_key = Vec::from(DA_VERIFIED_KEY_PREFIX.as_bytes());
         attested_key.extend_from_slice(&blob_hash);
 
         storage_outbound

--- a/nomos-services/data-availability/tests/src/indexer_integration.rs
+++ b/nomos-services/data-availability/tests/src/indexer_integration.rs
@@ -202,8 +202,13 @@ fn test_indexer() {
 
     // Mock attestation step where blob is persisted in nodes blob storage.
     let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(write_blob(blobs_dir, blob_info.blob_id().as_ref(), b"blob"))
-        .unwrap();
+    rt.block_on(write_blob(
+        blobs_dir,
+        blob_info.blob_id().as_ref(),
+        index.as_ref(),
+        b"blob",
+    ))
+    .unwrap();
 
     node1.spawn(async move {
         let mempool_outbound = mempool.connect().await.unwrap();
@@ -226,6 +231,7 @@ fn test_indexer() {
         // Mock attested blob by writting directly into the da storage.
         let mut attested_key = Vec::from(DA_VERIFIED_KEY_PREFIX.as_bytes());
         attested_key.extend_from_slice(&blob_hash);
+        attested_key.extend_from_slice(index.as_ref());
 
         storage_outbound
             .send(nomos_storage::StorageMsg::Store {

--- a/nomos-services/data-availability/verifier/src/lib.rs
+++ b/nomos-services/data-availability/verifier/src/lib.rs
@@ -2,9 +2,12 @@ pub mod backend;
 pub mod network;
 pub mod storage;
 
+use kzgrs_backend::common::ColumnIndex;
+use nomos_core::da::BlobId;
 // std
 use nomos_storage::StorageService;
 use overwatch_rs::services::life_cycle::LifecycleMessage;
+use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::{Debug, Formatter};
 use storage::DaStorageAdapter;
@@ -28,6 +31,11 @@ pub enum DaVerifierMsg<B, A> {
         blob: B,
         reply_channel: Sender<Option<A>>,
     },
+    GetBlob {
+        blob_id: BlobId,
+        columns: HashSet<ColumnIndex>,
+        reply_channel: Sender<Vec<B>>,
+    },
 }
 
 impl<B: 'static, A: 'static> Debug for DaVerifierMsg<B, A> {
@@ -35,6 +43,9 @@ impl<B: 'static, A: 'static> Debug for DaVerifierMsg<B, A> {
         match self {
             DaVerifierMsg::AddBlob { .. } => {
                 write!(f, "DaVerifierMsg::AddBlob")
+            }
+            DaVerifierMsg::GetBlob { .. } => {
+                write!(f, "DaVerifierMsg::GetBlob")
             }
         }
     }
@@ -179,18 +190,24 @@ where
                         }
                     }
                     Some(msg) = service_state.inbound_relay.recv() => {
-                        let DaVerifierMsg::AddBlob { blob, reply_channel } = msg;
-                        match Self::handle_new_blob(&verifier, &storage_adapter, &blob).await {
-                            Ok(attestation) => if let Err(err) = reply_channel.send(Some(attestation)) {
-                                error!("Error replying attestation {err:?}");
-                            },
-                            Err(err) => {
-                                error!("Error handling blob {blob:?} due to {err:?}");
-                                if let Err(err) = reply_channel.send(None) {
-                                    error!("Error replying attestation {err:?}");
-                                }
-                            },
-                        };
+                        match msg {
+                            DaVerifierMsg::AddBlob { blob, reply_channel } => {
+                                match Self::handle_new_blob(&verifier, &storage_adapter, &blob).await {
+                                    Ok(attestation) => if let Err(err) = reply_channel.send(Some(attestation)) {
+                                        error!("Error replying attestation {err:?}");
+                                    },
+                                    Err(err) => {
+                                        error!("Error handling blob {blob:?} due to {err:?}");
+                                        if let Err(err) = reply_channel.send(None) {
+                                            error!("Error replying attestation {err:?}");
+                                        }
+                                    },
+                                };
+                            }
+                            DaVerifierMsg::GetBlob{blob_id, columns, reply_channel} => {
+                                todo!()
+                            }
+                        }
                     }
                     Some(msg) = lifecycle_stream.next() => {
                         if Self::should_stop_service(msg).await {

--- a/nomos-services/data-availability/verifier/src/storage/adapters/rocksdb.rs
+++ b/nomos-services/data-availability/verifier/src/storage/adapters/rocksdb.rs
@@ -107,6 +107,8 @@ where
     }
 }
 
+// Combines a 32-byte blob ID (`[u8; 32]`) with a 2-byte column index
+// (`u16` represented as `[u8; 2]`).
 fn create_blob_idx(blob_id: &[u8], column_idx: &[u8]) -> [u8; 34] {
     let mut blob_idx = [0u8; 34];
     blob_idx[..blob_id.len()].copy_from_slice(blob_id);

--- a/nomos-services/data-availability/verifier/src/storage/adapters/rocksdb.rs
+++ b/nomos-services/data-availability/verifier/src/storage/adapters/rocksdb.rs
@@ -64,7 +64,8 @@ where
 
         write_blob(
             self.settings.blob_storage_directory.clone(),
-            &blob_idx,
+            blob.id().as_ref(),
+            blob.column_idx().as_ref(),
             &blob_bytes,
         )
         .await?;
@@ -80,12 +81,10 @@ where
             .map_err(|(e, _)| e.into())
     }
 
-    async fn get_attestation(
+    async fn get_blob(
         &self,
-        blob: &Self::Blob,
+        blob_idx: <Self::Blob as Blob>::BlobId,
     ) -> Result<Option<Self::Attestation>, DynError> {
-        let blob_idx = create_blob_idx(blob.id().as_ref(), blob.column_idx().as_ref());
-
         let key = key_bytes(DA_VERIFIED_KEY_PREFIX, blob_idx);
         let (reply_channel, reply_rx) = tokio::sync::oneshot::channel();
         self.storage_relay

--- a/nomos-services/data-availability/verifier/src/storage/mod.rs
+++ b/nomos-services/data-availability/verifier/src/storage/mod.rs
@@ -1,5 +1,6 @@
 pub mod adapters;
 
+use nomos_core::da::blob::Blob;
 use nomos_storage::{backends::StorageBackend, StorageService};
 use overwatch_rs::{
     services::{relay::OutboundRelay, ServiceData},
@@ -10,7 +11,7 @@ use overwatch_rs::{
 pub trait DaStorageAdapter {
     type Backend: StorageBackend + Send + Sync + 'static;
     type Settings: Clone;
-    type Blob: Clone;
+    type Blob: Blob + Clone;
     type Attestation: Clone;
 
     async fn new(
@@ -23,8 +24,9 @@ pub trait DaStorageAdapter {
         blob: &Self::Blob,
         attestation: &Self::Attestation,
     ) -> Result<(), DynError>;
-    async fn get_attestation(
+
+    async fn get_blob(
         &self,
-        blob: &Self::Blob,
+        blob_id: <Self::Blob as Blob>::BlobId,
     ) -> Result<Option<Self::Attestation>, DynError>;
 }

--- a/nomos-services/storage/src/backends/mock.rs
+++ b/nomos-services/storage/src/backends/mock.rs
@@ -54,6 +54,10 @@ impl<SerdeOp: StorageSerde + Send + Sync + 'static> StorageBackend for MockStora
         Ok(self.inner.get(key).cloned())
     }
 
+    async fn load_prefix(&mut self, _key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+        unimplemented!()
+    }
+
     async fn remove(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.inner.remove(key))
     }

--- a/nomos-services/storage/src/backends/mod.rs
+++ b/nomos-services/storage/src/backends/mod.rs
@@ -45,6 +45,7 @@ pub trait StorageBackend: Sized {
     fn new(config: Self::Settings) -> Result<Self, Self::Error>;
     async fn store(&mut self, key: Bytes, value: Bytes) -> Result<(), Self::Error>;
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
+    /// Loads all values whose keys start with the given prefix.
     async fn load_prefix(&mut self, prefix: &[u8]) -> Result<Vec<Bytes>, Self::Error>;
     async fn remove(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
     /// Execute a transaction in the current backend

--- a/nomos-services/storage/src/backends/mod.rs
+++ b/nomos-services/storage/src/backends/mod.rs
@@ -45,6 +45,7 @@ pub trait StorageBackend: Sized {
     fn new(config: Self::Settings) -> Result<Self, Self::Error>;
     async fn store(&mut self, key: Bytes, value: Bytes) -> Result<(), Self::Error>;
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
+    async fn load_prefix(&mut self, prefix: &[u8]) -> Result<Vec<Bytes>, Self::Error>;
     async fn remove(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error>;
     /// Execute a transaction in the current backend
     async fn execute(

--- a/nomos-services/storage/src/backends/sled.rs
+++ b/nomos-services/storage/src/backends/sled.rs
@@ -75,6 +75,10 @@ impl<SerdeOp: StorageSerde + Send + Sync + 'static> StorageBackend for SledBacke
         Ok(self.sled.get(key)?.map(|ivec| ivec.to_vec().into()))
     }
 
+    async fn load_prefix(&mut self, _key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+        unimplemented!()
+    }
+
     async fn remove(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
         Ok(self.sled.remove(key)?.map(|ivec| ivec.to_vec().into()))
     }


### PR DESCRIPTION
To allow verification of multiple columns for the same encoded data in a single node Blob holds column_idx, which is later used in da storage service and indexer.