### PR TITLE
DA: Nomos Cli dispersal tests

### DIFF
--- a/nomos-cli/src/api/mempool.rs
+++ b/nomos-cli/src/api/mempool.rs
@@ -6,7 +6,7 @@ pub async fn send_blob_info<I>(node: &Url, info: &I) -> Result<Response, Error>
 where
     I: Serialize,
 {
-    const NODE_CERT_PATH: &str = "mempool/add/cert";
+    const NODE_CERT_PATH: &str = "mempool/add/blobinfo";
     CLIENT
         .post(node.join(NODE_CERT_PATH).unwrap())
         .json(info)

--- a/nomos-cli/src/cmds/disseminate/mod.rs
+++ b/nomos-cli/src/cmds/disseminate/mod.rs
@@ -29,10 +29,18 @@ pub struct Disseminate {
     /// for block inclusion, if present.
     #[clap(long)]
     pub node_addr: Option<Url>,
+    // Application ID for dispersed data.
     #[clap(long)]
     pub app_id: String,
+    // Index for the Blob associated with Application ID.
     #[clap(long)]
     pub index: u64,
+    // Use Kzg RS cache.
+    #[clap(long)]
+    pub with_cache: bool,
+    // Number of columns to use for encoding.
+    #[clap(long, default_value = "4096")]
+    pub columns: usize,
     /// File to write the certificate to, if present.
     #[clap(long)]
     pub output: Option<PathBuf>,
@@ -70,6 +78,8 @@ impl Disseminate {
         let timeout = Duration::from_secs(self.timeout);
         let node_addr = self.node_addr.clone();
         let output = self.output.clone();
+        let num_columns = self.columns;
+        let with_cache = self.with_cache;
         let (payload_sender, payload_rx) = tokio::sync::mpsc::unbounded_channel();
         payload_sender.send(bytes.into_boxed_slice()).unwrap();
         std::thread::spawn(move || {
@@ -80,8 +90,8 @@ impl Disseminate {
                         payload: Arc::new(Mutex::new(payload_rx)),
                         timeout,
                         kzgrs_settings: KzgrsSettings {
-                            num_columns: 32,
-                            with_cache: false,
+                            num_columns,
+                            with_cache,
                         },
                         metadata,
                         status_updates,

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -210,8 +210,8 @@ impl ServiceCore for DisseminateService {
 
 #[derive(Debug, Clone, Args)]
 pub struct KzgrsSettings {
-    num_columns: usize,
-    with_cache: bool,
+    pub num_columns: usize,
+    pub with_cache: bool,
 }
 
 impl Default for KzgrsSettings {

--- a/nomos-cli/src/da/disseminate.rs
+++ b/nomos-cli/src/da/disseminate.rs
@@ -75,7 +75,7 @@ where
 
         if !res.status().is_success() {
             tracing::error!("ERROR: {:?}", res);
-            return Err(format!("Failed to send certificate to node: {}", res.status()).into());
+            return Err(format!("Failed to send blob info to node: {}", res.status()).into());
         }
     }
 

--- a/nomos-cli/src/da/network/backend.rs
+++ b/nomos-cli/src/da/network/backend.rs
@@ -57,8 +57,8 @@ pub struct ExecutorBackendSettings<Membership> {
     #[serde(with = "secret_key_serde", default = "ed25519::SecretKey::generate")]
     pub node_key: ed25519::SecretKey,
     /// Membership of DA network PoV set
-    membership: Membership,
-    node_addrs: HashMap<PeerId, Multiaddr>,
+    pub membership: Membership,
+    pub node_addrs: HashMap<PeerId, Multiaddr>,
 }
 
 impl<Membership> ExecutorBackend<Membership> {

--- a/nomos-services/api/src/http/mempool.rs
+++ b/nomos-services/api/src/http/mempool.rs
@@ -41,7 +41,7 @@ where
     }
 }
 
-pub async fn add_cert<N, A, V, Item, Key>(
+pub async fn add_blob_info<N, A, Item, Key>(
     handle: &overwatch_rs::overwatch::handle::OverwatchHandle,
     item: A::Payload,
     converter: impl Fn(&A::Payload) -> Key,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -42,6 +42,10 @@ time = "0.3"
 name = "test_cryptarchia_happy_path"
 path = "src/tests/cryptarchia/happy.rs"
 
+[[test]]
+name = "test_cli"
+path = "src/tests/cli.rs"
+
 [features]
 mixnet = ["nomos-network/mixnet"]
 metrics = ["nomos-node/metrics"]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod nodes;
-// pub use nodes::NomosNode;
+pub use nodes::NomosNode;
 use once_cell::sync::Lazy;
 
 use std::env;

--- a/tests/src/tests/cli.rs
+++ b/tests/src/tests/cli.rs
@@ -43,13 +43,12 @@ fn run_disseminate(disseminate: &Disseminate) {
 }
 
 async fn disseminate(config: &mut Disseminate) {
-    let node_configs = NomosNode::node_configs(SpawnConfig::chain_happy(2));
-    let first_node = NomosNode::spawn(node_configs[0].clone()).await;
+    let nodes = NomosNode::spawn_nodes(SpawnConfig::star_happy(2)).await;
 
-    let node_addrs: HashMap<PeerId, Multiaddr> = node_configs
+    let node_addrs: HashMap<PeerId, Multiaddr> = nodes
         .iter()
-        .map(|c| {
-            let libp2p_config = &c.network.backend.inner;
+        .map(|n| {
+            let libp2p_config = &n.config().network.backend.inner;
             let keypair = libp2p::identity::Keypair::from(ed25519::Keypair::from(
                 libp2p_config.node_key.clone(),
             ));
@@ -78,7 +77,7 @@ async fn disseminate(config: &mut Disseminate) {
     config.node_addr = Some(
         format!(
             "http://{}",
-            first_node.config().http.backend_settings.address.clone()
+            nodes[0].config().http.backend_settings.address.clone()
         )
         .parse()
         .unwrap(),

--- a/tests/src/tests/cli.rs
+++ b/tests/src/tests/cli.rs
@@ -1,10 +1,8 @@
-use mixnet::crypto::public_key_from;
 use nomos_cli::cmds::disseminate::Disseminate;
 use nomos_cli::da::network::backend::ExecutorBackend;
 use nomos_cli::da::network::backend::ExecutorBackendSettings;
 use nomos_da_network_service::NetworkConfig;
 use nomos_libp2p::ed25519;
-use nomos_libp2p::ed25519::PublicKey;
 use nomos_libp2p::libp2p;
 use nomos_libp2p::libp2p::multiaddr::multiaddr;
 use nomos_libp2p::Multiaddr;
@@ -49,19 +47,19 @@ async fn disseminate(config: &mut Disseminate) {
     let node_addrs: HashMap<PeerId, Multiaddr> = node_configs
         .iter()
         .map(|c| {
-            let libp2p_config = &config.network.backend.inner;
+            let libp2p_config = &c.network.backend.inner;
             let keypair = libp2p::identity::Keypair::from(ed25519::Keypair::from(
                 libp2p_config.node_key.clone(),
             ));
             let peer_id = PeerId::from(keypair.public());
-
             let address = multiaddr!(Ip4(libp2p_config.host), Udp(libp2p_config.port), QuicV1);
+            (peer_id, address)
         })
         .collect();
 
-    let peer_ids: Vec<PeerId> = node_addrs.keys().cloned().collect();
+    let peer_ids: Vec<nomos_libp2p::PeerId> = node_addrs.keys().cloned().collect();
 
-    let da_network_config = NetworkConfig {
+    let da_network_config: NetworkConfig<ExecutorBackend<FillFromNodeList>> = NetworkConfig {
         backend: ExecutorBackendSettings {
             node_key: ed25519::SecretKey::generate(),
             membership: FillFromNodeList::new(&peer_ids, 2, 1),

--- a/tests/src/tests/cli.rs
+++ b/tests/src/tests/cli.rs
@@ -1,0 +1,90 @@
+use nomos_cli::cmds::disseminate::Disseminate;
+use std::io::Write;
+use tempfile::NamedTempFile;
+use tests::nodes::NomosNode;
+use tests::Node;
+use tests::SpawnConfig;
+
+const CLI_BIN: &str = "../target/debug/nomos-cli";
+
+use std::process::Command;
+
+fn run_disseminate(disseminate: &Disseminate) {
+    let mut binding = Command::new(CLI_BIN);
+    let c = binding
+        .args(["disseminate", "--network-config"])
+        .arg(disseminate.network_config.as_os_str())
+        .arg("--app-id")
+        .arg(&disseminate.app_id)
+        .arg("--index")
+        .arg(disseminate.index.to_string())
+        .arg("--node-addr")
+        .arg(disseminate.node_addr.as_ref().unwrap().as_str());
+
+    match (&disseminate.data, &disseminate.file) {
+        (Some(data), None) => c.args(["--data", &data]),
+        (None, Some(file)) => c.args(["--file", file.as_os_str().to_str().unwrap()]),
+        (_, _) => panic!("Either data or file needs to be provided, but not both"),
+    };
+
+    c.status().expect("failed to execute nomos cli");
+}
+
+async fn disseminate(config: &mut Disseminate) {
+    let node_configs = NomosNode::node_configs(SpawnConfig::chain_happy(2));
+    let first_node = NomosNode::spawn(node_configs[0].clone()).await;
+
+    let mut file = NamedTempFile::new().unwrap();
+    let config_path = file.path().to_owned();
+    serde_yaml::to_writer(&mut file, &node_configs[1].network).unwrap();
+
+    config.timeout = 20;
+    config.network_config = config_path;
+    config.node_addr = Some(
+        format!(
+            "http://{}",
+            first_node.config().http.backend_settings.address.clone()
+        )
+        .parse()
+        .unwrap(),
+    );
+    config.app_id = "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715".to_string();
+    config.index = 0;
+
+    run_disseminate(&config);
+}
+
+#[tokio::test]
+async fn disseminate_blob() {
+    let mut config = Disseminate {
+        data: Some("hello world".to_string()),
+        ..Default::default()
+    };
+    disseminate(&mut config).await;
+}
+
+#[tokio::test]
+async fn disseminate_big_blob() {
+    const MSG_SIZE: usize = 1024;
+    let mut config = Disseminate {
+        data: std::iter::repeat(String::from("X"))
+            .take(MSG_SIZE)
+            .collect::<Vec<_>>()
+            .join("")
+            .into(),
+        ..Default::default()
+    };
+    disseminate(&mut config).await;
+}
+
+#[tokio::test]
+async fn disseminate_blob_from_file() {
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all("hello world".as_bytes()).unwrap();
+
+    let mut config = Disseminate {
+        file: Some(file.path().to_path_buf()),
+        ..Default::default()
+    };
+    disseminate(&mut config).await;
+}

--- a/tests/src/tests/cli.rs
+++ b/tests/src/tests/cli.rs
@@ -28,6 +28,8 @@ fn run_disseminate(disseminate: &Disseminate) {
         .arg(&disseminate.app_id)
         .arg("--index")
         .arg(disseminate.index.to_string())
+        .arg("--columns")
+        .arg(disseminate.columns.to_string())
         .arg("--node-addr")
         .arg(disseminate.node_addr.as_ref().unwrap().as_str());
 
@@ -83,6 +85,7 @@ async fn disseminate(config: &mut Disseminate) {
     );
     config.app_id = "fd3384e132ad02a56c78f45547ee40038dc79002b90d29ed90e08eee762ae715".to_string();
     config.index = 0;
+    config.columns = 32;
 
     run_disseminate(&config);
 }


### PR DESCRIPTION
Integration tests for nomos cli dispersing Kzgrs encoded data. For faster test times, the number of columns is set to `32`, cache is disabled.

To run these tests locally:
```bash
cargo test -p tests  -- --nocapture
```