### PR TITLE
CI: Jenkins risczero setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # BUILD IMAGE ---------------------------------------------------------
 
-FROM rust:1.80.0-slim-bullseye AS builder
+FROM rust:1.80.0-slim-bookworm AS builder
 
 WORKDIR /nomos
 COPY . . 
 
 # Install dependencies needed for building RocksDB.
 RUN apt-get update && apt-get install -yq \
-    git clang libssl-dev pkg-config protobuf-compiler
+    git gcc g++ clang libssl-dev pkg-config \
+    protobuf-compiler
 
 RUN cargo install cargo-binstall
 RUN cargo binstall -y cargo-risczero

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80.0-slim-bullseye
+FROM rust:1.80.0-slim-bookworm
 
 LABEL maintainer="augustinas@status.im" \
       source="https://github.com/logos-co/nomos-node" \
@@ -6,10 +6,9 @@ LABEL maintainer="augustinas@status.im" \
 
 # Dependecies for publishing documentation.
 RUN apt-get update && apt-get install -yq \
-    libssl-dev openssh-client git python3-pip clang \
-    pkg-config protobuf-compiler
+    libssl-dev openssh-client git gcc g++ \ 
+    clang pkg-config protobuf-compiler
 
-RUN pip install ghp-import
 RUN rustup component add rustfmt clippy
 
 # Jenkins user needs a specific UID/GID to work.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -15,3 +15,9 @@ RUN rustup component add rustfmt clippy
 # Jenkins user needs a specific UID/GID to work.
 RUN groupadd -g 1001 jenkins \
  && useradd -u 1001 -g jenkins jenkins
+
+USER jenkins
+
+RUN cargo install cargo-binstall
+RUN cargo binstall -y cargo-risczero
+RUN cargo risczero install

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,10 +12,6 @@ RUN apt-get update && apt-get install -yq \
 RUN pip install ghp-import
 RUN rustup component add rustfmt clippy
 
-RUN cargo install cargo-binstall
-RUN cargo binstall -y cargo-risczero
-RUN cargo risczero install
-
 # Jenkins user needs a specific UID/GID to work.
 RUN groupadd -g 1001 jenkins \
  && useradd -u 1001 -g jenkins jenkins

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -14,7 +14,13 @@ RUN rustup component add rustfmt clippy
 
 # Jenkins user needs a specific UID/GID to work.
 RUN groupadd -g 1001 jenkins \
- && useradd -u 1001 -g jenkins jenkins
+    && useradd -u 1001 -g jenkins jenkins
+
+# Create necessary directories and assign correct permissions
+RUN mkdir -p /home/jenkins/.local/share/cargo-risczero/toolchains \
+    && chown -R jenkins:jenkins /home/jenkins/.local \
+    && mkdir -p /home/jenkins/.cargo \
+    && chown -R jenkins:jenkins /home/jenkins/.cargo
 
 USER jenkins
 

--- a/ci/Jenkinsfile.nightly.integration
+++ b/ci/Jenkinsfile.nightly.integration
@@ -19,7 +19,9 @@ pipeline {
 
   environment {
     RUST_BACKTRACE = 1
+    /* Use increased slot time in Nomos consensus */
     CONSENSUS_SLOT_TIME = 5
+    /* Run Nomos tests in risc0 development mode */
     RISC0_DEV_MODE = true
   }
 

--- a/ci/Jenkinsfile.nightly.integration
+++ b/ci/Jenkinsfile.nightly.integration
@@ -18,10 +18,9 @@ pipeline {
   }
 
   environment {
-    /* Avoid cache poisoning by other jobs. */
-    GOCACHE = "${env.WORKSPACE_TMP}/go-build"
-    GOPATH  = "${env.WORKSPACE_TMP}/go"
     RUST_BACKTRACE = 1
+    CONSENSUS_SLOT_TIME = 5
+    RISC0_DEV_MODE = true
   }
 
   options {

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -1,13 +1,14 @@
 # BUILD IMAGE ---------------------------------------------------------
 
-FROM rust:1.80.0-slim-bullseye AS builder
+FROM rust:1.80.0-slim-bookworm AS builder
 
 WORKDIR /nomos
 COPY . . 
 
 # Install dependencies needed for building RocksDB and etcd.
 RUN apt-get update && apt-get install -yq \
-    git clang etcd-client libssl-dev pkg-config protobuf-compiler
+    git gcc g++ clang etcd-client libssl-dev \
+    pkg-config protobuf-compiler
 
 RUN cargo install cargo-binstall
 RUN cargo binstall -y cargo-risczero


### PR DESCRIPTION
## 1. What does this PR implement?

This PR updates the Docker images used in the Jenkins nightly integration tests. The changes include:

- Switching the Rust base image from Debian 11 (bullseye) to Debian 12 (bookworm).
- Adding `risczero` and related dependencies to the CI Docker image.
- Installing `cargo` dependencies as the Jenkins user in the CI environment.
- Updating all Dockerfiles to use Debian 12-based Rust images and ensuring `gcc` and `g++` are installed along with other dependencies.

These changes do not need to comply with the specification as they are strictly CI-related.

## 2. Does the code have enough context to be clearly understood?

Yes, the PR updates CI-related Dockerfiles and Jenkins configurations to use the latest dependencies and ensures that the build environment is correctly configured to run nightly integration tests. No functional changes to the product itself.

## 3. Who are the specification authors and who is accountable for this PR?

This PR is related to CI infrastructure and does not follow any product specification. The responsible parties for this PR are Nomos Engineering Team

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added (N/A for this PR).
* [x] 3. Main contact(s) (developers and CI maintainers) added.
* [x] 4. Implementation and Specification are 100% in sync including changes (N/A for this PR).
* [x] 5. Link PR to a specific milestone.
