### PR TITLE
fix: Coverage and PR workflows - no space left on device

### DIFF
--- a/.github/actions/prune-vm/action.yml
+++ b/.github/actions/prune-vm/action.yml
@@ -1,0 +1,27 @@
+# Inspired by https://github.com/AdityaGarg8/remove-unwanted-software
+# to free up disk space. Currently removes Dotnet, Android and Haskell.
+name: Remove unwanted software
+description: Default GitHub runners come with a lot of unnecessary software
+runs:
+  using: "composite"
+  steps:
+    - name: Disk space report before modification
+      shell: bash
+      run: |
+        echo "==> Available space before cleanup"
+        echo
+        df -h
+    - name: Maximize build disk space
+      shell: bash
+      run: |
+          set -euo pipefail
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc 
+          sudo rm -rf /usr/local/.ghcup
+    - name: Disk space report after modification
+      shell: bash
+      run: |
+          echo "==> Available space after cleanup"
+          echo
+          df -h

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,6 +54,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Remove unwanted software
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./.github/actions/prune-vm
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,6 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C instrument-coverage"
-      LLVM_PROFILE_FILE: "nomos-node-%p-%m.profraw"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,12 +20,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout submodules
         run: git submodule update --init --recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: llvm-tools-preview
       - uses: cargo-bins/cargo-binstall@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,6 +3,9 @@ on:
     - cron:  '0 3 * * *'
   workflow_dispatch:
 
+  push:
+    branches: [ fix-coverage-workflow-disk-space ]
+
 name: Codecov
 
 jobs:
@@ -13,11 +16,8 @@ jobs:
       LLVM_PROFILE_FILE: "nomos-node-%p-%m.profraw"
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v4.1
-        with:
-          remove-android: 'true'
-          remove-dotnet: 'true'
+      - name: Remove unwanted software
+        uses: ./.github/actions/prune-vm
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -41,7 +41,7 @@ jobs:
           CONSENSUS_SLOT_TIME: 5
         with:
           command: test
-          args: --all --no-default-features --features libp2p
+          args: --release --all --no-default-features --features libp2p
       - name: Run Grcov
         run: |
           cargo binstall -y grcov;

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,8 +2,6 @@ on:
   schedule:
     - cron:  '0 3 * * *'
   workflow_dispatch:
-  push:
-    branches: [ fix-coverage-workflow-disk-space ]
 
 name: Codecov
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,9 +3,6 @@ on:
     - cron:  '0 3 * * *'
   workflow_dispatch:
 
-  push:
-    branches: [ fix-coverage-workflow-disk-space ]
-
 name: Codecov
 
 jobs:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,10 @@ jobs:
       RUSTFLAGS: "-C instrument-coverage"
     runs-on: ubuntu-latest
     steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v4.1
+        with:
+          remove-android: 'true'
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -41,7 +45,7 @@ jobs:
           CONSENSUS_SLOT_TIME: 5
         with:
           command: test
-          args: --release --all --no-default-features --features libp2p
+          args: --all --no-default-features --features libp2p
       - name: Run Grcov
         run: |
           cargo binstall -y grcov;

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,11 +16,11 @@ jobs:
       LLVM_PROFILE_FILE: "nomos-node-%p-%m.profraw"
     runs-on: ubuntu-latest
     steps:
-      - name: Remove unwanted software
-        uses: ./.github/actions/prune-vm
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Remove unwanted software
+        uses: ./.github/actions/prune-vm
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,12 +12,14 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C instrument-coverage"
+      LLVM_PROFILE_FILE: "nomos-node-%p-%m.profraw"
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v4.1
         with:
           remove-android: 'true'
+          remove-dotnet: 'true'
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -26,6 +28,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: llvm-tools-preview
       - uses: cargo-bins/cargo-binstall@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,6 +2,8 @@ on:
   schedule:
     - cron:  '0 3 * * *'
   workflow_dispatch:
+  push:
+    branches: [ fix-coverage-workflow-disk-space ]
 
 name: Codecov
 


### PR DESCRIPTION
## What does this PR implement?

- Remove Android, Dotnet and Haskell support from Ubuntu Github runner to free up disk space. About 15 GB freed. 
- Add local `actions/prune-vm`
- Update coverage and PR workflows

