### PR TITLE
Prl add

### DIFF
--- a/nomos-da/kzgrs/Cargo.toml
+++ b/nomos-da/kzgrs/Cargo.toml
@@ -26,7 +26,8 @@ rayon = { version = "1.10", optional = true }
 [dev-dependencies]
 divan = "0.1"
 rayon = "1.10"
-tokio = "1.39"
+tokio = {version = "1", features = ["full"]}
+
 
 [[bench]]
 name = "kzg"

--- a/nomos-da/kzgrs/Cargo.toml
+++ b/nomos-da/kzgrs/Cargo.toml
@@ -26,6 +26,7 @@ rayon = { version = "1.10", optional = true }
 [dev-dependencies]
 divan = "0.1"
 rayon = "1.10"
+tokio = "1.39"
 
 [[bench]]
 name = "kzg"

--- a/nomos-da/kzgrs/Cargo.toml
+++ b/nomos-da/kzgrs/Cargo.toml
@@ -26,8 +26,6 @@ rayon = { version = "1.10", optional = true }
 [dev-dependencies]
 divan = "0.1"
 rayon = "1.10"
-tokio = {version = "1", features = ["full"]}
-
 
 [[bench]]
 name = "kzg"

--- a/nomos-da/kzgrs/src/fk20.rs
+++ b/nomos-da/kzgrs/src/fk20.rs
@@ -115,19 +115,23 @@ mod test {
         KZG10::<Bls12_381, DensePolynomial<Fr>>::setup(4096, true, &mut rng).unwrap()
     });
 
-    static BUFF: Lazy<Vec<u8>> = Lazy::new(|| {
-        (0..BYTES_PER_FIELD_ELEMENT * 256)
-            .map(|i| (i % 255) as u8)
-            .rev()
-            .collect()
-    });
+    const SIZE: usize = BYTES_PER_FIELD_ELEMENT * 256;
 
     #[test]
     fn test_generate_proofs() {
+        let buff: [u8; SIZE] = {
+            let mut arr = [0u8; SIZE];
+            let mut i = SIZE;
+            while i > 0 {
+                i -= 1;
+                arr[i] = (i % 255) as u8;
+            }
+            arr
+        };
         for size in [16, 32, 64, 128, 256] {
             let domain = GeneralEvaluationDomain::new(size).unwrap();
             let (evals, poly) = bytes_to_polynomial::<BYTES_PER_FIELD_ELEMENT>(
-                &BUFF[0..BYTES_PER_FIELD_ELEMENT * size],
+                &buff[0..BYTES_PER_FIELD_ELEMENT * size],
                 domain,
             )
             .unwrap();

--- a/nomos-da/kzgrs/src/fk20.rs
+++ b/nomos-da/kzgrs/src/fk20.rs
@@ -151,23 +151,17 @@ mod test {
                 .map(|i| (i % 255) as u8)
                 .rev()
                 .collect();
-
-            // Create evaluation domain
             let domain = GeneralEvaluationDomain::new(size).unwrap();
-
-            // Convert bytes to polynomial
             let (evals, poly) =
                 bytes_to_polynomial::<BYTES_PER_FIELD_ELEMENT>(&buff, domain).unwrap();
             let polynomial_degree = poly.len();
 
-            // Use tokio::join! to run them concurrently
             let (slow_proofs, fk20_proofs, fk20_proofs_with_toplcache) = tokio::join!(
                 generate_slow_proofs(polynomial_degree, &poly, &evals, &domain),
                 generate_fk20_proofs(&poly),
                 generate_fk20_proofs_with_cache(&poly, polynomial_degree),
             );
 
-            // Assertions
             assert_eq!(slow_proofs, fk20_proofs);
             assert_eq!(slow_proofs, fk20_proofs_with_toplcache);
         }

--- a/nomos-da/kzgrs/src/fk20.rs
+++ b/nomos-da/kzgrs/src/fk20.rs
@@ -99,6 +99,7 @@ impl Toeplitz1Cache {
 #[cfg(test)]
 mod test {
     use crate::fk20::{fk20_batch_generate_elements_proofs, Toeplitz1Cache};
+    use crate::Evaluations;
     use crate::{
         common::bytes_to_polynomial, kzg::generate_element_proof, GlobalParameters, Proof,
         BYTES_PER_FIELD_ELEMENT,
@@ -109,48 +110,66 @@ mod test {
     use ark_poly_commit::kzg10::KZG10;
     use once_cell::sync::Lazy;
     use rand::SeedableRng;
-    use rayon::iter::{IndexedParallelIterator, ParallelIterator};
-    use rayon::prelude::IntoParallelRefIterator;
 
     static GLOBAL_PARAMETERS: Lazy<GlobalParameters> = Lazy::new(|| {
         let mut rng = rand::rngs::StdRng::seed_from_u64(1987);
         KZG10::<Bls12_381, DensePolynomial<Fr>>::setup(4096, true, &mut rng).unwrap()
     });
 
-    async fn run_fn_async<F, Fut>(task: F)
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = Vec<Proof>>>
-    {
-        let res = task().await;
-        res
+    // Async function for generating slow proofs
+    async fn generate_slow_proofs(
+        polynomial_degree: usize,
+        poly: &DensePolynomial<Fr>,
+        evals: &Evaluations,
+        domain: &GeneralEvaluationDomain<Fr>,
+    ) -> Vec<Proof> {
+        (0..polynomial_degree)
+            .map(|i| generate_element_proof(i, poly, evals, &GLOBAL_PARAMETERS, *domain).unwrap())
+            .collect()
     }
 
-    #[test]
-    fn test_generate_proofs() {
+    // Async function for generating fk20 proofs
+    async fn generate_fk20_proofs(polynomial: &DensePolynomial<Fr>) -> Vec<Proof> {
+        fk20_batch_generate_elements_proofs(polynomial, &GLOBAL_PARAMETERS, None)
+    }
+
+    // Async function for generating fk20 proofs with Toeplitz1Cache
+    async fn generate_fk20_proofs_with_cache(
+        polynomial: &DensePolynomial<Fr>,
+        polynomial_degree: usize,
+    ) -> Vec<Proof> {
+        let tc = Toeplitz1Cache::with_size(&GLOBAL_PARAMETERS, polynomial_degree);
+        fk20_batch_generate_elements_proofs(polynomial, &GLOBAL_PARAMETERS, Some(&tc))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_generate_proofs() {
         let sizes = [16, 32, 64, 128, 256];
-        for size in sizes{
+        for &size in &sizes {
+            // Prepare the input buffer
             let buff: Vec<_> = (0..BYTES_PER_FIELD_ELEMENT * size)
                 .map(|i| (i % 255) as u8)
                 .rev()
                 .collect();
+
+            // Create evaluation domain
             let domain = GeneralEvaluationDomain::new(size).unwrap();
+
+            // Convert bytes to polynomial
             let (evals, poly) =
                 bytes_to_polynomial::<BYTES_PER_FIELD_ELEMENT>(&buff, domain).unwrap();
             let polynomial_degree = poly.len();
-            let slow_proofs: Vec<Proof> = (0..polynomial_degree)
-                .map(|i| {
-                    generate_element_proof(i, &poly, &evals, &GLOBAL_PARAMETERS, domain).unwrap()
-                })
-                .collect(); //I want slow proofs to be called asyncly
-            let fk20_proofs = fk20_batch_generate_elements_proofs(&poly, &GLOBAL_PARAMETERS, None);
-            assert_eq!(slow_proofs, fk20_proofs); //I want fast proofs to be called asyncly
 
-            // Test variant with Toeplitz1Cache param
-            let tc = Toeplitz1Cache::with_size(&GLOBAL_PARAMETERS.clone(), size);
-            let fk20_proofs_with_toplcache =
-                fk20_batch_generate_elements_proofs(&poly, &GLOBAL_PARAMETERS, Some(&tc));
-            assert_eq!(slow_proofs, fk20_proofs_with_toplcache); //I want fk20 proofs to be called asyncly
+            // Use tokio::join! to run them concurrently
+            let (slow_proofs, fk20_proofs, fk20_proofs_with_toplcache) = tokio::join!(
+                generate_slow_proofs(polynomial_degree, &poly, &evals, &domain),
+                generate_fk20_proofs(&poly),
+                generate_fk20_proofs_with_cache(&poly, polynomial_degree),
+            );
+
+            // Assertions
+            assert_eq!(slow_proofs, fk20_proofs);
+            assert_eq!(slow_proofs, fk20_proofs_with_toplcache);
         }
     }
 }

--- a/nomos-da/kzgrs/src/fk20.rs
+++ b/nomos-da/kzgrs/src/fk20.rs
@@ -109,7 +109,7 @@ mod test {
     use ark_poly_commit::kzg10::KZG10;
     use once_cell::sync::Lazy;
     use rand::SeedableRng;
-    use rayon::iter::ParallelIterator;
+    use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
     use rayon::prelude::IntoParallelRefIterator;
 
     static GLOBAL_PARAMETERS: Lazy<GlobalParameters> = Lazy::new(|| {
@@ -118,30 +118,40 @@ mod test {
     });
 
     #[test]
-    fn test_generate_proofs() {
-        let sizes = [16, 32, 64, 128, 256];
-        sizes.par_iter().for_each(|&size|{
-            let buff: Vec<_> = (0..BYTES_PER_FIELD_ELEMENT * size)
+    fn test_generate_proofs_optimized() {
+        [16, 32, 64, 128, 256].par_iter().for_each(|&size| {
+            // Create the FFT domain and the Toeplitz1 cache in parallel
+            let (domain, toeplitz_cache) = rayon::join(
+                || GeneralEvaluationDomain::new(size).expect("Domain should be able to build"),
+                || Toeplitz1Cache::with_size(&GLOBAL_PARAMETERS, size),
+            );
+    
+            // Generate a buffer with deterministic data in parallel
+            let buffer: Vec<u8> = (0..BYTES_PER_FIELD_ELEMENT * size)
+                .into_par_iter()
                 .map(|i| (i % 255) as u8)
                 .rev()
                 .collect();
-            let domain = GeneralEvaluationDomain::new(size).unwrap();
-            let (evals, poly) =
-                bytes_to_polynomial::<BYTES_PER_FIELD_ELEMENT>(&buff, domain).unwrap();
-            let polynomial_degree = poly.len();
-            let slow_proofs: Vec<Proof> = (0..polynomial_degree)
-                .map(|i| {
-                    generate_element_proof(i, &poly, &evals, &GLOBAL_PARAMETERS, domain).unwrap()
-                })
+    
+            // Convert the buffer into polynomial evaluations and the polynomial itself
+            let (evals, polynomial) =
+                bytes_to_polynomial::<BYTES_PER_FIELD_ELEMENT>(&buffer, domain).unwrap();
+    
+            // Generate proofs sequentially for the polynomial to use as a baseline for comparison
+            let slow_proofs: Vec<Proof> = (0..polynomial.len())
+                .into_par_iter()
+                .map(|i| generate_element_proof(i, &polynomial, &evals, &GLOBAL_PARAMETERS, domain).unwrap())
                 .collect();
-            let fk20_proofs = fk20_batch_generate_elements_proofs(&poly, &GLOBAL_PARAMETERS, None);
-            assert_eq!(slow_proofs, fk20_proofs);
-
-            // Test variant with Toeplitz1Cache param
-            let tc = Toeplitz1Cache::with_size(&GLOBAL_PARAMETERS.clone(), size);
-            let fk20_proofs =
-                fk20_batch_generate_elements_proofs(&poly, &GLOBAL_PARAMETERS, Some(&tc));
-            assert_eq!(slow_proofs, fk20_proofs);
+    
+            // Test the optimized FK20 proof generation without caching
+            let fk20_proofs = fk20_batch_generate_elements_proofs(&polynomial, &GLOBAL_PARAMETERS, None);
+            assert_eq!(slow_proofs, fk20_proofs, "Proofs without caching did not match");
+    
+            // Test the optimized FK20 proof generation with caching
+            let fk20_proofs_with_cache =
+                fk20_batch_generate_elements_proofs(&polynomial, &GLOBAL_PARAMETERS, Some(&toeplitz_cache));
+            assert_eq!(slow_proofs, fk20_proofs_with_cache, "Proofs with caching did not match");
         });
     }
+    
 }


### PR DESCRIPTION
@danielSanchezQ, Here I want to make improvements to the __fast kate amortized proof(fk 20)__ testing function.
I wanted to precompute all the buffer data and then take slice of particular input size of that buffered data and pass it into the 
`bytes_to_polynomial` function... However the runtime remains same...
I did not understand the reason...I would love to get some help from you.
 
---
*PS*: I also tried
- tokio::test
- rayon::iter macros and functions but it is worsening the runtime...