### PR TITLE
Fix: Sampling protocol test error

### DIFF
--- a/compose.static.yml
+++ b/compose.static.yml
@@ -74,7 +74,7 @@ services:
     ports:
       - "3003:3000/udp"
       - "18083:18080/tcp"
-    entrypoint: /etc/nomos/scripts/run_nomos_node.sh
+    entrypoint: /etc/nomos/scripts/run_nomos_executor.sh
 
   prometheus:
     container_name: prometheus

--- a/nomos-da/network/subnetworks-assignations/src/lib.rs
+++ b/nomos-da/network/subnetworks-assignations/src/lib.rs
@@ -4,25 +4,25 @@ use std::collections::HashSet;
 use std::hash::Hash;
 
 pub trait MembershipHandler {
-    // Subnetworks Id type
+    /// Subnetworks Id type
     type NetworkId: Eq + Hash;
-
-    // Members Id type
+    /// Members Id type
     type Id;
 
-    // Returns the set of NetworksIds an id is a member of
+    /// Returns the set of NetworksIds an id is a member of
     fn membership(&self, id: &Self::Id) -> HashSet<Self::NetworkId>;
 
-    // True if the id is a member of a network_id, False otherwise
+    /// True if the id is a member of a network_id, False otherwise
     fn is_member_of(&self, id: &Self::Id, network_id: &Self::NetworkId) -> bool {
         self.membership(id).contains(network_id)
     }
 
-    // Returns true if the member id is in the overall membership set
+    /// Returns true if the member id is in the overall membership set
     fn is_allowed(&self, id: &Self::Id) -> bool;
 
-    // Returns the set of members in a subnetwork by its NetworkId
+    /// Returns the set of members in a subnetwork by its NetworkId
     fn members_of(&self, network_id: &Self::NetworkId) -> HashSet<Self::Id>;
 
+    /// Returns the set of all members
     fn members(&self) -> HashSet<Self::Id>;
 }

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -30,6 +30,7 @@ EXPOSE 3000 8080 9000 60000
 RUN apt-get update && apt-get install -y libssl3
 
 COPY --from=builder /nomos/target/release/nomos-node /usr/bin/nomos-node
+COPY --from=builder /nomos/target/release/nomos-executor /usr/bin/nomos-executor
 COPY --from=builder /nomos/target/release/nomos-cli /usr/bin/nomos-cli
 COPY --from=builder /nomos/target/release/cfgsync-server /usr/bin/cfgsync-server
 COPY --from=builder /nomos/target/release/cfgsync-client /usr/bin/cfgsync-client

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, net::Ipv4Addr, str::FromStr};
 use nomos_libp2p::{Multiaddr, PeerId, Protocol};
 use rand::{thread_rng, Rng};
 use tests::topology::configs::{
+    api::GeneralApiConfig,
     consensus::{create_consensus_configs, ConsensusParams},
     da::{create_da_configs, DaParams},
     mix::create_mix_configs,
@@ -15,6 +16,7 @@ use tests::topology::configs::{
 const DEFAULT_LIBP2P_NETWORK_PORT: u16 = 3000;
 const DEFAULT_DA_NETWORK_PORT: u16 = 3300;
 const DEFAULT_MIX_PORT: u16 = 3400;
+const DEFAULT_API_PORT: u16 = 18080;
 
 #[derive(Eq, PartialEq, Hash, Clone)]
 pub enum HostKind {
@@ -67,6 +69,12 @@ pub fn create_node_configs(
     let da_configs = create_da_configs(&ids, da_params);
     let network_configs = create_network_configs(&ids, Default::default());
     let mix_configs = create_mix_configs(&ids);
+    let api_configs = ids
+        .iter()
+        .map(|_| GeneralApiConfig {
+            address: format!("0.0.0.0:{DEFAULT_API_PORT}").parse().unwrap(),
+        })
+        .collect::<Vec<_>>();
     let mut configured_hosts = HashMap::new();
 
     // Rebuild DA address lists.
@@ -84,6 +92,7 @@ pub fn create_node_configs(
 
     for (i, host) in hosts.into_iter().enumerate() {
         let consensus_config = consensus_configs[i].to_owned();
+        let api_config = api_configs[i].to_owned();
 
         // DA Libp2p network config.
         let mut da_config = da_configs[i].to_owned();
@@ -113,6 +122,7 @@ pub fn create_node_configs(
                 da_config,
                 network_config,
                 mix_config,
+                api_config,
             },
         );
     }

--- a/testnet/scripts/run_nomos_executor.sh
+++ b/testnet/scripts/run_nomos_executor.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+export CFG_FILE_PATH="/config.yaml" \
+       CFG_SERVER_ADDR="http://cfgsync:4400" \
+       CFG_HOST_IP=$(hostname -i) \
+       CFG_HOST_KIND="executor" \
+       LOG_LEVEL="INFO" \
+       RISC0_DEV_MODE=true
+
+/usr/bin/cfgsync-client && \
+    exec /usr/bin/nomos-executor /config.yaml --with-metrics

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -26,9 +26,9 @@ use nomos_node::api::paths::{CL_METRICS, DA_GET_RANGE};
 use nomos_node::RocksBackendSettings;
 use tempfile::NamedTempFile;
 
+use crate::adjust_timeout;
 use crate::nodes::LOGS_PREFIX;
 use crate::topology::configs::GeneralConfig;
-use crate::{adjust_timeout, get_available_port};
 
 use super::{create_tempdir, persist_tempdir, GetRangeReq, CLIENT};
 
@@ -200,9 +200,7 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
         log: Default::default(),
         http: nomos_api::ApiServiceSettings {
             backend_settings: AxumBackendSettings {
-                address: format!("127.0.0.1:{}", get_available_port())
-                    .parse()
-                    .unwrap(),
+                address: config.api_config.address,
                 cors_origins: vec![],
             },
         },

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -24,9 +24,9 @@ use nomos_node::{BlobInfo, HeaderId, Tx};
 use reqwest::Url;
 use tempfile::NamedTempFile;
 
+use crate::adjust_timeout;
 use crate::nodes::LOGS_PREFIX;
 use crate::topology::configs::GeneralConfig;
-use crate::{adjust_timeout, get_available_port};
 
 use super::{create_tempdir, persist_tempdir, GetRangeReq, CLIENT};
 
@@ -282,9 +282,7 @@ pub fn create_validator_config(config: GeneralConfig) -> Config {
         log: Default::default(),
         http: nomos_api::ApiServiceSettings {
             backend_settings: AxumBackendSettings {
-                address: format!("127.0.0.1:{}", get_available_port())
-                    .parse()
-                    .unwrap(),
+                address: config.api_config.address,
                 cors_origins: vec![],
             },
         },

--- a/tests/src/topology/configs/api.rs
+++ b/tests/src/topology/configs/api.rs
@@ -1,0 +1,18 @@
+use std::net::SocketAddr;
+
+use crate::get_available_port;
+
+#[derive(Clone)]
+pub struct GeneralApiConfig {
+    pub address: SocketAddr,
+}
+
+pub fn create_api_configs(ids: &[[u8; 32]]) -> Vec<GeneralApiConfig> {
+    ids.iter()
+        .map(|_| GeneralApiConfig {
+            address: format!("127.0.0.1:{}", get_available_port())
+                .parse()
+                .unwrap(),
+        })
+        .collect()
+}

--- a/tests/src/topology/configs/mod.rs
+++ b/tests/src/topology/configs/mod.rs
@@ -1,8 +1,10 @@
+pub mod api;
 pub mod consensus;
 pub mod da;
 pub mod mix;
 pub mod network;
 
+use api::GeneralApiConfig;
 use consensus::GeneralConsensusConfig;
 use da::GeneralDaConfig;
 use mix::GeneralMixConfig;
@@ -10,6 +12,7 @@ use network::GeneralNetworkConfig;
 
 #[derive(Clone)]
 pub struct GeneralConfig {
+    pub api_config: GeneralApiConfig,
     pub consensus_config: GeneralConsensusConfig,
     pub da_config: GeneralDaConfig,
     pub network_config: GeneralNetworkConfig,

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -13,6 +13,7 @@ use crate::{
         validator::{create_validator_config, Validator},
     },
     topology::configs::{
+        api::create_api_configs,
         consensus::{create_consensus_configs, ConsensusParams},
         mix::create_mix_configs,
     },
@@ -76,6 +77,7 @@ impl Topology {
         let da_configs = create_da_configs(&ids, config.da_params);
         let network_configs = create_network_configs(&ids, config.network_params);
         let mix_configs = create_mix_configs(&ids);
+        let api_configs = create_api_configs(&ids);
 
         let mut validators = Vec::new();
         for i in 0..config.n_validators {
@@ -84,6 +86,7 @@ impl Topology {
                 da_config: da_configs[i].to_owned(),
                 network_config: network_configs[i].to_owned(),
                 mix_config: mix_configs[i].to_owned(),
+                api_config: api_configs[i].to_owned(),
             });
             validators.push(Validator::spawn(config).await)
         }
@@ -95,6 +98,7 @@ impl Topology {
                 da_config: da_configs[i].to_owned(),
                 network_config: network_configs[i].to_owned(),
                 mix_config: mix_configs[i].to_owned(),
+                api_config: api_configs[i].to_owned(),
             });
             executors.push(Executor::spawn(config).await)
         }


### PR DESCRIPTION
@danielSanchezQ, The current version of the testing function is incorrect... Whenever one of the peer(in this case we have two peers) has successfully received 10 samples, it breaks out of the loop and closes the stream. This causes a sampling error for the other peer which ultimately results in an infinite loop for that peer.

I have
- Inserted two labels for the two async runtime threads `leading` and `trailing`.
- Created two separate flags `done1` and `done2` for the two tasks. If both are _true_, then I am exiting the loop.
- Refactored some variable  by using `Cow::borrowed` to mitigate unnecessary copying of a _peerId_.

Please check into this.