### PR TITLE
chore: clippy: remove irrefutable `let...else` patterns in DA

### DIFF
--- a/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
@@ -540,9 +540,7 @@ impl<M: MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'static> Netw
         connection_id: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        let Either::Left(event) = event else {
-            unreachable!()
-        };
+        let Either::Left(event) = event;
         self.stream_behaviour
             .on_connection_handler_event(peer_id, connection_id, event)
     }

--- a/nomos-da/network/core/src/protocols/dispersal/validator/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/validator/behaviour.rs
@@ -111,9 +111,7 @@ impl<M: MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'static> Netw
         connection_id: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        let Either::Left(event) = event else {
-            unreachable!()
-        };
+        let Either::Left(event) = event;
         self.stream_behaviour
             .on_connection_handler_event(peer_id, connection_id, event)
     }

--- a/nomos-da/network/core/src/protocols/sampling/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/behaviour.rs
@@ -630,9 +630,7 @@ impl<M: MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'static> Netw
         connection_id: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        let Either::Left(event) = event else {
-            unreachable!()
-        };
+        let Either::Left(event) = event;
         self.stream_behaviour
             .on_connection_handler_event(peer_id, connection_id, event)
     }


### PR DESCRIPTION
## 1. What does this PR implement?

Since Rust 1.82.0, the following error occurs from `cargo clippy`. This PR fixes this by removing the `else` clause, as suggested by clippy.
https://github.com/logos-co/nomos-node/actions/runs/11405557657/job/31737297344
```
Error:    --> nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs:543:9
    |
543 |         let Either::Left(event) = event else {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this pattern will always match, so the `else` clause is useless
    = help: consider removing the `else` clause
    = note: `-D irrefutable-let-patterns` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(irrefutable_let_patterns)]`
```

## 2. Does the code have enough context to be clearly understood?

> [!IMPORTANT]  
> Add a link to the specification document, pointing at the specific section.  
> Any implementation detail that could be considered idiosyncratic and not direct from the specification, should be  
> explained.  
> Always consider what someone new would need to know for the code to make sense, and add this context to it.

No spec is related. 

## 3. Who are the specification authors and who is accountable for this PR?

> [!IMPORTANT]  
> Ping the original specification author(s) and add them as reviewers, alongside any other from the engineering team.  
> You are accountable for the PR and its rapid resolution, so make sure anyone involved is aware and actively
> advancing  
> the review.

No spec is related. 

## 4. Is the specification accurate and complete?

> [!IMPORTANT]
> * If not, engage in a conversation directly with the authors, prompting any updates in the document.
> * You are accountable of this process, and the specification author needs to give priority to unblocking you.

No spec is related. 

## 5. Does the implementation introduce changes in the specification?

> [!IMPORTANT]
> * Contact the specification author(s) and engage in the necessary conversation to agree on the proposed  
    modification/solutions.
> * Ensure the new changes are on par with the implementation at the end of the process.
> * The PR should not be merged until parity between implementation and specifications has been reached.

No spec is related. 

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [ ] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 5. Link PR to a specific milestone.
