### PR TITLE
Chore: Use tokio 1 in deps

### DIFF
--- a/nodes/nomos-node/Cargo.toml
+++ b/nodes/nomos-node/Cargo.toml
@@ -45,7 +45,7 @@ cryptarchia-engine = { path = "../../consensus/cryptarchia-engine" }
 nomos-ledger = { path = "../../ledger/nomos-ledger" }
 rand_chacha = "0.3"
 cl = { path = "../../nomos-core/cl" }
-tokio = { version = "1.24", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 color-eyre = "0.6.0"

--- a/nomos-da/network/core/Cargo.toml
+++ b/nomos-da/network/core/Cargo.toml
@@ -21,12 +21,12 @@ log = "0.4"
 serde = "1.0"
 rand = "0.8"
 rand_chacha = "0.3"
-tokio = { version = "1.39" }
+tokio = { version = "1" }
 tokio-stream = "0.1"
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "1.39", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 libp2p = { version = "0.53", features = ["ed25519", "ping", "macros", "quic", "tcp", "yamux", "noise"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/nomos-da/network/messages/Cargo.toml
+++ b/nomos-da/network/messages/Cargo.toml
@@ -12,4 +12,4 @@ prost = "0.13.1"
 prost-build = "0.13.1"
 
 [dev-dependencies]
-tokio = { version = "1.38.1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/nomos-mix/network/Cargo.toml
+++ b/nomos-mix/network/Cargo.toml
@@ -13,6 +13,6 @@ nomos-mix-message = { path = "../message" }
 nomos-mix-queue = { path = "../queue" }
 
 [dev-dependencies]
-tokio = { version = "1.39", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 libp2p = { version = "0.53", features = ["ed25519", "tokio", "quic"] }
 tracing-subscriber = "0.3.18"

--- a/nomos-services/api/Cargo.toml
+++ b/nomos-services/api/Cargo.toml
@@ -35,7 +35,7 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 subnetworks-assignations = { path = "../../nomos-da/network/subnetworks-assignations" }
 nomos-da-network-core = { path = "../../nomos-da/network/core" }
-tokio = { version = "1.33", default-features = false, features = ["sync"] }
+tokio = { version = "1", default-features = false, features = ["sync"] }
 
 
 # axum related dependencies

--- a/nomos-services/data-availability/dispersal/Cargo.toml
+++ b/nomos-services/data-availability/dispersal/Cargo.toml
@@ -17,6 +17,6 @@ overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" 
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 subnetworks-assignations = { path = "../../../nomos-da/network/subnetworks-assignations" }
-tokio = "1.40"
+tokio = "1"
 thiserror = "1.0"
 tracing = "0.1"

--- a/nomos-services/system-sig/Cargo.toml
+++ b/nomos-services/system-sig/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 async-trait = "0.1"
 async-ctrlc = "1.2"
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
-tokio = "1.33.0"
+tokio = "1"
 log = "0.4.20"
 futures = "0.3.28"

--- a/testnet/cfgsync/Cargo.toml
+++ b/testnet/cfgsync/Cargo.toml
@@ -12,7 +12,7 @@ nomos-node = { path = "../../nodes/nomos-node" }
 rand = "0.8"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 tests = { path = "../../tests" }
-tokio = { version = "1.24", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"


### PR DESCRIPTION
## 1. What does this PR implement?
Changes all tokio deps to use the latest stable one at `1.x`.
## 2. Does the code have enough context to be clearly understood?
...

## 3. Who are the specification authors and who is accountable for this PR?
@danielSanchezQ @bacv 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
