### PR TITLE
Mix: Don't panic on SendError in libp2p mix backend

### DIFF
--- a/nomos-services/mix/src/backends/libp2p.rs
+++ b/nomos-services/mix/src/backends/libp2p.rs
@@ -178,7 +178,9 @@ impl MixSwarm {
         match event {
             SwarmEvent::Behaviour(nomos_mix_network::Event::Message(msg)) => {
                 tracing::debug!("Received message from a peer: {msg:?}");
-                self.incoming_message_sender.send(msg).unwrap();
+                if let Err(e) = self.incoming_message_sender.send(msg) {
+                    tracing::error!("Failed to send incoming message to channel: {e}");
+                }
             }
             SwarmEvent::Behaviour(nomos_mix_network::Event::Error(e)) => {
                 tracing::error!("Received error from mix network: {e:?}");


### PR DESCRIPTION
## 1. What does this PR implement?

Due to a subtle timing difference, incoming messages from other peers can arrive before the module that handles them is initialized. We pass those incoming messages to the module through the channel, and if that module is not initialized yet, the channel returns SendError. The application should not panic at this point, because the module will initialize shortly and handle subsequent incoming messages just fine.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
