### PR TITLE
poc: StorageBackend for SurrealDB

### DIFF
--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -17,6 +17,7 @@ rocksdb = { version = "0.22", optional = true }
 surrealdb = { version = "2.1.2", optional = true }
 thiserror = "1.0"
 tracing = "0.1"
+serde_json = "1.0.133"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time"] }

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -14,13 +14,14 @@ overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" 
 serde = "1.0"
 sled = { version = "0.34", optional = true }
 rocksdb = { version = "0.22", optional = true }
-surrealdb = { version = "2.1.2", optional = true}
+surrealdb = { version = "2.1.2", optional = true }
 thiserror = "1.0"
 tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time"] }
 tempfile = "3"
+surrealdb = { version = "2.1.2", features = ["kv-mem"] }
 
 [features]
 default = []

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1"
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time"] }
 tempfile = "3"
-surrealdb = { version = "2.1.2", features = ["kv-mem"] }
+surrealdb = { version = "2", features = ["kv-mem"] }
 
 [features]
 default = []

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-tokio = { version = "1.41.1", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }
 bytes = "1.2"
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 serde = "1.0"

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -8,12 +8,13 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1.41.1", features = ["sync"] }
 bytes = "1.2"
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 serde = "1.0"
 sled = { version = "0.34", optional = true }
 rocksdb = { version = "0.22", optional = true }
+surrealdb = { version = "2.1.2", optional = true}
 thiserror = "1.0"
 tracing = "0.1"
 
@@ -26,6 +27,7 @@ default = []
 mock = []
 sled-backend = ["sled"]
 rocksdb-backend = ["rocksdb"]
+surrealdb-backend = ["surrealdb"]
 
 [[bin]]
 name = "rocks"

--- a/nomos-services/storage/src/backends/mod.rs
+++ b/nomos-services/storage/src/backends/mod.rs
@@ -2,9 +2,10 @@
 pub mod mock;
 #[cfg(feature = "sled")]
 pub mod sled;
-
 #[cfg(feature = "rocksdb")]
 pub mod rocksdb;
+#[cfg(feature = "surrealdb-backend")]
+pub mod surrealdb;
 
 // std
 use std::error::Error;

--- a/nomos-services/storage/src/backends/mod.rs
+++ b/nomos-services/storage/src/backends/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "mock")]
 pub mod mock;
-#[cfg(feature = "sled")]
-pub mod sled;
 #[cfg(feature = "rocksdb")]
 pub mod rocksdb;
+#[cfg(feature = "sled")]
+pub mod sled;
 #[cfg(feature = "surrealdb-backend")]
 pub mod surrealdb;
 

--- a/nomos-services/storage/src/backends/surrealdb.rs
+++ b/nomos-services/storage/src/backends/surrealdb.rs
@@ -112,7 +112,7 @@ where
 
     async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
         let key = from_utf8(key)?;
-        let record: Option<Data> = self.db.select(("kv", key)).await?;
+        let record: Option<Data> = self.db.select(("kv", key)).await?; // TODO: Fix kv
         Ok(record.as_ref().map(Data::to_bytes))
     }
 
@@ -146,7 +146,7 @@ mod tests {
     use crate::backends::testing::NoStorageSerde;
     use tokio::runtime::Handle;
 
-    fn get_test_config() -> SurrealBackendSettings {
+    pub fn get_test_config() -> SurrealBackendSettings {
         let (sender, _) = tokio::sync::mpsc::channel(1);
         SurrealBackendSettings::new(
             String::from("mem://"),

--- a/nomos-services/storage/src/backends/surrealdb.rs
+++ b/nomos-services/storage/src/backends/surrealdb.rs
@@ -1,0 +1,73 @@
+use crate::backends::{StorageBackend, StorageSerde, StorageTransaction};
+use bytes::Bytes;
+use surrealdb::{Error, Surreal};
+use tokio::task::spawn_blocking;
+
+pub struct SurrealBackendSettings {
+    pub db_path: String,
+}
+
+pub struct SurrealBackendTransaction {}
+
+impl SurrealBackendTransaction {
+    pub fn execute(&self) -> Self::Result {
+        todo!()
+    }
+}
+
+impl StorageTransaction for SurrealBackendTransaction {
+    type Result = Result<Option<Bytes>, Error>;
+    type Transaction = Self;
+}
+
+pub struct SurrealBackend<Connection: surrealdb::Connection> {
+    db: Surreal<Connection>,
+}
+
+impl<Connection: surrealdb::Connection> StorageBackend for SurrealBackend<Connection> {
+    type Settings = SurrealBackendSettings;
+    type Error = Error;
+    type Transaction = SurrealBackendTransaction;
+    type SerdeOperator = ();
+
+    fn new(config: Self::Settings) -> Result<Self, Self::Error> {
+        let Self::Settings { db_path } = config;
+        let db = Surreal::new(db_path);
+        spawn_blocking(async {
+            db.connect().await?;
+            Ok(Self { db })
+        })
+    }
+
+    async fn store(&mut self, key: Bytes, value: Bytes) -> Result<(), Self::Error> {
+        let key = String::from(key);
+        let _record = self.db.create(("kv", key)).content(value).await?;
+        Ok(())
+    }
+
+    async fn load(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+        let key = String::from(key);
+        let record = self.db.select(("kv", key)).await?;
+        Ok(record)
+    }
+
+    async fn load_prefix(&mut self, prefix: &[u8]) -> Result<Vec<Bytes>, Self::Error> {
+        let prefix = String::from(prefix);
+        let query =
+            format!("SELECT * FROM kv WHERE string::starts_with(record::id(id), \"{prefix}\")");
+        let mut response = self.db.query(query).await?;
+        let records = response.stream(()).map(|record| record.content()).collect();
+        Ok(records)
+    }
+
+    async fn remove(&mut self, key: &[u8]) -> Result<Option<Bytes>, Self::Error> {
+        Ok(self.db.delete(("kv", key)).await?)
+    }
+
+    async fn execute(
+        &mut self,
+        transaction: Self::Transaction,
+    ) -> Result<<Self::Transaction as StorageTransaction>::Result, Self::Error> {
+        todo!()
+    }
+}

--- a/nomos-services/tracing/Cargo.toml
+++ b/nomos-services/tracing/Cargo.toml
@@ -10,8 +10,8 @@ async-trait = "0.1"
 futures = "0.3"
 nomos-tracing = { path = "../../nomos-tracing" }
 opentelemetry = { version = "0.25" }
-opentelemetry-otlp = "0.25"
-opentelemetry_sdk = { version = "0.25", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.26"
+opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "2f70806" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
## 1. What does this PR implement?
Implements StorageBackend for SurrealDB with the intention to verify it works on different platforms.

I didn't know what labels to assing.

## 2. Does the code have enough context to be clearly understood?
A couple relevant quirks worth mentioning:
1. Couldn't find a way to directly use bytes, when using `db.create().content()` objects are required.
2. `StorageBackend::new` is sync. Due SurrealDB's `connect` being async, `block_in_place` is used alongside `block_on` for connection:
    - An alternative to this would be initialising the connection in the `Overwatch` handle, and passing it to the `StorageBackend` via `Settings`.
    - Related [Discord Thread](https://discord.com/channels/1111286067413405788/1312075484611346504)
3. Transactions are not currently supported by the [Rust SDK](https://github.com/surrealdb/surrealdb/blob/c717b27005b7fb2608c9b08c1f6c94fdd6764a84/crates/sdk/src/api/method/mod.rs#L257). 
    - You  still can write transactions by chaining queries (e.g. `db.query("CREATE ...").query("SELECT ...").await`), as those calls would be wrapped in a single transaction. Is it worth adding transactions this way now, or shall we wait until they're fully available?
 4. `opentelemetry`'s version had to be updated due to `SurrealDB` requiring a newer `Tokio` version.

## 3. Who are the specification authors and who is accountable for this PR?
@AlejandroCabeza @danielSanchezQ 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. Description added.
* [X] 2. Context and links to Specification document(s) added.
* [X] 3. Main contact(s) (developers and specification authors) added
* [X] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 5. Link PR to a specific milestone.
