### PR TITLE
clippy: remove empty lines under comment documents

### DIFF
--- a/nomos-mix/message/src/mock/mod.rs
+++ b/nomos-mix/message/src/mock/mod.rs
@@ -3,12 +3,8 @@ pub mod error;
 use error::Error;
 
 use crate::MixMessage;
-// TODO: Remove all the mock below once the actual implementation is integrated to the system.
-//
-/// A mock implementation of the Sphinx encoding.
 
 const NODE_ID_SIZE: usize = 32;
-
 // TODO: Move MAX_PAYLOAD_SIZE and MAX_LAYERS to the upper layer (service layer).
 const MAX_PAYLOAD_SIZE: usize = 2048;
 const PAYLOAD_PADDING_SEPARATOR: u8 = 0x01;
@@ -17,6 +13,7 @@ const MAX_LAYERS: usize = 5;
 pub const MESSAGE_SIZE: usize =
     NODE_ID_SIZE * MAX_LAYERS + MAX_PAYLOAD_SIZE + PAYLOAD_PADDING_SEPARATOR_SIZE;
 
+/// A mock implementation of the Sphinx encoding.
 #[derive(Clone, Debug)]
 pub struct MockMixMessage;
 

--- a/nomos-services/storage/src/backends/rocksdb.rs
+++ b/nomos-services/storage/src/backends/rocksdb.rs
@@ -41,7 +41,6 @@ impl StorageTransaction for Transaction {
 }
 
 /// Rocks storage backend
-
 pub struct RocksBackend<SerdeOp> {
     rocks: Arc<DB>,
     _serde_op: PhantomData<SerdeOp>,


### PR DESCRIPTION
## 1. What does this PR implement?
The following error occurs since clippy has been updated to the latest. This PR removes empty lines under the comment documents.
```
error: empty line after doc comment
Error:   --> nomos-mix/message/src/mock/mod.rs:8:1
   |
8  | / /// A mock implementation of the Sphinx encoding.
9  | |
   | |_
10 |   const NODE_ID_SIZE: usize = 32;
   |   ------------------------- the comment documents this constant
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
   = help: if the empty line is unintentional remove **it**
```

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
N/A

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [ ] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 5. Link PR to a specific milestone.
