### PR TITLE
fix(blend): correctly check the last layer in `MockBlendMessage`

### DIFF
--- a/nomos-blend/message/src/mock/error.rs
+++ b/nomos-blend/message/src/mock/error.rs
@@ -1,4 +1,4 @@
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
     #[error("Invalid blend message format")]
     InvalidBlendMessage,
@@ -6,6 +6,8 @@ pub enum Error {
     PayloadTooLarge,
     #[error("Invalid number of layers")]
     InvalidNumberOfLayers,
+    #[error("Invalid public key")]
+    InvalidPublicKey,
     #[error("Unwrapping a message is not allowed to this node")]
     /// e.g. the message cannot be unwrapped using the private key provided
     MsgUnwrapNotAllowed,

--- a/nomos-blend/message/src/mock/mod.rs
+++ b/nomos-blend/message/src/mock/mod.rs
@@ -1,7 +1,5 @@
 pub mod error;
 
-use std::u8;
-
 use error::Error;
 
 use crate::BlendMessage;

--- a/nomos-blend/message/src/mock/mod.rs
+++ b/nomos-blend/message/src/mock/mod.rs
@@ -1,5 +1,7 @@
 pub mod error;
 
+use std::u8;
+
 use error::Error;
 
 use crate::BlendMessage;
@@ -12,6 +14,7 @@ const PAYLOAD_PADDING_SEPARATOR_SIZE: usize = 1;
 const MAX_LAYERS: usize = 5;
 pub const MESSAGE_SIZE: usize =
     NODE_ID_SIZE * MAX_LAYERS + MAX_PAYLOAD_SIZE + PAYLOAD_PADDING_SEPARATOR_SIZE;
+const DUMMY_NODE_ID: [u8; NODE_ID_SIZE] = [u8::MAX; NODE_ID_SIZE];
 
 /// A mock implementation of the Sphinx encoding.
 #[derive(Clone, Debug)]
@@ -42,11 +45,14 @@ impl BlendMessage for MockBlendMessage {
 
         let mut message: Vec<u8> = Vec::with_capacity(MESSAGE_SIZE);
 
-        node_ids.iter().for_each(|node_id| {
+        for node_id in node_ids {
+            if node_id == &DUMMY_NODE_ID {
+                return Err(Error::InvalidPublicKey);
+            }
             message.extend(node_id);
-        });
-        // If there is any remaining layers, fill them with zeros.
-        (0..MAX_LAYERS - node_ids.len()).for_each(|_| message.extend(&[0; NODE_ID_SIZE]));
+        }
+        // If there is any remaining layers, fill them with [`DUMMY_NODE_ID`].
+        (0..MAX_LAYERS - node_ids.len()).for_each(|_| message.extend(&DUMMY_NODE_ID));
 
         // Append payload with padding
         message.extend(payload);
@@ -70,7 +76,7 @@ impl BlendMessage for MockBlendMessage {
         }
 
         // If this is the last layer
-        if message[NODE_ID_SIZE..NODE_ID_SIZE * 2] == [0; NODE_ID_SIZE] {
+        if message[NODE_ID_SIZE..NODE_ID_SIZE * 2] == DUMMY_NODE_ID {
             let padded_payload = &message[NODE_ID_SIZE * MAX_LAYERS..];
             // remove the payload padding
             match padded_payload
@@ -86,7 +92,7 @@ impl BlendMessage for MockBlendMessage {
 
         let mut new_message: Vec<u8> = Vec::with_capacity(MESSAGE_SIZE);
         new_message.extend(&message[NODE_ID_SIZE..NODE_ID_SIZE * MAX_LAYERS]);
-        new_message.extend(&[0; NODE_ID_SIZE]);
+        new_message.extend(&DUMMY_NODE_ID);
         new_message.extend(&message[NODE_ID_SIZE * MAX_LAYERS..]); // padded payload
         Ok((new_message, false))
     }
@@ -117,5 +123,16 @@ mod tests {
             MockBlendMessage::unwrap_message(&message, &node_ids[2]).unwrap();
         assert!(is_fully_unwrapped);
         assert_eq!(unwrapped_payload, payload);
+    }
+
+    #[test]
+    fn invalid_node_id() {
+        let mut node_ids = (0..3).map(|i| [i; NODE_ID_SIZE]).collect::<Vec<_>>();
+        node_ids.push(DUMMY_NODE_ID);
+        let payload = [7; 10];
+        assert_eq!(
+            MockBlendMessage::build_message(&payload, &node_ids),
+            Err(Error::InvalidPublicKey)
+        );
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #956

As explained in #956, this PR fixes `MockBlendMessage` to correctly check if the current layer is the last. Previously, it has been used `[0u8; 32]` to represent a dummy node ID, but it is common that users use the `[0u8; 32]` as an actual node ID. Then, the check logic fails. So, this PR uses `[u8::MAX; 32]` as a dummy node ID, and return error if users use it as an actual node ID. I think this fix is good enough because it's just a mock (used in simulations).

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [ ] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 5. Link PR to a specific milestone.
