### PR TITLE
feature(kzgrs): Use only commitment hash on encoder and verifier.

### DIFF
--- a/nomos-da/kzgrs-backend/src/common/mod.rs
+++ b/nomos-da/kzgrs-backend/src/common/mod.rs
@@ -139,13 +139,9 @@ impl FromIterator<Row> for ChunksMatrix {
     }
 }
 
-pub fn hash_column_and_commitment<const HASH_SIZE: usize>(
-    column: &Column,
-    commitment: &Commitment,
-) -> [u8; HASH_SIZE] {
+pub fn hash_commitment<const HASH_SIZE: usize>(commitment: &Commitment) -> [u8; HASH_SIZE] {
     let mut hasher = blake2::Blake2bVar::new(HASH_SIZE)
         .unwrap_or_else(|e| panic!("Blake2b should work for size {HASH_SIZE}, {e}"));
-    hasher.update(column.as_bytes().as_ref());
     hasher.update(commitment_to_bytes(commitment).as_ref());
     hasher
         .finalize_boxed()


### PR DESCRIPTION
## 1. What does this PR implement?
Use only commitment hash on encoder and verifier.

Closes: https://github.com/logos-co/nomos-node/issues/972

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@AlejandroCabeza 
@danielSanchezQ 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No, it actually updates code according to [spec](https://www.notion.so/NomosDA-Cryptographic-Protocol-4bf3bb62cfb64422ab48b5b60aab6a73#0ce1b4fca39341f4b6c6cecafcfe3fab).

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. Description added.
* [X] 2. Context and links to Specification document(s) added.
* [X] 3. Main contact(s) (developers and specification authors) added
* [X] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 5. Link PR to a specific milestone.