### PR TITLE
fix: Temporarily downgrade cargo-binstall to 1.10.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -yq \
     git gcc g++ clang libssl-dev pkg-config \
     protobuf-compiler
 
-RUN cargo install cargo-binstall
+RUN cargo install cargo-binstall --version 1.10.19
 RUN cargo binstall -y cargo-risczero
 RUN cargo risczero install
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -23,6 +23,6 @@ RUN mkdir -p /home/jenkins/.local/share/cargo-risczero/toolchains \
 
 USER jenkins
 
-RUN cargo install cargo-binstall
+RUN cargo install cargo-binstall --version 1.10.19
 RUN cargo binstall -y cargo-risczero
 RUN cargo risczero install

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -yq \
     git gcc g++ clang libssl-dev \
     pkg-config protobuf-compiler
 
-RUN cargo install cargo-binstall
+RUN cargo install cargo-binstall --version 1.10.19
 RUN cargo binstall -y cargo-risczero
 RUN cargo risczero install
 


### PR DESCRIPTION
## 1. What does this PR implement?

This PR addresses a problem with dependency resolution for rust:1.82.0-slim-bookworm and latest cargo-binstall v1.10.20. 

```
cargo install cargo-binstall --version 1.10.20
    Updating crates.io index
  Installing cargo-binstall v1.10.20
    Updating crates.io index
error: failed to compile `cargo-binstall v1.10.20`, intermediate artifacts can be found at `/tmp/cargo-installIR4Yju`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  failed to select a version for the requirement `log = "^0.4.24"`
  candidate versions found which didn't match: 0.4.22, 0.4.21, 0.4.20, ...
  location searched: crates.io index
  required by package `cargo-binstall v1.10.20`
  if you are looking for the prerelease package it needs to be specified explicitly
      log = { version = "0.4.0-rc.1" }
```

## 2. Does the code have enough context to be clearly understood?

It fixes installation issue by downgrading to cargo-binstall version 1.10.19 - one minor behind.

## 3. Who are the specification authors and who is accountable for this PR?

@romanzac 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
