### PR TITLE
feat(kms): add filesystem backend

### DIFF
--- a/nomos-services/key-management-system/Cargo.toml
+++ b/nomos-services/key-management-system/Cargo.toml
@@ -11,3 +11,18 @@ bytes = "1"
 futures = "0.3"
 async-trait = "0.1"
 log = "0.4.22"
+aes-gcm = { version = "0.10", optional = true }
+pbkdf2 = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+uuid = { version = "1", optional = true, features = ["v4"] }
+rand = "0.8"
+thiserror = "2"
+zeroize = "1"
+ed25519-dalek = { version = "2", features = ["zeroize", "rand_core"] }
+
+[features]
+default = ["fs"]
+fs = ["aes-gcm", "pbkdf2", "sha2", "uuid"]
+
+[dev-dependencies]
+tempfile = "3"

--- a/nomos-services/key-management-system/src/backend/fs.rs
+++ b/nomos-services/key-management-system/src/backend/fs.rs
@@ -1,0 +1,223 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce};
+use bytes::Bytes;
+use either::Either;
+use overwatch_rs::DynError;
+use pbkdf2::pbkdf2_hmac;
+use sha2::Sha256;
+use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::{keys::ed25519::Ed25519Key, secure_key::SecuredKey, KMSOperator};
+
+use super::KMSBackend;
+
+type UuidBytes = [u8; 16];
+
+pub struct FileSystemKMSBackend {
+    dir: PathBuf,
+    encryption_key: aes_gcm::Key<Aes256Gcm>,
+    keys: HashMap<UuidBytes, Box<dyn SecuredKey + Sync + Send>>,
+}
+
+#[derive(Clone)]
+pub struct FileSystemKMSBackendSettings {
+    pub dir: PathBuf,
+    pub password: String,
+    pub salt: String,
+    pub rounds: u32,
+}
+
+#[async_trait::async_trait]
+impl KMSBackend for FileSystemKMSBackend {
+    type SupportedKeys = SupportedKeys;
+    type KeyId = UuidBytes;
+    type Settings = FileSystemKMSBackendSettings;
+
+    fn new(settings: Self::Settings) -> Self {
+        // Derive an encryption key from the password using PBKDF2
+        let mut derived_key = [0u8; 32];
+        pbkdf2_hmac::<Sha256>(
+            settings.password.as_bytes(),
+            settings.salt.as_bytes(),
+            settings.rounds,
+            &mut derived_key,
+        );
+        let encryption_key = *aes_gcm::Key::<Aes256Gcm>::from_slice(&derived_key);
+        derived_key.zeroize();
+
+        Self {
+            dir: settings.dir,
+            encryption_key,
+            keys: HashMap::new(),
+        }
+    }
+
+    fn register(
+        &mut self,
+        key: Either<Self::SupportedKeys, Self::KeyId>,
+    ) -> Result<Self::KeyId, DynError> {
+        let key_id = match key {
+            Either::Left(key_type) => {
+                // Generate a new key
+                let key_id = Uuid::new_v4();
+                let (key, key_bytes) = key_type.generate();
+
+                // Encrypt the key
+                let encrypted_key = Aes256Gcm::new(&self.encryption_key)
+                    .encrypt(Nonce::from_slice(key_id.as_bytes()), key_bytes.as_ref())
+                    .map_err(|_| Error::EncryptionFailed)?;
+
+                // Write the encrypted key to disk
+                std::fs::write(self.dir.join(key_id.to_string()), encrypted_key)?;
+
+                // Keep the key in memory
+                let key_id = key_id.into_bytes();
+                self.keys.insert(key_id, key);
+                key_id
+            }
+            Either::Right(key_id) => {
+                let encrypted_key =
+                    std::fs::read(self.dir.join(Uuid::from_bytes(key_id).to_string()))?;
+                let key_bytes = Zeroizing::new(
+                    Aes256Gcm::new(&self.encryption_key)
+                        .decrypt(Nonce::from_slice(&key_id), encrypted_key.as_ref())
+                        .map_err(|_| Error::DecryptionFailed)?,
+                );
+                self.keys
+                    .insert(key_id, Self::SupportedKeys::load(&key_bytes)?);
+                key_id
+            }
+        };
+        Ok(key_id)
+    }
+
+    fn public_key(&self, key_id: Self::KeyId) -> Result<Bytes, DynError> {
+        Ok(self
+            .keys
+            .get(&key_id)
+            .ok_or(Error::KeyIdNotRegistered(key_id))?
+            .as_pk())
+    }
+
+    fn sign(&mut self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError> {
+        self.keys
+            .get_mut(&key_id)
+            .ok_or(Error::KeyIdNotRegistered(key_id))?
+            .sign(data)
+    }
+
+    async fn execute(&mut self, key_id: Self::KeyId, mut op: KMSOperator) -> Result<(), DynError> {
+        op(self
+            .keys
+            .get_mut(&key_id)
+            .ok_or(Error::KeyIdNotRegistered(key_id))?)
+        .await
+    }
+}
+
+#[repr(u8)]
+#[allow(dead_code)] // TODO: Remove this macro once this is used outside
+pub enum SupportedKeys {
+    Ed25519 = 0,
+}
+
+impl SupportedKeys {
+    fn generate(&self) -> (Box<dyn SecuredKey + Sync + Send>, Zeroizing<Vec<u8>>) {
+        match self {
+            SupportedKeys::Ed25519 => {
+                let key = Ed25519Key::generate();
+                let mut bytes = Zeroizing::new(Vec::new());
+                bytes.push(SupportedKeys::Ed25519 as u8);
+                bytes.extend_from_slice(key.as_bytes());
+                (Box::new(key), bytes)
+            }
+        }
+    }
+
+    fn load(bytes: &[u8]) -> Result<Box<dyn SecuredKey + Sync + Send>, Error> {
+        match bytes.first() {
+            Some(val) if *val == SupportedKeys::Ed25519 as u8 => Ok(Box::new(
+                Ed25519Key::from_bytes(bytes.get(1..).ok_or(Error::InvalidKeyBytes)?),
+            )),
+            Some(_) => Err(Error::UnknownKeyType(bytes[0])),
+            None => Err(Error::InvalidKeyBytes),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Encryption failed")]
+    EncryptionFailed,
+    #[error("Decryption failed")]
+    DecryptionFailed,
+    #[error("Unknown key type: {0}")]
+    UnknownKeyType(u8),
+    #[error("Invalid key bytes")]
+    InvalidKeyBytes,
+    #[error("Key ID not registered: {0:?}")]
+    KeyIdNotRegistered(UuidBytes),
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::{tempdir, TempDir};
+
+    use super::*;
+
+    #[test]
+    fn generate_and_load() {
+        let dir = tempdir().unwrap();
+        let settings = settings(&dir);
+
+        let mut backend = FileSystemKMSBackend::new(settings.clone());
+        let key_id = backend
+            .register(Either::Left(SupportedKeys::Ed25519))
+            .unwrap();
+        let public_key = backend.public_key(key_id).unwrap();
+        let signature = backend.sign(key_id, Bytes::from("data")).unwrap();
+
+        let mut backend = FileSystemKMSBackend::new(settings);
+        assert_eq!(backend.register(Either::Right(key_id)).unwrap(), key_id,);
+        assert_eq!(backend.public_key(key_id).unwrap(), public_key);
+        assert_eq!(
+            backend.sign(key_id, Bytes::from("data")).unwrap(),
+            signature,
+        );
+    }
+
+    #[test]
+    fn load_with_wrong_password() {
+        let dir = tempdir().unwrap();
+        let mut settings = settings(&dir);
+
+        let mut backend = FileSystemKMSBackend::new(settings.clone());
+        let key_id = backend
+            .register(Either::Left(SupportedKeys::Ed25519))
+            .unwrap();
+
+        settings.password = "wrong".to_string();
+        let mut backend = FileSystemKMSBackend::new(settings);
+        assert!(backend.register(Either::Right(key_id)).is_err());
+    }
+
+    #[test]
+    fn unregistered_key() {
+        let dir = tempdir().unwrap();
+        let mut backend = FileSystemKMSBackend::new(settings(&dir));
+        let key_id = [0u8; 16];
+        assert!(backend.public_key(key_id).is_err());
+        assert!(backend.sign(key_id, Bytes::from("data")).is_err());
+    }
+
+    fn settings(dir: &TempDir) -> FileSystemKMSBackendSettings {
+        FileSystemKMSBackendSettings {
+            dir: dir.path().to_path_buf(),
+            password: "password".to_string(),
+            salt: "salt".to_string(),
+            rounds: 1000,
+        }
+    }
+}

--- a/nomos-services/key-management-system/src/backend/mod.rs
+++ b/nomos-services/key-management-system/src/backend/mod.rs
@@ -1,3 +1,5 @@
+pub mod fs;
+
 use crate::KMSOperator;
 use bytes::Bytes;
 use either::Either;
@@ -15,6 +17,6 @@ pub trait KMSBackend {
         key: Either<Self::SupportedKeys, Self::KeyId>,
     ) -> Result<Self::KeyId, DynError>;
     fn public_key(&self, key_id: Self::KeyId) -> Result<Bytes, DynError>;
-    fn sign(&self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;
-    async fn execute(&mut self, op: KMSOperator);
+    fn sign(&mut self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;
+    async fn execute(&mut self, key_id: Self::KeyId, mut op: KMSOperator) -> Result<(), DynError>;
 }

--- a/nomos-services/key-management-system/src/keys/ed25519.rs
+++ b/nomos-services/key-management-system/src/keys/ed25519.rs
@@ -1,0 +1,36 @@
+use bytes::Bytes;
+use ed25519_dalek::ed25519::signature::SignerMut;
+use overwatch_rs::DynError;
+use rand::rngs::OsRng;
+use zeroize::Zeroizing;
+
+use crate::secure_key::SecuredKey;
+
+/// [`ed25519_dalek::SigningKey`] implements [`zeroize::Zeroize`] internally.
+pub struct Ed25519Key(ed25519_dalek::SigningKey);
+
+impl SecuredKey for Ed25519Key {
+    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError> {
+        Ok(Bytes::copy_from_slice(&self.0.sign(&data).to_bytes()))
+    }
+
+    fn as_pk(&self) -> Bytes {
+        Bytes::copy_from_slice(self.0.verifying_key().as_bytes())
+    }
+}
+
+impl Ed25519Key {
+    pub fn generate() -> Self {
+        Self(ed25519_dalek::SigningKey::generate(&mut OsRng))
+    }
+
+    pub fn as_bytes(&self) -> &ed25519_dalek::SecretKey {
+        self.0.as_bytes()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut secret_key = Zeroizing::new([0u8; 32]);
+        secret_key.copy_from_slice(bytes);
+        Self(ed25519_dalek::SigningKey::from_bytes(&secret_key))
+    }
+}

--- a/nomos-services/key-management-system/src/keys/mod.rs
+++ b/nomos-services/key-management-system/src/keys/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod ed25519;

--- a/nomos-services/key-management-system/src/lib.rs
+++ b/nomos-services/key-management-system/src/lib.rs
@@ -12,16 +12,22 @@ use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
 use overwatch_rs::DynError;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
+use std::pin::Pin;
 use tokio::sync::oneshot;
 
 mod backend;
+mod keys;
 mod secure_key;
 
 const KMS_TAG: ServiceId = "KMS";
 
 // TODO: Use [`AsyncFnMut`](https://doc.rust-lang.org/stable/std/ops/trait.AsyncFnMut.html#tymethod.async_call_mut) once it is stabilized.
 pub type KMSOperator = Box<
-    dyn FnMut(&mut dyn SecuredKey) -> Box<dyn Future<Output = Result<(), DynError>>> + Send + Sync,
+    dyn FnMut(
+            &mut Box<dyn SecuredKey + Send + Sync>,
+        ) -> Pin<Box<dyn Future<Output = Result<(), DynError>> + Send + Sync>>
+        + Send
+        + Sync,
 >;
 
 pub enum KMSMessage<Backend>
@@ -42,6 +48,7 @@ where
         reply_channel: oneshot::Sender<Bytes>,
     },
     Execute {
+        key_id: Backend::KeyId,
         operator: KMSOperator,
     },
 }
@@ -202,8 +209,11 @@ where
                     error!("Could not reply public key to request channel");
                 }
             }
-            KMSMessage::Execute { operator } => {
-                backend.execute(operator).await;
+            KMSMessage::Execute { key_id, operator } => {
+                backend
+                    .execute(key_id, operator)
+                    .await
+                    .expect("Could not execute operator");
             }
         }
     }

--- a/nomos-services/key-management-system/src/secure_key.rs
+++ b/nomos-services/key-management-system/src/secure_key.rs
@@ -2,6 +2,6 @@ use bytes::Bytes;
 use overwatch_rs::DynError;
 
 pub trait SecuredKey {
-    fn sign(&self) -> Result<Bytes, DynError>;
+    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError>;
     fn as_pk(&self) -> Bytes;
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR implements `FileSystemKMSBackend`, which stores and loads keys to a disk. Keys are encrypted by a password.

This backend can be used as the most naive option. In the future, it would be good to implement `KeyringKMSBackend` using the [`keyring`](https://docs.rs/keyring/latest/keyring/) crate, or so.

The APIs defined by the #981 have been slightly modified to accommodate the implementations. I added PR comments for details.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [ ] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 5. Link PR to a specific milestone.
