### PR TITLE
feat(kms): add the preload backend

### DIFF
--- a/nomos-services/key-management-system/Cargo.toml
+++ b/nomos-services/key-management-system/Cargo.toml
@@ -11,3 +11,15 @@ bytes = "1"
 futures = "0.3"
 async-trait = "0.1"
 log = "0.4.22"
+thiserror = "2"
+zeroize = { version = "1", features = ["zeroize_derive"] }
+ed25519-dalek = { version = "2", features = ["serde", "zeroize"] }
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+rand = "0.8"
+
+[features]
+default = ["preload"]
+preload = []

--- a/nomos-services/key-management-system/Cargo.toml
+++ b/nomos-services/key-management-system/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "4160cdd" }
-either = "1"
 tokio = { version = "1", features = ["macros"] }
 bytes = "1"
 futures = "0.3"

--- a/nomos-services/key-management-system/src/backend/mod.rs
+++ b/nomos-services/key-management-system/src/backend/mod.rs
@@ -3,19 +3,19 @@ pub mod preload;
 
 use crate::KMSOperator;
 use bytes::Bytes;
-use either::Either;
 use overwatch_rs::DynError;
 
 #[async_trait::async_trait]
 pub trait KMSBackend {
-    type SupportedKeys;
+    type SupportedKeyTypes;
     type KeyId;
     type Settings;
 
     fn new(settings: Self::Settings) -> Self;
     fn register(
         &mut self,
-        key: Either<Self::SupportedKeys, Self::KeyId>,
+        key_id: Self::KeyId,
+        key_scheme: Self::SupportedKeyTypes,
     ) -> Result<Self::KeyId, DynError>;
     fn public_key(&self, key_id: Self::KeyId) -> Result<Bytes, DynError>;
     fn sign(&self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;

--- a/nomos-services/key-management-system/src/backend/mod.rs
+++ b/nomos-services/key-management-system/src/backend/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "preload")]
+pub mod preload;
+
 use crate::KMSOperator;
 use bytes::Bytes;
 use either::Either;
@@ -15,6 +18,6 @@ pub trait KMSBackend {
         key: Either<Self::SupportedKeys, Self::KeyId>,
     ) -> Result<Self::KeyId, DynError>;
     fn public_key(&self, key_id: Self::KeyId) -> Result<Bytes, DynError>;
-    fn sign(&self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;
-    async fn execute(&mut self, op: KMSOperator);
+    fn sign(&mut self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;
+    async fn execute(&mut self, key_id: Self::KeyId, mut op: KMSOperator) -> Result<(), DynError>;
 }

--- a/nomos-services/key-management-system/src/backend/mod.rs
+++ b/nomos-services/key-management-system/src/backend/mod.rs
@@ -18,6 +18,6 @@ pub trait KMSBackend {
         key: Either<Self::SupportedKeys, Self::KeyId>,
     ) -> Result<Self::KeyId, DynError>;
     fn public_key(&self, key_id: Self::KeyId) -> Result<Bytes, DynError>;
-    fn sign(&mut self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;
+    fn sign(&self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError>;
     async fn execute(&mut self, key_id: Self::KeyId, mut op: KMSOperator) -> Result<(), DynError>;
 }

--- a/nomos-services/key-management-system/src/backend/preload.rs
+++ b/nomos-services/key-management-system/src/backend/preload.rs
@@ -111,8 +111,6 @@ impl Key {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Not supported")]
-    NotSupported,
     #[error("Key({0}) was not registered")]
     KeyNotRegistered(String),
     #[error("KeyType mismatch: {0:?} != {1:?}")]

--- a/nomos-services/key-management-system/src/backend/preload.rs
+++ b/nomos-services/key-management-system/src/backend/preload.rs
@@ -1,0 +1,196 @@
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use either::Either;
+use overwatch_rs::DynError;
+use serde::{Deserialize, Serialize};
+use zeroize::ZeroizeOnDrop;
+
+use crate::{keys::ed25519::Ed25519Key, secure_key::SecuredKey, KMSOperator};
+
+use super::KMSBackend;
+
+pub struct PreloadKMSBackend {
+    keys: HashMap<String, Key>,
+}
+
+/// This settings contain all [`Key`]s to be loaded into the [`PreloadKMSBackend`].
+/// This implements [`serde::Serialize`] for users to populate the settings from bytes.
+/// The [`Key`] also implements [`zeroize::ZeroizeOnDrop`] for security.
+#[derive(Serialize, Deserialize)]
+pub struct PreloadKMSBackendSettings {
+    keys: HashMap<String, Key>,
+}
+
+#[async_trait::async_trait]
+impl KMSBackend for PreloadKMSBackend {
+    type SupportedKeys = SupportedKeys;
+    type KeyId = String;
+    type Settings = PreloadKMSBackendSettings;
+
+    fn new(settings: Self::Settings) -> Self {
+        Self {
+            keys: settings.keys,
+        }
+    }
+
+    /// This function just checks if the key_id was preloaded successfully.
+    /// This backend doesn't support generating a new key based on the [`SupportedKeys`] provided,
+    /// because this backend preloads all keys from the settings.
+    /// In other words, the users can execute operations with the key_id
+    /// even without the need to register it, if the key was specified in the settings.
+    fn register(
+        &mut self,
+        key: Either<Self::SupportedKeys, Self::KeyId>,
+    ) -> Result<Self::KeyId, DynError> {
+        match key {
+            Either::Left(_) => Err(Error::NotSupported.into()),
+            Either::Right(key_id) => {
+                if self.keys.contains_key(&key_id) {
+                    Ok(key_id)
+                } else {
+                    Err(Error::KeyNotRegistered(key_id).into())
+                }
+            }
+        }
+    }
+
+    fn public_key(&self, key_id: Self::KeyId) -> Result<Bytes, DynError> {
+        Ok(self
+            .keys
+            .get(&key_id)
+            .ok_or(Error::KeyNotRegistered(key_id))?
+            .as_pk())
+    }
+
+    fn sign(&mut self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError> {
+        self.keys
+            .get_mut(&key_id)
+            .ok_or(Error::KeyNotRegistered(key_id))?
+            .sign(data)
+    }
+
+    async fn execute(&mut self, key_id: Self::KeyId, mut op: KMSOperator) -> Result<(), DynError> {
+        op(self
+            .keys
+            .get_mut(&key_id)
+            .ok_or(Error::KeyNotRegistered(key_id))?)
+        .await
+    }
+}
+
+// This enum won't be used outside of this module
+// because [`PreloadKMSBackend`] doesn't support generating new keys.
+#[allow(dead_code)]
+pub enum SupportedKeys {
+    Ed25519,
+}
+
+#[derive(Serialize, Deserialize, ZeroizeOnDrop)]
+enum Key {
+    Ed25519(Ed25519Key),
+}
+
+impl SecuredKey for Key {
+    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError> {
+        match self {
+            Self::Ed25519(key) => key.sign(data),
+        }
+    }
+
+    fn as_pk(&self) -> Bytes {
+        match self {
+            Self::Ed25519(key) => key.as_pk(),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Not supported")]
+    NotSupported,
+    #[error("Key({0}) was not registered")]
+    KeyNotRegistered(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rand::rngs::OsRng;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn preload_backend() {
+        // Initialize a backend with a pre-generated key in the setting
+        let key_id = "blend/1".to_string();
+        let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let mut backend = PreloadKMSBackend::new(PreloadKMSBackendSettings {
+            keys: HashMap::from_iter(vec![(
+                key_id.clone(),
+                Key::Ed25519(Ed25519Key(key.clone())),
+            )]),
+        });
+
+        // Check if the key was preloaded successfully
+        assert_eq!(
+            backend.register(Either::Right(key_id.clone())).unwrap(),
+            key_id
+        );
+
+        // Check if the result of key operations of the backend are the same as
+        // the direct operation on the key itself.
+        let mut key = Ed25519Key(key.clone());
+        assert_eq!(backend.public_key(key_id.clone()).unwrap(), key.as_pk());
+        let data = Bytes::from("data");
+        assert_eq!(
+            backend.sign(key_id.clone(), data.clone()).unwrap(),
+            key.sign(data).unwrap()
+        );
+
+        // Check if the execute function works as expected
+        backend
+            .execute(
+                key_id.clone(),
+                Box::new(move |_: &mut dyn SecuredKey| Box::pin(async move { Ok(()) })),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn key_generation_not_supported() {
+        let mut backend = PreloadKMSBackend::new(PreloadKMSBackendSettings {
+            keys: HashMap::new(),
+        });
+
+        // This backend shouldn't support generating new keys.
+        assert!(backend
+            .register(Either::Left(SupportedKeys::Ed25519))
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn key_not_registered() {
+        let mut backend = PreloadKMSBackend::new(PreloadKMSBackendSettings {
+            keys: HashMap::from_iter(vec![(
+                "blend/1".to_string(),
+                Key::Ed25519(Ed25519Key(ed25519_dalek::SigningKey::generate(&mut OsRng))),
+            )]),
+        });
+
+        let unknown_key = "blend/not_registered".to_string();
+        assert!(backend.public_key(unknown_key.clone()).is_err());
+        assert!(backend
+            .sign(unknown_key.clone(), Bytes::from("data"))
+            .is_err());
+        assert!(backend
+            .execute(
+                unknown_key,
+                Box::new(move |_: &mut dyn SecuredKey| Box::pin(async move { Ok(()) })),
+            )
+            .await
+            .is_err());
+    }
+}

--- a/nomos-services/key-management-system/src/backend/preload.rs
+++ b/nomos-services/key-management-system/src/backend/preload.rs
@@ -63,9 +63,9 @@ impl KMSBackend for PreloadKMSBackend {
             .as_pk())
     }
 
-    fn sign(&mut self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError> {
+    fn sign(&self, key_id: Self::KeyId, data: Bytes) -> Result<Bytes, DynError> {
         self.keys
-            .get_mut(&key_id)
+            .get(&key_id)
             .ok_or(Error::KeyNotRegistered(key_id))?
             .sign(data)
     }
@@ -92,7 +92,7 @@ enum Key {
 }
 
 impl SecuredKey for Key {
-    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError> {
+    fn sign(&self, data: Bytes) -> Result<Bytes, DynError> {
         match self {
             Self::Ed25519(key) => key.sign(data),
         }
@@ -141,7 +141,7 @@ mod tests {
 
         // Check if the result of key operations of the backend are the same as
         // the direct operation on the key itself.
-        let mut key = Ed25519Key(key.clone());
+        let key = Ed25519Key(key.clone());
         assert_eq!(backend.public_key(key_id.clone()).unwrap(), key.as_pk());
         let data = Bytes::from("data");
         assert_eq!(

--- a/nomos-services/key-management-system/src/keys/ed25519.rs
+++ b/nomos-services/key-management-system/src/keys/ed25519.rs
@@ -1,0 +1,20 @@
+use bytes::Bytes;
+use ed25519_dalek::ed25519::signature::SignerMut;
+use overwatch_rs::DynError;
+use serde::{Deserialize, Serialize};
+use zeroize::ZeroizeOnDrop;
+
+use crate::secure_key::SecuredKey;
+
+#[derive(Serialize, Deserialize, ZeroizeOnDrop)]
+pub struct Ed25519Key(pub(crate) ed25519_dalek::SigningKey);
+
+impl SecuredKey for Ed25519Key {
+    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError> {
+        Ok(Bytes::copy_from_slice(&self.0.sign(&data).to_bytes()))
+    }
+
+    fn as_pk(&self) -> Bytes {
+        Bytes::copy_from_slice(self.0.verifying_key().as_bytes())
+    }
+}

--- a/nomos-services/key-management-system/src/keys/ed25519.rs
+++ b/nomos-services/key-management-system/src/keys/ed25519.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use ed25519_dalek::ed25519::signature::SignerMut;
+use ed25519_dalek::ed25519::signature::Signer;
 use overwatch_rs::DynError;
 use serde::{Deserialize, Serialize};
 use zeroize::ZeroizeOnDrop;
@@ -10,7 +10,7 @@ use crate::secure_key::SecuredKey;
 pub struct Ed25519Key(pub(crate) ed25519_dalek::SigningKey);
 
 impl SecuredKey for Ed25519Key {
-    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError> {
+    fn sign(&self, data: Bytes) -> Result<Bytes, DynError> {
         Ok(Bytes::copy_from_slice(&self.0.sign(&data).to_bytes()))
     }
 

--- a/nomos-services/key-management-system/src/keys/mod.rs
+++ b/nomos-services/key-management-system/src/keys/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod ed25519;

--- a/nomos-services/key-management-system/src/secure_key.rs
+++ b/nomos-services/key-management-system/src/secure_key.rs
@@ -2,6 +2,6 @@ use bytes::Bytes;
 use overwatch_rs::DynError;
 
 pub trait SecuredKey {
-    fn sign(&self) -> Result<Bytes, DynError>;
+    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError>;
     fn as_pk(&self) -> Bytes;
 }

--- a/nomos-services/key-management-system/src/secure_key.rs
+++ b/nomos-services/key-management-system/src/secure_key.rs
@@ -2,6 +2,6 @@ use bytes::Bytes;
 use overwatch_rs::DynError;
 
 pub trait SecuredKey {
-    fn sign(&mut self, data: Bytes) -> Result<Bytes, DynError>;
+    fn sign(&self, data: Bytes) -> Result<Bytes, DynError>;
     fn as_pk(&self) -> Bytes;
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR implements a naive KMS backend, which preloads all keys from the setting struct provided by an user. As we've been currently doing, the user must specify all keys in the config file, for example.
This backend provides key operations on only the keys preloaded. It doesn't support generating new keys. 

This is the most simplest version of the KMS backend. We'll be able to design an ideal backend once the requirement from the validator protocol is determined clearly. A possible approach may be making the backend hold a single master key and derive all keys from the master key along with a key ID provided by user, deterministically. This approach is almost the same as the HD key derivation, which most of cyrpto wallets are using, or any other deterministic key derivation algorithms. 

But anyway, it's enough to have this simple preload backend for now.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
@danielSanchezQ @youngjoon-lee 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
