### PR TITLE
Cli: Allow basic auth for dispersal request

### DIFF
--- a/nomos-cli/src/cmds/executor.rs
+++ b/nomos-cli/src/cmds/executor.rs
@@ -25,6 +25,12 @@ pub struct Disseminate {
     /// Executor address which is responsible for dissemination.
     #[clap(long)]
     pub addr: Url,
+    /// Optional username for authentication.
+    #[clap(long)]
+    pub username: Option<String>,
+    /// Optional password for authentication.
+    #[clap(long)]
+    pub password: Option<String>,
 }
 
 impl Disseminate {
@@ -32,7 +38,8 @@ impl Disseminate {
         tracing::subscriber::set_global_default(tracing_subscriber::FmtSubscriber::new())
             .expect("setting tracing default failed");
 
-        let client = ExecutorHttpClient::new(reqwest::Client::new(), self.addr.clone());
+        let client = ExecutorHttpClient::new(reqwest::Client::new(), self.addr.clone())
+            .with_auth(self.username, self.password);
 
         let mut bytes: Vec<u8> = if let Some(data) = &self.data {
             data.clone().into_bytes()


### PR DESCRIPTION
## 1. What does this PR implement?

Basic auth option for the nomos-cli data dispersal.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
