### PR TITLE
refactor: make `PersistentTransmission` accept generic type, not only `Vec<u8>`

### DIFF
--- a/nomos-services/blend/src/lib.rs
+++ b/nomos-services/blend/src/lib.rs
@@ -115,19 +115,16 @@ where
 
         // tier 1 persistent transmission
         let (persistent_sender, persistent_receiver) = mpsc::unbounded_channel();
-        let mut persistent_transmission_messages: PersistentTransmissionStream<
-            _,
-            _,
-            SphinxMessage,
-            _,
-        > = UnboundedReceiverStream::new(persistent_receiver).persistent_transmission(
-            blend_config.persistent_transmission,
-            ChaCha12Rng::from_entropy(),
-            IntervalStream::new(time::interval(Duration::from_secs_f64(
-                1.0 / blend_config.persistent_transmission.max_emission_frequency,
-            )))
-            .map(|_| ()),
-        );
+        let mut persistent_transmission_messages: PersistentTransmissionStream<_, _, _> =
+            UnboundedReceiverStream::new(persistent_receiver).persistent_transmission(
+                blend_config.persistent_transmission,
+                ChaCha12Rng::from_entropy(),
+                IntervalStream::new(time::interval(Duration::from_secs_f64(
+                    1.0 / blend_config.persistent_transmission.max_emission_frequency,
+                )))
+                .map(|_| ()),
+                SphinxMessage::DROP_MESSAGE.to_vec(),
+            );
 
         // tier 2 blend
         let temporal_scheduler = TemporalScheduler::new(


### PR DESCRIPTION
## 1. What does this PR implement?

So far, the `PersistentTransmissionStream` has been accepting and returning `Vec<u8>`. It's fine in general because the blend protocol deals with only byte arrays, doesn't need to interpret its contents. 

Nevertheless, it's better to make it handle generic type, not only `Vec<u8>`, especially for the [nomos-simulation](https://github.com/logos-co/nomos-simulations). I was updating the simulation to deal with a certain `struct`, instead of just `Vec<u8>`, in order to make the simulation more powerful. Of course, it's okay to serialize the `struct` into `Vec<u8>` and deserialize it back. But, it's more efficient to pass the `struct` to the `PersistentTransmissionStream`, as it is.

This change doesn't bring downsides to our implementation. Even, it simplifies the code.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
