### PR TITLE
Unpin cargo binstall version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN apt-get update && apt-get install -yq \
     git gcc g++ clang libssl-dev pkg-config
 
-RUN cargo install cargo-binstall --version 1.10.19
+RUN cargo install cargo-binstall
 RUN cargo binstall -y cargo-risczero
 RUN cargo risczero install
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -23,6 +23,6 @@ RUN mkdir -p /home/jenkins/.local/share/cargo-risczero/toolchains \
 
 USER jenkins
 
-RUN cargo install cargo-binstall --version 1.10.19
+RUN cargo install cargo-binstall
 RUN cargo binstall -y cargo-risczero
 RUN cargo risczero install

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN apt-get update && apt-get install -yq \
     git gcc g++ clang libssl-dev pkg-config ca-certificates
 
-RUN cargo install cargo-binstall --version 1.10.19
+RUN cargo install cargo-binstall
 RUN cargo binstall cargo-risczero@1.2.0 --no-confirm
 RUN cargo risczero install
 


### PR DESCRIPTION
Unpin `cargo binstall` version, the change was made in an attempt to pin risc0 version, but has no effect and the `risc0` issue in Docker images was solved in this [PR](https://github.com/logos-co/nomos-node/pull/1041)