### PR TITLE
feature(tracing): Nomos tracing ability to set panic hook

### DIFF
--- a/nomos-services/tracing/src/lib.rs
+++ b/nomos-services/tracing/src/lib.rs
@@ -1,6 +1,7 @@
 // std
 use std::fmt::{Debug, Formatter};
 use std::io::Write;
+use std::panic;
 use std::sync::{Arc, Mutex};
 // crates
 use futures::StreamExt;
@@ -233,6 +234,8 @@ impl ServiceCore for Tracing {
             .with(LevelFilter::from(config.level))
             .with(layers)
             .init();
+
+        panic::set_hook(Box::new(nomos_tracing::panic::panic_hook));
 
         Ok(Self {
             service_state,

--- a/nomos-tracing/src/lib.rs
+++ b/nomos-tracing/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod filter;
 pub mod logging;
 pub mod metrics;
+pub mod panic;
 pub mod tracing;

--- a/nomos-tracing/src/panic.rs
+++ b/nomos-tracing/src/panic.rs
@@ -1,0 +1,30 @@
+use std::{
+    backtrace::{Backtrace, BacktraceStatus},
+    panic::PanicHookInfo,
+};
+
+pub fn panic_hook(panic_info: &PanicHookInfo) {
+    let payload = panic_info.payload();
+
+    #[allow(clippy::manual_map)]
+    let payload = if let Some(s) = payload.downcast_ref::<&str>() {
+        Some(&**s)
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        Some(s.as_str())
+    } else {
+        None
+    };
+
+    let location = panic_info.location().map(|l| l.to_string());
+    let backtrace = Backtrace::capture();
+    let note = (backtrace.status() == BacktraceStatus::Disabled)
+        .then_some("run with RUST_BACKTRACE=1 environment variable to display a backtrace");
+
+    tracing::error!(
+        panic.payload = payload,
+        panic.location = location,
+        panic.backtrace = backtrace.to_string(),
+        panic.note = note,
+        "A panic occurred",
+    );
+}

--- a/testnet/monitoring/tempo.yaml
+++ b/testnet/monitoring/tempo.yaml
@@ -12,25 +12,17 @@ query_frontend:
 
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
-    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
-      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
-        thrift_http:                   #
-        grpc:                          # for a production deployment you should only enable the receivers you need!
-        thrift_binary:
-        thrift_compact:
-    zipkin:
     otlp:
       protocols:
-        http:
         grpc:
-    opencensus:
+          endpoint: "0.0.0.0:4317"
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
 
 compactor:
   compaction:
-    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+    block_retention: 24h
 
 metrics_generator:
   registry:


### PR DESCRIPTION
## 1. What does this PR implement?

Panic were not intercepted and sent to tracing subscriber before, this PR provides ability to do that.
A minor change to the Tempo config for the testnet was made - by default Tempo now listens on the localhost only, `0.0.0.0` is required to be set in the config explicitly.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
