### PR TITLE
chore: revert codecov workflow to using self-hosted runners

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C instrument-coverage"
       LLVM_PROFILE_FILE: "nomos-node-%p-%m.profraw"
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes https://github.com/logos-co/nomos-node/issues/1019. Self-hosted runners (both macos and linux) have now support for `rustup` binary. Infra repo issue: https://github.com/status-im/infra-ci/issues/174#issuecomment-2659690561. Running workflows: [linux](https://github.com/logos-co/nomos-node/actions/runs/13365314080/job/37321774933) and [macos](https://github.com/logos-co/nomos-node/actions/runs/13365348318/job/37321874239).

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [z] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [z] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [z] 5. Link PR to a specific milestone.
