### PR TITLE
refactor: extract `should_stop_service` into nomos-utils

### DIFF
--- a/nomos-services/blend/Cargo.toml
+++ b/nomos-services/blend/Cargo.toml
@@ -16,6 +16,7 @@ nomos-blend-network = { path = "../../nomos-blend/network", features = [
 ] }
 nomos-blend-message = { path = "../../nomos-blend/message" }
 nomos-network = { path = "../network" }
+nomos-utils = { path = "../../nomos-utils" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 rand = "0.8.5"
 rand_chacha = "0.3"

--- a/nomos-services/blend/src/lib.rs
+++ b/nomos-services/blend/src/lib.rs
@@ -191,7 +191,7 @@ where
                     Self::wrap_and_send_to_persistent_transmission(msg, &mut cryptographic_processor, &persistent_sender);
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
                         break;
                     }

--- a/nomos-services/cryptarchia-consensus/Cargo.toml
+++ b/nomos-services/cryptarchia-consensus/Cargo.toml
@@ -23,6 +23,7 @@ nomos-mempool = { path = "../mempool" }
 nomos-core = { path = "../../nomos-core/chain-defs" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 nomos-storage = { path = "../storage" }
+nomos-utils = { path = "../../nomos-utils" }
 rand_chacha = "0.3"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -518,7 +518,7 @@ where
                         Self::process_message(&cryptarchia, &self.block_subscription_sender, msg);
                     }
                     Some(msg) = lifecycle_stream.next() => {
-                        if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                        if lifecycle::should_stop_service::<Self>(&msg).await {
                             break;
                         }
                     }

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -30,7 +30,7 @@ use nomos_mempool::{
 };
 use nomos_network::NetworkService;
 use nomos_storage::{backends::StorageBackend, StorageMsg, StorageService};
-use overwatch_rs::services::life_cycle::LifecycleMessage;
+use nomos_utils::lifecycle;
 use overwatch_rs::services::relay::{OutboundRelay, Relay, RelayMessage};
 use overwatch_rs::services::state::ServiceState;
 use overwatch_rs::services::{handle::ServiceStateHandle, ServiceCore, ServiceData, ServiceId};
@@ -518,7 +518,7 @@ where
                         Self::process_message(&cryptarchia, &self.block_subscription_sender, msg);
                     }
                     Some(msg) = lifecycle_stream.next() => {
-                        if Self::should_stop_service(msg).await {
+                        if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
                             break;
                         }
                     }
@@ -646,21 +646,6 @@ where
     SamplingNetworkAdapter: nomos_da_sampling::network::NetworkAdapter,
     SamplingStorage: nomos_da_sampling::storage::DaStorageAdapter,
 {
-    async fn should_stop_service(message: LifecycleMessage) -> bool {
-        match message {
-            LifecycleMessage::Shutdown(sender) => {
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
-
     fn process_message(
         cryptarchia: &Cryptarchia,
         block_channel: &broadcast::Sender<Block<ClPool::Item, DaPool::Item>>,

--- a/nomos-services/data-availability/indexer/Cargo.toml
+++ b/nomos-services/data-availability/indexer/Cargo.toml
@@ -17,6 +17,7 @@ nomos-da-sampling = { path = "../sampling" }
 nomos-storage = { path = "../../../nomos-services/storage" }
 nomos-mempool = { path = "../../../nomos-services/mempool" }
 nomos-tracing = { path = "../../../nomos-tracing" }
+nomos-utils = { path = "../../../nomos-utils" }
 cryptarchia-consensus = { path = "../../../nomos-services/cryptarchia-consensus" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }

--- a/nomos-services/data-availability/indexer/src/lib.rs
+++ b/nomos-services/data-availability/indexer/src/lib.rs
@@ -480,7 +480,7 @@ where
                     }
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         break;
                     }
                 }

--- a/nomos-services/data-availability/indexer/src/lib.rs
+++ b/nomos-services/data-availability/indexer/src/lib.rs
@@ -18,8 +18,8 @@ use nomos_mempool::{backend::MemPool, network::NetworkAdapter as MempoolAdapter}
 use nomos_storage::backends::StorageBackend;
 use nomos_storage::StorageService;
 use nomos_tracing::info_with_id;
+use nomos_utils::lifecycle;
 use overwatch_rs::services::handle::ServiceStateHandle;
-use overwatch_rs::services::life_cycle::LifecycleMessage;
 use overwatch_rs::services::relay::{Relay, RelayMessage};
 use overwatch_rs::services::state::{NoOperator, NoState};
 use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
@@ -29,7 +29,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use storage::DaStorageAdapter;
 use tokio::sync::oneshot::Sender;
-use tracing::{error, instrument};
+use tracing::instrument;
 
 const DA_INDEXER_TAG: ServiceId = "DA-Indexer";
 
@@ -335,21 +335,6 @@ where
             }
         }
     }
-
-    async fn should_stop_service(message: LifecycleMessage) -> bool {
-        match message {
-            LifecycleMessage::Shutdown(sender) => {
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
 }
 
 #[async_trait::async_trait]
@@ -495,7 +480,7 @@ where
                     }
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
                         break;
                     }
                 }

--- a/nomos-services/data-availability/network/Cargo.toml
+++ b/nomos-services/data-availability/network/Cargo.toml
@@ -13,6 +13,7 @@ nomos-core = { path = "../../../nomos-core/chain-defs" }
 nomos-libp2p = { path = "../../../nomos-libp2p" }
 nomos-da-network-core = { path = "../../../nomos-da/network/core" }
 nomos-tracing = { path = "../../../nomos-tracing" }
+nomos-utils = { path = "../../../nomos-utils" }
 subnetworks-assignations = { path = "../../../nomos-da/network/subnetworks-assignations" }
 libp2p = { version = "0.53", features = ["ed25519"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/nomos-services/data-availability/network/src/lib.rs
+++ b/nomos-services/data-availability/network/src/lib.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use async_trait::async_trait;
 use backends::NetworkBackend;
 use futures::{Stream, StreamExt};
-use overwatch_rs::services::life_cycle::LifecycleMessage;
+use nomos_utils::lifecycle;
 use overwatch_rs::services::{
     handle::ServiceStateHandle,
     relay::RelayMessage,
@@ -16,7 +16,6 @@ use overwatch_rs::services::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
-use tracing::error;
 // internal
 
 const DA_NETWORK_TAG: ServiceId = "DA-Network";
@@ -107,7 +106,8 @@ where
                     Self::handle_network_service_message(msg, &mut backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                        // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
                         backend.shutdown();
                         break;
                     }
@@ -139,22 +139,6 @@ where
                         "client hung up before a subscription handle could be established"
                     )
                 }),
-        }
-    }
-
-    async fn should_stop_service(msg: LifecycleMessage) -> bool {
-        match msg {
-            LifecycleMessage::Kill => true,
-            LifecycleMessage::Shutdown(signal_sender) => {
-                // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
-                if signal_sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
         }
     }
 }

--- a/nomos-services/data-availability/network/src/lib.rs
+++ b/nomos-services/data-availability/network/src/lib.rs
@@ -106,7 +106,7 @@ where
                     Self::handle_network_service_message(msg, &mut backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
                         backend.shutdown();
                         break;

--- a/nomos-services/data-availability/sampling/Cargo.toml
+++ b/nomos-services/data-availability/sampling/Cargo.toml
@@ -17,6 +17,7 @@ nomos-da-network-service = { path = "../../../nomos-services/data-availability/n
 nomos-da-storage = { path = "../../../nomos-da/storage" }
 nomos-storage = { path = "../../../nomos-services/storage" }
 nomos-tracing = { path = "../../../nomos-tracing" }
+nomos-utils = { path = "../../../nomos-utils" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/nomos-services/data-availability/sampling/src/lib.rs
+++ b/nomos-services/data-availability/sampling/src/lib.rs
@@ -245,7 +245,7 @@ where
                     Self::handle_sampling_message(sampling_message, &mut sampler, &storage_adapter).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         break;
                     }
                 }

--- a/nomos-services/data-availability/sampling/src/lib.rs
+++ b/nomos-services/data-availability/sampling/src/lib.rs
@@ -13,7 +13,6 @@ use nomos_da_network_service::backends::libp2p::common::SamplingEvent;
 use nomos_da_network_service::NetworkService;
 use nomos_storage::StorageService;
 use overwatch_rs::services::handle::ServiceStateHandle;
-use overwatch_rs::services::life_cycle::LifecycleMessage;
 use overwatch_rs::services::relay::{Relay, RelayMessage};
 use overwatch_rs::services::state::{NoOperator, NoState};
 use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
@@ -26,6 +25,7 @@ use tracing::{error, instrument};
 // internal
 use backend::{DaSamplingServiceBackend, SamplingState};
 use nomos_tracing::{error_with_id, info_with_id};
+use nomos_utils::lifecycle;
 use storage::DaStorageAdapter;
 
 const DA_SAMPLING_TAG: ServiceId = "DA-Sampling";
@@ -79,21 +79,6 @@ where
     DaNetwork::Settings: Clone,
     DaStorage: DaStorageAdapter<Blob = DaBlob>,
 {
-    async fn should_stop_service(message: LifecycleMessage) -> bool {
-        match message {
-            LifecycleMessage::Shutdown(sender) => {
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
-
     #[instrument(skip_all)]
     async fn handle_service_message(
         msg: <Self as ServiceData>::Message,
@@ -260,7 +245,7 @@ where
                     Self::handle_sampling_message(sampling_message, &mut sampler, &storage_adapter).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
                         break;
                     }
                 }

--- a/nomos-services/data-availability/verifier/Cargo.toml
+++ b/nomos-services/data-availability/verifier/Cargo.toml
@@ -18,6 +18,7 @@ nomos-da-network-core = { path = "../../../nomos-da/network/core" }
 nomos-da-network-service = { path = "../../../nomos-services/data-availability/network" }
 nomos-storage = { path = "../../../nomos-services/storage" }
 nomos-tracing = { path = "../../../nomos-tracing" }
+nomos-utils = { path = "../../../nomos-utils" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/nomos-services/data-availability/verifier/src/lib.rs
+++ b/nomos-services/data-availability/verifier/src/lib.rs
@@ -192,7 +192,7 @@ where
                     };
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         break;
                     }
                 }

--- a/nomos-services/key-management-system/Cargo.toml
+++ b/nomos-services/key-management-system/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = { workspace = true }
 
 [dependencies]
-overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "4160cdd" }
+overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 tokio = { version = "1", features = ["macros"] }
 bytes = "1"
 futures = "0.3"
@@ -15,6 +15,7 @@ thiserror = "2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 ed25519-dalek = { version = "2", features = ["serde", "zeroize"] }
 serde = { version = "1", features = ["derive"] }
+nomos-utils = { path = "../../nomos-utils" }
 
 [dev-dependencies]
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/nomos-services/key-management-system/src/lib.rs
+++ b/nomos-services/key-management-system/src/lib.rs
@@ -3,8 +3,8 @@ use crate::secure_key::SecuredKey;
 use bytes::Bytes;
 use futures::StreamExt;
 use log::error;
+use nomos_utils::lifecycle;
 use overwatch_rs::services::handle::ServiceStateHandle;
-use overwatch_rs::services::life_cycle::LifecycleMessage;
 use overwatch_rs::services::relay::RelayMessage;
 use overwatch_rs::services::state::{NoOperator, NoState};
 use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
@@ -122,7 +122,10 @@ where
     Backend::SupportedKeyTypes: Debug + Send,
     Backend::Settings: Clone + Send + Sync,
 {
-    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+    fn init(
+        service_state: ServiceStateHandle<Self>,
+        _initial_state: Self::State,
+    ) -> Result<Self, DynError> {
         let KMSServiceSettings { backend_settings } =
             service_state.settings_reader.get_updated_settings();
         let backend = Backend::new(backend_settings);
@@ -144,7 +147,9 @@ where
                     Self::handle_kms_message(msg, &mut backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    Self::should_stop_service(msg).await;
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                        return Ok(());
+                    }
                 }
             }
         }
@@ -158,20 +163,6 @@ where
     Backend::SupportedKeyTypes: Debug,
     Backend::Settings: Clone,
 {
-    async fn should_stop_service(message: LifecycleMessage) -> bool {
-        match message {
-            LifecycleMessage::Shutdown(sender) => {
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
     async fn handle_kms_message(msg: KMSMessage<Backend>, backend: &mut Backend) {
         match msg {
             KMSMessage::Register {

--- a/nomos-services/key-management-system/src/lib.rs
+++ b/nomos-services/key-management-system/src/lib.rs
@@ -147,7 +147,7 @@ where
                     Self::handle_kms_message(msg, &mut backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         return Ok(());
                     }
                 }

--- a/nomos-services/mempool/Cargo.toml
+++ b/nomos-services/mempool/Cargo.toml
@@ -14,6 +14,7 @@ nomos-network = { path = "../network" }
 nomos-da-network-core = { path = "../../nomos-da/network/core" }
 nomos-da-sampling = { path = "../../nomos-services/data-availability/sampling/" }
 nomos-core = { path = "../../nomos-core/chain-defs" }
+nomos-utils = { path = "../../nomos-utils" }
 full-replication = { path = "../../nomos-da/full-replication" }
 kzgrs-backend = { path = "../../nomos-da/kzgrs-backend" }
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }

--- a/nomos-services/mempool/src/da/service.rs
+++ b/nomos-services/mempool/src/da/service.rs
@@ -157,7 +157,7 @@ where
                     tracing::info!(counter.da_mempool_pending_items = pool.pending_item_count());
                 }
                 Some(msg) = lifecycle_stream.next() =>  {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         break;
                     }
                 }

--- a/nomos-services/mempool/src/da/service.rs
+++ b/nomos-services/mempool/src/da/service.rs
@@ -21,14 +21,13 @@ use nomos_da_sampling::{
     DaSamplingService, DaSamplingServiceMsg,
 };
 use nomos_network::{NetworkMsg, NetworkService};
-use overwatch_rs::services::life_cycle::LifecycleMessage;
+use nomos_utils::lifecycle;
 use overwatch_rs::services::{
     handle::ServiceStateHandle,
     relay::{OutboundRelay, Relay},
     state::{NoOperator, NoState},
     ServiceCore, ServiceData, ServiceId,
 };
-use tracing::error;
 
 pub struct DaMempoolService<N, P, DB, DN, R, SamplingStorage>
 where
@@ -158,7 +157,7 @@ where
                     tracing::info!(counter.da_mempool_pending_items = pool.pending_item_count());
                 }
                 Some(msg) = lifecycle_stream.next() =>  {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
                         break;
                     }
                 }
@@ -186,21 +185,6 @@ where
     DaStorage: DaStorageAdapter,
     R: SeedableRng + RngCore,
 {
-    async fn should_stop_service(message: LifecycleMessage) -> bool {
-        match message {
-            LifecycleMessage::Shutdown(sender) => {
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
-
     async fn handle_mempool_message(
         message: MempoolMsg<P::BlockId, N::Payload, P::Item, P::Key>,
         pool: &mut P,

--- a/nomos-services/mempool/src/tx/service.rs
+++ b/nomos-services/mempool/src/tx/service.rs
@@ -14,14 +14,13 @@ use crate::backend::MemPool;
 use crate::network::NetworkAdapter;
 use crate::{MempoolMetrics, MempoolMsg};
 use nomos_network::{NetworkMsg, NetworkService};
-use overwatch_rs::services::life_cycle::LifecycleMessage;
+use nomos_utils::lifecycle;
 use overwatch_rs::services::{
     handle::ServiceStateHandle,
     relay::{OutboundRelay, Relay},
     state::{NoOperator, NoState},
     ServiceCore, ServiceData, ServiceId,
 };
-use tracing::error;
 
 pub struct TxMempoolService<N, P>
 where
@@ -117,7 +116,7 @@ where
                     tracing::info!(counter.tx_mempool_pending_items = pool.pending_item_count());
                 }
                 Some(msg) = lifecycle_stream.next() =>  {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
                         break;
                     }
                 }
@@ -137,21 +136,6 @@ where
     P::BlockId: Debug + Send + 'static,
     N: NetworkAdapter<Payload = P::Item, Key = P::Key> + Send + Sync + 'static,
 {
-    async fn should_stop_service(message: LifecycleMessage) -> bool {
-        match message {
-            LifecycleMessage::Shutdown(sender) => {
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
-
     async fn handle_mempool_message(
         message: MempoolMsg<P::BlockId, P::Item, P::Item, P::Key>,
         pool: &mut P,

--- a/nomos-services/mempool/src/tx/service.rs
+++ b/nomos-services/mempool/src/tx/service.rs
@@ -116,7 +116,7 @@ where
                     tracing::info!(counter.tx_mempool_pending_items = pool.pending_item_count());
                 }
                 Some(msg) = lifecycle_stream.next() =>  {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         break;
                     }
                 }

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3"
 parking_lot = "0.12"
 nomos-core = { path = "../../nomos-core/chain-defs" }
 nomos-libp2p = { path = "../../nomos-libp2p", optional = true }
+nomos-utils = { path = "../../nomos-utils" }
 
 utoipa = { version = "4.0", optional = true }
 serde_json = { version = "1", optional = true }

--- a/nomos-services/network/src/lib.rs
+++ b/nomos-services/network/src/lib.rs
@@ -105,7 +105,7 @@ where
                     Self::handle_network_service_message(msg, &mut backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
                         break;
                     }

--- a/nomos-services/network/src/lib.rs
+++ b/nomos-services/network/src/lib.rs
@@ -10,14 +10,14 @@ use tokio::sync::broadcast;
 use tokio::sync::oneshot;
 // internal
 use backends::NetworkBackend;
-use overwatch_rs::services::life_cycle::LifecycleMessage;
 use overwatch_rs::services::{
     handle::ServiceStateHandle,
     relay::RelayMessage,
     state::{NoOperator, ServiceState},
     ServiceCore, ServiceData, ServiceId,
 };
-use tracing::error;
+
+use nomos_utils::lifecycle;
 
 pub enum NetworkMsg<B: NetworkBackend> {
     Process(B::Message),
@@ -105,7 +105,8 @@ where
                     Self::handle_network_service_message(msg, &mut backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                        // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
                         break;
                     }
                 }
@@ -135,22 +136,6 @@ where
                         "client hung up before a subscription handle could be established"
                     )
                 }),
-        }
-    }
-
-    async fn should_stop_service(msg: LifecycleMessage) -> bool {
-        match msg {
-            LifecycleMessage::Kill => true,
-            LifecycleMessage::Shutdown(signal_sender) => {
-                // TODO: Maybe add a call to backend to handle this. Maybe trying to save unprocessed messages?
-                if signal_sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
         }
     }
 }

--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -17,6 +17,7 @@ sled = { version = "0.34", optional = true }
 rocksdb = { version = "0.22", optional = true }
 thiserror = "1.0"
 tracing = "0.1"
+nomos-utils = { path = "../../nomos-utils" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time"] }

--- a/nomos-services/storage/src/lib.rs
+++ b/nomos-services/storage/src/lib.rs
@@ -1,22 +1,22 @@
 pub mod backends;
 
-// std
-use std::fmt::{Debug, Formatter};
-use std::marker::PhantomData;
 // crates
 use async_trait::async_trait;
-use bytes::Bytes;
-use futures::StreamExt;
-use overwatch_rs::services::handle::ServiceStateHandle;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 // internal
 use backends::StorageBackend;
 use backends::{StorageSerde, StorageTransaction};
-use overwatch_rs::services::life_cycle::LifecycleMessage;
+use bytes::Bytes;
+use futures::StreamExt;
+use nomos_utils::lifecycle;
+use overwatch_rs::services::handle::ServiceStateHandle;
 use overwatch_rs::services::relay::RelayMessage;
 use overwatch_rs::services::state::{NoOperator, NoState};
 use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+// std
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
 use tracing::error;
 
 /// Storage message that maps to [`StorageBackend`] trait
@@ -176,21 +176,6 @@ pub struct StorageService<Backend: StorageBackend + Send + Sync + 'static> {
 }
 
 impl<Backend: StorageBackend + Send + Sync + 'static> StorageService<Backend> {
-    async fn should_stop_service(msg: LifecycleMessage) -> bool {
-        match msg {
-            LifecycleMessage::Shutdown(sender) => {
-                // TODO: Try to finish pending transactions if any and close connections properly
-                if sender.send(()).is_err() {
-                    error!(
-                        "Error sending successful shutdown signal from service {}",
-                        Self::SERVICE_ID
-                    );
-                }
-                true
-            }
-            LifecycleMessage::Kill => true,
-        }
-    }
     async fn handle_storage_message(msg: StorageMsg<Backend>, backend: &mut Backend) {
         if let Err(e) = match msg {
             StorageMsg::Load { key, reply_channel } => {
@@ -330,7 +315,8 @@ impl<Backend: StorageBackend + Send + Sync + 'static> ServiceCore for StorageSer
                     Self::handle_storage_message(msg, backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if Self::should_stop_service(msg).await {
+                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                        // TODO: Try to finish pending transactions if any and close connections properly
                         break;
                     }
                 }

--- a/nomos-services/storage/src/lib.rs
+++ b/nomos-services/storage/src/lib.rs
@@ -315,7 +315,7 @@ impl<Backend: StorageBackend + Send + Sync + 'static> ServiceCore for StorageSer
                     Self::handle_storage_message(msg, backend).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if lifecycle::should_stop_service::<Self>(&msg).await {
                         // TODO: Try to finish pending transactions if any and close connections properly
                         break;
                     }

--- a/nomos-services/system-sig/Cargo.toml
+++ b/nomos-services/system-sig/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 async-trait = "0.1"
 async-ctrlc = "1.2"
 overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
+nomos-utils = { path = "../../nomos-utils" }
 tokio = "1"
 log = "0.4.20"
 futures = "0.3.28"

--- a/nomos-services/system-sig/src/lib.rs
+++ b/nomos-services/system-sig/src/lib.rs
@@ -49,7 +49,7 @@ impl ServiceCore for SystemSig {
                     Self::ctrlc_signal_received(&service_state.overwatch_handle).await;
                 }
                 Some(msg) = lifecycle_stream.next() => {
-                    if  lifecycle::should_stop_service(&msg, Self::SERVICE_ID).await {
+                    if  lifecycle::should_stop_service::<Self>(&msg).await {
                         break;
                     }
                 }

--- a/nomos-utils/Cargo.toml
+++ b/nomos-utils/Cargo.toml
@@ -9,6 +9,8 @@ serde = ["dep:serde"]
 
 [dependencies]
 const-hex = "1"
+overwatch-rs = { git = "https://github.com/logos-co/Overwatch", rev = "f5f7ea0" }
 serde = { version = "1.0", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
+tracing = "0.1"

--- a/nomos-utils/src/lib.rs
+++ b/nomos-utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod fisheryates;
+pub mod lifecycle;
 
 #[cfg(feature = "serde")]
 pub mod serde {

--- a/nomos-utils/src/lifecycle.rs
+++ b/nomos-utils/src/lifecycle.rs
@@ -1,18 +1,22 @@
 use overwatch_rs::services::life_cycle::LifecycleMessage;
+use overwatch_rs::services::ServiceData;
 use tracing::{debug, error};
 
 /// Handles the shutdown signal from `Overwatch`
-pub async fn should_stop_service(msg: &LifecycleMessage, service_id: &str) -> bool {
+pub async fn should_stop_service<S: ServiceData>(msg: &LifecycleMessage) -> bool {
     match msg {
         LifecycleMessage::Shutdown(sender) => {
             if sender.send(()).is_err() {
-                error!("Error sending successful shutdown signal from service {service_id}",);
+                error!(
+                    "Error sending successful shutdown signal from service {}",
+                    S::SERVICE_ID
+                );
             }
-            debug!(service_id, "Shutting down service");
+            debug!("{} {}", S::SERVICE_ID, "Shutting down service");
             true
         }
         LifecycleMessage::Kill => {
-            debug!(service_id, "Killing service");
+            debug!("{} {}", S::SERVICE_ID, "Killing service");
             true
         }
     }

--- a/nomos-utils/src/lifecycle.rs
+++ b/nomos-utils/src/lifecycle.rs
@@ -1,0 +1,19 @@
+use overwatch_rs::services::life_cycle::LifecycleMessage;
+use tracing::{debug, error};
+
+/// Handles the shutdown signal from `Overwatch`
+pub async fn should_stop_service(msg: &LifecycleMessage, service_id: &str) -> bool {
+    match msg {
+        LifecycleMessage::Shutdown(sender) => {
+            if sender.send(()).is_err() {
+                error!("Error sending successful shutdown signal from service {service_id}",);
+            }
+            debug!(service_id, "Shutting down service");
+            true
+        }
+        LifecycleMessage::Kill => {
+            debug!(service_id, "Killing service");
+            true
+        }
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?

Currently all OverWatch services share the common code to listen shutdown signal. This PR refactors this code into `nomos-utils`

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
