### PR TITLE
fix: docker triggering job

### DIFF
--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -2,11 +2,20 @@ name: "Install Risc0"
 
 description: "Install the Risc0 toolchain. Requires the Rust toolchain to be installed."
 
+inputs:
+  github_token:
+    description: "The GitHub token to use for rate limiting."
+    required: true
+
 runs:
   using: "composite"
   steps:
     - name: Install cargo-binstall
       uses: cargo-bins/cargo-binstall@v1.11.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
     - name: Install risc0 using cargo-binstall
       run: cargo binstall -y cargo-risczero@1.2.4 && cargo risczero install
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -13,9 +13,11 @@ runs:
     - name: Install cargo-binstall
       uses: cargo-bins/cargo-binstall@v1.11.1
       env:
+        # Required to avoid throttling by GitHub
         GITHUB_TOKEN: ${{ inputs.github_token }}
     - name: Install risc0 using cargo-binstall
       run: cargo binstall -y cargo-risczero@1.2.0 && cargo risczero install
       shell: bash
       env:
+        # Required to avoid throttling by GitHub
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -15,7 +15,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
     - name: Install risc0 using cargo-binstall
-      run: cargo binstall -y cargo-risczero@1.2.4 && cargo risczero install
+      run: cargo binstall -y cargo-risczero@1.2.0 && cargo risczero install
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/setup-cargo-cache/action.yml
+++ b/.github/actions/setup-cargo-cache/action.yml
@@ -14,7 +14,8 @@ runs:
   using: composite
   steps:
     - name: Force toolchain update
-      uses: actions-rs/toolchain@v1
+      shell: bash
+      run: rustup update
     - name: Set up Cargo cache
       uses: actions/cache/restore@v4
       with:

--- a/.github/actions/setup-cargo-cache/action.yml
+++ b/.github/actions/setup-cargo-cache/action.yml
@@ -13,6 +13,8 @@ description: Set up cache read operations for Cargo artifacts
 runs:
   using: composite
   steps:
+    - name: Force toolchain update
+      uses: actions-rs/toolchain@v1
     - name: Set up Cargo cache
       uses: actions/cache/restore@v4
       with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -112,9 +112,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - formatting
-      - cargo-deny
-      - lints
-      - tests
+      # - cargo-deny
+      # - lints
+      # - tests
     env:
       DOCKER_BUILD_WORKFLOW_FILE: build-docker.yml # Change this in case of file renamings
     steps:
@@ -126,5 +126,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: '${{ env.DOCKER_BUILD_WORKFLOW_FILE }}',
-              ref: '${{ github.ref }}',
+              ref: '${{ github.head_ref || github.ref }}',
             })

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -112,9 +112,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - formatting
-      # - cargo-deny
-      # - lints
-      # - tests
+      - cargo-deny
+      - lints
+      - tests
     env:
       DOCKER_BUILD_WORKFLOW_FILE: build-docker.yml # Change this in case of file renamings
     steps:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install risc0 dependencies
         uses: ./.github/actions/install-risc0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Cargo cache
         uses: ./.github/actions/setup-cargo-cache
         with:
@@ -75,6 +77,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install risc0 dependencies
         uses: ./.github/actions/install-risc0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Cargo cache
         uses: ./.github/actions/setup-cargo-cache
         with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -46,7 +46,8 @@ jobs:
         uses: ./.github/actions/install-risc0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Cargo cache
+      - name: Set up Cargo cache (if not on `master`)
+        if: ${{ github.ref != 'refs/heads/master' }}
         uses: ./.github/actions/setup-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}
@@ -58,8 +59,8 @@ jobs:
         with:
           command: clippy
           args: --all --all-targets --all-features -- -D warnings
-      - name: Update Cargo cache
-        if: success() || failure()
+      - name: Update Cargo cache (if not on `master`)
+        if: ${{ github.ref != 'refs/heads/master' }} && (success() || failure())
         uses: ./.github/actions/update-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}
@@ -79,7 +80,8 @@ jobs:
         uses: ./.github/actions/install-risc0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Cargo cache
+      - name: Set up Cargo cache (if not on `master`)
+        if: ${{ github.ref != 'refs/heads/master' }}
         uses: ./.github/actions/setup-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
@@ -98,8 +100,8 @@ jobs:
           command: test
           # We don't test benches as they take 6h+, leading to a timeout
           args: --all --lib --bins --tests --examples --all-features
-      - name: Update Cargo cache
-        if: success() || failure()
+      - name: Update Cargo cache (if not on `master`)
+        if: ${{ github.ref != 'refs/heads/master' }} && (success() || failure())
         uses: ./.github/actions/update-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -82,8 +82,7 @@ jobs:
       - name: Setup Cargo cache
         uses: ./.github/actions/setup-cargo-cache
         with:
-          # We use the same cache key for both OSes
-          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}
+          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
           github-token: ${{ secrets.GITHUB_TOKEN }}        
       - name: Build required binaries
         uses: actions-rs/cargo@v1
@@ -103,7 +102,7 @@ jobs:
         if: success() || failure()
         uses: ./.github/actions/update-cargo-cache
         with:
-          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}
+          key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
       - name: Upload integration tests results
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -46,8 +46,7 @@ jobs:
         uses: ./.github/actions/install-risc0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Cargo cache (if not on `master`)
-        if: ${{ github.ref != 'refs/heads/master' }}
+      - name: Set up Cargo cache
         uses: ./.github/actions/setup-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}
@@ -59,8 +58,8 @@ jobs:
         with:
           command: clippy
           args: --all --all-targets --all-features -- -D warnings
-      - name: Update Cargo cache (if not on `master`)
-        if: ${{ github.ref != 'refs/heads/master' }} && (success() || failure())
+      - name: Update Cargo cache
+        if: success() || failure()
         uses: ./.github/actions/update-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}
@@ -80,8 +79,7 @@ jobs:
         uses: ./.github/actions/install-risc0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Cargo cache (if not on `master`)
-        if: ${{ github.ref != 'refs/heads/master' }}
+      - name: Set up Cargo cache
         uses: ./.github/actions/setup-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
@@ -100,8 +98,8 @@ jobs:
           command: test
           # We don't test benches as they take 6h+, leading to a timeout
           args: --all --lib --bins --tests --examples --all-features
-      - name: Update Cargo cache (if not on `master`)
-        if: ${{ github.ref != 'refs/heads/master' }} && (success() || failure())
+      - name: Update Cargo cache
+        if: success() || failure()
         uses: ./.github/actions/update-cargo-cache
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,6 +20,8 @@ jobs:
         run: rustup component add llvm-tools-preview
       - name: Install risc0 dependencies
         uses: ./.github/actions/install-risc0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build required binaries
         uses: actions-rs/cargo@v1
         with:

--- a/nomos-services/utils/src/overwatch/recovery/operators.rs
+++ b/nomos-services/utils/src/overwatch/recovery/operators.rs
@@ -50,7 +50,6 @@ where
         Backend::from_settings(settings)
             .load_state()
             .map(Option::from)
-            .map_err(RecoveryError::from)
     }
 
     fn from_settings(settings: <Self::StateInput as ServiceState>::Settings) -> Self {
@@ -59,10 +58,7 @@ where
     }
 
     async fn run(&mut self, state: Self::StateInput) {
-        let save_result = self
-            .recovery_backend
-            .save_state(&state)
-            .map_err(RecoveryError::from);
+        let save_result = self.recovery_backend.save_state(&state);
         if let Err(error) = save_result {
             error!("{}", error);
         }


### PR DESCRIPTION
## 1. What does this PR implement?

Use the pull request ref (`head_ref`) or, if absent, the branch name (`ref`) to trigger the Docker build workflow. It also re-adds the `github_token` input for the risczero action as without it the CI is throttled.

Since it seems GitHub is not strictly enforcing rules on stored caches either, I also opted for splitting the test caches into one for each OS, so that they are both faster to run.