### PR TITLE
fix: Cfgsync tests for DA addressbook update

### DIFF
--- a/testnet/cfgsync/Cargo.toml
+++ b/testnet/cfgsync/Cargo.toml
@@ -10,6 +10,7 @@ clap                  = { version = "4", features = ["derive"] }
 nomos-blend           = { workspace = true }
 nomos-blend-message   = { workspace = true }
 nomos-blend-service   = { workspace = true }
+nomos-da-network-core = { workspace = true }
 nomos-executor        = { workspace = true }
 nomos-libp2p          = { workspace = true }
 nomos-node            = { workspace = true }
@@ -23,3 +24,6 @@ serde_yaml            = "0.9"
 tests                 = { workspace = true }
 tokio                 = { version = "1", features = ["rt-multi-thread"] }
 tracing               = "0.1"
+
+[dev-dependencies]
+futures = "0.3"

--- a/testnet/cfgsync/src/bin/cfgsync-client.rs
+++ b/testnet/cfgsync/src/bin/cfgsync-client.rs
@@ -1,15 +1,9 @@
 use std::{env, fs, net::Ipv4Addr, process};
 
+use cfgsync::client::get_config;
 use nomos_executor::config::Config as ExecutorConfig;
 use nomos_node::Config as ValidatorConfig;
-use reqwest::Client;
 use serde::{de::DeserializeOwned, Serialize};
-
-#[derive(Serialize)]
-struct ClientIp {
-    ip: Ipv4Addr,
-    identifier: String,
-}
 
 fn parse_ip(ip_str: String) -> Ipv4Addr {
     ip_str.parse().unwrap_or_else(|_| {
@@ -18,30 +12,13 @@ fn parse_ip(ip_str: String) -> Ipv4Addr {
     })
 }
 
-async fn get_config<Config: Serialize + DeserializeOwned>(
+async fn pull_to_file<Config: Serialize + DeserializeOwned>(
     ip: Ipv4Addr,
     identifier: String,
     url: &str,
     config_file: &str,
 ) -> Result<(), String> {
-    let client = Client::new();
-
-    let response = client
-        .post(url)
-        .json(&ClientIp { ip, identifier })
-        .send()
-        .await
-        .map_err(|err| format!("Failed to send IP announcement: {}", err))?;
-
-    if !response.status().is_success() {
-        return Err(format!("Server error: {:?}", response.status()));
-    }
-
-    let config = response
-        .json::<Config>()
-        .await
-        .map_err(|err| format!("Failed to parse response: {}", err))?;
-
+    let config = get_config::<Config>(ip, identifier, url).await?;
     let yaml = serde_yaml::to_string(&config)
         .map_err(|err| format!("Failed to serialize config to YAML: {}", err))?;
 
@@ -69,12 +46,17 @@ async fn main() {
 
     let config_result = match host_kind.as_str() {
         "executor" => {
-            get_config::<ExecutorConfig>(ip, identifier, &node_config_endpoint, &config_file_path)
+            pull_to_file::<ExecutorConfig>(ip, identifier, &node_config_endpoint, &config_file_path)
                 .await
         }
         _ => {
-            get_config::<ValidatorConfig>(ip, identifier, &node_config_endpoint, &config_file_path)
-                .await
+            pull_to_file::<ValidatorConfig>(
+                ip,
+                identifier,
+                &node_config_endpoint,
+                &config_file_path,
+            )
+            .await
         }
     };
 

--- a/testnet/cfgsync/src/bin/cfgsync-server.rs
+++ b/testnet/cfgsync/src/bin/cfgsync-server.rs
@@ -1,132 +1,12 @@
-use std::{fs, net::Ipv4Addr, num::NonZero, path::PathBuf, process, sync::Arc, time::Duration};
+use std::{path::PathBuf, process};
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
-use cfgsync::{
-    config::Host,
-    repo::{ConfigRepo, RepoResponse},
-};
+use cfgsync::server::{cfgsync_app, CfgSyncConfig};
 use clap::Parser;
-use nomos_tracing_service::TracingSettings;
-use serde::{Deserialize, Serialize};
-use tests::{
-    nodes::{executor::create_executor_config, validator::create_validator_config},
-    topology::configs::{consensus::ConsensusParams, da::DaParams},
-};
-use tokio::sync::oneshot::channel;
 
 #[derive(Parser, Debug)]
 #[command(about = "CfgSync")]
 struct Args {
     config: PathBuf,
-}
-
-#[derive(Debug, Deserialize)]
-struct CfgSyncConfig {
-    port: u16,
-    n_hosts: usize,
-    timeout: u64,
-
-    // ConsensusConfig related parameters
-    security_param: NonZero<u32>,
-    active_slot_coeff: f64,
-
-    // DaConfig related parameters
-    subnetwork_size: usize,
-    dispersal_factor: usize,
-    num_samples: u16,
-    num_subnets: u16,
-    old_blobs_check_interval_secs: u64,
-    blobs_validity_duration_secs: u64,
-    global_params_path: String,
-
-    // Tracing params
-    tracing_settings: TracingSettings,
-}
-
-impl CfgSyncConfig {
-    fn load_from_file(file_path: &PathBuf) -> Result<Self, String> {
-        let config_content = fs::read_to_string(file_path)
-            .map_err(|err| format!("Failed to read config file: {}", err))?;
-        serde_yaml::from_str(&config_content)
-            .map_err(|err| format!("Failed to parse config file: {}", err))
-    }
-
-    fn to_consensus_params(&self) -> ConsensusParams {
-        ConsensusParams {
-            n_participants: self.n_hosts,
-            security_param: self.security_param,
-            active_slot_coeff: self.active_slot_coeff,
-        }
-    }
-
-    fn to_da_params(&self) -> DaParams {
-        let default = DaParams::default();
-        DaParams {
-            subnetwork_size: self.subnetwork_size,
-            dispersal_factor: self.dispersal_factor,
-            num_samples: self.num_samples,
-            num_subnets: self.num_subnets,
-            old_blobs_check_interval: Duration::from_secs(self.old_blobs_check_interval_secs),
-            blobs_validity_duration: Duration::from_secs(self.blobs_validity_duration_secs),
-            global_params_path: self.global_params_path.clone(),
-            policy_settings: default.policy_settings,
-            monitor_settings: default.monitor_settings,
-            balancer_interval: default.balancer_interval,
-            redial_cooldown: default.redial_cooldown,
-        }
-    }
-
-    fn to_tracing_settings(&self) -> TracingSettings {
-        self.tracing_settings.clone()
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-struct ClientIp {
-    ip: Ipv4Addr,
-    identifier: String,
-}
-
-async fn validator_config(
-    State(config_repo): State<Arc<ConfigRepo>>,
-    Json(payload): Json<ClientIp>,
-) -> impl IntoResponse {
-    let ClientIp { ip, identifier } = payload;
-
-    let (reply_tx, reply_rx) = channel();
-    config_repo.register(Host::default_validator_from_ip(ip, identifier), reply_tx);
-
-    match reply_rx.await {
-        Ok(config_response) => match config_response {
-            RepoResponse::Config(config) => {
-                let config = create_validator_config(*config);
-                (StatusCode::OK, Json(config)).into_response()
-            }
-            RepoResponse::Timeout => (StatusCode::REQUEST_TIMEOUT).into_response(),
-        },
-        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Error receiving config").into_response(),
-    }
-}
-
-async fn executor_config(
-    State(config_repo): State<Arc<ConfigRepo>>,
-    Json(payload): Json<ClientIp>,
-) -> impl IntoResponse {
-    let ClientIp { ip, identifier } = payload;
-
-    let (reply_tx, reply_rx) = channel();
-    config_repo.register(Host::default_executor_from_ip(ip, identifier), reply_tx);
-
-    match reply_rx.await {
-        Ok(config_response) => match config_response {
-            RepoResponse::Config(config) => {
-                let config = create_executor_config(*config);
-                (StatusCode::OK, Json(config)).into_response()
-            }
-            RepoResponse::Timeout => (StatusCode::REQUEST_TIMEOUT).into_response(),
-        },
-        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Error receiving config").into_response(),
-    }
 }
 
 #[tokio::main]
@@ -137,24 +17,12 @@ async fn main() {
         eprintln!("{}", err);
         process::exit(1);
     });
-    let consensus_params = config.to_consensus_params();
-    let da_params = config.to_da_params();
-    let tracing_settings = config.to_tracing_settings();
 
-    let config_repo = ConfigRepo::new(
-        config.n_hosts,
-        consensus_params,
-        da_params,
-        tracing_settings,
-        Duration::from_secs(config.timeout),
-    );
-    let app = Router::new()
-        .route("/validator", post(validator_config))
-        .route("/executor", post(executor_config))
-        .with_state(config_repo.clone());
+    let port = config.port;
+    let app = cfgsync_app(config.into());
 
-    println!("Server running on http://0.0.0.0:{}", config.port);
-    axum::Server::bind(&format!("0.0.0.0:{}", config.port).parse().unwrap())
+    println!("Server running on http://0.0.0.0:{}", port);
+    axum::Server::bind(&format!("0.0.0.0:{}", port).parse().unwrap())
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/testnet/cfgsync/src/client.rs
+++ b/testnet/cfgsync/src/client.rs
@@ -1,0 +1,31 @@
+// std
+use std::net::Ipv4Addr;
+// crates
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+// internal
+use crate::server::ClientIp;
+
+pub async fn get_config<Config: DeserializeOwned>(
+    ip: Ipv4Addr,
+    identifier: String,
+    url: &str,
+) -> Result<Config, String> {
+    let client = Client::new();
+
+    let response = client
+        .post(url)
+        .json(&ClientIp { ip, identifier })
+        .send()
+        .await
+        .map_err(|err| format!("Failed to send IP announcement: {}", err))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Server error: {:?}", response.status()));
+    }
+
+    response
+        .json::<Config>()
+        .await
+        .map_err(|err| format!("Failed to parse response: {}", err))
+}

--- a/testnet/cfgsync/src/client.rs
+++ b/testnet/cfgsync/src/client.rs
@@ -1,9 +1,8 @@
-// std
 use std::net::Ipv4Addr;
-// crates
+
 use reqwest::Client;
 use serde::de::DeserializeOwned;
-// internal
+
 use crate::server::ClientIp;
 
 pub async fn get_config<Config: DeserializeOwned>(

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -10,7 +10,7 @@ use tests::topology::configs::{
     api::GeneralApiConfig,
     blend::create_blend_configs,
     consensus::{create_consensus_configs, ConsensusParams},
-    da::{create_da_configs, DaParams},
+    da::{create_da_configs, DaParams, GeneralDaConfig},
     network::create_network_configs,
     time::default_time_config,
     tracing::GeneralTracingConfig,
@@ -86,17 +86,10 @@ pub fn create_node_configs(
     let mut configured_hosts = HashMap::new();
 
     // Rebuild DA address lists.
-    let peer_addresses = da_configs[0].addresses.clone();
     let host_network_init_peers = update_network_init_peers(hosts.clone());
-    let host_da_peer_addresses = update_da_peer_addresses(hosts.clone(), peer_addresses);
+    let host_da_peer_addresses = update_da_peer_addresses(hosts.clone(), da_configs.clone());
     let host_blend_membership =
         update_blend_membership(hosts.clone(), blend_configs[0].membership.clone());
-
-    let new_peer_addresses: HashMap<PeerId, Multiaddr> = host_da_peer_addresses
-        .clone()
-        .into_iter()
-        .map(|(peer_id, (multiaddr, _))| (peer_id, multiaddr))
-        .collect();
 
     for (i, host) in hosts.into_iter().enumerate() {
         let consensus_config = consensus_configs[i].to_owned();
@@ -104,7 +97,7 @@ pub fn create_node_configs(
 
         // DA Libp2p network config.
         let mut da_config = da_configs[i].to_owned();
-        da_config.addresses = new_peer_addresses.clone();
+        da_config.addresses = host_da_peer_addresses.clone();
         da_config.listening_address = Multiaddr::from_str(&format!(
             "/ip4/0.0.0.0/udp/{}/quic-v1",
             host.da_network_port,
@@ -156,19 +149,19 @@ fn update_network_init_peers(hosts: Vec<Host>) -> Vec<Multiaddr> {
 
 fn update_da_peer_addresses(
     hosts: Vec<Host>,
-    peer_addresses: HashMap<PeerId, Multiaddr>,
-) -> HashMap<PeerId, (Multiaddr, Ipv4Addr)> {
-    peer_addresses
+    da_configs: Vec<GeneralDaConfig>,
+) -> HashMap<PeerId, Multiaddr> {
+    da_configs
         .into_iter()
         .zip(hosts)
-        .map(|((peer_id, _), host)| {
+        .map(|(config, host)| {
             let new_multiaddr = Multiaddr::from_str(&format!(
                 "/ip4/{}/udp/{}/quic-v1",
                 host.ip, host.da_network_port,
             ))
             .unwrap();
 
-            (peer_id, (new_multiaddr, host.ip))
+            (config.peer_id, new_multiaddr)
         })
         .collect()
 }
@@ -236,14 +229,15 @@ fn update_tracing_identifier(
 mod cfgsync_tests {
     use std::{net::Ipv4Addr, num::NonZero, str::FromStr, time::Duration};
 
-    use nomos_libp2p::{Multiaddr, Protocol};
+    use nomos_libp2p::{ed25519, libp2p, Multiaddr, PeerId, Protocol};
     use nomos_tracing_service::{
         FilterLayer, LoggerLayer, MetricsLayer, TracingLayer, TracingSettings,
     };
-    use tests::topology::configs::{consensus::ConsensusParams, da::DaParams};
+    use tests::topology::configs::{consensus::ConsensusParams, da::DaParams, GeneralConfig};
     use tracing::Level;
 
     use super::{create_node_configs, Host, HostKind};
+    use crate::tests::extract_ip;
 
     #[test]
     fn basic_ip_list() {
@@ -295,7 +289,22 @@ mod cfgsync_tests {
             assert_eq!(network_port, host.network_port);
             assert_eq!(da_network_port, host.da_network_port);
             assert_eq!(blend_port, host.blend_port);
+
+            check_da_membership(host.ip, config);
         }
+    }
+
+    pub fn check_da_membership(my_ip: Ipv4Addr, config: &GeneralConfig) {
+        let key = libp2p::identity::Keypair::from(ed25519::Keypair::from(
+            config.da_config.node_key.clone(),
+        ));
+        let my_peer_id = PeerId::from_public_key(&key.public());
+        let my_multiaddr = config.da_config.addresses.get(&my_peer_id).unwrap();
+        let my_multiaddr_ip = extract_ip(my_multiaddr).unwrap();
+        assert_eq!(
+            my_ip, my_multiaddr_ip,
+            "DA membership ip doesn't match host ip"
+        );
     }
 
     fn extract_port(multiaddr: &Multiaddr) -> u16 {

--- a/testnet/cfgsync/src/lib.rs
+++ b/testnet/cfgsync/src/lib.rs
@@ -7,6 +7,7 @@ pub mod server;
 mod tests {
     use std::{
         net::{Ipv4Addr, SocketAddr},
+        num::NonZero,
         str::FromStr,
         time::Duration,
     };
@@ -14,6 +15,7 @@ mod tests {
     use futures::future::join_all;
     use nomos_libp2p::{ed25519, libp2p, Multiaddr, PeerId, Protocol};
     use nomos_node::Config as ValidatorConfig;
+    use nomos_tracing_service::TracingSettings;
     use tokio::time::timeout;
 
     use crate::{
@@ -27,7 +29,18 @@ mod tests {
         let config = CfgSyncConfig {
             n_hosts,
             timeout: 10,
-            ..Default::default()
+            port: 16,
+            security_param: NonZero::new(1).unwrap(),
+            active_slot_coeff: 0.0,
+            subnetwork_size: 0,
+            dispersal_factor: 0,
+            num_samples: 0,
+            num_subnets: 0,
+            old_blobs_check_interval_secs: 0,
+            blobs_validity_duration_secs: 0,
+            global_params_path: "".into(),
+            balancer_interval_secs: 0,
+            tracing_settings: TracingSettings::default(),
         };
 
         let app_addr: SocketAddr = "127.0.0.1:4321".parse().unwrap();

--- a/testnet/cfgsync/src/lib.rs
+++ b/testnet/cfgsync/src/lib.rs
@@ -1,2 +1,95 @@
+pub mod client;
 pub mod config;
 pub mod repo;
+pub mod server;
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        str::FromStr,
+        time::Duration,
+    };
+
+    use futures::future::join_all;
+    use nomos_libp2p::{ed25519, libp2p, Multiaddr, PeerId, Protocol};
+    use nomos_node::Config as ValidatorConfig;
+    use tokio::time::timeout;
+
+    use crate::{
+        client::get_config,
+        server::{cfgsync_app, CfgSyncConfig},
+    };
+
+    #[tokio::test]
+    async fn test_address_book() {
+        let n_hosts = 4;
+        let config = CfgSyncConfig {
+            n_hosts,
+            timeout: 10,
+            ..Default::default()
+        };
+
+        let app_addr: SocketAddr = "127.0.0.1:4321".parse().unwrap();
+        let app = cfgsync_app(config.into());
+
+        let (tx, app_ready) = tokio::sync::oneshot::channel();
+        let _server_task = tokio::spawn(async move {
+            tx.send(()).unwrap();
+            axum::Server::bind(&app_addr)
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        assert!(timeout(Duration::from_millis(50), app_ready).await.is_ok());
+
+        let client_fn = |i| async move {
+            let ip = Ipv4Addr::from_str(&format!("1.0.0.{i}")).unwrap();
+            (
+                ip,
+                get_config::<ValidatorConfig>(
+                    ip,
+                    ip.to_string(),
+                    &format!("http://{app_addr}/validator"),
+                )
+                .await,
+            )
+        };
+
+        let tasks: Vec<_> = (0..n_hosts).map(client_fn).collect();
+        let results = join_all(tasks).await;
+
+        for (my_ip, config) in results.into_iter() {
+            assert_eq_da_membership(my_ip, &config.unwrap());
+        }
+    }
+
+    pub fn assert_eq_da_membership(my_ip: Ipv4Addr, config: &ValidatorConfig) {
+        let key = libp2p::identity::Keypair::from(ed25519::Keypair::from(
+            config.da_network.backend.node_key.clone(),
+        ));
+        let my_peer_id = PeerId::from_public_key(&key.public());
+        let my_multiaddr = config
+            .da_network
+            .backend
+            .addresses
+            .get(&my_peer_id)
+            .unwrap();
+        let my_multiaddr_ip = extract_ip(my_multiaddr).unwrap();
+        assert_eq!(
+            my_ip, my_multiaddr_ip,
+            "DA membership ip doesn't match host ip"
+        );
+    }
+
+    pub fn extract_ip(multiaddr: &Multiaddr) -> Option<Ipv4Addr> {
+        for protocol in multiaddr.iter() {
+            match protocol {
+                Protocol::Ip4(ip) => return Some(ip),
+                _ => continue,
+            }
+        }
+        None
+    }
+}

--- a/testnet/cfgsync/src/repo.rs
+++ b/testnet/cfgsync/src/repo.rs
@@ -8,8 +8,10 @@ use nomos_tracing_service::TracingSettings;
 use tests::topology::configs::{consensus::ConsensusParams, da::DaParams, GeneralConfig};
 use tokio::{sync::oneshot::Sender, time::timeout};
 
-use crate::config::{create_node_configs, Host};
-use crate::server::CfgSyncConfig;
+use crate::{
+    config::{create_node_configs, Host},
+    server::CfgSyncConfig,
+};
 
 pub enum RepoResponse {
     Config(Box<GeneralConfig>),

--- a/testnet/cfgsync/src/server.rs
+++ b/testnet/cfgsync/src/server.rs
@@ -1,0 +1,144 @@
+// std
+use std::fs;
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+// crates
+use axum::extract::State;
+use axum::Json;
+use axum::{http::StatusCode, response::IntoResponse, routing::post, Router};
+use nomos_da_network_core::swarm::{DAConnectionMonitorSettings, DAConnectionPolicySettings};
+use nomos_tracing_service::TracingSettings;
+use serde::{Deserialize, Serialize};
+use tests::nodes::executor::create_executor_config;
+use tests::nodes::validator::create_validator_config;
+use tests::topology::configs::consensus::ConsensusParams;
+use tests::topology::configs::da::DaParams;
+use tokio::sync::oneshot::channel;
+// internal
+use crate::config::Host;
+use crate::repo::{ConfigRepo, RepoResponse};
+
+#[derive(Default, Debug, Deserialize)]
+pub struct CfgSyncConfig {
+    pub port: u16,
+    pub n_hosts: usize,
+    pub timeout: u64,
+
+    // ConsensusConfig related parameters
+    pub security_param: u32,
+    pub active_slot_coeff: f64,
+
+    // DaConfig related parameters
+    pub subnetwork_size: usize,
+    pub dispersal_factor: usize,
+    pub num_samples: u16,
+    pub num_subnets: u16,
+    pub old_blobs_check_interval_secs: u64,
+    pub blobs_validity_duration_secs: u64,
+    pub global_params_path: String,
+    pub balancer_interval_secs: u64,
+
+    // Tracing params
+    pub tracing_settings: TracingSettings,
+}
+
+impl CfgSyncConfig {
+    pub fn load_from_file(file_path: &PathBuf) -> Result<Self, String> {
+        let config_content = fs::read_to_string(file_path)
+            .map_err(|err| format!("Failed to read config file: {}", err))?;
+        serde_yaml::from_str(&config_content)
+            .map_err(|err| format!("Failed to parse config file: {}", err))
+    }
+
+    pub fn to_consensus_params(&self) -> ConsensusParams {
+        ConsensusParams {
+            n_participants: self.n_hosts,
+            security_param: self.security_param,
+            active_slot_coeff: self.active_slot_coeff,
+        }
+    }
+
+    pub fn to_da_params(&self) -> DaParams {
+        DaParams {
+            subnetwork_size: self.subnetwork_size,
+            dispersal_factor: self.dispersal_factor,
+            num_samples: self.num_samples,
+            num_subnets: self.num_subnets,
+            old_blobs_check_interval: Duration::from_secs(self.old_blobs_check_interval_secs),
+            blobs_validity_duration: Duration::from_secs(self.blobs_validity_duration_secs),
+            global_params_path: self.global_params_path.clone(),
+            policy_settings: DAConnectionPolicySettings {
+                min_dispersal_peers: self.num_subnets as usize,
+                min_replication_peers: self.dispersal_factor,
+                max_dispersal_failures: 0,
+                max_sampling_failures: 0,
+                max_replication_failures: 0,
+                malicious_threshold: 0,
+            },
+            monitor_settings: DAConnectionMonitorSettings::default(),
+            balancer_interval: Duration::from_secs(self.balancer_interval_secs),
+            redial_cooldown: Duration::ZERO,
+        }
+    }
+
+    pub fn to_tracing_settings(&self) -> TracingSettings {
+        self.tracing_settings.clone()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ClientIp {
+    pub ip: Ipv4Addr,
+    pub identifier: String,
+}
+
+async fn validator_config(
+    State(config_repo): State<Arc<ConfigRepo>>,
+    Json(payload): Json<ClientIp>,
+) -> impl IntoResponse {
+    let ClientIp { ip, identifier } = payload;
+
+    let (reply_tx, reply_rx) = channel();
+    config_repo.register(Host::default_validator_from_ip(ip, identifier), reply_tx);
+
+    match reply_rx.await {
+        Ok(config_response) => match config_response {
+            RepoResponse::Config(config) => {
+                let config = create_validator_config(*config);
+                (StatusCode::OK, Json(config)).into_response()
+            }
+            RepoResponse::Timeout => (StatusCode::REQUEST_TIMEOUT).into_response(),
+        },
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Error receiving config").into_response(),
+    }
+}
+
+async fn executor_config(
+    State(config_repo): State<Arc<ConfigRepo>>,
+    Json(payload): Json<ClientIp>,
+) -> impl IntoResponse {
+    let ClientIp { ip, identifier } = payload;
+
+    let (reply_tx, reply_rx) = channel();
+    config_repo.register(Host::default_executor_from_ip(ip, identifier), reply_tx);
+
+    match reply_rx.await {
+        Ok(config_response) => match config_response {
+            RepoResponse::Config(config) => {
+                let config = create_executor_config(*config);
+                (StatusCode::OK, Json(config)).into_response()
+            }
+            RepoResponse::Timeout => (StatusCode::REQUEST_TIMEOUT).into_response(),
+        },
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Error receiving config").into_response(),
+    }
+}
+
+pub fn cfgsync_app(config_repo: Arc<ConfigRepo>) -> Router {
+    Router::new()
+        .route("/validator", post(validator_config))
+        .route("/executor", post(executor_config))
+        .with_state(config_repo.clone())
+}

--- a/testnet/cfgsync/src/server.rs
+++ b/testnet/cfgsync/src/server.rs
@@ -1,33 +1,28 @@
-// std
-use std::fs;
-use std::net::Ipv4Addr;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
-// crates
-use axum::extract::State;
-use axum::Json;
-use axum::{http::StatusCode, response::IntoResponse, routing::post, Router};
+use std::{fs, net::Ipv4Addr, num::NonZero, path::PathBuf, sync::Arc, time::Duration};
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use nomos_da_network_core::swarm::{DAConnectionMonitorSettings, DAConnectionPolicySettings};
 use nomos_tracing_service::TracingSettings;
 use serde::{Deserialize, Serialize};
-use tests::nodes::executor::create_executor_config;
-use tests::nodes::validator::create_validator_config;
-use tests::topology::configs::consensus::ConsensusParams;
-use tests::topology::configs::da::DaParams;
+use tests::{
+    nodes::{executor::create_executor_config, validator::create_validator_config},
+    topology::configs::{consensus::ConsensusParams, da::DaParams},
+};
 use tokio::sync::oneshot::channel;
-// internal
-use crate::config::Host;
-use crate::repo::{ConfigRepo, RepoResponse};
 
-#[derive(Default, Debug, Deserialize)]
+use crate::{
+    config::Host,
+    repo::{ConfigRepo, RepoResponse},
+};
+
+#[derive(Debug, Deserialize)]
 pub struct CfgSyncConfig {
     pub port: u16,
     pub n_hosts: usize,
     pub timeout: u64,
 
     // ConsensusConfig related parameters
-    pub security_param: u32,
+    pub security_param: NonZero<u32>,
     pub active_slot_coeff: f64,
 
     // DaConfig related parameters

--- a/tests/src/topology/configs/da.rs
+++ b/tests/src/topology/configs/da.rs
@@ -62,7 +62,7 @@ impl Default for DaParams {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct GeneralDaConfig {
     pub node_key: ed25519::SecretKey,
     pub peer_id: PeerId,


### PR DESCRIPTION
## 1. What does this PR implement?

It was observed that after cfgsync (used in testnet to create and distribute node configs to hosts that register) updates the da peer addressbook to host ip, the peer ids were shuffled and didn't correspond to actual peer id that is assigned to host.

The issue was in `fn update_da_peer_addresses`, hashmap was iterated and the iteration index was used to pick host, believing it will correspond to the peerid assignation order.

- Added tests and fix for this issue.
- For more ergonomic tests, cfgsync server and client modules were extracted from cfgsync binaries.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
