### PR TITLE
chore: pin Rust toolchain version

### DIFF
--- a/.github/actions/setup-cargo-cache/action.yml
+++ b/.github/actions/setup-cargo-cache/action.yml
@@ -13,9 +13,6 @@ description: Set up cache read operations for Cargo artifacts
 runs:
   using: composite
   steps:
-    - name: Force toolchain update
-      shell: bash
-      run: rustup update
     - name: Set up Cargo cache
       uses: actions/cache/restore@v4
       with:

--- a/.github/rust_update_issue_template.md
+++ b/.github/rust_update_issue_template.md
@@ -1,5 +1,5 @@
 ---
-title: [CI-TEST] Update Rust to version {{ env.RUST_VERSION }}
+title: "[CI-TEST] Update Rust to version {{ env.RUST_VERSION }}"
 labels: "ci-actions"
 ---
 Update Rust to version {{ env.RUST_VERSION }}

--- a/.github/rust_update_issue_template.md
+++ b/.github/rust_update_issue_template.md
@@ -1,5 +1,5 @@
 ---
-title: "[CI-TEST] Update Rust to version {{ env.RUST_VERSION }}"
+title: "[CI GENERATED] Update Rust to version {{ env.RUST_VERSION }}"
 labels: "ci-actions"
 ---
-Update Rust to version {{ env.RUST_VERSION }}
+Update Rust to version {{ env.RUST_VERSION }}.

--- a/.github/rust_update_issue_template.md
+++ b/.github/rust_update_issue_template.md
@@ -1,0 +1,5 @@
+---
+title: [CI-TEST] Update Rust to version {{ env.RUST_VERSION }}
+labels: ci-actions
+---
+Update Rust to version {{ env.RUST_VERSION }}

--- a/.github/rust_update_issue_template.md
+++ b/.github/rust_update_issue_template.md
@@ -1,5 +1,5 @@
 ---
 title: [CI-TEST] Update Rust to version {{ env.RUST_VERSION }}
-labels: ci-actions
+labels: "ci-actions"
 ---
 Update Rust to version {{ env.RUST_VERSION }}

--- a/.github/workflows/rust-latest-version-check.yml
+++ b/.github/workflows/rust-latest-version-check.yml
@@ -1,12 +1,11 @@
-name: Check for new Rust versions
+name: Check for a new Rust version
 
 on:
-  push:
-    branches: 
-      - aa/rustc-version-pin
+  schedule:
+    - cron: "0 3 * * *"
 
 jobs:
-  check-latest-release:
+  check-latest-version:
     name: Fetch and compare latest Rust release
     runs-on: ubuntu-latest
     steps:
@@ -23,33 +22,32 @@ jobs:
         run: |
           INSTALLED=$(cargo --version | awk '{print $2}')
           echo "Installed Rust version: $INSTALLED"
-          # echo "VERSION=$INSTALLED" >> $GITHUB_OUTPUT
-          echo "VERSION=1.84.0" >> $GITHUB_OUTPUT
+          echo "VERSION=$INSTALLED" >> $GITHUB_OUTPUT
       - name: Compare latest and local Rust versions
         id: compare-versions
         run: |
           if [ "${{ steps.latest-version.outputs.VERSION }}" != "${{ steps.installed-version.outputs.VERSION }}" ]; then
-            NEW_VERSION=true
+            NEW_VERSION_AVAILABLE=true
           else
-            NEW_VERSION=false
+            NEW_VERSION_AVAILABLE=false
           fi
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "NEW_VERSION_AVAILABLE=$NEW_VERSION_AVAILABLE" >> $GITHUB_OUTPUT
     outputs:
-      new-version-available: ${{ steps.compare-versions.outputs.NEW_VERSION }}
+      new-version-available: ${{ steps.compare-versions.outputs.NEW_VERSION_AVAILABLE }}
       new-version: ${{ steps.latest-version.outputs.VERSION }}
-  notify-new-release:
-    name: Notify of new Rust release
+  notify-new-version:
+    name: Notify of new Rust version
     runs-on: ubuntu-latest
-    needs: check-latest-release
-    if: ${{ needs.check-latest-release.outputs.new-version-available == 'true' }}
+    needs: check-latest-version
+    if: ${{ needs.check-latest-version.outputs.new-version-available == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Create a GH issue
+      - name: Create a GH issue (if it does not exist)
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUST_VERSION: ${{ needs.check-latest-release.outputs.new-version }}
+          RUST_VERSION: ${{ needs.check-latest-version.outputs.new-version }}
         with:
           assignees: danielSanchezQ, ntn-x2
           filename: ./.github/rust_update_issue_template.md

--- a/.github/workflows/rust-stable-check.yml
+++ b/.github/workflows/rust-stable-check.yml
@@ -25,19 +25,20 @@ jobs:
           echo "Installed Rust version: $INSTALLED"
           echo "VERSION=1.84.0" >> $GITHUB_OUTPUT
       - name: Compare latest and local Rust versions
+        id: compare-versions
         run: |
           if [ "${{ steps.latest-version.outputs.VERSION }}" != "${{ steps.installed-version.outputs.VERSION }}" ]; then
             NEW_VERSION=true
-            echo "There's a new version."
           else
             NEW_VERSION=false
-            echo "There's no new version."
           fi
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+    outputs:
+      new-version: ${{ steps.compare-versions.outputs.NEW_VERSION }}
   notify-new-release:
     name: Notify of new Rust release
     runs-on: ubuntu-latest
     needs: check-latest-release
-    if: ${{ needs.check-latest-release.outputs.NEW_VERSION == 'true' }}
+    if: ${{ needs.check-latest-release.outputs.new-version == 'true' }}
     steps:
       - run: echo "Ok"

--- a/.github/workflows/rust-stable-check.yml
+++ b/.github/workflows/rust-stable-check.yml
@@ -28,8 +28,10 @@ jobs:
         run: |
           if [ "${{ steps.latest-version.outputs.VERSION }}" != "${{ steps.installed-version.outputs.VERSION }}" ]; then
             NEW_VERSION=true
+            echo "There's a new version."
           else
             NEW_VERSION=false
+            echo "There's no new version."
           fi
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
   notify-new-release:

--- a/.github/workflows/rust-stable-check.yml
+++ b/.github/workflows/rust-stable-check.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           INSTALLED=$(cargo --version | awk '{print $2}')
           echo "Installed Rust version: $INSTALLED"
-          echo "VERSION=$INSTALLED" >> $GITHUB_OUTPUT
+          echo "VERSION=1.84.0" >> $GITHUB_OUTPUT
       - name: Compare latest and local Rust versions
         run: |
           if [ "${{ steps.latest-version.outputs.VERSION }}" != "${{ steps.installed-version.outputs.VERSION }}" ]; then

--- a/.github/workflows/rust-stable-check.yml
+++ b/.github/workflows/rust-stable-check.yml
@@ -1,0 +1,41 @@
+name: Check for new Rust versions
+
+on:
+  push:
+    branches: 
+      - aa/rustc-version-pin
+
+jobs:
+  check-latest-release:
+    name: Fetch and compare latest Rust release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Fetch latest Rust release
+        id: latest-version
+        run: |
+          LATEST=$(curl -s https://api.github.com/repos/rust-lang/rust/releases/latest | jq -r .tag_name)
+          echo "Latest Rust version: $LATEST"
+          echo "VERSION=$LATEST" >> $GITHUB_OUTPUT
+      - name: Retrieve local Rust version
+        id: installed-version
+        run: |
+          INSTALLED=$(cargo --version | awk '{print $2}')
+          echo "Installed Rust version: $INSTALLED"
+          echo "VERSION=$INSTALLED" >> $GITHUB_OUTPUT
+      - name: Compare latest and local Rust versions
+        run: |
+          if [ "${{ steps.latest-version.outputs.VERSION }}" != "${{ steps.installed-version.outputs.VERSION }}" ]; then
+            NEW_VERSION=true
+          else
+            NEW_VERSION=false
+          fi
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+  notify-new-release:
+    name: Notify of new Rust release
+    runs-on: ubuntu-latest
+    needs: check-latest-release
+    if: ${{ needs.check-latest-release.outputs.NEW_VERSION == 'true' }}
+    steps:
+      - run: echo "Ok"

--- a/.github/workflows/rust-stable-check.yml
+++ b/.github/workflows/rust-stable-check.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           INSTALLED=$(cargo --version | awk '{print $2}')
           echo "Installed Rust version: $INSTALLED"
+          # echo "VERSION=$INSTALLED" >> $GITHUB_OUTPUT
           echo "VERSION=1.84.0" >> $GITHUB_OUTPUT
       - name: Compare latest and local Rust versions
         id: compare-versions
@@ -34,11 +35,23 @@ jobs:
           fi
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
     outputs:
-      new-version: ${{ steps.compare-versions.outputs.NEW_VERSION }}
+      new-version-available: ${{ steps.compare-versions.outputs.NEW_VERSION }}
+      new-version: ${{ steps.latest-version.outputs.VERSION }}
   notify-new-release:
     name: Notify of new Rust release
     runs-on: ubuntu-latest
     needs: check-latest-release
-    if: ${{ needs.check-latest-release.outputs.new-version == 'true' }}
+    if: ${{ needs.check-latest-release.outputs.new-version-available == 'true' }}
     steps:
-      - run: echo "Ok"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create a GH issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUST_VERSION: ${{ needs.check-latest-release.outputs.new-version }}
+        with:
+          assignees: danielSanchezQ, ntn-x2
+          filename: ./.github/workflows/rust_update_issue_template.md
+          update_existing: false
+          search_existing: all

--- a/.github/workflows/rust-stable-check.yml
+++ b/.github/workflows/rust-stable-check.yml
@@ -52,6 +52,6 @@ jobs:
           RUST_VERSION: ${{ needs.check-latest-release.outputs.new-version }}
         with:
           assignees: danielSanchezQ, ntn-x2
-          filename: ./.github/workflows/rust_update_issue_template.md
+          filename: ./.github/rust_update_issue_template.md
           update_existing: false
           search_existing: all

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.85"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85"
+channel = "1.85.0"


### PR DESCRIPTION
## 1. What does this PR implement?

* Pin the toolchain version to a specific version to avoid any overnight breaking changes in dependencies (since we also don't commit the `Cargo.lock` file)
* Introduce a cronjob action that checks for a new release compared to the one in the toolchain file, and create a new ticket only the first time it is detected. Example of a [successful run,](https://github.com/logos-co/nomos-node/actions/runs/13566503368), a [successful run for an existing ticket](https://github.com/logos-co/nomos-node/actions/runs/13566526760), and the [created ticket](https://github.com/logos-co/nomos-node/issues/1087).

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [ ] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [ ] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
