### PR TITLE
fix(risc0): Align risc0-build and risc0-zkvm with the host server version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ tests                    = { path = "./tests" }
 # External
 overwatch-derive = { git = "https://github.com/logos-co/Overwatch", rev = "86c7405" }
 overwatch-rs     = { git = "https://github.com/logos-co/Overwatch", rev = "86c7405" }
+risc0-zkvm       = "1.2.0"
 
 [workspace.package]
 license = "MIT or Apache-2.0"

--- a/ledger/nomos-ledger/Cargo.toml
+++ b/ledger/nomos-ledger/Cargo.toml
@@ -15,7 +15,7 @@ nomos-utils            = { workspace = true, optional = true }
 nomos_proof_statements = { workspace = true }
 rand                   = "0.8.5"
 rand_core              = "0.6.0"
-risc0-zkvm             = { version = "1.1", optional = true }
+risc0-zkvm             = { workspace = true, optional = true }
 rpds                   = "1"
 serde                  = { version = "1.0", features = ["derive"], optional = true }
 sha2                   = "0.10"

--- a/nomos-core/chain-defs/Cargo.toml
+++ b/nomos-core/chain-defs/Cargo.toml
@@ -23,14 +23,14 @@ nomos_proof_statements = { workspace = true }
 nomos_risc0_proofs     = { path = "../risc0_proofs" }
 once_cell              = "1.0"
 raptorq                = { version = "1.7", optional = true }
-risc0-zkvm             = "1.1"
+risc0-zkvm             = { workspace = true }
 serde                  = { version = "1.0", features = ["derive"] }
 thiserror              = "1.0"
 tracing                = "0.1"
 
 [dev-dependencies]
 rand       = "0.8"
-risc0-zkvm = { version = "1.1", features = ["prove"] }
+risc0-zkvm = { workspace = true, features = ["prove"] }
 
 [features]
 default = []

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -5,7 +5,7 @@ name    = "nomos_risc0_proofs"
 version = "0.1.0"
 
 [build-dependencies]
-risc0-build = { version = "1.0" }
+risc0-build = "1.2.0"
 
 [package.metadata.risc0]
 methods = ["bundle_balance", "covenant_nop", "proof_of_leadership", "ptx"]

--- a/nomos-core/risc0_proofs/bundle_balance/Cargo.toml
+++ b/nomos-core/risc0_proofs/bundle_balance/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 [dependencies]
 cl                     = { path = "../../cl" }
 nomos_proof_statements = { path = "../../proof_statements" }
-risc0-zkvm             = { version = "1.0", default-features = false, features = ['std'] }
+risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 serde                  = { version = "1.0", features = ["derive"] }
 
 [patch.crates-io]

--- a/nomos-core/risc0_proofs/covenant_nop/Cargo.toml
+++ b/nomos-core/risc0_proofs/covenant_nop/Cargo.toml
@@ -9,5 +9,5 @@ version = "0.1.0"
 [dependencies]
 cl                     = { path = "../../cl" }
 nomos_proof_statements = { path = "../../proof_statements" }
-risc0-zkvm             = { version = "1.0", default-features = false, features = ['std'] }
+risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 serde                  = { version = "1.0", features = ["derive"] }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 cl                     = { path = "../../cl" }
 crypto-bigint          = "0.5.5"
 nomos_proof_statements = { path = "../../proof_statements" }
-risc0-zkvm             = { version = "1.0", default-features = false, features = ['std'] }
+risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 serde                  = { version = "1.0", features = ["derive"] }
 sha2                   = "0.10"
 

--- a/nomos-core/risc0_proofs/ptx/Cargo.toml
+++ b/nomos-core/risc0_proofs/ptx/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 [dependencies]
 cl                     = { path = "../../cl" }
 nomos_proof_statements = { path = "../../proof_statements" }
-risc0-zkvm             = { version = "1.0", default-features = false, features = ['std'] }
+risc0-zkvm             = { version = "1.2.0", default-features = false, features = ['std'] }
 serde                  = { version = "1.0", features = ["derive"] }
 
 [patch.crates-io]

--- a/nomos-services/cryptarchia-consensus/Cargo.toml
+++ b/nomos-services/cryptarchia-consensus/Cargo.toml
@@ -27,7 +27,7 @@ nomos_proof_statements = { workspace = true }
 overwatch-rs           = { workspace = true }
 rand                   = "0.8"
 rand_chacha            = "0.3"
-risc0-zkvm             = "1.1"
+risc0-zkvm             = { workspace = true }
 serde                  = { version = "1", features = ["derive"] }
 serde_json             = { version = "1", optional = true }
 serde_with             = "3.0.0"


### PR DESCRIPTION
## 1. What does this PR implement?

Nomos ci, docker files and github actions pin the risc0 server to a specific verions. In the process of updating the risc0, our build dependencies needs to be updated as well. 
Caught in `nomos-e2e-tests` run, lost the original error message but it was about incompatible risc0 client and host server.

Since `nomos-core/risc0_proofs` is excluded from the workspace, the versions in that crate will need to be updated manually.

## 2. Does the code have enough context to be clearly understood?

N/A

## 3. Who are the specification authors and who is accountable for this PR?

@bacv @zeegomo 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
