### PR TITLE
chore: switch tests to use tokio ephemerals + nomos-da sampling tests to in memory

### DIFF
--- a/nomos-da/network/core/Cargo.toml
+++ b/nomos-da/network/core/Cargo.toml
@@ -28,7 +28,7 @@ tracing-subscriber       = "0.3.18"
 [dev-dependencies]
 blake2             = "0.10"
 kzgrs-backend      = { workspace = true, features = ["testutils"] }
-libp2p             = { version = "0.55", features = ["ed25519", "macros", "noise", "ping", "quic", "tcp", "yamux"] }
-libp2p-swarm-test  = "0.5.0"
+libp2p             = { version = "0.55", features = ["ed25519", "macros", "noise", "ping", "quic", "tcp", "yamux", "plaintext"] }
+libp2p-swarm-test  = { version = "0.5.0", features = ["tokio"]}
 tokio              = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/nomos-da/network/core/src/maintenance/balancer.rs
+++ b/nomos-da/network/core/src/maintenance/balancer.rs
@@ -195,11 +195,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_balancer_dials_provided_peers() {
-        let mut dialer = Swarm::new_ephemeral(|_| {
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| {
             ConnectionBalancerBehaviour::new(AddressBook::empty(), MockBalancer::default())
         });
 
-        let mut listener = Swarm::new_ephemeral(|_| {
+        let mut listener = Swarm::new_ephemeral_tokio(|_| {
             ConnectionBalancerBehaviour::new(AddressBook::empty(), MockBalancer::default())
         });
 
@@ -258,7 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_balancer_dials_all_peers_from_poll() {
-        let mut dialer = Swarm::new_ephemeral(|_| {
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| {
             ConnectionBalancerBehaviour::new(AddressBook::empty(), MockBalancer::default())
         });
 

--- a/nomos-da/network/core/src/maintenance/monitor.rs
+++ b/nomos-da/network/core/src/maintenance/monitor.rs
@@ -266,10 +266,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_dial_unhealthy_peer() {
-        let mut dialer = Swarm::new_ephemeral(|_| {
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| {
             ConnectionMonitorBehaviour::new(MockMonitor::default(), Duration::from_secs(1))
         });
-        let mut listener = Swarm::new_ephemeral(|_| {
+        let mut listener = Swarm::new_ephemeral_tokio(|_| {
             ConnectionMonitorBehaviour::new(MockMonitor::default(), Duration::from_secs(1))
         });
         listener.listen().with_memory_addr_external().await;
@@ -287,10 +287,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_can_dial_unhealthy_peer_after_cooldown() {
-        let mut dialer = Swarm::new_ephemeral(|_| {
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| {
             ConnectionMonitorBehaviour::new(MockMonitor::default(), Duration::from_millis(100))
         });
-        let mut listener = Swarm::new_ephemeral(|_| {
+        let mut listener = Swarm::new_ephemeral_tokio(|_| {
             ConnectionMonitorBehaviour::new(MockMonitor::default(), Duration::from_millis(100))
         });
         listener.listen().with_memory_addr_external().await;
@@ -314,10 +314,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_accept_malicious_peer() {
-        let mut dialer = Swarm::new_ephemeral(|_| {
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| {
             ConnectionMonitorBehaviour::new(MockMonitor::default(), Duration::ZERO)
         });
-        let mut listener = Swarm::new_ephemeral(|_| {
+        let mut listener = Swarm::new_ephemeral_tokio(|_| {
             ConnectionMonitorBehaviour::new(MockMonitor::default(), Duration::ZERO)
         });
         listener.listen().with_memory_addr_external().await;

--- a/nomos-da/network/core/src/protocols/dispersal/mod.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/mod.rs
@@ -40,10 +40,11 @@ pub mod test {
             .collect(),
         };
 
-        let mut executor = Swarm::new_ephemeral(|_| {
+        let mut executor = Swarm::new_ephemeral_tokio(|_| {
             DispersalExecutorBehaviour::new(neighbours.clone(), AddressBook::empty())
         });
-        let mut validator = Swarm::new_ephemeral(|_| DispersalValidatorBehaviour::new(neighbours));
+        let mut validator =
+            Swarm::new_ephemeral_tokio(|_| DispersalValidatorBehaviour::new(neighbours));
 
         validator.listen().with_memory_addr_external().await;
         executor

--- a/nomos-da/network/core/src/protocols/dispersal/mod.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/mod.rs
@@ -3,11 +3,6 @@ pub mod validator;
 
 #[cfg(test)]
 pub mod test {
-    use std::{
-        collections::HashSet,
-        sync::{Arc, Mutex},
-    };
-
     use futures::StreamExt;
     use kzgrs_backend::common::{blob::DaBlob, Column};
     use libp2p::{
@@ -35,18 +30,16 @@ pub mod test {
             .with_writer(TestWriter::default())
             .try_init();
 
-        let neighbours = AllNeighbours {
-            neighbours: Arc::new(Mutex::new(HashSet::new())),
-        };
+        let neighbours = AllNeighbours::default();
 
         let mut executor = Swarm::new_ephemeral_tokio(|k1| {
             let p1 = PeerId::from_public_key(&k1.public());
-            neighbours.neighbours.lock().unwrap().insert(p1);
+            neighbours.add_neighbour(p1);
             DispersalExecutorBehaviour::new(neighbours.clone(), AddressBook::empty())
         });
         let mut validator = Swarm::new_ephemeral_tokio(|k2| {
             let p2 = PeerId::from_public_key(&k2.public());
-            neighbours.neighbours.lock().unwrap().insert(p2);
+            neighbours.add_neighbour(p2);
             DispersalValidatorBehaviour::new(neighbours.clone())
         });
 

--- a/nomos-da/network/core/src/protocols/replication/mod.rs
+++ b/nomos-da/network/core/src/protocols/replication/mod.rs
@@ -3,10 +3,7 @@ pub mod handler;
 
 #[cfg(test)]
 mod test {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
+    use std::time::Duration;
 
     use blake2::{Blake2s256, Digest};
     use futures::StreamExt;
@@ -57,16 +54,10 @@ mod test {
         let k1 = libp2p::identity::Keypair::generate_ed25519();
         let k2 = libp2p::identity::Keypair::generate_ed25519();
 
-        let neighbours = AllNeighbours {
-            neighbours: Arc::new(Mutex::new(
-                [
-                    PeerId::from_public_key(&k1.public()),
-                    PeerId::from_public_key(&k2.public()),
-                ]
-                .into_iter()
-                .collect(),
-            )),
-        };
+        let neighbours = AllNeighbours::default();
+        neighbours.add_neighbour(PeerId::from_public_key(&k1.public()));
+        neighbours.add_neighbour(PeerId::from_public_key(&k2.public()));
+
         let mut swarm_1 = get_swarm(k1, neighbours.clone());
         let mut swarm_2 = get_swarm(k2, neighbours);
 

--- a/nomos-da/network/core/src/protocols/replication/mod.rs
+++ b/nomos-da/network/core/src/protocols/replication/mod.rs
@@ -3,7 +3,10 @@ pub mod handler;
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
     use blake2::{Blake2s256, Digest};
     use futures::StreamExt;
@@ -55,12 +58,14 @@ mod test {
         let k2 = libp2p::identity::Keypair::generate_ed25519();
 
         let neighbours = AllNeighbours {
-            neighbours: [
-                PeerId::from_public_key(&k1.public()),
-                PeerId::from_public_key(&k2.public()),
-            ]
-            .into_iter()
-            .collect(),
+            neighbours: Arc::new(Mutex::new(
+                [
+                    PeerId::from_public_key(&k1.public()),
+                    PeerId::from_public_key(&k2.public()),
+                ]
+                .into_iter()
+                .collect(),
+            )),
         };
         let mut swarm_1 = get_swarm(k1, neighbours.clone());
         let mut swarm_2 = get_swarm(k2, neighbours);

--- a/nomos-da/network/core/src/protocols/sampling/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/mod.rs
@@ -6,44 +6,18 @@ mod test {
 
     use futures::StreamExt;
     use kzgrs_backend::common::{blob::DaBlob, Column};
-    use libp2p::{
-        identity::Keypair, quic, swarm::SwarmEvent, Multiaddr, PeerId, Swarm, SwarmBuilder,
-    };
+    use libp2p::{identity::Keypair, swarm::SwarmEvent, Multiaddr, PeerId, Swarm};
     use log::debug;
+    use rand::Rng;
     use subnetworks_assignations::MembershipHandler;
     use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 
     use crate::{
-        address_book::AddressBook,
         protocols::sampling::behaviour::{BehaviourSampleRes, SamplingBehaviour, SamplingEvent},
-        test_utils::AllNeighbours,
+        test_utils::{new_swarm_in_memory, AllNeighbours},
         SubnetworkId,
     };
 
-    pub fn sampling_swarm(
-        key: Keypair,
-        membership: impl MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'static,
-        addresses: AddressBook,
-    ) -> Swarm<
-        SamplingBehaviour<impl MembershipHandler<Id = PeerId, NetworkId = SubnetworkId> + 'static>,
-    > {
-        SwarmBuilder::with_existing_identity(key)
-            .with_tokio()
-            .with_other_transport(|key| quic::tokio::Transport::new(quic::Config::new(key)))
-            .unwrap()
-            .with_behaviour(|key| {
-                SamplingBehaviour::new(
-                    PeerId::from_public_key(&key.public()),
-                    membership,
-                    addresses,
-                )
-            })
-            .unwrap()
-            .with_swarm_config(|cfg| {
-                cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
-            })
-            .build()
-    }
     #[tokio::test]
     async fn test_sampling_two_peers() {
         let _ = tracing_subscriber::fmt()
@@ -62,24 +36,30 @@ mod test {
             .collect(),
         };
 
-        let p1_address = "/ip4/127.0.0.1/udp/5080/quic-v1"
-            .parse::<Multiaddr>()
-            .unwrap()
-            .with_p2p(PeerId::from_public_key(&k1.public()))
-            .unwrap();
-        let p2_address = "/ip4/127.0.0.1/udp/5081/quic-v1"
-            .parse::<Multiaddr>()
-            .unwrap()
-            .with_p2p(PeerId::from_public_key(&k2.public()))
-            .unwrap();
+        // Generate a random peer ids not to conflict with other tests
+        let p1_id = rand::thread_rng().gen::<u64>();
+        let p1_address: Multiaddr = format!("/memory/{}", p1_id).parse().unwrap();
+
+        let p2_id = rand::thread_rng().gen::<u64>();
+        let p2_address: Multiaddr = format!("/memory/{}", p2_id).parse().unwrap();
+
         let p1_addresses = vec![(PeerId::from_public_key(&k2.public()), p2_address.clone())];
         let p2_addresses = vec![(PeerId::from_public_key(&k1.public()), p1_address.clone())];
-        let mut p1 = sampling_swarm(
-            k1.clone(),
+
+        let p1_behavior = SamplingBehaviour::new(
+            PeerId::from_public_key(&k1.public()),
             neighbours.clone(),
             p1_addresses.into_iter().collect(),
         );
-        let mut p2 = sampling_swarm(k2.clone(), neighbours, p2_addresses.into_iter().collect());
+
+        let mut p1 = new_swarm_in_memory(k1.clone(), p1_behavior);
+
+        let p2_behavior = SamplingBehaviour::new(
+            PeerId::from_public_key(&k2.public()),
+            neighbours.clone(),
+            p2_addresses.into_iter().collect(),
+        );
+        let mut p2 = new_swarm_in_memory(k2.clone(), p2_behavior);
 
         let request_sender_1 = p1.behaviour().sample_request_channel();
         let request_sender_2 = p2.behaviour().sample_request_channel();

--- a/nomos-da/network/core/src/protocols/sampling/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/mod.rs
@@ -2,7 +2,10 @@ pub mod behaviour;
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
     use futures::StreamExt;
     use kzgrs_backend::common::{blob::DaBlob, Column};
@@ -28,12 +31,14 @@ mod test {
         let k1 = Keypair::generate_ed25519();
         let k2 = Keypair::generate_ed25519();
         let neighbours = AllNeighbours {
-            neighbours: [
-                PeerId::from_public_key(&k1.public()),
-                PeerId::from_public_key(&k2.public()),
-            ]
-            .into_iter()
-            .collect(),
+            neighbours: Arc::new(Mutex::new(
+                [
+                    PeerId::from_public_key(&k1.public()),
+                    PeerId::from_public_key(&k2.public()),
+                ]
+                .into_iter()
+                .collect(),
+            )),
         };
 
         // Generate a random peer ids not to conflict with other tests

--- a/nomos-da/network/core/src/protocols/sampling/mod.rs
+++ b/nomos-da/network/core/src/protocols/sampling/mod.rs
@@ -2,10 +2,7 @@ pub mod behaviour;
 
 #[cfg(test)]
 mod test {
-    use std::{
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
+    use std::time::Duration;
 
     use futures::StreamExt;
     use kzgrs_backend::common::{blob::DaBlob, Column};
@@ -30,16 +27,9 @@ mod test {
             .try_init();
         let k1 = Keypair::generate_ed25519();
         let k2 = Keypair::generate_ed25519();
-        let neighbours = AllNeighbours {
-            neighbours: Arc::new(Mutex::new(
-                [
-                    PeerId::from_public_key(&k1.public()),
-                    PeerId::from_public_key(&k2.public()),
-                ]
-                .into_iter()
-                .collect(),
-            )),
-        };
+        let neighbours = AllNeighbours::default();
+        neighbours.add_neighbour(PeerId::from_public_key(&k1.public()));
+        neighbours.add_neighbour(PeerId::from_public_key(&k2.public()));
 
         // Generate a random peer ids not to conflict with other tests
         let p1_id = rand::thread_rng().gen::<u64>();

--- a/nomos-da/network/core/src/test_utils.rs
+++ b/nomos-da/network/core/src/test_utils.rs
@@ -1,10 +1,11 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
-use libp2p::core::{transport::MemoryTransport, upgrade::Version};
-use libp2p::PeerId;
-use libp2p::Transport;
-use libp2p::{identity::Keypair, swarm::NetworkBehaviour};
-use std::time::Duration;
+use libp2p::{
+    core::{transport::MemoryTransport, upgrade::Version},
+    identity::Keypair,
+    swarm::NetworkBehaviour,
+    PeerId, Transport,
+};
 use subnetworks_assignations::MembershipHandler;
 
 use crate::SubnetworkId;

--- a/nomos-da/network/core/src/test_utils.rs
+++ b/nomos-da/network/core/src/test_utils.rs
@@ -62,6 +62,6 @@ where
         .unwrap()
         .with_behaviour(|_| behavior)
         .unwrap()
-        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(20)))
         .build()
 }

--- a/nomos-da/network/core/src/test_utils.rs
+++ b/nomos-da/network/core/src/test_utils.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use libp2p::{
     core::{transport::MemoryTransport, upgrade::Version},
@@ -12,7 +16,7 @@ use crate::SubnetworkId;
 
 #[derive(Clone)]
 pub struct AllNeighbours {
-    pub neighbours: HashSet<PeerId>,
+    pub neighbours: Arc<Mutex<HashSet<PeerId>>>,
 }
 
 impl MembershipHandler for AllNeighbours {
@@ -28,11 +32,11 @@ impl MembershipHandler for AllNeighbours {
     }
 
     fn members_of(&self, _network_id: &Self::NetworkId) -> HashSet<Self::Id> {
-        self.neighbours.clone()
+        self.neighbours.lock().unwrap().clone()
     }
 
     fn members(&self) -> HashSet<Self::Id> {
-        self.neighbours.clone()
+        self.neighbours.lock().unwrap().clone()
     }
 
     fn last_subnetwork_id(&self) -> Self::NetworkId {

--- a/nomos-da/network/core/src/test_utils.rs
+++ b/nomos-da/network/core/src/test_utils.rs
@@ -16,7 +16,25 @@ use crate::SubnetworkId;
 
 #[derive(Clone)]
 pub struct AllNeighbours {
-    pub neighbours: Arc<Mutex<HashSet<PeerId>>>,
+    neighbours: Arc<Mutex<HashSet<PeerId>>>,
+}
+
+impl Default for AllNeighbours {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AllNeighbours {
+    pub fn new() -> Self {
+        Self {
+            neighbours: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub fn add_neighbour(&self, id: PeerId) {
+        self.neighbours.lock().unwrap().insert(id);
+    }
 }
 
 impl MembershipHandler for AllNeighbours {


### PR DESCRIPTION
## 1. What does this PR implement?

Update `libp2p_swarm_tests` usage to tokio version. 
Nomos-da sampling tests don't use in memory transport. 
Fix membership in tests.

## 2. Does the code have enough context to be clearly understood?

Yes, it is trivial.

## 3. Who are the specification authors and who is accountable for this PR?

N/A.

## 4. Is the specification accurate and complete?
N/A.

## 5. Does the implementation introduce changes in the specification?

N/A.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
