### PR TITLE
fix(DA): Dispersal service expects correct number of verifier responses

### DIFF
--- a/nomos-da/network/core/src/protocols/sampling/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/sampling/behaviour.rs
@@ -70,7 +70,11 @@ pub enum SamplingError {
     #[error("Malformed blob id: {blob_id:?}")]
     InvalidBlobId { peer_id: PeerId, blob_id: Vec<u8> },
     #[error("Blob not found: {blob_id:?}")]
-    BlobNotFound { peer_id: PeerId, blob_id: Vec<u8> },
+    BlobNotFound {
+        peer_id: PeerId,
+        blob_id: Vec<u8>,
+        subnetwork_id: SubnetworkId,
+    },
     #[error("Canceled response: {error}")]
     ResponseChannel { error: Canceled, peer_id: PeerId },
 }
@@ -153,9 +157,14 @@ impl Clone for SamplingError {
                 peer_id: *peer_id,
                 blob_id: blob_id.clone(),
             },
-            Self::BlobNotFound { blob_id, peer_id } => Self::BlobNotFound {
+            Self::BlobNotFound {
+                blob_id,
+                peer_id,
+                subnetwork_id,
+            } => Self::BlobNotFound {
                 peer_id: *peer_id,
                 blob_id: blob_id.clone(),
+                subnetwork_id: *subnetwork_id,
             },
         }
     }
@@ -192,6 +201,7 @@ pub enum BehaviourSampleRes {
     },
     SampleNotFound {
         blob_id: BlobId,
+        subnetwork_id: SubnetworkId,
     },
 }
 
@@ -201,13 +211,15 @@ impl From<BehaviourSampleRes> for sampling::SampleResponse {
             BehaviourSampleRes::SamplingSuccess { blob, blob_id, .. } => {
                 Self::Blob(common::LightBlob::new(blob_id, *blob))
             }
-            BehaviourSampleRes::SampleNotFound { blob_id } => {
-                Self::Error(sampling::SampleError::new(
-                    blob_id,
-                    sampling::SampleErrorType::NotFound,
-                    "Sample not found",
-                ))
-            }
+            BehaviourSampleRes::SampleNotFound {
+                blob_id,
+                subnetwork_id,
+            } => Self::Error(sampling::SampleError::new(
+                blob_id,
+                subnetwork_id,
+                sampling::SampleErrorType::NotFound,
+                "Sample not found",
+            )),
         }
     }
 }

--- a/nomos-da/network/messages/src/sampling.rs
+++ b/nomos-da/network/messages/src/sampling.rs
@@ -14,6 +14,7 @@ pub enum SampleErrorType {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SampleError {
     pub blob_id: BlobId,
+    pub column_idx: ColumnIndex,
     pub error_type: SampleErrorType,
     pub error_description: String,
 }
@@ -21,11 +22,13 @@ pub struct SampleError {
 impl SampleError {
     pub fn new(
         blob_id: BlobId,
+        column_idx: ColumnIndex,
         error_type: SampleErrorType,
         error_description: impl Into<String>,
     ) -> Self {
         Self {
             blob_id,
+            column_idx,
             error_type,
             error_description: error_description.into(),
         }

--- a/nomos-services/data-availability/dispersal/Cargo.toml
+++ b/nomos-services/data-availability/dispersal/Cargo.toml
@@ -20,4 +20,5 @@ rand                     = "0.8"
 serde                    = { version = "1.0", features = ["derive"] }
 subnetworks-assignations = { workspace = true }
 tokio                    = "1"
+tokio-stream             = "0.1.15"
 tracing                  = "0.1"

--- a/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
+++ b/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
@@ -1,14 +1,20 @@
-use std::{fmt::Debug, pin::Pin};
+use std::{collections::HashSet, fmt::Debug, pin::Pin, time::Duration};
 
 use futures::{stream::BoxStream, Stream, StreamExt};
 use kzgrs_backend::common::blob::DaBlob;
 use nomos_core::da::BlobId;
 use nomos_da_network_core::{
-    protocols::dispersal::executor::behaviour::DispersalExecutorEvent, PeerId, SubnetworkId,
+    protocols::{
+        dispersal::executor::behaviour::DispersalExecutorEvent, sampling::behaviour::SamplingError,
+    },
+    PeerId, SubnetworkId,
 };
 use nomos_da_network_service::{
-    backends::libp2p::executor::{
-        DaNetworkEvent, DaNetworkEventKind, DaNetworkExecutorBackend, ExecutorDaNetworkMessage,
+    backends::libp2p::{
+        common::SamplingEvent,
+        executor::{
+            DaNetworkEvent, DaNetworkEventKind, DaNetworkExecutorBackend, ExecutorDaNetworkMessage,
+        },
     },
     DaNetworkMsg, NetworkService,
 };
@@ -31,6 +37,36 @@ where
         + 'static,
 {
     outbound_relay: OutboundRelay<DaNetworkMsg<DaNetworkExecutorBackend<Membership>>>,
+}
+
+impl<Membership> Libp2pNetworkAdapter<Membership>
+where
+    Membership: MembershipHandler<NetworkId = SubnetworkId, Id = PeerId>
+        + Clone
+        + Debug
+        + Send
+        + Sync
+        + 'static,
+{
+    async fn start_sampling(
+        &self,
+        blob_id: BlobId,
+        subnets: &[SubnetworkId],
+    ) -> Result<(), DynError> {
+        for id in subnets {
+            let subnetwork_id = id;
+            self.outbound_relay
+                .send(DaNetworkMsg::Process(
+                    ExecutorDaNetworkMessage::RequestSample {
+                        blob_id,
+                        subnetwork_id: *subnetwork_id,
+                    },
+                ))
+                .await
+                .expect("RequestSample message should have been sent");
+        }
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -99,5 +135,90 @@ where
                 }))
                     as BoxStream<'static, Result<(BlobId, Self::SubnetworkId), DynError>>
             })
+    }
+
+    async fn get_blob_samples(
+        &self,
+        blob_id: BlobId,
+        subnets: &[SubnetworkId],
+        cooldown: Duration,
+    ) -> Result<(), DynError> {
+        let expected_count = subnets.len();
+        let mut success_count = 0;
+
+        let mut pending_subnets: HashSet<SubnetworkId> = subnets.iter().copied().collect();
+
+        let (stream_sender, stream_receiver) = oneshot::channel();
+
+        self.outbound_relay
+            .send(DaNetworkMsg::Subscribe {
+                kind: DaNetworkEventKind::Sampling,
+                sender: stream_sender,
+            })
+            .await
+            .map_err(|(error, _)| error)?;
+
+        self.start_sampling(blob_id, subnets).await?;
+
+        let stream = match stream_receiver.await {
+            Ok(stream) => stream,
+            Err(error) => return Err(Box::new(error) as DynError),
+        };
+
+        enum SampleOutcome {
+            Success(u16),
+            Retry(u16),
+        }
+
+        let mut stream = tokio_stream::StreamExt::filter_map(stream, move |event| match event {
+            DaNetworkEvent::Sampling(SamplingEvent::SamplingSuccess {
+                blob_id: event_blob_id,
+                ref blob,
+            }) if event_blob_id == blob_id => Some(SampleOutcome::Success(blob.column_idx)),
+            DaNetworkEvent::Sampling(SamplingEvent::SamplingError { ref error }) => match error {
+                SamplingError::Protocol {
+                    error,
+                    subnetwork_id,
+                    ..
+                } if error.blob_id == blob_id => Some(SampleOutcome::Retry(*subnetwork_id)),
+                SamplingError::Deserialize {
+                    blob_id: event_blob_id,
+                    subnetwork_id,
+                    ..
+                } if *event_blob_id == blob_id => Some(SampleOutcome::Retry(*subnetwork_id)),
+                SamplingError::BlobNotFound {
+                    blob_id: event_blob_id,
+                    subnetwork_id,
+                    ..
+                } if *event_blob_id == blob_id => Some(SampleOutcome::Retry(*subnetwork_id)),
+                _ => None,
+            },
+            _ => None,
+        });
+
+        loop {
+            tokio::select! {
+                Some(event) = stream.next() => {
+                    match event {
+                        SampleOutcome::Success(subnetwork_id) => {
+                            success_count += 1;
+                            pending_subnets.remove(&subnetwork_id);
+                            if success_count >= expected_count {
+                                return Ok(());
+                            }
+                        }
+                        SampleOutcome::Retry(subnetwork_id) => {
+                            pending_subnets.insert(subnetwork_id);
+                        }
+                    }
+                }
+                () = tokio::time::sleep(cooldown) => {
+                    if !pending_subnets.is_empty() {
+                        let retry_subnets: Vec<_> = pending_subnets.iter().copied().collect();
+                        self.start_sampling(blob_id, &retry_subnets).await?;
+                    }
+                }
+            }
+        }
     }
 }

--- a/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
+++ b/nomos-services/data-availability/dispersal/src/adapters/network/libp2p.rs
@@ -160,10 +160,7 @@ where
 
         self.start_sampling(blob_id, subnets).await?;
 
-        let stream = match stream_receiver.await {
-            Ok(stream) => stream,
-            Err(error) => return Err(Box::new(error) as DynError),
-        };
+        let stream = stream_receiver.await.map_err(Box::new)?;
 
         enum SampleOutcome {
             Success(u16),

--- a/nomos-services/data-availability/dispersal/src/adapters/network/mod.rs
+++ b/nomos-services/data-availability/dispersal/src/adapters/network/mod.rs
@@ -1,9 +1,10 @@
 pub mod libp2p;
-use std::pin::Pin;
+use std::{pin::Pin, time::Duration};
 
 use futures::Stream;
 use kzgrs_backend::common::blob::DaBlob;
 use nomos_core::da::BlobId;
+use nomos_da_network_core::SubnetworkId;
 use overwatch_rs::{
     services::{relay::OutboundRelay, ServiceData},
     DynError,
@@ -27,4 +28,11 @@ pub trait DispersalNetworkAdapter {
         Pin<Box<dyn Stream<Item = Result<(BlobId, Self::SubnetworkId), DynError>> + Send>>,
         DynError,
     >;
+
+    async fn get_blob_samples(
+        &self,
+        blob_id: BlobId,
+        subnets: &[SubnetworkId],
+        cooldown: Duration,
+    ) -> Result<(), DynError>;
 }

--- a/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
@@ -7,13 +7,28 @@ use kzgrs_backend::{
     encoder::{DaEncoderParams, EncodedData},
 };
 use nomos_core::da::{BlobId, DaDispersal, DaEncoder};
+use nomos_tracing::info_with_id;
 use overwatch_rs::DynError;
+use rand::{seq::IteratorRandom, thread_rng};
 use serde::{Deserialize, Serialize};
+use tokio::time::error::Elapsed;
+use tracing::instrument;
 
 use crate::{
     adapters::{mempool::DaMempoolAdapter, network::DispersalNetworkAdapter},
     backend::DispersalBackend,
 };
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum MempoolPublishStrategy {
+    Immediately,
+    Timeout(Duration),
+    SampleSubnetworks {
+        num_to_sample: usize,
+        timeout: Duration,
+        cooldown: Duration,
+    },
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EncoderSettings {
@@ -26,7 +41,9 @@ pub struct EncoderSettings {
 pub struct DispersalKZGRSBackendSettings {
     pub encoder_settings: EncoderSettings,
     pub dispersal_timeout: Duration,
+    pub mempool_strategy: MempoolPublishStrategy,
 }
+
 pub struct DispersalKZGRSBackend<NetworkAdapter, MempoolAdapter> {
     settings: DispersalKZGRSBackendSettings,
     network_adapter: Arc<NetworkAdapter>,
@@ -156,5 +173,57 @@ where
         metadata: Self::Metadata,
     ) -> Result<(), DynError> {
         self.mempool_adapter.post_blob_id(blob_id, metadata).await
+    }
+
+    #[instrument(skip_all)]
+    async fn process_dispersal(
+        &self,
+        data: Vec<u8>,
+        metadata: Self::Metadata,
+    ) -> Result<(), DynError> {
+        let (blob_id, encoded_data) = self.encode(data).await?;
+        info_with_id!(blob_id.as_ref(), "ProcessDispersal");
+        self.disperse(encoded_data).await?;
+        match self.settings.mempool_strategy {
+            MempoolPublishStrategy::Immediately => {
+                self.publish_to_mempool(blob_id, metadata).await?;
+            }
+            MempoolPublishStrategy::Timeout(wait_duration) => {
+                tokio::time::sleep(wait_duration).await;
+                self.publish_to_mempool(blob_id, metadata).await?;
+            }
+            MempoolPublishStrategy::SampleSubnetworks {
+                num_to_sample,
+                timeout,
+                cooldown,
+            } => {
+                let subnets = {
+                    // ThreadRng is not Send, need to drop before await bound.
+                    let mut rng = thread_rng();
+                    (0..self.settings.encoder_settings.num_columns as u16)
+                        .choose_multiple(&mut rng, num_to_sample)
+                };
+
+                match tokio::time::timeout(
+                    timeout,
+                    self.network_adapter
+                        .get_blob_samples(blob_id, &subnets, cooldown),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        self.publish_to_mempool(blob_id, metadata).await?;
+                    }
+                    Ok(Err(e)) => return Err(e),
+                    Err(Elapsed { .. }) => {
+                        return Err(Box::new(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("Dispersed blob sampling timed out for blob_id {blob_id:?}"),
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
@@ -54,7 +54,7 @@ where
 
     async fn disperse(&self, encoded_data: Self::EncodedData) -> Result<(), Self::Error> {
         let adapter = self.adapter.as_ref();
-        let encoded_size = encoded_data.extended_data.len();
+        let num_columns = encoded_data.column_commitments.len();
         let blob_id = build_blob_id(
             &encoded_data.aggregated_column_commitment,
             &encoded_data.row_commitments,
@@ -74,7 +74,7 @@ where
                     _ => None,
                 }
             })
-            .take(encoded_size)
+            .take(num_columns)
             .collect();
         // timeout when collecting positive responses
         tokio::time::timeout(self.timeout, valid_responses)

--- a/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/dispersal/src/backend/kzgrs.rs
@@ -24,7 +24,7 @@ pub enum MempoolPublishStrategy {
     Immediately,
     Timeout(Duration),
     SampleSubnetworks {
-        num_to_sample: usize,
+        sample_threshold: usize,
         timeout: Duration,
         cooldown: Duration,
     },
@@ -193,7 +193,7 @@ where
                 self.publish_to_mempool(blob_id, metadata).await?;
             }
             MempoolPublishStrategy::SampleSubnetworks {
-                num_to_sample,
+                sample_threshold,
                 timeout,
                 cooldown,
             } => {
@@ -201,7 +201,7 @@ where
                     // ThreadRng is not Send, need to drop before await bound.
                     let mut rng = thread_rng();
                     (0..self.settings.encoder_settings.num_columns as u16)
-                        .choose_multiple(&mut rng, num_to_sample)
+                        .choose_multiple(&mut rng, sample_threshold)
                 };
 
                 match tokio::time::timeout(

--- a/nomos-services/data-availability/network/src/backends/libp2p/common.rs
+++ b/nomos-services/data-availability/network/src/backends/libp2p/common.rs
@@ -58,6 +58,23 @@ pub enum SamplingEvent {
     SamplingError { error: SamplingError },
 }
 
+impl SamplingEvent {
+    #[must_use]
+    pub fn blob_id(&self) -> Option<&BlobId> {
+        match self {
+            Self::SamplingRequest { blob_id, .. } | Self::SamplingSuccess { blob_id, .. } => {
+                Some(blob_id)
+            }
+            Self::SamplingError { error } => error.blob_id(),
+        }
+    }
+
+    #[must_use]
+    pub fn has_blob_id(&self, target: &BlobId) -> bool {
+        self.blob_id() == Some(target)
+    }
+}
+
 /// Task that handles forwarding of events to the subscriptions channels/stream
 pub(crate) async fn handle_validator_events_stream(
     events_streams: ValidatorEventsStream,

--- a/nomos-services/data-availability/network/src/backends/libp2p/common.rs
+++ b/nomos-services/data-availability/network/src/backends/libp2p/common.rs
@@ -98,14 +98,14 @@ pub(crate) async fn handle_validator_events_stream(
                                         subnetwork_id: blob.column_idx,
                                         blob: Box::new(blob),
                                     },
-                                    None => BehaviourSampleRes::SampleNotFound { blob_id },
+                                    None => BehaviourSampleRes::SampleNotFound { blob_id, subnetwork_id: column_idx },
                                 };
 
                                 if response_sender.send(result).is_err() {
                                     error!("Error sending sampling success response");
                                 }
                             } else if response_sender
-                                .send(BehaviourSampleRes::SampleNotFound { blob_id })
+                                .send(BehaviourSampleRes::SampleNotFound { blob_id, subnetwork_id: column_idx })
                                 .is_err()
                             {
                                 error!("Error sending sampling success response");

--- a/testnet/cfgsync.yaml
+++ b/testnet/cfgsync.yaml
@@ -18,6 +18,15 @@ min_dispersal_peers: 1
 min_replication_peers: 1
 monitor_failure_time_window_secs: 5
 balancer_interval_secs: 5
+# Dispersal mempool publish strategy
+mempool_publish_strategy: !SampleSubnetworks
+  num_to_sample: 2
+  dispersal_timeout:
+    secs: 2
+    nanos: 0
+  cooldown:
+    secs: 0
+    nanos: 100_000_000
 
 # Tracing
 tracing_settings:

--- a/testnet/cfgsync.yaml
+++ b/testnet/cfgsync.yaml
@@ -20,7 +20,7 @@ monitor_failure_time_window_secs: 5
 balancer_interval_secs: 5
 # Dispersal mempool publish strategy
 mempool_publish_strategy: !SampleSubnetworks
-  num_to_sample: 2
+  sample_threshold: 2
   dispersal_timeout:
     secs: 2
     nanos: 0

--- a/testnet/cfgsync/Cargo.toml
+++ b/testnet/cfgsync/Cargo.toml
@@ -10,6 +10,7 @@ clap                     = { version = "4", features = ["derive"] }
 nomos-blend              = { workspace = true }
 nomos-blend-message      = { workspace = true }
 nomos-blend-service      = { workspace = true }
+nomos-da-dispersal       = { workspace = true }
 nomos-da-network-core    = { workspace = true }
 nomos-executor           = { workspace = true }
 nomos-libp2p             = { workspace = true }

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -239,6 +239,7 @@ fn update_tracing_identifier(
 mod cfgsync_tests {
     use std::{net::Ipv4Addr, num::NonZero, str::FromStr, time::Duration};
 
+    use nomos_da_dispersal::backend::kzgrs::MempoolPublishStrategy;
     use nomos_da_network_core::swarm::{DAConnectionMonitorSettings, DAConnectionPolicySettings};
     use nomos_libp2p::{ed25519, libp2p, Multiaddr, PeerId, Protocol};
     use nomos_tracing_service::{
@@ -278,6 +279,7 @@ mod cfgsync_tests {
                 old_blobs_check_interval: Duration::from_secs(5),
                 blobs_validity_duration: Duration::from_secs(u64::MAX),
                 global_params_path: String::new(),
+                mempool_strategy: MempoolPublishStrategy::Immediately,
                 policy_settings: DAConnectionPolicySettings::default(),
                 monitor_settings: DAConnectionMonitorSettings::default(),
                 balancer_interval: Duration::ZERO,

--- a/testnet/cfgsync/src/lib.rs
+++ b/testnet/cfgsync/src/lib.rs
@@ -13,6 +13,7 @@ mod tests {
     };
 
     use futures::future::join_all;
+    use nomos_da_dispersal::backend::kzgrs::MempoolPublishStrategy;
     use nomos_libp2p::{ed25519, libp2p, Multiaddr, PeerId, Protocol};
     use nomos_node::Config as ValidatorConfig;
     use nomos_tracing_service::TracingSettings;
@@ -40,6 +41,7 @@ mod tests {
             old_blobs_check_interval_secs: 0,
             blobs_validity_duration_secs: 0,
             global_params_path: String::new(),
+            mempool_publish_strategy: MempoolPublishStrategy::Immediately,
             min_dispersal_peers: 0,
             min_replication_peers: 0,
             monitor_failure_time_window_secs: 0,
@@ -102,9 +104,8 @@ mod tests {
 
     pub fn extract_ip(multiaddr: &Multiaddr) -> Option<Ipv4Addr> {
         for protocol in multiaddr {
-            match protocol {
-                Protocol::Ip4(ip) => return Some(ip),
-                _ => continue,
+            if let Protocol::Ip4(ip) = protocol {
+                return Some(ip);
             }
         }
         None

--- a/testnet/cfgsync/src/server.rs
+++ b/testnet/cfgsync/src/server.rs
@@ -1,6 +1,7 @@
 use std::{fs, net::Ipv4Addr, num::NonZero, path::PathBuf, sync::Arc, time::Duration};
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
+use nomos_da_dispersal::backend::kzgrs::MempoolPublishStrategy;
 use nomos_da_network_core::swarm::{DAConnectionMonitorSettings, DAConnectionPolicySettings};
 use nomos_tracing_service::TracingSettings;
 use serde::{Deserialize, Serialize};
@@ -37,6 +38,7 @@ pub struct CfgSyncConfig {
     pub min_replication_peers: usize,
     pub monitor_failure_time_window_secs: u64,
     pub balancer_interval_secs: u64,
+    pub mempool_publish_strategy: MempoolPublishStrategy,
 
     // Tracing params
     pub tracing_settings: TracingSettings,
@@ -69,6 +71,7 @@ impl CfgSyncConfig {
             old_blobs_check_interval: Duration::from_secs(self.old_blobs_check_interval_secs),
             blobs_validity_duration: Duration::from_secs(self.blobs_validity_duration_secs),
             global_params_path: self.global_params_path.clone(),
+            mempool_strategy: self.mempool_publish_strategy.clone(),
             policy_settings: DAConnectionPolicySettings {
                 min_dispersal_peers: self.min_dispersal_peers,
                 min_replication_peers: self.min_replication_peers,

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -16,7 +16,7 @@ use nomos_blend::{
     persistent_transmission::PersistentTransmissionSettings,
 };
 use nomos_da_dispersal::{
-    backend::kzgrs::{DispersalKZGRSBackendSettings, EncoderSettings},
+    backend::kzgrs::{DispersalKZGRSBackendSettings, EncoderSettings, MempoolPublishStrategy},
     DispersalServiceSettings,
 };
 use nomos_da_indexer::{
@@ -282,6 +282,11 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
                     global_params_path: config.da_config.global_params_path,
                 },
                 dispersal_timeout: Duration::from_secs(20),
+                mempool_strategy: MempoolPublishStrategy::SampleSubnetworks {
+                    num_to_sample: config.da_config.num_subnets as usize,
+                    timeout: Duration::from_secs(10),
+                    cooldown: Duration::from_millis(100),
+                },
             },
         },
         time: TimeServiceSettings {

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -281,7 +281,7 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
                     with_cache: false,
                     global_params_path: config.da_config.global_params_path,
                 },
-                dispersal_timeout: Duration::from_secs(u64::MAX),
+                dispersal_timeout: Duration::from_secs(20),
             },
         },
         time: TimeServiceSettings {

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -16,7 +16,7 @@ use nomos_blend::{
     persistent_transmission::PersistentTransmissionSettings,
 };
 use nomos_da_dispersal::{
-    backend::kzgrs::{DispersalKZGRSBackendSettings, EncoderSettings, MempoolPublishStrategy},
+    backend::kzgrs::{DispersalKZGRSBackendSettings, EncoderSettings},
     DispersalServiceSettings,
 };
 use nomos_da_indexer::{
@@ -282,11 +282,7 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
                     global_params_path: config.da_config.global_params_path,
                 },
                 dispersal_timeout: Duration::from_secs(20),
-                mempool_strategy: MempoolPublishStrategy::SampleSubnetworks {
-                    num_to_sample: config.da_config.num_subnets as usize,
-                    timeout: Duration::from_secs(10),
-                    cooldown: Duration::from_millis(100),
-                },
+                mempool_strategy: config.da_config.mempool_strategy,
             },
         },
         time: TimeServiceSettings {

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use kzgrs_backend::reconstruction::reconstruct_without_missing_data;
+use kzgrs_backend::{dispersal::Index, reconstruction::reconstruct_without_missing_data};
 use tests::{
     common::da::{disseminate_with_metadata, wait_for_indexed_blob, APP_ID},
     topology::{Topology, TopologyConfig},
@@ -54,11 +54,11 @@ async fn disseminate_retrieve_reconstruct() {
     let executor = &topology.executors()[0];
     let num_subnets = executor.config().da_network.backend.num_subnets as usize;
 
-    let data = [1u8; 31];
     let app_id = hex::decode(APP_ID).unwrap();
     let app_id: [u8; 32] = app_id.clone().try_into().unwrap();
-    let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, 0u64.into());
+    let data = [1u8; 31 * 5];
 
+    let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(0));
     disseminate_with_metadata(executor, &data, metadata).await;
 
     let from = 0u64.to_be_bytes();

--- a/tests/src/tests/da/disperse.rs
+++ b/tests/src/tests/da/disperse.rs
@@ -50,33 +50,41 @@ async fn disseminate_and_retrieve() {
 
 #[tokio::test]
 async fn disseminate_retrieve_reconstruct() {
+    const ITERATIONS: usize = 10;
+
     let topology = Topology::spawn(TopologyConfig::validator_and_executor()).await;
     let executor = &topology.executors()[0];
     let num_subnets = executor.config().da_network.backend.num_subnets as usize;
 
     let app_id = hex::decode(APP_ID).unwrap();
     let app_id: [u8; 32] = app_id.clone().try_into().unwrap();
-    let data = [1u8; 31 * 5];
 
-    let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(0));
-    disseminate_with_metadata(executor, &data, metadata).await;
+    let data = [1u8; 31 * ITERATIONS];
 
-    let from = 0u64.to_be_bytes();
-    let to = 1u64.to_be_bytes();
+    for i in 0..ITERATIONS {
+        let data_size = 31 * (i + 1);
+        println!("disseminating {data_size} bytes");
+        let data = &data[..data_size]; // test increasing size data
+        let metadata = kzgrs_backend::dispersal::Metadata::new(app_id, Index::from(i as u64));
+        disseminate_with_metadata(executor, data, metadata).await;
 
-    wait_for_indexed_blob(executor, app_id, from, to, num_subnets).await;
+        let from = i.to_be_bytes();
+        let to = (i + 1).to_be_bytes();
 
-    let executor_blobs = executor.get_indexer_range(app_id, from..to).await;
-    let executor_idx_0_blobs: Vec<_> = executor_blobs
-        .iter()
-        .filter(|(i, _)| i == &from)
-        .flat_map(|(_, blobs)| blobs)
-        .collect();
+        wait_for_indexed_blob(executor, app_id, from, to, num_subnets).await;
 
-    // Reconstruction is performed from the one of the two blobs.
-    let blobs = vec![executor_idx_0_blobs[0].clone()];
-    let reconstructed = reconstruct_without_missing_data(&blobs);
-    assert_eq!(reconstructed, data);
+        let executor_blobs = executor.get_indexer_range(app_id, from..to).await;
+        let executor_idx_0_blobs: Vec<_> = executor_blobs
+            .iter()
+            .filter(|(i, _)| i == &from)
+            .flat_map(|(_, blobs)| blobs)
+            .collect();
+
+        // Reconstruction is performed from the one of the two blobs.
+        let blobs = vec![executor_idx_0_blobs[0].clone()];
+        let reconstructed = reconstruct_without_missing_data(&blobs);
+        assert_eq!(reconstructed, data);
+    }
 }
 
 #[ignore = "for local debugging"]

--- a/tests/src/topology/configs/da.rs
+++ b/tests/src/topology/configs/da.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use nomos_da_dispersal::backend::kzgrs::MempoolPublishStrategy;
 use nomos_da_network_core::swarm::{DAConnectionMonitorSettings, DAConnectionPolicySettings};
 use nomos_libp2p::{ed25519, Multiaddr, PeerId};
 use nomos_node::NomosDaMembership;
@@ -34,6 +35,7 @@ pub struct DaParams {
     pub old_blobs_check_interval: Duration,
     pub blobs_validity_duration: Duration,
     pub global_params_path: String,
+    pub mempool_strategy: MempoolPublishStrategy,
     pub policy_settings: DAConnectionPolicySettings,
     pub monitor_settings: DAConnectionMonitorSettings,
     pub balancer_interval: Duration,
@@ -50,6 +52,11 @@ impl Default for DaParams {
             old_blobs_check_interval: Duration::from_secs(5),
             blobs_validity_duration: Duration::from_secs(60),
             global_params_path: GLOBAL_PARAMS_PATH.to_string(),
+            mempool_strategy: MempoolPublishStrategy::SampleSubnetworks {
+                num_to_sample: 2,
+                timeout: Duration::from_secs(10),
+                cooldown: Duration::from_millis(100),
+            },
             policy_settings: DAConnectionPolicySettings {
                 min_dispersal_peers: 1,
                 min_replication_peers: 1,
@@ -80,6 +87,7 @@ pub struct GeneralDaConfig {
     pub verifier_index: HashSet<u16>,
     pub num_samples: u16,
     pub num_subnets: u16,
+    pub mempool_strategy: MempoolPublishStrategy,
     pub old_blobs_check_interval: Duration,
     pub blobs_validity_duration: Duration,
     pub policy_settings: DAConnectionPolicySettings,
@@ -144,6 +152,7 @@ pub fn create_da_configs(ids: &[[u8; 32]], da_params: &DaParams) -> Vec<GeneralD
                 num_subnets: da_params.num_subnets,
                 old_blobs_check_interval: da_params.old_blobs_check_interval,
                 blobs_validity_duration: da_params.blobs_validity_duration,
+                mempool_strategy: da_params.mempool_strategy.clone(),
                 policy_settings: da_params.policy_settings.clone(),
                 monitor_settings: da_params.monitor_settings.clone(),
                 balancer_interval: da_params.balancer_interval,

--- a/tests/src/topology/configs/da.rs
+++ b/tests/src/topology/configs/da.rs
@@ -53,7 +53,7 @@ impl Default for DaParams {
             blobs_validity_duration: Duration::from_secs(60),
             global_params_path: GLOBAL_PARAMS_PATH.to_string(),
             mempool_strategy: MempoolPublishStrategy::SampleSubnetworks {
-                num_to_sample: 2,
+                sample_threshold: 2,
                 timeout: Duration::from_secs(10),
                 cooldown: Duration::from_millis(100),
             },


### PR DESCRIPTION
## 1. What does this PR implement?

Dispersal would halt after sending blob with more than 2 chunks in it, the problem was in dispersal service expecting number of confirmations from subnetwork nodes that corresponded to the number or rows, not the number of columns.

## 2. Does the code have enough context to be clearly understood?

Yes, related issue https://github.com/logos-co/nomos-node/issues/1046, might not close yet.

## 3. Who are the specification authors and who is accountable for this PR?

@bacv @danielSanchezQ 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
