### PR TITLE
chore: Remove RUSTSEC-2025-0009 related deny rules

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -13,8 +13,6 @@ ignore = [
   { id = "RUSTSEC-2024-0384", reason = "`instant` is unmaintained; consider using an alternative. Use `cargo tree -p instant -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained; consider using an alternative. Use `cargo tree -p derivative -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` has a security vulnerability; consider using an alternative. Use `cargo tree -p paste -i > tmp.txt` to check the dependency tree." },
-  { id = "RUSTSEC-2025-0009", reason = "`ring@0.17.9` has a security vulnerability; consider using an alternative. Use `cargo tree -p ring@0.17.9 -i > tmp.txt` to check the dependency tree." },
-  { id = "RUSTSEC-2025-0010", reason = "`ring@0.16.20` is unmaintained; consider using an alternative. Use `cargo tree -p ring@0.16.20 -i > tmp.txt` to check the dependency tree." },
 ]
 yanked = "deny"
 
@@ -35,7 +33,6 @@ allow = [
   "MIT",
   "MPL-2.0",
   "NCSA",
-  "OpenSSL",
   "Unicode-3.0",
   "Zlib",
 ]


### PR DESCRIPTION
## 1. What does this PR implement?

Remove RUSTSEC-2025-0009 related deny rules

## 2. Does the code have enough context to be clearly understood?

Related https://github.com/libp2p/rust-libp2p/commit/e99ab755a41672625434f40a38043bf5fd975d26 

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
