### PR TITLE
PoC(sync): add sleep when spawning nodes in tests

### DIFF
--- a/tests/src/tests/cryptarchia/sync/sync.rs
+++ b/tests/src/tests/cryptarchia/sync/sync.rs
@@ -236,6 +236,7 @@ fn setup_nodes(
     };
 
     let passive_node = OverwatchRunner::<NomosLightNode>::run(passive_settings, None).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(100));
     let active_node = OverwatchRunner::<NomosLightNode>::run(active_settings, None).unwrap();
 
     let runtime = passive_node.handle().runtime();


### PR DESCRIPTION
NOTE: This is a PoC to be merged to the `feat/cryptarchia-sync` branch. So, this doesn't follow the PR description template. This PoC will be substantially refactored in the future before opening PRs for the `master`.

The semi-integration tests sometime fail with the following error from a passive node.
```
Apr 08 11:32:11.515 ERROR nomos_network::backends::libp2p::swarm: failed to send sync request: SendError(IncomingSyncRequest { kind: Tip, reply_channel: Sender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x15d816550, tail_position: 0 }, semaphore: Semaphore { semaphore: Semaphore { permits: 10 }, bound: 10 }, rx_waker: AtomicWaker, tx_count: 1, rx_fields: "..." } } } })
```
It's because an active node sent a sync request to the passive node before the passive node is ready to handle requests.

For now, simply adding a sleep before running the active node is enough.

I ran all sync tests more than 20 times, but didn't see the error anymore.