### PR TITLE
PoC(sync): bump tracing-subscriber to avoid cargo-deny error

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,7 +19,6 @@ futures                  = "0.3"
 futures-util             = "0.3.31"
 hex                      = "0.4.3"
 kzgrs-backend            = { workspace = true }
-overwatch                = { workspace = true }
 nomos-api                = { workspace = true }
 nomos-blend              = { workspace = true }
 nomos-blend-message      = { workspace = true }
@@ -41,21 +40,21 @@ nomos-storage            = { workspace = true, features = ["rocksdb-backend"] }
 nomos-time               = { workspace = true }
 nomos-tracing            = { workspace = true }
 nomos-tracing-service    = { workspace = true }
-services-utils           = { workspace = true }
 once_cell                = "1"
+overwatch                = { workspace = true }
 rand                     = "0.8"
 reqwest                  = { workspace = true, features = ["json"] }
 serde                    = { version = "1", features = ["derive"] }
 serde_json               = "1.0"
 serde_yaml               = "0.9"
+services-utils           = { workspace = true }
 subnetworks-assignations = { workspace = true }
 tempfile                 = "3.6"
 time                     = "0.3"
 tokio                    = "1"
 tracing                  = "0.1"
+tracing-subscriber       = "0.3"
 x25519-dalek             = { version = "2", features = ["getrandom", "static_secrets"] }
-tracing-subscriber       = "0.2.25"
-
 
 [[test]]
 name = "test_cryptarchia_happy_path"
@@ -72,4 +71,3 @@ path = "src/tests/da/api.rs"
 [[test]]
 name = "test_sync"
 path = "src/tests/cryptarchia/sync/sync.rs"
-


### PR DESCRIPTION
NOTE: This is a PoC to be merged to the `feat/cryptarchia-sync` branch. So, this doesn't follow the PR description template. This PoC will be substantially refactored in the future before opening PRs for the `master`.

The cargo-deny returns the following error due to `ansi_term` which is used by `tracing_subscriber=0.2`.

```
error[unmaintained]: ansi_term is Unmaintained
   ┌─ /github/workspace/Cargo.lock:14:1
   │
14 │ ansi_term 0.12.1 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2021-0139
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0139
   ├ The maintainer has advised that this crate is deprecated and will not receive any maintenance.
     
     The crate does not seem to have much dependencies and may or may not be ok to use as-is.
     
     Last release seems to have been three years ago.
     
     ## Possible Alternative(s)
     
      The below list has not been vetted in any way and may or may not contain alternatives;
     
      - [ansiterm](https://crates.io/crates/ansiterm)
      - [anstyle](https://github.com/epage/anstyle)
      - [console](https://crates.io/crates/console)
      - [nu-ansi-term](https://crates.io/crates/nu-ansi-term)
      - [owo-colors](https://crates.io/crates/owo-colors)
      - [stylish](https://crates.io/crates/stylish)
      - [yansi](https://crates.io/crates/yansi)
     
     ## Dependency Specific Migration(s)
     
      - [structopt, clap2](https://github.com/clap-rs/clap/discussions/4172)
   ├ Announcement: https://github.com/ogham/rust-ansi-term/issues/72
   ├ Solution: No safe upgrade is available!

 advisories FAILED: 1 errors, 0 warnings, 12 notes
           bans ok: 0 errors, 0 warnings, 0 notes
       licenses ok: 0 errors, 0 warnings, 1014 notes
        sources ok: 0 errors, 0 warnings, 2 notes
```