### PR TITLE
refactor(storage): do not serialize storage key for avoid potential error of LoadPrefix

### DIFF
--- a/nomos-services/api/src/http/storage.rs
+++ b/nomos-services/api/src/http/storage.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Display};
 
+use bytes::Bytes;
 use nomos_core::{block::Block, da::blob::Share, header::HeaderId};
 use nomos_da_storage::rocksdb::{
     create_share_idx, key_bytes, DA_SHARED_COMMITMENTS_PREFIX, DA_SHARE_PREFIX,
@@ -24,7 +25,8 @@ where
         AsServiceId<StorageService<RocksBackend<S>, RuntimeServiceId>> + Debug + Sync + Display,
 {
     let relay = handle.relay().await?;
-    let (msg, receiver) = StorageMsg::new_load_message(id);
+    let key: [u8; 32] = id.into();
+    let (msg, receiver) = StorageMsg::new_load_message(Bytes::copy_from_slice(&key));
     relay.send(msg).await.map_err(|(e, _)| e)?;
 
     wait_with_timeout(

--- a/nomos-services/cryptarchia-consensus/Cargo.toml
+++ b/nomos-services/cryptarchia-consensus/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 
 [dependencies]
 async-trait            = "0.1"
+bytes                  = "1"
 cl                     = { workspace = true }
 cryptarchia-engine     = { workspace = true, features = ["serde"] }
 futures                = "0.3"

--- a/nomos-services/cryptarchia-consensus/src/lib.rs
+++ b/nomos-services/cryptarchia-consensus/src/lib.rs
@@ -9,6 +9,7 @@ pub mod storage;
 use core::fmt::Debug;
 use std::{collections::BTreeSet, fmt::Display, hash::Hash, path::PathBuf};
 
+use bytes::Bytes;
 use cryptarchia_engine::Slot;
 use futures::StreamExt;
 pub use leadership::LeaderConfig;
@@ -853,7 +854,9 @@ where
                 .await;
 
                 // store block
-                let msg = <StorageMsg<_>>::new_store_message(header.id(), block.clone());
+                let key: [u8; 32] = header.id().into();
+                let msg =
+                    <StorageMsg<_>>::new_store_message(Bytes::copy_from_slice(&key), block.clone());
                 if let Err((e, _msg)) = relays.storage_adapter().storage_relay.send(msg).await {
                     tracing::error!("Could not send block to storage: {e}");
                 }

--- a/nomos-services/cryptarchia-consensus/src/storage/adapters/storage.rs
+++ b/nomos-services/cryptarchia-consensus/src/storage/adapters/storage.rs
@@ -1,9 +1,10 @@
 use std::{hash::Hash, marker::PhantomData};
 
+use bytes::Bytes;
 use nomos_core::{block::Block, header::HeaderId};
 use nomos_storage::{backends::StorageBackend, StorageMsg, StorageService};
 use overwatch::services::{relay::OutboundRelay, ServiceData};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 
 use crate::storage::StorageAdapter as StorageAdapterTrait;
 
@@ -34,9 +35,8 @@ where
     /// # Returns
     ///
     /// The value for the given key. If no value is found, returns None.
-    pub async fn get_value<Key, Value>(&self, key: &Key) -> Option<Value>
+    pub async fn get_value<Value>(&self, key: Bytes) -> Option<Value>
     where
-        Key: Serialize + Send + Sync,
         Value: DeserializeOwned,
     {
         let (msg, receiver) = <StorageMsg<Storage>>::new_load_message(key);
@@ -69,6 +69,7 @@ where
     }
 
     async fn get_block(&self, key: &HeaderId) -> Option<Self::Block> {
-        self.get_value(key).await
+        let key: [u8; 32] = (*key).into();
+        self.get_value(Bytes::copy_from_slice(&key)).await
     }
 }

--- a/nomos-services/storage/src/lib.rs
+++ b/nomos-services/storage/src/lib.rs
@@ -89,10 +89,7 @@ impl<Backend: StorageBackend> StorageReplyReceiver<Option<Bytes>, Backend> {
 }
 
 impl<Backend: StorageBackend> StorageMsg<Backend> {
-    pub fn new_load_message<K: Serialize>(
-        key: K,
-    ) -> (Self, StorageReplyReceiver<Option<Bytes>, Backend>) {
-        let key = Backend::SerdeOperator::serialize(key);
+    pub fn new_load_message(key: Bytes) -> (Self, StorageReplyReceiver<Option<Bytes>, Backend>) {
         let (reply_channel, receiver) = tokio::sync::oneshot::channel();
         (
             Self::Load { key, reply_channel },
@@ -100,16 +97,12 @@ impl<Backend: StorageBackend> StorageMsg<Backend> {
         )
     }
 
-    pub fn new_store_message<K: Serialize, V: Serialize>(key: K, value: V) -> Self {
-        let key = Backend::SerdeOperator::serialize(key);
+    pub fn new_store_message<V: Serialize>(key: Bytes, value: V) -> Self {
         let value = Backend::SerdeOperator::serialize(value);
         Self::Store { key, value }
     }
 
-    pub fn new_remove_message<K: Serialize>(
-        key: K,
-    ) -> (Self, StorageReplyReceiver<Option<Bytes>, Backend>) {
-        let key = Backend::SerdeOperator::serialize(key);
+    pub fn new_remove_message(key: Bytes) -> (Self, StorageReplyReceiver<Option<Bytes>, Backend>) {
         let (reply_channel, receiver) = tokio::sync::oneshot::channel();
         (
             Self::Remove { key, reply_channel },


### PR DESCRIPTION
## 1. What does this PR implement?

The current storage service provides the `new_store_message` function that serialize both key and value using the wire type specified when the storage service is declared. 

However, this can cause potential error when `LoadPrefix` is called. Since the wiring may add a prefix in front of the key, the `LoadPrefix` won't work as intended. To avoid this failure, the DA logic is constructing the `Store` message manually without using the `new_store_message` function. 

This PR modifies the `new_store_message` to not serialize the key automatically. Rather, it now accepts a `Bytes` to avoid potential misuses.

This refactor will be useful for implementing the range scan that will be used for the chain sync soon.  

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

NaN

## 5. Does the implementation introduce changes in the specification?

NaN

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. Description added.
* [x] 2. Context and links to Specification document(s) added.
* [x] 3. Main contact(s) (developers and specification authors) added
* [x] 4. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 5. Link PR to a specific milestone.
