### PR TITLE
chore: more rustc lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,13 +220,20 @@ unused_crate_dependencies = { level = "allow" } # Too many false positives espec
 unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
 
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports     = { level = "warn" }
-redundant_lifetimes   = { level = "warn" }
-unused_extern_crates  = { level = "warn" }
-unused_import_braces  = { level = "warn" }
-unused_lifetimes      = { level = "warn" }
-unused_macro_rules    = { level = "warn" }
-unused_qualifications = { level = "warn" }
+impl_trait_redundant_captures = { level = "warn" }
+missing_unsafe_on_extern      = { level = "warn" }
+redundant_imports             = { level = "warn" }
+redundant_lifetimes           = { level = "warn" }
+single_use_lifetimes          = { level = "warn" }
+trivial_numeric_casts         = { level = "warn" }
+unsafe_attr_outside_unsafe    = { level = "warn" }
+unsafe_op_in_unsafe_fn        = { level = "warn" }
+unstable_features             = { level = "warn" }
+unused_extern_crates          = { level = "warn" }
+unused_import_braces          = { level = "warn" }
+unused_lifetimes              = { level = "warn" }
+unused_macro_rules            = { level = "warn" }
+unused_qualifications         = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
 # When doing so, please update the same table for all crates that are not part of the workspace.
@@ -241,7 +248,6 @@ explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-impl_trait_redundant_captures                = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }
 keyword_idents_2024                          = { level = "allow" }
@@ -252,7 +258,6 @@ meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-missing_unsafe_on_extern                     = { level = "allow" }
 non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
@@ -261,17 +266,12 @@ rust_2021_prelude_collisions                 = { level = "allow" }
 rust_2024_guarded_string_incompatible_syntax = { level = "allow" }
 rust_2024_incompatible_pat                   = { level = "allow" }
 rust_2024_prelude_collisions                 = { level = "allow" }
-single_use_lifetimes                         = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
-trivial_numeric_casts                        = { level = "allow" }
 unit_bindings                                = { level = "allow" }
 unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
-unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
-unsafe_op_in_unsafe_fn                       = { level = "allow" }
-unstable_features                            = { level = "allow" }
 variant_size_differences                     = { level = "allow" }
 
 [workspace.package]

--- a/nomos-core/proof_statements/Cargo.toml
+++ b/nomos-core/proof_statements/Cargo.toml
@@ -117,13 +117,20 @@ unused_crate_dependencies = { level = "allow" } # Too many false positives espec
 unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
 
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports     = { level = "warn" }
-redundant_lifetimes   = { level = "warn" }
-unused_extern_crates  = { level = "warn" }
-unused_import_braces  = { level = "warn" }
-unused_lifetimes      = { level = "warn" }
-unused_macro_rules    = { level = "warn" }
-unused_qualifications = { level = "warn" }
+impl_trait_redundant_captures = { level = "warn" }
+missing_unsafe_on_extern      = { level = "warn" }
+redundant_imports             = { level = "warn" }
+redundant_lifetimes           = { level = "warn" }
+single_use_lifetimes          = { level = "warn" }
+trivial_numeric_casts         = { level = "warn" }
+unsafe_attr_outside_unsafe    = { level = "warn" }
+unsafe_op_in_unsafe_fn        = { level = "warn" }
+unstable_features             = { level = "warn" }
+unused_extern_crates          = { level = "warn" }
+unused_import_braces          = { level = "warn" }
+unused_lifetimes              = { level = "warn" }
+unused_macro_rules            = { level = "warn" }
+unused_qualifications         = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
 # When doing so, please update the same table for all crates that are not part of the workspace.
@@ -138,7 +145,6 @@ explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-impl_trait_redundant_captures                = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }
 keyword_idents_2024                          = { level = "allow" }
@@ -149,7 +155,6 @@ meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-missing_unsafe_on_extern                     = { level = "allow" }
 non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
@@ -158,15 +163,10 @@ rust_2021_prelude_collisions                 = { level = "allow" }
 rust_2024_guarded_string_incompatible_syntax = { level = "allow" }
 rust_2024_incompatible_pat                   = { level = "allow" }
 rust_2024_prelude_collisions                 = { level = "allow" }
-single_use_lifetimes                         = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
-trivial_numeric_casts                        = { level = "allow" }
 unit_bindings                                = { level = "allow" }
 unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
-unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
-unsafe_op_in_unsafe_fn                       = { level = "allow" }
-unstable_features                            = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -125,13 +125,20 @@ unused_crate_dependencies = { level = "allow" } # Too many false positives espec
 unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
 
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports     = { level = "warn" }
-redundant_lifetimes   = { level = "warn" }
-unused_extern_crates  = { level = "warn" }
-unused_import_braces  = { level = "warn" }
-unused_lifetimes      = { level = "warn" }
-unused_macro_rules    = { level = "warn" }
-unused_qualifications = { level = "warn" }
+impl_trait_redundant_captures = { level = "warn" }
+missing_unsafe_on_extern      = { level = "warn" }
+redundant_imports             = { level = "warn" }
+redundant_lifetimes           = { level = "warn" }
+single_use_lifetimes          = { level = "warn" }
+trivial_numeric_casts         = { level = "warn" }
+unsafe_attr_outside_unsafe    = { level = "warn" }
+unsafe_op_in_unsafe_fn        = { level = "warn" }
+unstable_features             = { level = "warn" }
+unused_extern_crates          = { level = "warn" }
+unused_import_braces          = { level = "warn" }
+unused_lifetimes              = { level = "warn" }
+unused_macro_rules            = { level = "warn" }
+unused_qualifications         = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
 # When doing so, please update the same table for all crates that are not part of the workspace.
@@ -146,7 +153,6 @@ explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-impl_trait_redundant_captures                = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }
 keyword_idents_2024                          = { level = "allow" }
@@ -157,7 +163,6 @@ meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-missing_unsafe_on_extern                     = { level = "allow" }
 non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
@@ -166,15 +171,10 @@ rust_2021_prelude_collisions                 = { level = "allow" }
 rust_2024_guarded_string_incompatible_syntax = { level = "allow" }
 rust_2024_incompatible_pat                   = { level = "allow" }
 rust_2024_prelude_collisions                 = { level = "allow" }
-single_use_lifetimes                         = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
-trivial_numeric_casts                        = { level = "allow" }
 unit_bindings                                = { level = "allow" }
 unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
-unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
-unsafe_op_in_unsafe_fn                       = { level = "allow" }
-unstable_features                            = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -123,13 +123,20 @@ unused_crate_dependencies = { level = "allow" } # Too many false positives espec
 unused_results            = { level = "allow" } # We have Clippy lints to warn on unused `must_use` results. This is too pedantic as it complains on EVERY unused result.
 
 # Lints which are allow-by-default but have been changed to "warn"
-redundant_imports     = { level = "warn" }
-redundant_lifetimes   = { level = "warn" }
-unused_extern_crates  = { level = "warn" }
-unused_import_braces  = { level = "warn" }
-unused_lifetimes      = { level = "warn" }
-unused_macro_rules    = { level = "warn" }
-unused_qualifications = { level = "warn" }
+impl_trait_redundant_captures = { level = "warn" }
+missing_unsafe_on_extern      = { level = "warn" }
+redundant_imports             = { level = "warn" }
+redundant_lifetimes           = { level = "warn" }
+single_use_lifetimes          = { level = "warn" }
+trivial_numeric_casts         = { level = "warn" }
+unsafe_attr_outside_unsafe    = { level = "warn" }
+unsafe_op_in_unsafe_fn        = { level = "warn" }
+unstable_features             = { level = "warn" }
+unused_extern_crates          = { level = "warn" }
+unused_import_braces          = { level = "warn" }
+unused_lifetimes              = { level = "warn" }
+unused_macro_rules            = { level = "warn" }
+unused_qualifications         = { level = "warn" }
 
 # TODO: Address these allow-by-default Rustc lints at some point by either allowing them permanently or enforce them, and move them to the relative section according to the decision.
 # When doing so, please update the same table for all crates that are not part of the workspace.
@@ -144,7 +151,6 @@ explicit_outlives_requirements               = { level = "allow" }
 ffi_unwind_calls                             = { level = "allow" }
 if_let_rescope                               = { level = "allow" }
 impl_trait_overcaptures                      = { level = "allow" }
-impl_trait_redundant_captures                = { level = "allow" }
 keyword-idents                               = { level = "allow" }
 keyword_idents_2018                          = { level = "allow" }
 keyword_idents_2024                          = { level = "allow" }
@@ -155,7 +161,6 @@ meta_variable_misuse                         = { level = "allow" }
 missing_copy_implementations                 = { level = "allow" }
 missing_debug_implementations                = { level = "allow" }
 missing_docs                                 = { level = "allow" }
-missing_unsafe_on_extern                     = { level = "allow" }
 non_ascii_idents                             = { level = "allow" }
 rust_2021_incompatible_closure_captures      = { level = "allow" }
 rust_2021_incompatible_or_patterns           = { level = "allow" }
@@ -164,15 +169,10 @@ rust_2021_prelude_collisions                 = { level = "allow" }
 rust_2024_guarded_string_incompatible_syntax = { level = "allow" }
 rust_2024_incompatible_pat                   = { level = "allow" }
 rust_2024_prelude_collisions                 = { level = "allow" }
-single_use_lifetimes                         = { level = "allow" }
 tail_expr_drop_order                         = { level = "allow" }
 trivial_casts                                = { level = "allow" }
-trivial_numeric_casts                        = { level = "allow" }
 unit_bindings                                = { level = "allow" }
 unnameable_types                             = { level = "allow" }
 unreachable_pub                              = { level = "allow" }
-unsafe_attr_outside_unsafe                   = { level = "allow" }
 unsafe_code                                  = { level = "allow" }
-unsafe_op_in_unsafe_fn                       = { level = "allow" }
-unstable_features                            = { level = "allow" }
 variant_size_differences                     = { level = "allow" }

--- a/nomos-services/api/src/http/consensus/cryptarchia.rs
+++ b/nomos-services/api/src/http/consensus/cryptarchia.rs
@@ -68,7 +68,6 @@ pub type Cryptarchia<
 >;
 
 pub async fn cryptarchia_info<
-    'a,
     Tx,
     SS,
     SamplingBackend,
@@ -83,7 +82,7 @@ pub async fn cryptarchia_info<
     RuntimeServiceId,
     const SIZE: usize,
 >(
-    handle: &'a OverwatchHandle<RuntimeServiceId>,
+    handle: &OverwatchHandle<RuntimeServiceId>,
 ) -> Result<CryptarchiaInfo, DynError>
 where
     Tx: Transaction + Eq + Clone + Debug + Serialize + DeserializeOwned + Send + Sync + 'static,
@@ -138,7 +137,6 @@ where
 }
 
 pub async fn cryptarchia_headers<
-    'a,
     Tx,
     SS,
     SamplingBackend,
@@ -153,7 +151,7 @@ pub async fn cryptarchia_headers<
     RuntimeServiceId,
     const SIZE: usize,
 >(
-    handle: &'a OverwatchHandle<RuntimeServiceId>,
+    handle: &OverwatchHandle<RuntimeServiceId>,
     from: Option<HeaderId>,
     to: Option<HeaderId>,
 ) -> Result<Vec<HeaderId>, DynError>

--- a/nomos-services/data-availability/sampling/src/backend/kzgrs.rs
+++ b/nomos-services/data-availability/sampling/src/backend/kzgrs.rs
@@ -90,7 +90,7 @@ impl<R: Rng + Sync + Send> DaSamplingServiceBackend<R> for KzgrsSamplingBackend<
                 column_idx,
                 hex::encode(blob_id)
             );
-            ctx.subnets.insert(column_idx as SubnetworkId);
+            ctx.subnets.insert(column_idx);
 
             // sampling of this blob_id terminated successfully
             if ctx.subnets.len() == self.settings.num_samples as usize {
@@ -128,7 +128,7 @@ impl<R: Rng + Sync + Send> DaSamplingServiceBackend<R> for KzgrsSamplingBackend<
             return SamplingState::Terminated;
         }
 
-        let subnets: Vec<SubnetworkId> = (0..self.settings.num_subnets as SubnetworkId)
+        let subnets: Vec<SubnetworkId> = (0..self.settings.num_subnets)
             .choose_multiple(&mut self.rng, self.settings.num_samples.into());
 
         let ctx: SamplingContext = SamplingContext {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR enforces the following rustc lints:
* `impl_trait_redundant_captures` -> warns on unnecessary `use<>` syntax, which we don't anyway have, and that changes the behaviour of the code in Rust edition 2024
* `missing_unsafe_on_extern` -> we don't have any `extern` code, but this should anyway not be allowed
* `single_use_lifetimes` -> unnecessary single-use lifetimes (we had one of such instances, which this PR removes)
* `trivial_numeric_casts` -> trying to cast a `u16` to a `u16` should be a warning (we had two instances of this)
* `unsafe_attr_outside_unsafe` -> this will most likely become warn-by-default anyway in the near future, according to the [docs](https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#explanation-48)
* `unsafe_op_in_unsafe_fn` -> this is already warn-by-default in Rust 2024
* `unstable_features` -> not really needed since we are on stable, but it does not hurt to have it in the list of warnings, since we're not really supposed to have unstable features in production code

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
