### PR TITLE
fix(blend): use an ephemeral signing key for each encapsulation

### DIFF
--- a/nomos-blend/core/src/message_blend/crypto.rs
+++ b/nomos-blend/core/src/message_blend/crypto.rs
@@ -29,7 +29,7 @@ pub struct CryptographicProcessor<NodeId, Rng> {
 #[derivative(Debug)]
 pub struct CryptographicProcessorSettings {
     /// The non-ephemeral signing key corresponding to the public key
-    /// (provider_id) registered in the membership (SDP).
+    /// registered in the membership (SDP).
     #[serde(with = "ed25519_privkey_hex")]
     #[derivative(Debug = "ignore")]
     pub signing_private_key: Ed25519PrivateKey,
@@ -46,8 +46,8 @@ where
         membership: Membership<NodeId>,
         rng: Rng,
     ) -> Self {
-        /// Derive the non-ephemeral encryption key
-        /// from the non-ephemeral signing key.
+        // Derive the non-ephemeral encryption key
+        // from the non-ephemeral signing key.
         let encryption_private_key = settings.signing_private_key.derive_x25519();
         Self {
             settings,
@@ -70,7 +70,7 @@ where
         payload_type: PayloadType,
         payload: &[u8],
     ) -> Result<Vec<u8>, Error> {
-        /// Retrieve the non-ephemeral signing keys of the blend nodes
+        // Retrieve the non-ephemeral signing keys of the blend nodes
         let blend_node_signing_keys = self
             .membership
             .choose_remote_nodes(&mut self.rng, self.settings.num_blend_layers)
@@ -81,8 +81,8 @@ where
             blend_node_signing_keys
                 .iter()
                 .map(|blend_node_signing_key| {
-                    /// Generate an ephemeral signing key for each
-                    /// encapsulation.
+                    // Generate an ephemeral signing key for each
+                    // encapsulation.
                     let ephemeral_signing_key = Ed25519PrivateKey::generate();
                     EncapsulationInput::new(
                         ephemeral_signing_key,


### PR DESCRIPTION
## 1. What does this PR implement?

This is a stacked PR based on #1390.

We have to generate a new ephemeral signing key for each encapsulation (for privacy), as described in the following specs:
- [Message Encapsulation - Keys and Proof Generation](https://www.notion.so/Message-Encapsulation-Mechanism-215261aa09df81309d7fd7f1c2da086b?source=copy_link#215261aa09df8189a4dffe9a92bb701a)
- [Key Types and Generation Spec - Ephemeral Signing Key](https://www.notion.so/Key-Types-and-Generation-Specification-215261aa09df81088b8fd7c3089162e8?source=copy_link#215261aa09df81a39222e41a5d84f1fd)

However, the integration PR #1385 uses the **non-ephemeral** signing key for that purpose. That's wrong.

So, this PR fixes it by generating an ephemeral signing key for each encapsulation.

I also added some comments on each key in the code for avoid confusion.
But, I didn't define specific types to differentiate non-ephemeral keys and ephemeral keys, because all keys managed in any struct are non-ephemeral. Ephemeral keys should be generated on demand and used immediately.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

spec @madxor
code @youngjoon-lee @ntn-x2  

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
