### PR TITLE
chore(cryptarchia): change argument names and comments in pruning

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -399,42 +399,43 @@ where
         &self.local_chain
     }
 
-    /// Prune all blocks that are included in forks that diverged at or before
-    /// the `depth`th block from the current local chain.
-    ///
-    /// For example, if the tip of the canonical chain is at height 10 (i.e., 11
-    /// blocks long), calling `self.prune_forks(10)` will remove any forks
-    /// stemming from the genesis block, with height `0`, which is the 10th
-    /// block in the past.
-    ///
-    /// This function does not apply any particular logic when evaluating forks
-    /// other than the height at which they diverged from the local
-    /// canonical chain.
-    ///
+    /// Prune all blocks that are included in forks that diverged before
+    /// the `max_div_depth`-th block from the current local chain tip.
     /// It returns the block IDs that were part of the pruned forks.
-    pub fn prune_forks(&mut self, depth: u64) -> impl Iterator<Item = Id> + '_ {
+    ///
+    /// For example,
+    /// Given a block tree:
+    ///               b6
+    ///             /
+    /// G - b1 - b2 - b3 - b4 - b5 == local chain tip
+    ///                  \
+    ///                    b7
+    /// Calling `prune_forks(2)` will remove `b6` because it is diverged from
+    /// `b2`, which is deeper than the 2nd block `b3` from the local chain tip.
+    /// The `b7` is not removed since it is diverged from `b3`.
+    pub fn prune_forks(&mut self, max_div_depth: u64) -> impl Iterator<Item = Id> + '_ {
         #[expect(
             clippy::needless_collect,
             reason = "We need to collect since we cannot borrow both immutably (in `self.prunable_forks`) and mutably (in `self.prune_fork`) at the same time."
         )]
         // Collect prunable forks first to avoid borrowing issues
-        let forks: Vec<_> = self.prunable_forks(depth).collect();
+        let forks: Vec<_> = self.prunable_forks(max_div_depth).collect();
         forks
             .into_iter()
             .flat_map(move |prunable_fork_info| self.prune_fork(&prunable_fork_info))
     }
 
-    /// Get an iterator over the forks that can be pruned given the provided
-    /// depth.
-    ///
-    /// This means that all forks that diverged from the canonical chain at or
-    /// before the provided `depth` height are returned.
-    pub fn prunable_forks(&self, depth: u64) -> impl Iterator<Item = ForkDivergenceInfo<Id>> + '_ {
+    /// Get an iterator over the prunable forks that diverged before
+    /// the `max_div_depth`-th block from the current local chain tip.
+    pub fn prunable_forks(
+        &self,
+        max_div_depth: u64,
+    ) -> impl Iterator<Item = ForkDivergenceInfo<Id>> + '_ {
         let local_chain = self.local_chain;
-        let Some(target_height) = local_chain.length.checked_sub(depth) else {
+        let Some(deepest_div_block) = local_chain.length.checked_sub(max_div_depth) else {
             tracing::debug!(
                 target: LOG_TARGET,
-                "No prunable fork, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided depth: {}", local_chain.length, depth
+                "No prunable fork, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided max_div_depth: {}", local_chain.length, max_div_depth
             );
             return Box::new(core::iter::empty())
                 as Box<dyn Iterator<Item = ForkDivergenceInfo<Id>>>;
@@ -443,7 +444,8 @@ where
             // We calculate LCA once and store it in `ForkInfo` so it can be consumed
             // elsewhere without the need to re-calculate it.
             let lca = self.branches.lca(&local_chain, &fork);
-            (lca.length < target_height).then_some(ForkDivergenceInfo { tip: fork, lca })
+            // If the fork is diverged deeper than `deepest_div_block`, it's prunable.
+            (lca.length < deepest_div_block).then_some(ForkDivergenceInfo { tip: fork, lca })
         }))
     }
 
@@ -809,6 +811,9 @@ pub mod tests {
             // Add a fork from block 39
             .receive_block([101; 32], hash(&39u64), 40.into())
             .expect("test block to be applied successfully.")
+            // Add a fork from block 40
+            .receive_block([102; 32], hash(&40u64), 41.into())
+            .expect("test block to be applied successfully.")
             .online();
         let mut chain = chain_pre.clone();
         let pruned_blocks = chain.prune_forks(10);
@@ -817,11 +822,18 @@ pub mod tests {
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
         assert!(!chain.branches.tips.contains(&[100; 32]));
         assert!(!chain.branches.branches.contains_key(&[100; 32]));
-        // Fork at block 40 was not pruned.
+        // Fork at block 39 was not pruned because it is diverged
+        // at the 10th block from the local chain tip.
         assert!(chain_pre.branches.tips.contains(&[101; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[101; 32]));
         assert!(chain.branches.tips.contains(&[101; 32]));
         assert!(chain.branches.branches.contains_key(&[101; 32]));
+        // Fork at block 40 was not pruned because it is diverged
+        // after the 10th block from the local chain tip.
+        assert!(chain_pre.branches.tips.contains(&[102; 32]));
+        assert!(chain_pre.branches.branches.contains_key(&[102; 32]));
+        assert!(chain.branches.tips.contains(&[102; 32]));
+        assert!(chain.branches.branches.contains_key(&[102; 32]));
     }
 
     #[test]
@@ -844,12 +856,12 @@ pub mod tests {
             pruned_blocks.collect::<HashSet<_>>(),
             [[100; 32], [200; 32]].into()
         );
-        // First fork at block 39 was pruned.
+        // First fork at block 38 was pruned.
         assert!(chain_pre.branches.tips.contains(&[100; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[100; 32]));
         assert!(!chain.branches.tips.contains(&[100; 32]));
         assert!(!chain.branches.branches.contains_key(&[100; 32]));
-        // Second fork at block 39 was pruned.
+        // Second fork at block 38 was pruned.
         assert!(chain_pre.branches.tips.contains(&[200; 32]));
         assert!(chain_pre.branches.branches.contains_key(&[200; 32]));
         assert!(!chain.branches.tips.contains(&[200; 32]));

--- a/nomos-services/cryptarchia-consensus/src/states.rs
+++ b/nomos-services/cryptarchia-consensus/src/states.rs
@@ -146,7 +146,13 @@ mod tests {
                 cryptarchia_engine_config,
             );
 
-            // Add 3 more blocks to canonical chain. Blocks `0`, `1`, `2` and `3` represent
+            //      b4 - b5
+            //    /
+            // b0 - b1 - b2 - b3 == local chain tip
+            //    \    \    \
+            //      b6   b7   b8
+            //
+            // Add 3 more blocks to canonical chain. `b0`, `b1`, `b2`, and `b3` represent
             // the canonical chain now.
             cryptarchia = cryptarchia
                 .receive_block([1; 32].into(), genesis_header_id, 1.into())
@@ -198,17 +204,16 @@ mod tests {
             )
             .unwrap();
 
-        // We configured `k = 2`, and since the canonical chain is 4-block long (blocks
-        // `0` to `3`), it means that all forks diverging before 2
-        // blocks in the past are considered prunable.
+        // We configured `k = 2`, and since the canonical chain is 4-block long (`b0` to
+        // `b3`), it means that all forks diverging before 2 blocks in the past
+        // are considered prunable.
         // That is:
-        // - Blocks `3` and `4`, belonging to the first fork from genesis.
-        // - Block `6` belonging to the second fork from genesis.
+        // - `b3` and `b4`, belonging to the first fork from genesis.
+        // - `b6` belonging to the second fork from genesis.
         // On the other hand:
-        // - Block `7` is not pruned since it diverged from block `1`, which is the LIB.
-        // - Block `8` is not pruned since it diverged from block `2`, which is 1 block
-        //   younger
-        // than LIB.
+        // - `b7` is not pruned since it diverged from `b1`, which is the LIB.
+        // - `b8` is not pruned since it diverged from `b2`, which is 1 block younger
+        //   than LIB.
         assert_eq!(
             recovery_state
                 .prunable_blocks


### PR DESCRIPTION
## 1. What does this PR implement?

This is a stacked PR based on #1395 opened by @strinnityk. Today, I started working on this fix before being aware that Alex already opened the same PR yesterday.

Since Alex made the same fix, this PR is just suggesting the new argument names that represent the behavior of pruning clearer.
Also, I modified some comments accordingly.



## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

- Spec: @davidrusu 
- Impl: @zeegomo @youngjoon-lee + @strinnityk @ntn-x2 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
