### PR TITLE
feat(cryptarchia): optimize LIB-descendant check

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -348,7 +348,7 @@ where
     ) -> Result<(Self, PrunedBlocks<Id>), Error<Id>> {
         // Check if the block is a descendant of the LIB,
         // by checking if parent.height >= LIB.height.
-        // This works because all forks diverged before LIB has been pruned.
+        // This works because all forks diverged before LIB have been pruned.
         let parent_branch = self
             .branches
             .get(&parent)


### PR DESCRIPTION
## 1. What does this PR implement?

(This is a stacked PR based on https://github.com/logos-co/nomos/pull/1403.)

This PR resolves a [TODO comment](https://github.com/logos-co/nomos/blob/5f57d55059a3ddf1dd57829486c2b3dcf25c088a/consensus/cryptarchia-engine/src/lib.rs#L222) in the `cryptarchia-engine`, optimizing checking whether a new block is a descendant of the LIB, as part of block validation.
Previously, we had used `is_ancestor(lib, block)`. However, the [spec](https://www.notion.so/nomos-tech/Cryptarchia-v1-Protocol-Specification-21c261aa09df810cb85eff1c76e5798c?source=copy_link#21c261aa09df81978b9df055c4b8e67a) proposes to optimize it by just comparing heights, with the assumption that all old forks (diverged before LIB) are pruned completely.

#1403 implements pruning forks whenever LIB is updated. So, this PR optimizes the LIB descendant check based on #1403.

This PR has a long history, but I believe I’ve come up with the most reasonable solution. If you're busy, please read only the last bullet point below.

- At the beginning, I just simply replaced `is_ancestor(lib, block)` with `lib.height < block.height` in the `Branches::apply_header`: https://github.com/logos-co/nomos/commit/618efc2d40bbd9c7b4762f5437a60939c35d8a25.
- Although that was super simple, I thought it's not safe, as discussed in the [comment](https://github.com/logos-co/nomos/pull/1404#discussion_r2172268014) below. So, I refactored `Branches` and `Cryptarchia` in a way that I believe is safer. What I had refactored can be found in the [gist](https://gist.github.com/youngjoon-lee/fa4f8de63d4632db7eb720aa1992e75c) and [92bebae](https://github.com/logos-co/nomos/pull/1404/commits/92bebae700b7b7b31c97fa583ee12f261ebe8616). This removes `Branches` and merge everything into `Cryptarchia`.
- But, @zeegomo shared me the rationale of `Branches` in the [comment](https://github.com/logos-co/nomos/pull/1404#pullrequestreview-2979364399) below. I respect it and don't want to break it by this PR. 
- So, I've come up with the final version, which is again super simple and safer than the initial version.
  - It moves `Branches::lib` to `Cryptarchia::lib`. It makes sense because `local_chain` is also defined in the `Cryptarchia`. Now, `Branches` manages only a tree. All protocol-specific information is managed in the `Cryptarchia`.
  - Whenever a new block is received, `Cryptarchia` first checks if the block is a descendant of LIB, by just comparing its height with LIB's height. It works because `Cryptarchia` always prune forks diverged before LIB.
  - After that, `Cryptarchia` lets `Branches` to do the rest. If everything is good, `Cryptarchia` updates `local_chain` and `lib`, and prunes forks according to the updated `lib`.

  


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@zeegomo @youngjoon-lee 

I'm also adding @ntn-x2 since he's reviewing #1403.

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
