### PR TITLE
feat(bincode): Handle `Op` serde

### DIFF
--- a/nomos-core/chain-defs/src/mantle/ops/internal.rs
+++ b/nomos-core/chain-defs/src/mantle/ops/internal.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Serialize};
+
+use super::{
+    blob::BlobOp,
+    channel_keys::SetChannelKeysOp,
+    inscribe::InscriptionOp,
+    leader_claim::LeaderClaimOp,
+    native::NativeOp,
+    opcode::{
+        BLOB, INSCRIBE, LEADER_CLAIM, NATIVE, SDP_ACTIVE, SDP_DECLARE, SDP_WITHDRAW,
+        SET_CHANNEL_KEYS,
+    },
+    sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
+    serde_, Op,
+};
+
+/// Core set of supported Mantle operations and their serialization behaviour.
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum OpSer<'a> {
+    Inscribe(
+        #[serde(serialize_with = "serde_::serialize_op_variant::<{INSCRIBE}, InscriptionOp, _>")]
+        &'a InscriptionOp,
+    ),
+    Blob(#[serde(serialize_with = "serde_::serialize_op_variant::<{BLOB}, BlobOp, _>")] &'a BlobOp),
+    SetChannelKeys(
+        #[serde(
+            serialize_with = "serde_::serialize_op_variant::<{SET_CHANNEL_KEYS}, SetChannelKeysOp, _>"
+        )]
+        &'a SetChannelKeysOp,
+    ),
+    Native(
+        #[serde(serialize_with = "serde_::serialize_op_variant::<{NATIVE}, NativeOp, _>")]
+        &'a NativeOp,
+    ),
+    SDPDeclare(
+        #[serde(serialize_with = "serde_::serialize_op_variant::<{SDP_DECLARE}, SDPDeclareOp, _>")]
+        &'a SDPDeclareOp,
+    ),
+    SDPWithdraw(
+        #[serde(
+            serialize_with = "serde_::serialize_op_variant::<{SDP_WITHDRAW}, SDPWithdrawOp, _>"
+        )]
+        &'a SDPWithdrawOp,
+    ),
+    SDPActive(
+        #[serde(serialize_with = "serde_::serialize_op_variant::<{SDP_ACTIVE}, SDPActiveOp, _>")]
+        &'a SDPActiveOp,
+    ),
+    LeaderClaim(
+        #[serde(
+            serialize_with = "serde_::serialize_op_variant::<{LEADER_CLAIM}, LeaderClaimOp, _>"
+        )]
+        &'a LeaderClaimOp,
+    ),
+}
+
+impl<'a> From<&'a Op> for OpSer<'a> {
+    fn from(value: &'a Op) -> Self {
+        match value {
+            Op::Inscribe(op) => OpSer::Inscribe(op),
+            Op::Blob(op) => OpSer::Blob(op),
+            Op::SetChannelKeys(op) => OpSer::SetChannelKeys(op),
+            Op::Native(op) => OpSer::Native(op),
+            Op::SDPDeclare(op) => OpSer::SDPDeclare(op),
+            Op::SDPWithdraw(op) => OpSer::SDPWithdraw(op),
+            Op::SDPActive(op) => OpSer::SDPActive(op),
+            Op::LeaderClaim(op) => OpSer::LeaderClaim(op),
+        }
+    }
+}
+
+/// Core set of supported Mantle operations and their deserialization behaviour.
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum OpDe {
+    Inscribe(
+        #[serde(
+            deserialize_with = "serde_::deserialize_op_variant::<{INSCRIBE}, InscriptionOp, _>"
+        )]
+        InscriptionOp,
+    ),
+    Blob(#[serde(deserialize_with = "serde_::deserialize_op_variant::<{BLOB}, BlobOp, _>")] BlobOp),
+    SetChannelKeys(
+        #[serde(
+            deserialize_with = "serde_::deserialize_op_variant::<{SET_CHANNEL_KEYS}, SetChannelKeysOp, _>"
+        )]
+        SetChannelKeysOp,
+    ),
+    Native(
+        #[serde(deserialize_with = "serde_::deserialize_op_variant::<{NATIVE}, NativeOp, _>")]
+        NativeOp,
+    ),
+    SDPDeclare(
+        #[serde(
+            deserialize_with = "serde_::deserialize_op_variant::<{SDP_DECLARE}, SDPDeclareOp, _>"
+        )]
+        SDPDeclareOp,
+    ),
+    SDPWithdraw(
+        #[serde(
+            deserialize_with = "serde_::deserialize_op_variant::<{SDP_WITHDRAW}, SDPWithdrawOp, _>"
+        )]
+        SDPWithdrawOp,
+    ),
+    SDPActive(
+        #[serde(
+            deserialize_with = "serde_::deserialize_op_variant::<{SDP_ACTIVE}, SDPActiveOp, _>"
+        )]
+        SDPActiveOp,
+    ),
+    LeaderClaim(
+        #[serde(
+            deserialize_with = "serde_::deserialize_op_variant::<{LEADER_CLAIM}, LeaderClaimOp, _>"
+        )]
+        LeaderClaimOp,
+    ),
+}
+
+impl From<OpDe> for Op {
+    fn from(value: OpDe) -> Self {
+        match value {
+            OpDe::Inscribe(inscribe) => Self::Inscribe(inscribe),
+            OpDe::Blob(blob) => Self::Blob(blob),
+            OpDe::SetChannelKeys(set_channel_keys) => Self::SetChannelKeys(set_channel_keys),
+            OpDe::Native(native) => Self::Native(native),
+            OpDe::SDPDeclare(sdp_declare) => Self::SDPDeclare(sdp_declare),
+            OpDe::SDPWithdraw(sdp_withdraw) => Self::SDPWithdraw(sdp_withdraw),
+            OpDe::SDPActive(sdp_active) => Self::SDPActive(sdp_active),
+            OpDe::LeaderClaim(leader_claim) => Self::LeaderClaim(leader_claim),
+        }
+    }
+}

--- a/nomos-core/chain-defs/src/mantle/ops/mod.rs
+++ b/nomos-core/chain-defs/src/mantle/ops/mod.rs
@@ -1,13 +1,15 @@
 pub mod blob;
 pub mod channel_keys;
 pub mod inscribe;
+pub(crate) mod internal;
 mod leader_claim;
 pub mod native;
 pub mod opcode;
 pub mod sdp;
 mod serde_;
+mod wire;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{
     gas::{Gas, GasConstants, GasPrice},
@@ -24,70 +26,69 @@ use super::{
         sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
     },
 };
+use crate::mantle::ops::{
+    internal::{OpDe, OpSer},
+    wire::OpWireVisitor,
+};
 pub type Ed25519PublicKey = [u8; 32];
 pub type ChannelId = u64;
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[serde(untagged)]
+/// Core set of supported Mantle operations.
+///
+/// This type serves as the public-facing representation of [`OpSer`] and
+/// [`OpDe`], delegating default serialization and deserialization to them.
+///
+/// Serialization and deserialization are performed using [`serde_::WireOpSer`]
+/// and [`serde_::WireOpDe`], which introduce a custom `opcode` tag to identify
+/// the correct variant. Due to limitations in [`bincode`] and [`serde`]'s
+/// `#[serde(untagged)]` enums, binary deserialization is routed through
+/// [`OpWireVisitor`], which correctly handles `opcode` to select the
+/// appropriate variant.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Op {
-    Inscribe(
-        #[serde(serialize_with = "serde_::serialize_op_variant::<{INSCRIBE}, InscriptionOp, _>")]
-        #[serde(
-            deserialize_with = "serde_::deserialize_op_variant::<{INSCRIBE}, InscriptionOp, _>"
-        )]
-        InscriptionOp,
-    ),
-    Blob(
-        #[serde(serialize_with = "serde_::serialize_op_variant::<{BLOB}, BlobOp, _>")]
-        #[serde(deserialize_with = "serde_::deserialize_op_variant::<{BLOB}, BlobOp, _>")]
-        BlobOp,
-    ),
-    SetChannelKeys(
-        #[serde(
-            serialize_with = "serde_::serialize_op_variant::<{SET_CHANNEL_KEYS}, SetChannelKeysOp, _>"
-        )]
-        #[serde(
-            deserialize_with = "serde_::deserialize_op_variant::<{SET_CHANNEL_KEYS}, SetChannelKeysOp, _>"
-        )]
-        SetChannelKeysOp,
-    ),
-    Native(
-        #[serde(serialize_with = "serde_::serialize_op_variant::<{NATIVE}, NativeOp, _>")]
-        #[serde(deserialize_with = "serde_::deserialize_op_variant::<{NATIVE}, NativeOp, _>")]
-        NativeOp,
-    ),
-    SDPDeclare(
-        #[serde(serialize_with = "serde_::serialize_op_variant::<{SDP_DECLARE}, SDPDeclareOp, _>")]
-        #[serde(
-            deserialize_with = "serde_::deserialize_op_variant::<{SDP_DECLARE}, SDPDeclareOp, _>"
-        )]
-        SDPDeclareOp,
-    ),
-    SDPWithdraw(
-        #[serde(
-            serialize_with = "serde_::serialize_op_variant::<{SDP_WITHDRAW}, SDPWithdrawOp, _>"
-        )]
-        #[serde(
-            deserialize_with = "serde_::deserialize_op_variant::<{SDP_WITHDRAW}, SDPWithdrawOp, _>"
-        )]
-        SDPWithdrawOp,
-    ),
-    SDPActive(
-        #[serde(serialize_with = "serde_::serialize_op_variant::<{SDP_ACTIVE}, SDPActiveOp, _>")]
-        #[serde(
-            deserialize_with = "serde_::deserialize_op_variant::<{SDP_ACTIVE}, SDPActiveOp, _>"
-        )]
-        SDPActiveOp,
-    ),
-    LeaderClaim(
-        #[serde(
-            serialize_with = "serde_::serialize_op_variant::<{LEADER_CLAIM}, LeaderClaimOp, _>"
-        )]
-        #[serde(
-            deserialize_with = "serde_::deserialize_op_variant::<{LEADER_CLAIM}, LeaderClaimOp, _>"
-        )]
-        LeaderClaimOp,
-    ),
+    Inscribe(InscriptionOp),
+    Blob(BlobOp),
+    SetChannelKeys(SetChannelKeysOp),
+    Native(NativeOp),
+    SDPDeclare(SDPDeclareOp),
+    SDPWithdraw(SDPWithdrawOp),
+    SDPActive(SDPActiveOp),
+    LeaderClaim(LeaderClaimOp),
+}
+
+/// Delegates serialization through the [`OpInternal`] representation.
+impl Serialize for Op {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let op_ser = OpSer::from(self);
+        op_ser.serialize(serializer)
+    }
+}
+
+/// Delegates deserialization through the [`OpInternal`] representation.
+///
+/// If the deserializer is non-human-readable, it assumes the input was encoded
+/// using [`wire`] and uses [`OpWireVisitor`] to deserialize it.
+/// Otherwise, it falls back to deserializing via [`OpInternal`]'s default
+/// behaviour.
+///
+/// # Notes
+/// - When using the `wire` format, the tuple must contain the exact number of
+///   fields expected by [`WireOpDes`](serde_::WireOpDes), or unexpected
+///   behaviour may occur.
+impl<'de> Deserialize<'de> for Op {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            OpDe::deserialize(deserializer).map(Self::from)
+        } else {
+            deserializer.deserialize_tuple(2, OpWireVisitor)
+        }
+    }
 }
 
 impl GasPrice for Op {
@@ -134,9 +135,10 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::{blob::BlobOp, Op};
+    use crate::wire;
 
     #[test]
-    fn test_serialize_deserialize_blob_op() {
+    fn test_json_serialize_deserialize_blob_op() {
         let zeros = json!([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
@@ -154,6 +156,30 @@ mod tests {
         let serialized = serde_json::to_value(&op).unwrap();
         assert_eq!(serialized, repr);
         let deserialized = serde_json::from_value::<Op>(repr).unwrap();
+        assert_eq!(deserialized, op);
+    }
+
+    #[test]
+    fn test_bincode_serialize_deserialize_blob_op() {
+        // opcode + payload
+        let expected_bincode = vec![
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        let blob_op = BlobOp {
+            channel: 0,
+            blob: [0; 32],
+            blob_size: 0,
+            after_tx: None,
+            signer: [0; 32],
+        };
+        let op = Op::Blob(blob_op);
+
+        let serialized = wire::serialize(&op).unwrap();
+        assert_eq!(serialized, expected_bincode);
+        let deserialized = wire::deserialize::<Op>(&serialized).unwrap();
         assert_eq!(deserialized, op);
     }
 }

--- a/nomos-core/chain-defs/src/mantle/ops/serde_.rs
+++ b/nomos-core/chain-defs/src/mantle/ops/serde_.rs
@@ -14,7 +14,7 @@ where
 }
 
 #[derive(Deserialize)]
-struct WireOpDes<Inner> {
+struct WireOpDe<Inner> {
     // #[expect(dead_code, reason = "Op codes are just used for deserialization")]
     pub opcode: u8,
     pub payload: Inner,
@@ -41,7 +41,7 @@ impl<'de, const CODE: u8, Inner: Deserialize<'de>> Deserialize<'de> for WireOp<C
     where
         D: Deserializer<'de>,
     {
-        let op = WireOpDes::<Inner>::deserialize(deserializer)?.payload;
+        let op = WireOpDe::<Inner>::deserialize(deserializer)?.payload;
         Ok(Self { op })
     }
 }
@@ -60,7 +60,7 @@ pub fn serialize_op_variant<const CODE: u8, Op: Serialize, S: Serializer>(
 pub fn deserialize_op_variant<'de, const CODE: u8, Op: Deserialize<'de>, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Op, D::Error> {
-    let op = WireOpDes::<Op>::deserialize(deserializer)?;
+    let op = WireOpDe::<Op>::deserialize(deserializer)?;
     if op.opcode != CODE {
         return Err(serde::de::Error::custom(format!(
             "Invalid opcode {} for type {}",

--- a/nomos-core/chain-defs/src/mantle/ops/wire.rs
+++ b/nomos-core/chain-defs/src/mantle/ops/wire.rs
@@ -1,0 +1,83 @@
+use serde::de::{Error, SeqAccess, Visitor};
+
+use crate::mantle::ops::{opcode, Op};
+
+/// Visitor for deserializing binary-encoded Mantle operations using the
+/// [`wire`](crate::wire) format. Although [`Op`] and [`OpInternal`] are
+/// untagged enums in Serde terms, binary serde is handled through
+/// custom logic using [`WireOpSer`](crate::mantle::ops::serde_::WireOpSer) and
+/// [`WireOpDes`](crate::mantle::ops::serde_::WireOpDes). They add an
+/// explicit `opcode` tag to identify the variant.
+///
+/// This visitor is responsible for interpreting that tagged binary format and
+/// deserializing the appropriate variant accordingly.
+pub struct OpWireVisitor;
+
+impl<'de> Visitor<'de> for OpWireVisitor {
+    type Value = Op;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "a binary encoded Op")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let opcode: u8 = seq
+            .next_element()?
+            .ok_or_else(|| Error::custom("missing opcode"))?;
+
+        match opcode {
+            opcode::INSCRIBE => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing Inscription payload"))?;
+                Ok(Op::Inscribe(payload))
+            }
+            opcode::BLOB => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing Blob payload"))?;
+                Ok(Op::Blob(payload))
+            }
+            opcode::SET_CHANNEL_KEYS => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing SetChannelKeys payload"))?;
+                Ok(Op::SetChannelKeys(payload))
+            }
+            opcode::NATIVE => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing Native payload"))?;
+                Ok(Op::Native(payload))
+            }
+            opcode::SDP_DECLARE => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing SDPDeclare payload"))?;
+                Ok(Op::SDPDeclare(payload))
+            }
+            opcode::SDP_WITHDRAW => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing SDPWithdraw payload"))?;
+                Ok(Op::SDPWithdraw(payload))
+            }
+            opcode::SDP_ACTIVE => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing SDPActive payload"))?;
+                Ok(Op::SDPActive(payload))
+            }
+            opcode::LEADER_CLAIM => {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| Error::custom("missing LeaderClaim payload"))?;
+                Ok(Op::LeaderClaim(payload))
+            }
+            _ => Err(Error::custom(format!("unknown opcode: {opcode}"))),
+        }
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?
Handle `Op` serde within bincode context. In order to achieve that:
- Split `Op` into `OpSer` (private, serialization), `OpDe` (private, deserialization) and `Op` (public, serde).
- Implement `OpWireVisitor`, a `Visitor` that knows how to interpret the `opcode` tag and select the appropriate variant.
- Add binary deserialization test.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
