### PR TITLE
refactor(chain): encapsulate block removal into BlockProcessor

### DIFF
--- a/nomos-services/chain-service/src/processor.rs
+++ b/nomos-services/chain-service/src/processor.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::Debug,
 };
 
-use cryptarchia_engine::PrunedBlocks;
 use nomos_blend_service::network::NetworkAdapter as BlendNetworkAdapter;
 use nomos_core::{
     block::Block,
@@ -33,11 +32,32 @@ use crate::{
     Cryptarchia, Error, LOG_TARGET,
 };
 
+#[async_trait::async_trait]
+pub trait BlockProcessor {
+    type Block;
+
+    async fn process_block_and_update_service_state<CryptarchiaState>(
+        &mut self,
+        cryptarchia: Cryptarchia<CryptarchiaState>,
+        block: Self::Block,
+    ) -> Cryptarchia<CryptarchiaState>
+    where
+        CryptarchiaState: cryptarchia_engine::CryptarchiaState + Send;
+
+    async fn process_block<CryptarchiaState>(
+        &mut self,
+        cryptarchia: Cryptarchia<CryptarchiaState>,
+        block: Self::Block,
+    ) -> Cryptarchia<CryptarchiaState>
+    where
+        CryptarchiaState: cryptarchia_engine::CryptarchiaState + Send;
+}
+
 #[expect(
     clippy::type_complexity,
     reason = "CryptarchiaConsensusState and CryptarchiaConsensusRelays amount of generics."
 )]
-pub struct BlockProcessor<
+pub struct NomosBlockProcessor<
     'a,
     BlendAdapter,
     BS,
@@ -96,6 +116,202 @@ pub struct BlockProcessor<
             >,
         >,
     >,
+    leader: &'a Leader,
+    storage_blocks_to_remove: HashSet<HeaderId>,
+}
+
+#[async_trait::async_trait]
+impl<
+        BlendAdapter,
+        BS,
+        ClPool,
+        ClPoolAdapter,
+        DaPool,
+        DaPoolAdapter,
+        NetworkAdapter,
+        SamplingBackend,
+        SamplingRng,
+        Storage,
+        TxS,
+        DaVerifierBackend,
+        RuntimeServiceId,
+    > BlockProcessor
+    for NomosBlockProcessor<
+        '_,
+        BlendAdapter,
+        BS,
+        ClPool,
+        ClPoolAdapter,
+        DaPool,
+        DaPoolAdapter,
+        NetworkAdapter,
+        SamplingBackend,
+        SamplingRng,
+        Storage,
+        TxS,
+        DaVerifierBackend,
+        RuntimeServiceId,
+    >
+where
+    BlendAdapter:
+        blend::BlendAdapter<RuntimeServiceId, Network: BlendNetworkAdapter<RuntimeServiceId>>,
+    BlendAdapter::Settings: Send + Sync,
+    BS: BlobSelect<BlobId = DaPool::Item>,
+    BS::Settings: Send + Sync,
+    ClPool: RecoverableMempool<BlockId = HeaderId>,
+    ClPool::RecoveryState: Serialize + for<'de> Deserialize<'de>,
+    ClPool::Item: Transaction<Hash = ClPool::Key>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + 'static,
+    ClPool::Key: Debug + Send + 'static,
+    ClPool::Settings: Clone + Sync,
+    ClPoolAdapter: MempoolAdapter<RuntimeServiceId, Payload = ClPool::Item, Key = ClPool::Key>,
+    DaPool: RecoverableMempool<BlockId = HeaderId>,
+    DaPool::BlockId: Debug,
+    DaPool::Item: DispersedBlobInfo<BlobId = DaPool::Key>
+        + BlobMetadata
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + 'static,
+    DaPool::Key: Ord + Debug + Send + 'static,
+    DaPool::RecoveryState: Serialize + for<'de> Deserialize<'de>,
+    DaPool::Settings: Clone + Sync,
+    DaPoolAdapter: MempoolAdapter<RuntimeServiceId, Key = DaPool::Key>,
+    DaPoolAdapter::Payload: DispersedBlobInfo + Into<DaPool::Item> + Debug,
+    NetworkAdapter: network::NetworkAdapter<RuntimeServiceId>,
+    NetworkAdapter::Settings: Send + Sync,
+    SamplingBackend: DaSamplingServiceBackend<SamplingRng, BlobId = DaPool::Key> + Send,
+    SamplingBackend::Settings: Clone,
+    SamplingBackend::Share: Debug + 'static,
+    SamplingRng: SeedableRng + RngCore,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Block:
+        TryFrom<Block<ClPool::Item, DaPool::Item>> + TryInto<Block<ClPool::Item, DaPool::Item>>,
+    TxS: TxSelect<Tx = ClPool::Item>,
+    TxS::Settings: Send + Sync,
+    DaVerifierBackend: nomos_da_verifier::backend::VerifierBackend + Send + Sync + 'static,
+    DaVerifierBackend::Settings: Clone,
+{
+    type Block = Block<ClPool::Item, DaPool::Item>;
+
+    async fn process_block_and_update_service_state<CryptarchiaState>(
+        &mut self,
+        cryptarchia: Cryptarchia<CryptarchiaState>,
+        block: Self::Block,
+    ) -> Cryptarchia<CryptarchiaState>
+    where
+        CryptarchiaState: cryptarchia_engine::CryptarchiaState + Send,
+    {
+        let cryptarchia = self.process_block(cryptarchia, block).await;
+
+        self.storage_blocks_to_remove = self
+            .storage
+            .remove_blocks_and_collect_failures(self.storage_blocks_to_remove.iter().copied())
+            .await;
+
+        match CryptarchiaConsensusState::<_, _, _, _>::from_cryptarchia_and_unpruned_blocks(
+            &cryptarchia,
+            self.leader,
+            self.storage_blocks_to_remove.clone(),
+        ) {
+            Ok(state) => {
+                self.state_updater.update(Some(state));
+            }
+            Err(e) => {
+                error!(target: LOG_TARGET, "Failed to update state: {}", e);
+            }
+        }
+
+        cryptarchia
+    }
+
+    /// Try to add a [`Block`] to [`Cryptarchia`].
+    /// A [`Block`] is only added if it's valid
+    #[instrument(level = "debug", skip(self, cryptarchia))]
+    async fn process_block<CryptarchiaState>(
+        &mut self,
+        cryptarchia: Cryptarchia<CryptarchiaState>,
+        block: Self::Block,
+    ) -> Cryptarchia<CryptarchiaState>
+    where
+        CryptarchiaState: cryptarchia_engine::CryptarchiaState + Send,
+    {
+        debug!("received proposal {:?}", block);
+
+        let sampled_blobs = match get_sampled_blobs(self.relays.sampling_relay().clone()).await {
+            Ok(sampled_blobs) => sampled_blobs,
+            Err(error) => {
+                error!("Unable to retrieved sampled blobs: {error}");
+                return cryptarchia;
+            }
+        };
+        if !Self::validate_blocks_blobs(&block, &sampled_blobs) {
+            error!("Invalid block: {block:?}");
+            return cryptarchia;
+        }
+
+        // TODO: filter on time?
+        let header = block.header();
+        let id = header.id();
+
+        match cryptarchia.try_apply_header(header) {
+            Ok((cryptarchia, pruned_blocks)) => {
+                // remove included content from mempool
+                mark_in_block(
+                    self.relays.cl_mempool_relay().clone(),
+                    block.transactions().map(Transaction::hash),
+                    id,
+                )
+                .await;
+                mark_in_block(
+                    self.relays.da_mempool_relay().clone(),
+                    block.blobs().map(DispersedBlobInfo::blob_id),
+                    id,
+                )
+                .await;
+
+                mark_blob_in_block(
+                    self.relays.sampling_relay().clone(),
+                    block.blobs().map(DispersedBlobInfo::blob_id).collect(),
+                )
+                .await;
+
+                if let Err(e) = self.storage.store_block(header.id(), block.clone()).await {
+                    error!("Could not store block {e}");
+                }
+
+                if let Err(e) = self.block_subscription_sender.send(block) {
+                    error!("Could not notify block to services {e}");
+                }
+
+                self.storage_blocks_to_remove.extend(&pruned_blocks);
+                return cryptarchia;
+            }
+            Err(
+                Error::Ledger(nomos_ledger::LedgerError::ParentNotFound(parent))
+                | Error::Consensus(cryptarchia_engine::Error::ParentMissing(parent)),
+            ) => {
+                debug!("missing parent {:?}", parent);
+                // TODO: request parent block
+            }
+            Err(e) => {
+                debug!("invalid block {:?}: {e:?}", block);
+            }
+        }
+
+        cryptarchia
+    }
 }
 
 impl<
@@ -114,7 +330,7 @@ impl<
         DaVerifierBackend,
         RuntimeServiceId,
     >
-    BlockProcessor<
+    NomosBlockProcessor<
         'a,
         BlendAdapter,
         BS,
@@ -213,127 +429,17 @@ where
                 >,
             >,
         >,
+        leader: &'a Leader,
+        storage_blocks_to_remove: HashSet<HeaderId>,
     ) -> Self {
         Self {
             storage,
             relays,
             block_subscription_sender,
             state_updater,
-        }
-    }
-
-    pub async fn process_block_and_update_service_state<CryptarchiaState>(
-        &self,
-        cryptarchia: Cryptarchia<CryptarchiaState>,
-        leader: &Leader,
-        block: Block<ClPool::Item, DaPool::Item>,
-        storage_blocks_to_remove: &HashSet<HeaderId>,
-    ) -> (Cryptarchia<CryptarchiaState>, HashSet<HeaderId>)
-    where
-        CryptarchiaState: cryptarchia_engine::CryptarchiaState + Send,
-    {
-        let (cryptarchia, pruned_blocks) = self.process_block(cryptarchia, block).await;
-
-        let storage_blocks_to_remove = self
-            .storage
-            .remove_blocks_and_collect_failures(
-                pruned_blocks
-                    .iter()
-                    .chain(storage_blocks_to_remove.iter())
-                    .copied(),
-            )
-            .await;
-
-        match CryptarchiaConsensusState::<_, _, _, _>::from_cryptarchia_and_unpruned_blocks(
-            &cryptarchia,
             leader,
-            storage_blocks_to_remove.clone(),
-        ) {
-            Ok(state) => {
-                self.state_updater.update(Some(state));
-            }
-            Err(e) => {
-                error!(target: LOG_TARGET, "Failed to update state: {}", e);
-            }
+            storage_blocks_to_remove,
         }
-
-        (cryptarchia, storage_blocks_to_remove)
-    }
-
-    /// Try to add a [`Block`] to [`Cryptarchia`].
-    /// A [`Block`] is only added if it's valid
-    #[instrument(level = "debug", skip(self, cryptarchia))]
-    pub async fn process_block<CryptarchiaState>(
-        &self,
-        cryptarchia: Cryptarchia<CryptarchiaState>,
-        block: Block<ClPool::Item, DaPool::Item>,
-    ) -> (Cryptarchia<CryptarchiaState>, PrunedBlocks<HeaderId>)
-    where
-        CryptarchiaState: cryptarchia_engine::CryptarchiaState + Send,
-    {
-        debug!("received proposal {:?}", block);
-
-        let sampled_blobs = match get_sampled_blobs(self.relays.sampling_relay().clone()).await {
-            Ok(sampled_blobs) => sampled_blobs,
-            Err(error) => {
-                error!("Unable to retrieved sampled blobs: {error}");
-                return (cryptarchia, PrunedBlocks::new());
-            }
-        };
-        if !Self::validate_blocks_blobs(&block, &sampled_blobs) {
-            error!("Invalid block: {block:?}");
-            return (cryptarchia, PrunedBlocks::new());
-        }
-
-        // TODO: filter on time?
-        let header = block.header();
-        let id = header.id();
-
-        match cryptarchia.try_apply_header(header) {
-            Ok((cryptarchia, pruned_blocks)) => {
-                // remove included content from mempool
-                mark_in_block(
-                    self.relays.cl_mempool_relay().clone(),
-                    block.transactions().map(Transaction::hash),
-                    id,
-                )
-                .await;
-                mark_in_block(
-                    self.relays.da_mempool_relay().clone(),
-                    block.blobs().map(DispersedBlobInfo::blob_id),
-                    id,
-                )
-                .await;
-
-                mark_blob_in_block(
-                    self.relays.sampling_relay().clone(),
-                    block.blobs().map(DispersedBlobInfo::blob_id).collect(),
-                )
-                .await;
-
-                if let Err(e) = self.storage.store_block(header.id(), block.clone()).await {
-                    error!("Could not store block {e}");
-                }
-
-                if let Err(e) = self.block_subscription_sender.send(block) {
-                    error!("Could not notify block to services {e}");
-                }
-
-                return (cryptarchia, pruned_blocks);
-            }
-            Err(
-                Error::Ledger(nomos_ledger::LedgerError::ParentNotFound(parent))
-                | Error::Consensus(cryptarchia_engine::Error::ParentMissing(parent)),
-            ) => {
-                debug!("missing parent {:?}", parent);
-                // TODO: request parent block
-            }
-            Err(e) => {
-                debug!("invalid block {:?}: {e:?}", block);
-            }
-        }
-
-        (cryptarchia, PrunedBlocks::new())
     }
 
     fn validate_blocks_blobs(


### PR DESCRIPTION
## 1. What does this PR implement?

(This is a next step of the PR #1431).

It's cumbersome to carry around the `storage_blocks_to_remove` and handle them. It'll be even worse when we implement IBD which also need that behavior.

So, this PR encapsulates deleting the pruned blocks into `BlockProcessor`. Now, `BlockProcessor` remove blocks automatically, and the caller doesn't care about it. It makes sense because we delete the pruned blocks from storage right after processing a new block.

This makes the main service loop cleaner, and also makes IBD (which will be introduced in a next PR) simpler.

Also, I introduced the `BlockProcessor` trait for easy testing (which will be added along with IBD).

p.s.
I know that the shape of `BlockProcessor` is not optimal yet. But, I didn't wanna change the logic a lot before having the IBD in the next PR. After that, I will reshape `BlockProcessor` much better.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@zeegomo @youngjoon-lee 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
