### PR TITLE
refactor(chain): introduce `Block` associated type for `NetworkAdapter`

### DIFF
--- a/nomos-services/chain-service/src/lib.rs
+++ b/nomos-services/chain-service/src/lib.rs
@@ -398,7 +398,7 @@ impl<
         RuntimeServiceId,
     >
 where
-    NetAdapter: NetworkAdapter<RuntimeServiceId, Tx = ClPool::Item, BlobCertificate = DaPool::Item>
+    NetAdapter: NetworkAdapter<RuntimeServiceId, Block = Block<ClPool::Item, DaPool::Item>>
         + Clone
         + Send
         + Sync

--- a/nomos-services/chain-service/src/network/adapters/libp2p.rs
+++ b/nomos-services/chain-service/src/network/adapters/libp2p.rs
@@ -66,9 +66,8 @@ where
 {
     type Backend = Libp2p;
     type Settings = LibP2pAdapterSettings;
-    type Tx = Tx;
-    type BlobCertificate = BlobCert;
     type PeerId = PeerId;
+    type Block = Block<Tx, BlobCert>;
 
     async fn new(settings: Self::Settings, network_relay: Relay<Libp2p, RuntimeServiceId>) -> Self {
         let relay = network_relay.clone();
@@ -85,9 +84,7 @@ where
         }
     }
 
-    async fn blocks_stream(
-        &self,
-    ) -> Result<BoxedStream<Block<Self::Tx, Self::BlobCertificate>>, DynError> {
+    async fn blocks_stream(&self) -> Result<BoxedStream<Self::Block>, DynError> {
         let (sender, receiver) = oneshot::channel();
         if let Err((e, _)) = self
             .network_relay
@@ -159,8 +156,7 @@ where
         local_tip: HeaderId,
         latest_immutable_block: HeaderId,
         additional_blocks: HashSet<HeaderId>,
-    ) -> Result<BoxedStream<Result<Block<Self::Tx, Self::BlobCertificate>, DynError>>, DynError>
-    {
+    ) -> Result<BoxedStream<Result<Self::Block, DynError>>, DynError> {
         let (reply_sender, receiver) = oneshot::channel();
         if let Err((e, _)) = self
             .network_relay


### PR DESCRIPTION
## 1. What does this PR implement?

Yeah, this is finally the end of the long journey of preparing for the implementation of IBD (which will be introduced in the next PR).

This is not necessarily required by IBD, but without this, it's so hard to test the IBD and others. 

This PR abstracts `Block` as an associate type for `NetworkAdapter`. In this way, we can write tests by defining a mock `NetworkAdapter` that returns a mock `Block`.
This is useful because building the real `nomos_core::block::Block` is not easy (especially building the proof). 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
@zeegomo @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
