### PR TITLE
chore: update codeowner path for chain-service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Consensus
 /consensus/ @zeegomo @youngjoon-lee
-/nomos-services/cryptarchia-consensus @zeegomo @youngjoon-lee
+/nomos-services/chain-service @zeegomo @youngjoon-lee
 
 # Mantle
 /ledger/ @zeegomo @danielSanchezQ


### PR DESCRIPTION
## 1. What does this PR implement?

The `cryptarchia-consensus` service has been renamed to `chain-service`, but the CODEOWNER file hasn't been updated. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
