### PR TITLE
chore(da-network): wrap membership in arc to avoid deep copies

### DIFF
--- a/nomos-services/data-availability/network/src/membership/handler.rs
+++ b/nomos-services/data-availability/network/src/membership/handler.rs
@@ -62,3 +62,49 @@ where
         self.membership.load().subnetworks()
     }
 }
+
+#[derive(Clone)]
+pub struct DaMembershipHandlerArc<Membership> {
+    membership: Arc<Membership>,
+}
+
+impl<Membership> DaMembershipHandlerArc<Membership> {
+    pub fn new(membership: Membership) -> Self {
+        Self {
+            membership: Arc::new(membership),
+        }
+    }
+}
+
+// Implement MembershipHandler for DaMembershipHandlerArc
+impl<Membership> MembershipHandler for DaMembershipHandlerArc<Membership>
+where
+    Membership: MembershipHandler + Clone,
+{
+    type NetworkId = Membership::NetworkId;
+    type Id = Membership::Id;
+
+    fn membership(&self, id: &Self::Id) -> HashSet<Self::NetworkId> {
+        self.membership.membership(id)
+    }
+
+    fn is_allowed(&self, id: &Self::Id) -> bool {
+        self.membership.is_allowed(id)
+    }
+
+    fn members_of(&self, network_id: &Self::NetworkId) -> HashSet<Self::Id> {
+        self.membership.members_of(network_id)
+    }
+
+    fn members(&self) -> HashSet<Self::Id> {
+        self.membership.members()
+    }
+
+    fn last_subnetwork_id(&self) -> Self::NetworkId {
+        self.membership.last_subnetwork_id()
+    }
+
+    fn subnetworks(&self) -> SubnetworkAssignations<Self::NetworkId, Self::Id> {
+        self.membership.subnetworks()
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?

Passed historic membership was using history aware assignations clone while being passed along. To mitigate this I have introduced a new type that wraps it in Arc so it can be safely passed around and cloned.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 
## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
