### PR TITLE
chore(storage): bump rocksdb to 0.24

### DIFF
--- a/nomos-services/storage/Cargo.toml
+++ b/nomos-services/storage/Cargo.toml
@@ -15,7 +15,7 @@ libp2p-identity    = { version = "0.2", features = ["peerid", "serde"] }
 multiaddr          = "0.18"
 nomos-core         = { workspace = true }
 overwatch          = { workspace = true }
-rocksdb            = { version = "0.22", optional = true }
+rocksdb            = { version = "0.24", optional = true }
 serde              = { version = "1.0", features = ["derive"] }
 thiserror          = "1.0"
 tokio              = { version = "1", features = ["macros", "sync"] }


### PR DESCRIPTION
## 1. What does this PR implement?

rocksdb v0.22 (which we're using) doesn't compile in gcc 15+, which is the [latest version](https://gcc.gnu.org/releases.html) released recently.
```
cargo:warning=rocksdb/trace_replay/trace_record_result.cc:118:31: error: 'uint64_t' has not been declared
```
This issue has been fixed in the rocksdb [v0.24](https://github.com/rust-rocksdb/rust-rocksdb/releases/tag/v0.24.0) (latest): https://github.com/rust-rocksdb/rust-rocksdb/pull/1007.
This PR bumps rocksdb to v0.24.

This issue hasn't been detected in our CI because the CI uses the older version of gcc:
```
gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04) 
```

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
