### PR TITLE
fix(chain): IBD: do not skip downloads for duplicate targets

### DIFF
--- a/tests/src/tests/cryptarchia/bootstrap.rs
+++ b/tests/src/tests/cryptarchia/bootstrap.rs
@@ -71,6 +71,7 @@ async fn test_ibd_behind_nodes() {
         .then(|n| async move { n.consensus_info().await.height })
         .collect::<Vec<_>>()
         .await;
+    println!("initial_validator_heights: {heights:?}");
 
     let max_initial_validator_height = heights
         .iter()
@@ -95,7 +96,10 @@ async fn test_ibd_behind_nodes() {
         behind_node_info
             .height
             .abs_diff(*max_initial_validator_height)
-            <= height_margin
+            <= height_margin,
+        "behind_node_info.height:{}, max_initial_validator_height:{}",
+        behind_node_info.height,
+        max_initial_validator_height,
     );
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

This issue has been found from an occasional CI failure: https://github.com/logos-co/nomos/pull/1568.

Previously, we were not starting a download for a peer, if there is another peer that has the same tip (i.e. target). It was for saving network bandwidth.
For example, if there are two peers A and B that have the tip id `10`, we initiate a download from only the peer A.

However, if the chain of peer B grows, but if the chain of peer A doesn't grow for some reason, the IBD of the catching-up node will finish without catching up with the peer B.
Also, there may be many other cases where those peers later diverge.

According to the definition of IBD, we need to try our best to catch up with all the peers specified, unless any error occurs.

So, this PR fixes this issue by **not skipping** downloads for duplicate targets.
In this way, we will consume more network bandwidth, but I think it's a safer approach for now.
Later, we can optimize the network consumption by introducing smarter download managements. 
But for now, I'd like to go with this simple solution.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @zeegomo 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
