### PR TITLE
chore: bump risc0 to v2.3.2

### DIFF
--- a/.github/actions/install-risc0/action.yml
+++ b/.github/actions/install-risc0/action.yml
@@ -27,7 +27,7 @@ runs:
       # * .github/workflows/code-check.yml (the `risc0-clippy` within the `lints` job)
       run: |
         cargo install rzup --version 0.4.1 --locked \
-          && ~/.cargo/bin/rzup install cargo-risczero 2.3.0 \
+          && ~/.cargo/bin/rzup install cargo-risczero 2.3.2 \
           && ~/.cargo/bin/rzup install rust 1.88.0
       shell: bash
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ overwatch         = { git = "https://github.com/logos-co/Overwatch", rev = "f5a9
 overwatch-derive  = { git = "https://github.com/logos-co/Overwatch", rev = "f5a9902" }
 rand              = "0.8"
 reqwest           = "0.12"
-risc0-zkvm        = "2.3.0"
+risc0-zkvm        = "2.3.2"
 serde_with        = "3.12.0"
 tempfile          = "3"
 tracing           = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -yq \
 
 RUN cargo install cargo-binstall --locked
 RUN cargo install rzup --version 0.4.1 --locked
-RUN rzup install cargo-risczero 2.3.0
+RUN rzup install cargo-risczero 2.3.2
 RUN rzup install rust 1.88.0
 
 RUN cargo build --release -p nomos-node

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -25,5 +25,5 @@ USER jenkins
 
 RUN cargo install cargo-binstall --locked
 RUN cargo install rzup --version 0.4.1 --locked
-RUN /home/jenkins/.cargo/bin/rzup install cargo-risczero 2.3.0
+RUN /home/jenkins/.cargo/bin/rzup install cargo-risczero 2.3.2
 RUN /home/jenkins/.cargo/bin/rzup install rust 1.88.0

--- a/nomos-core/chain-defs/Cargo.toml
+++ b/nomos-core/chain-defs/Cargo.toml
@@ -29,7 +29,7 @@ tracing                = { workspace = true }
 
 [dev-dependencies]
 rand       = { workspace = true }
-risc0-zkvm = { workspace = true, features = ["prove"] }
+risc0-zkvm = { workspace = true }
 serde_json = "1.0"
 
 [features]

--- a/nomos-core/risc0_proofs/Cargo.toml
+++ b/nomos-core/risc0_proofs/Cargo.toml
@@ -5,7 +5,7 @@ name    = "nomos_risc0_proofs"
 version = "0.1.0"
 
 [build-dependencies]
-risc0-build = "2.3.0"
+risc0-build = "2.3.2"
 
 [package.metadata.risc0]
 methods = ["proof_of_leadership"]

--- a/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
+++ b/nomos-core/risc0_proofs/proof_of_leadership/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 
 [dependencies]
 nomos_proof_statements = { path = "../../proof_statements" }
-risc0-zkvm             = { version = "2.3.0", default-features = false, features = ['std'] }
+risc0-zkvm             = { version = "2.3.2", default-features = false, features = ['std'] }
 
 [patch.crates-io]
 # add RISC Zero accelerator support for all downstream usages of the following crates.

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -yq \
 
 RUN cargo install cargo-binstall --locked
 RUN cargo install rzup --version 0.4.1 --locked
-RUN rzup install cargo-risczero 2.3.0
+RUN rzup install cargo-risczero 2.3.2
 RUN rzup install rust 1.88.0
 
 RUN cargo build --release


### PR DESCRIPTION
## 1. What does this PR implement?

update risc0 to v2.3.2

Also removes the "prove" feature from dev-dependencies to fix a compilation error in risc0-zkvm 2.3.2 where SYS_PROVE_ZKR constant has a type mismatch.

---
There is 1 test failure but not related I think because in another agent it's green.

```
thread 'test_update_get_membership_http' panicked at tests/src/tests/membership/api.rs:70:5:
assertion `left == right` failed
  left: 0
 right: 2
 ```

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
