### PR TITLE
feat(blend): add SessionEventStream for sessions and transitions

### DIFF
--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -36,6 +36,7 @@ blend:
     round_duration: [1, 0]
     # Defined in the spec
     rounds_per_observation_window: 30
+    rounds_per_session_transition_period: 30
   scheduler:
     intervals_for_safety_buffer: 100
     message_frequency_per_round: 1.0

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -36,6 +36,7 @@ blend:
     round_duration: [1, 0]
     # Defined in the spec
     rounds_per_observation_window: 30
+    rounds_per_session_transition_period: 30
   scheduler:
     intervals_for_safety_buffer: 100
     message_frequency_per_round: 1.0

--- a/nodes/nomos-node/node/src/config/blend.rs
+++ b/nodes/nomos-node/node/src/config/blend.rs
@@ -15,6 +15,7 @@ impl BlendConfig {
     fn proxy(&self) -> <BlendService as ServiceData>::Settings {
         nomos_blend_service::settings::Settings {
             crypto: self.0.crypto.clone(),
+            time: self.0.time.clone(),
             membership: self.0.membership.clone(),
             minimal_network_size: self.0.minimum_network_size,
         }

--- a/nomos-blend/scheduling/src/lib.rs
+++ b/nomos-blend/scheduling/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod membership;
 pub mod message_blend;
+pub mod session;
 pub use message_blend::crypto::{
     deserialize_encapsulated_message, serialize_encapsulated_message, EncapsulatedMessage,
     UnwrappedMessage,

--- a/nomos-blend/scheduling/src/session.rs
+++ b/nomos-blend/scheduling/src/session.rs
@@ -1,0 +1,178 @@
+use std::{
+    future::Future as _,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::Stream;
+use tokio::time::{sleep, Sleep};
+
+pub enum SessionEvent<Session> {
+    NewSession(Session),
+    TransitionPeriodExpired,
+}
+
+/// A stream that alternates between yielding [`SessionEvent::NewSession`]
+/// and [`SessionEvent::TransitionPeriodExpired`].
+///
+/// It wraps a stream of [`Session`]s and yields a [`SessionEvent::NewSession`]
+/// as soon as a new [`Session`] is available from the inner stream.
+/// Then, it yields a [`SessionEvent::TransitionPeriodExpired`] after
+/// the transition period has elapsed.
+///
+/// # Stream Timeline
+/// ```text
+/// event stream  : O--E-------O--E--------------O--E-------
+/// session stream: |----S1----|--------S2-------|----S3----
+///
+/// (O: NewSession, E: TransitionPeriodExpired, S*: Sessions)
+/// ```
+pub struct SessionEventStream<Session> {
+    session_stream: Pin<Box<dyn Stream<Item = Session> + Send + Sync>>,
+    transition_period: Duration,
+    transition_period_timer: Option<Pin<Box<Sleep>>>,
+}
+
+impl<Session> SessionEventStream<Session> {
+    #[must_use]
+    pub fn new(
+        session_stream: Pin<Box<dyn Stream<Item = Session> + Send + Sync>>,
+        transition_period: Duration,
+    ) -> Self {
+        Self {
+            session_stream,
+            transition_period,
+            transition_period_timer: None,
+        }
+    }
+}
+
+impl<Session> Stream for SessionEventStream<Session> {
+    type Item = SessionEvent<Session>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Check if a new session is available.
+        match self.session_stream.as_mut().poll_next(cx) {
+            Poll::Ready(Some(session)) => {
+                // Start the transition period timer, and yield the new session.
+                // If the previous transition period timer has not been expired yet,
+                // it will be overwritten.
+                self.transition_period_timer = Some(Box::pin(sleep(self.transition_period)));
+                return Poll::Ready(Some(SessionEvent::NewSession(session)));
+            }
+            Poll::Ready(None) => return Poll::Ready(None),
+            Poll::Pending => {}
+        }
+
+        // Check if the transition period has expired.
+        if let Some(timer) = &mut self.transition_period_timer {
+            if timer.as_mut().poll(cx).is_ready() {
+                self.transition_period_timer = None;
+                return Poll::Ready(Some(SessionEvent::TransitionPeriodExpired));
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt as _;
+    use tokio::time::{interval, Instant};
+    use tokio_stream::wrappers::IntervalStream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn yield_two_events_alternately() {
+        let session_duration = Duration::from_millis(100);
+        let transition_period = Duration::from_millis(10);
+
+        let mut stream = SessionEventStream::new(
+            Box::pin(IntervalStream::new(interval(session_duration))),
+            transition_period,
+        );
+
+        // NewSession should be emitted immediately.
+        let start_time = Instant::now();
+        assert!(matches!(
+            stream.next().await,
+            Some(SessionEvent::NewSession(_))
+        ));
+        let elapsed = start_time.elapsed();
+        let tolerance = Duration::from_millis(5);
+        assert!(elapsed <= tolerance, "elapsed:{elapsed:?}");
+
+        // TransitionEnd should be emitted after transition_period.
+        let start_time = Instant::now();
+        assert!(matches!(
+            stream.next().await,
+            Some(SessionEvent::TransitionPeriodExpired)
+        ));
+        let elapsed = start_time.elapsed();
+        assert!(
+            elapsed.abs_diff(transition_period) <= tolerance,
+            "elapsed:{elapsed:?}, expected:{transition_period:?}",
+        );
+
+        // NewSession should be emitted after session_duration - transition_period.
+        let start_time = Instant::now();
+        assert!(matches!(
+            stream.next().await,
+            Some(SessionEvent::NewSession(_))
+        ));
+        let elapsed = start_time.elapsed();
+        assert!(
+            elapsed.abs_diff(session_duration - transition_period) <= tolerance,
+            "elapsed:{elapsed:?}, expected:{:?}",
+            session_duration - transition_period
+        );
+
+        // TransitionEnd should be emitted after transition_period.
+        let start_time = Instant::now();
+        assert!(matches!(
+            stream.next().await,
+            Some(SessionEvent::TransitionPeriodExpired)
+        ));
+        let elapsed = start_time.elapsed();
+        assert!(
+            elapsed.abs_diff(transition_period) <= tolerance,
+            "elapsed:{elapsed:?}, expected:{transition_period:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn transition_period_shorter_than_session() {
+        let session_duration = Duration::from_millis(10);
+        let transition_period = Duration::from_millis(20);
+
+        let mut stream = SessionEventStream::new(
+            Box::pin(IntervalStream::new(interval(session_duration))),
+            transition_period,
+        );
+
+        // NewSession should be emitted immediately.
+        let start_time = Instant::now();
+        assert!(matches!(
+            stream.next().await,
+            Some(SessionEvent::NewSession(_))
+        ));
+        let elapsed = start_time.elapsed();
+        let tolerance = Duration::from_millis(5);
+        assert!(elapsed <= tolerance, "elapsed:{elapsed:?}");
+
+        // NewSession should be emitted again after session_duration.
+        let start_time = Instant::now();
+        assert!(matches!(
+            stream.next().await,
+            Some(SessionEvent::NewSession(_))
+        ));
+        let elapsed = start_time.elapsed();
+        assert!(
+            elapsed.abs_diff(session_duration) <= tolerance,
+            "elapsed:{elapsed:?}, expected:{session_duration:?}",
+        );
+    }
+}

--- a/nomos-services/blend/src/core/mod.rs
+++ b/nomos-services/blend/src/core/mod.rs
@@ -19,6 +19,7 @@ use nomos_blend_network::EncapsulatedMessageWithValidatedPublicHeader;
 use nomos_blend_scheduling::{
     message_blend::crypto::CryptographicProcessor,
     message_scheduler::{round_info::RoundInfo, MessageScheduler},
+    session::SessionEventStream,
     UninitializedMessageScheduler,
 };
 use nomos_core::wire;
@@ -151,8 +152,11 @@ where
                 .await?,
             blend_config.crypto.signing_private_key.public_key(),
         );
-        let mut _membership_stream = membership_adapter.subscribe().await?;
-        // TODO: Use membership_stream as a session stream: https://github.com/logos-co/nomos/issues/1532
+        let mut _session_stream = SessionEventStream::new(
+            membership_adapter.subscribe().await?,
+            blend_config.time.session_transition_period(),
+        );
+        // TODO: Use session_stream: https://github.com/logos-co/nomos/issues/1532
 
         // Yields once every randomly-scheduled release round.
         let mut message_scheduler = UninitializedMessageScheduler::<

--- a/nomos-services/blend/src/edge/mod.rs
+++ b/nomos-services/blend/src/edge/mod.rs
@@ -10,7 +10,9 @@ use std::{
 };
 
 use backends::BlendBackend;
-use nomos_blend_scheduling::message_blend::crypto::CryptographicProcessor;
+use nomos_blend_scheduling::{
+    message_blend::crypto::CryptographicProcessor, session::SessionEventStream,
+};
 use nomos_core::wire;
 use nomos_utils::blake_rng::BlakeRng;
 use overwatch::{
@@ -104,8 +106,11 @@ where
                 .await?,
             settings.crypto.signing_private_key.public_key(),
         );
-        let mut _membership_stream = membership_adapter.subscribe().await?;
-        // TODO: Use membership_stream as a session stream: https://github.com/logos-co/nomos/issues/1532
+        let mut _session_stream = SessionEventStream::new(
+            membership_adapter.subscribe().await?,
+            settings.time.session_transition_period(),
+        );
+        // TODO: Use session_stream: https://github.com/logos-co/nomos/issues/1532
 
         wait_until_services_are_ready!(
             &service_resources_handle.overwatch_handle,

--- a/nomos-services/blend/src/lib.rs
+++ b/nomos-services/blend/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures::StreamExt as _;
+use nomos_blend_scheduling::session::SessionEventStream;
 use nomos_network::NetworkService;
 use overwatch::{
     services::{
@@ -123,8 +124,11 @@ where
                 .await?,
             settings.crypto.signing_private_key.public_key(),
         );
-        let mut _membership_stream = membership_adapter.subscribe().await?;
-        // TODO: Use membership_stream as a session stream: https://github.com/logos-co/nomos/issues/1532
+        let mut _session_stream = SessionEventStream::new(
+            membership_adapter.subscribe().await?,
+            settings.time.session_transition_period(),
+        );
+        // TODO: Use session_stream: https://github.com/logos-co/nomos/issues/1532
 
         // TODO: Add logic to start/stop the core or edge service based on the new
         // membership info.

--- a/nomos-services/blend/src/settings.rs
+++ b/nomos-services/blend/src/settings.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Settings<NodeId> {
     pub crypto: CryptographicProcessorSettings,
+    pub time: TimingSettings,
     pub minimal_network_size: NonZeroU64,
     // TODO: Replace with SDP membership stream.
     pub membership: Vec<Node<NodeId>>,
@@ -24,6 +25,8 @@ pub struct TimingSettings {
     /// Duration of a round.
     pub round_duration: Duration,
     pub rounds_per_observation_window: NonZeroU64,
+    /// Session transition period in rounds.
+    pub rounds_per_session_transition_period: NonZeroU64,
 }
 
 impl TimingSettings {
@@ -35,5 +38,12 @@ impl TimingSettings {
     #[must_use]
     pub fn intervals_per_session(&self) -> NonZeroU64 {
         NonZeroU64::try_from(self.rounds_per_session.get() / self.rounds_per_interval.get()).expect("Obtained `0` when calculating the number of intervals per session, which is not allowed.")
+    }
+
+    #[must_use]
+    pub const fn session_transition_period(&self) -> Duration {
+        Duration::from_secs(
+            self.rounds_per_session_transition_period.get() * self.round_duration.as_secs(),
+        )
     }
 }

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -364,6 +364,8 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
                     .expect("Rounds per session cannot be zero."),
                 rounds_per_observation_window: NonZeroU64::try_from(30u64)
                     .expect("Rounds per observation window cannot be zero."),
+                rounds_per_session_transition_period: NonZeroU64::try_from(30u64)
+                    .expect("Rounds per session transition period cannot be zero."),
             },
             scheduler: SchedulerSettingsExt {
                 cover: CoverTrafficSettingsExt {

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -389,6 +389,8 @@ pub fn create_validator_config(config: GeneralConfig) -> Config {
                     .expect("Rounds per session cannot be zero."),
                 rounds_per_observation_window: NonZeroU64::try_from(30u64)
                     .expect("Rounds per observation window cannot be zero."),
+                rounds_per_session_transition_period: NonZeroU64::try_from(30u64)
+                    .expect("Rounds per session transition period cannot be zero."),
             },
             scheduler: SchedulerSettingsExt {
                 cover: CoverTrafficSettingsExt {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR defines the `SessionEventStream` that alternately yields a new session and a transition expiration.

I think that having this stream is better that implementing the transition period tracking in all the places where it is need. Please see the doc comment, which explains the details.

This stream will be integrated to the system in a next PR. We're almost there.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee @madxor 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
