### PR TITLE
feat(blend): session transition for edge service

### DIFF
--- a/nomos-services/blend/src/edge/backends/libp2p/mod.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/mod.rs
@@ -1,12 +1,7 @@
 mod settings;
 mod swarm;
 
-use std::pin::Pin;
-
-use futures::{
-    future::{AbortHandle, Abortable},
-    Stream,
-};
+use futures::future::{AbortHandle, Abortable};
 use libp2p::PeerId;
 use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
 use overwatch::overwatch::OverwatchHandle;
@@ -36,8 +31,7 @@ impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBac
     fn new<Rng>(
         settings: Self::Settings,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<PeerId>> + Send>>,
-        current_membership: Option<Membership<PeerId>>,
+        membership: Membership<PeerId>,
         rng: Rng,
     ) -> Self
     where
@@ -46,8 +40,7 @@ impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBac
         let (swarm_command_sender, swarm_command_receiver) = mpsc::channel(CHANNEL_SIZE);
         let swarm = BlendSwarm::new(
             &settings,
-            session_stream,
-            current_membership,
+            membership,
             rng,
             swarm_command_receiver,
             settings.protocol_name.clone().into_inner(),

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/message_handling.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/message_handling.rs
@@ -57,11 +57,10 @@ async fn edge_message_propagation() {
     let EdgeTestSwarm {
         swarm: edge_swarm,
         command_sender: edge_swarm_command_sender,
-    } = EdgeSwarmBuilder::default()
+    } = EdgeSwarmBuilder::new(membership_for_edge_swarm)
         // We test that we can pick the `min` between the replication factor and the available
         // peers.
         .with_replication_factor(usize::MAX)
-        .with_membership(membership_for_edge_swarm)
         .build();
     spawn(async move { edge_swarm.run().await });
 
@@ -139,8 +138,7 @@ async fn replication_factor() {
     let EdgeTestSwarm {
         swarm: edge_swarm,
         command_sender: edge_swarm_command_sender,
-    } = EdgeSwarmBuilder::default()
-        .with_membership(membership_for_edge_swarm)
+    } = EdgeSwarmBuilder::new(membership_for_edge_swarm)
         .with_replication_factor(2)
         .build();
     spawn(async move { edge_swarm.run().await });

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -24,16 +24,15 @@ async fn edge_redial_same_peer() {
     let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
 
     // Configure swarm with an unreachable member.
-    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::default()
-        .with_membership(Membership::new(
-            from_ref(&Node {
-                address: empty_multiaddr.clone(),
-                id: random_peer_id,
-                public_key: Ed25519PrivateKey::generate().public_key(),
-            }),
-            None,
-        ))
-        .build();
+    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(Membership::new(
+        from_ref(&Node {
+            address: empty_multiaddr.clone(),
+            id: random_peer_id,
+            public_key: Ed25519PrivateKey::generate().public_key(),
+        }),
+        None,
+    ))
+    .build();
     let message = TestEncapsulatedMessage::new(b"test-payload");
     swarm.send_message(&message);
 
@@ -148,9 +147,7 @@ async fn edge_redial_different_peer_after_redial_limit() {
     let EdgeTestSwarm {
         swarm: mut edge_swarm,
         ..
-    } = EdgeSwarmBuilder::default()
-        .with_membership(edge_membership)
-        .build();
+    } = EdgeSwarmBuilder::new(edge_membership).build();
 
     let message = TestEncapsulatedMessage::new(b"test-payload");
 

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
@@ -1,6 +1,5 @@
 use core::num::NonZeroUsize;
 
-use futures::stream::{pending, Pending};
 use libp2p::PeerId;
 use nomos_blend_scheduling::membership::Membership;
 use nomos_utils::blake_rng::BlakeRng;
@@ -13,20 +12,21 @@ use crate::{
 };
 
 pub struct TestSwarm {
-    pub swarm: BlendSwarm<Pending<Membership<PeerId>>, BlakeRng>,
+    pub swarm: BlendSwarm<BlakeRng>,
     pub command_sender: mpsc::Sender<Command>,
 }
 
-#[derive(Default)]
 pub struct SwarmBuilder {
-    membership: Option<Membership<PeerId>>,
+    membership: Membership<PeerId>,
     replication_factor: Option<NonZeroUsize>,
 }
 
 impl SwarmBuilder {
-    pub fn with_membership(mut self, membership: Membership<PeerId>) -> Self {
-        self.membership = Some(membership);
-        self
+    pub fn new(membership: Membership<PeerId>) -> Self {
+        Self {
+            membership,
+            replication_factor: None,
+        }
     }
 
     pub fn with_replication_factor(mut self, replication_factor: usize) -> Self {
@@ -42,7 +42,6 @@ impl SwarmBuilder {
             command_receiver,
             3u64.try_into().unwrap(),
             BlakeRng::from_entropy(),
-            pending(),
             PROTOCOL_NAME,
             self.replication_factor
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),

--- a/nomos-services/blend/src/edge/backends/mod.rs
+++ b/nomos-services/blend/src/edge/backends/mod.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "libp2p")]
 pub mod libp2p;
 
-use std::pin::Pin;
-
-use futures::Stream;
 use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
@@ -19,8 +16,7 @@ where
     fn new<Rng>(
         settings: Self::Settings,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<NodeId>> + Send>>,
-        current_membership: Option<Membership<NodeId>>,
+        membership: Membership<NodeId>,
         rng: Rng,
     ) -> Self
     where

--- a/nomos-services/blend/src/edge/mod.rs
+++ b/nomos-services/blend/src/edge/mod.rs
@@ -10,27 +10,31 @@ use std::{
 };
 
 use backends::BlendBackend;
+use futures::{Stream, StreamExt as _};
 use nomos_blend_scheduling::{
-    message_blend::crypto::CryptographicProcessor, session::SessionEventStream,
+    membership::Membership,
+    message_blend::crypto::CryptographicProcessor,
+    session::{SessionEvent, SessionEventStream},
 };
 use nomos_core::wire;
 use nomos_utils::blake_rng::BlakeRng;
 use overwatch::{
+    overwatch::OverwatchHandle,
     services::{
+        resources::ServiceResourcesHandle,
         state::{NoOperator, NoState},
         AsServiceId, ServiceCore, ServiceData,
     },
     OpaqueServiceResourcesHandle,
 };
-use rand::{RngCore, SeedableRng as _};
+use rand::SeedableRng as _;
 use serde::Serialize;
 pub(crate) use service_components::ServiceComponents;
 use services_utils::wait_until_services_are_ready;
 use settings::BlendConfig;
-use tokio::time::interval;
-use tokio_stream::{wrappers::IntervalStream, StreamExt as _};
+use tracing::{debug, warn};
 
-use crate::{membership, message::ServiceMessage};
+use crate::{membership, message::ServiceMessage, settings::constant_membership_stream};
 
 const LOG_TARGET: &str = "blend::service::edge";
 
@@ -87,118 +91,409 @@ where
 
     async fn run(mut self) -> Result<(), overwatch::DynError> {
         let Self {
-            service_resources_handle,
+            service_resources_handle:
+                ServiceResourcesHandle {
+                    inbound_relay,
+                    overwatch_handle,
+                    settings_handle,
+                    ..
+                },
             ..
         } = self;
 
-        let settings = service_resources_handle
-            .settings_handle
-            .notifier()
-            .get_updated_settings();
+        let settings = settings_handle.notifier().get_updated_settings();
         let membership = settings.membership();
-        let current_membership = Some(membership.clone());
-        let minimum_network_size = settings.minimum_network_size;
 
-        let membership_adapter = MembershipAdapter::new(
-            service_resources_handle
-                .overwatch_handle
+        let _membership_stream = MembershipAdapter::new(
+            overwatch_handle
                 .relay::<<MembershipAdapter as membership::Adapter>::Service>()
                 .await?,
             settings.crypto.signing_private_key.public_key(),
-        );
-        let mut _session_stream = SessionEventStream::new(
-            membership_adapter.subscribe().await?,
+        )
+        .subscribe()
+        .await?;
+        // TODO: Use membership_stream once the membership/SDP services are ready to provide the real membership: https://github.com/logos-co/nomos/issues/1532
+
+        let session_stream = SessionEventStream::new(
+            Box::pin(constant_membership_stream(
+                membership.clone(),
+                settings.time.session_duration(),
+            )),
             settings.time.session_transition_period(),
         );
-        // TODO: Use session_stream: https://github.com/logos-co/nomos/issues/1532
+
+        let messages_to_blend = inbound_relay.map(|ServiceMessage::Blend(message)| {
+            wire::serialize(&message)
+                .expect("Message from internal services should not fail to serialize")
+        });
 
         wait_until_services_are_ready!(
-            &service_resources_handle.overwatch_handle,
+            &overwatch_handle,
             Some(Duration::from_secs(60)),
             <MembershipAdapter as membership::Adapter>::Service
         )
         .await?;
 
-        // TODO: Add logic to try process new sessions. I.e:
-        // * If the old session membership was too small and the new one is large
-        //   enough, create a new backend and start blending incoming messages.
-        // * If the old and new session membership are both too small, do nothing.
-        // * If the old session membership was large and the new one too small, simply
-        //   drop the backend.
-        // * If the old and new session membership are both large enough, perform
-        //   session rotation logic and maintain the swarm backend.
-        // Ideally, this service would be stopped altogether by the proxy service when a
-        // session is too small. Yet, the service itself must be resilient in case of
-        // bugs where the proxy service does not do that, hence the need for this
-        // additional logic.
-        if membership.size() < minimum_network_size.get() as usize {
-            tracing::warn!(target: LOG_TARGET, "Blend network size is smaller than the required minimum. Not starting swarm, hence no messages will be blended in this session.");
-            // We still mark the service as ready, albeit other services won't be able to
-            // interact with this service by sending messages to it, and it indeed should
-            // not happen, as all interactions should happen via the proxy service.
-            service_resources_handle.status_updater.notify_ready();
-            tracing::info!(
-                target: LOG_TARGET,
-                "Service '{}' is ready.",
-                <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
-            );
-        } else {
-            let mut cryptoraphic_processor = CryptographicProcessor::new(
-                settings.crypto.clone(),
-                settings.membership(),
-                BlakeRng::from_entropy(),
-            );
-            let mut messages_to_blend =
-                service_resources_handle
-                    .inbound_relay
-                    .map(|ServiceMessage::Blend(message)| {
-                        wire::serialize(&message)
-                            .expect("Message from internal services should not fail to serialize")
-                    });
-            let backend = <Backend as BlendBackend<NodeId, RuntimeServiceId>>::new(
-                settings.backend,
-                service_resources_handle.overwatch_handle.clone(),
-                Box::pin(
-                    IntervalStream::new(interval(settings.time.session_duration()))
-                        .map(move |_| membership.clone()),
-                ),
-                current_membership,
-                BlakeRng::from_entropy(),
-            );
-
-            service_resources_handle.status_updater.notify_ready();
-            tracing::info!(
-                target: LOG_TARGET,
-                "Service '{}' is ready.",
-                <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
-            );
-
-            while let Some(message) = messages_to_blend.next().await {
-                handle_messages_to_blend(message, &mut cryptoraphic_processor, &backend).await;
-            }
-        }
-
-        Ok(())
+        run::<Backend, _, _>(
+            membership,
+            session_stream,
+            messages_to_blend,
+            &settings,
+            &overwatch_handle,
+        )
+        .await
     }
 }
 
-/// Blend a new message received from another service.
-async fn handle_messages_to_blend<NodeId, Rng, Backend, RuntimeServiceId>(
-    message: Vec<u8>,
-    cryptographic_processor: &mut CryptographicProcessor<NodeId, Rng>,
-    backend: &Backend,
-) where
+/// Run the main loop of the service.
+///
+/// It listens for new sessions and messages to blend, and handles them
+/// accordingly.
+///
+/// It recreates the [`MessageHandler`] on each new session.
+///
+/// If the membership is smaller than the minimum network size, it drops and
+/// doesn't recreate the [`MessageHandler`]. Inbound messages are ignored in
+/// this case.
+async fn run<Backend, NodeId, RuntimeServiceId>(
+    initial_membership: Membership<NodeId>,
+    mut session_stream: impl Stream<Item = SessionEvent<Membership<NodeId>>> + Send + Unpin,
+    mut messages_to_blend: impl Stream<Item = Vec<u8>> + Send + Unpin,
+    settings: &Settings<Backend, NodeId, RuntimeServiceId>,
+    overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+) -> Result<(), overwatch::DynError>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
+    NodeId: Clone + Eq + Hash + Send + Sync + 'static,
+    RuntimeServiceId: Clone,
+{
+    let mut message_handler = None;
+    if initial_membership.size() >= settings.minimum_network_size.get() as usize {
+        message_handler = Some(MessageHandler::<Backend, NodeId, RuntimeServiceId>::new(
+            settings,
+            initial_membership,
+            overwatch_handle.clone(),
+        ));
+    }
+
+    loop {
+        tokio::select! {
+            Some(SessionEvent::NewSession(membership)) = session_stream.next() => {
+                message_handler = handle_new_session(membership, settings, overwatch_handle);
+            }
+            Some(message) = messages_to_blend.next() => {
+                if let Some(message_handler) = message_handler.as_mut() {
+                    message_handler.handle_messages_to_blend(message).await;
+                } else {
+                    warn!(target: LOG_TARGET, "Ignoring message as the blend network is too small");
+                }
+            }
+        }
+    }
+}
+
+/// Handle a new session.
+///
+/// It creates a new [`MessageHandler`] if the membership is larger than the
+/// minimum network size. Otherwise, it returns [`None`].
+fn handle_new_session<Backend, NodeId, RuntimeServiceId>(
+    membership: Membership<NodeId>,
+    settings: &Settings<Backend, NodeId, RuntimeServiceId>,
+    overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+) -> Option<MessageHandler<Backend, NodeId, RuntimeServiceId>>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
+    NodeId: Clone + Send + 'static,
+    RuntimeServiceId: Clone,
+{
+    if membership.size() < settings.minimum_network_size.get() as usize {
+        warn!(target: LOG_TARGET, "Not creating a new message handler as the blend network is too small");
+        return None;
+    }
+
+    debug!(target: LOG_TARGET, "Creating a new message handler");
+    Some(MessageHandler::<Backend, NodeId, RuntimeServiceId>::new(
+        settings,
+        membership,
+        overwatch_handle.clone(),
+    ))
+}
+
+type Settings<Backend, NodeId, RuntimeServiceId> =
+    BlendConfig<<Backend as BlendBackend<NodeId, RuntimeServiceId>>::Settings, NodeId>;
+
+struct MessageHandler<Backend, NodeId, RuntimeServiceId> {
+    cryptographic_processor: CryptographicProcessor<NodeId, BlakeRng>,
+    backend: Backend,
+    _phantom: PhantomData<RuntimeServiceId>,
+}
+
+impl<Backend, NodeId, RuntimeServiceId> MessageHandler<Backend, NodeId, RuntimeServiceId>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
+    NodeId: Clone + Send + 'static,
+{
+    fn new(
+        settings: &Settings<Backend, NodeId, RuntimeServiceId>,
+        membership: Membership<NodeId>,
+        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
+        let cryptographic_processor = CryptographicProcessor::new(
+            settings.crypto.clone(),
+            membership.clone(),
+            BlakeRng::from_entropy(),
+        );
+        let backend = Backend::new(
+            settings.backend.clone(),
+            overwatch_handle,
+            membership,
+            BlakeRng::from_entropy(),
+        );
+        Self {
+            cryptographic_processor,
+            backend,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Backend, NodeId, RuntimeServiceId> MessageHandler<Backend, NodeId, RuntimeServiceId>
+where
     NodeId: Eq + Hash + Clone + Send,
-    Rng: RngCore + Send,
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync,
 {
-    let Ok(message) = cryptographic_processor
-        .encapsulate_data_payload(&message)
-        .inspect_err(|e| {
-            tracing::error!(target: LOG_TARGET, "Failed to encapsulate message: {e:?}");
-        })
-    else {
-        return;
+    /// Blend a new message received from another service.
+    async fn handle_messages_to_blend(&mut self, message: Vec<u8>) {
+        let Ok(message) = self
+            .cryptographic_processor
+            .encapsulate_data_payload(&message)
+            .inspect_err(|e| {
+                tracing::error!(target: LOG_TARGET, "Failed to encapsulate message: {e:?}");
+            })
+        else {
+            return;
+        };
+        self.backend.send(message).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use libp2p::Multiaddr;
+    use nomos_blend_message::crypto::{Ed25519PrivateKey, Ed25519PublicKey};
+    use nomos_blend_scheduling::{
+        membership::Node, message_blend::CryptographicProcessorSettings, EncapsulatedMessage,
     };
-    backend.send(message).await;
+    use overwatch::overwatch::commands::OverwatchCommand;
+    use rand::{rngs::OsRng, RngCore};
+    use tokio::{
+        sync::mpsc::{self, error::TryRecvError},
+        time::sleep,
+    };
+    use tokio_stream::wrappers::ReceiverStream;
+
+    use super::*;
+    use crate::settings::TimingSettings;
+
+    #[test_log::test(tokio::test)]
+    async fn run_with_session_transition() {
+        let (session_sender, session_receiver) = mpsc::channel(1);
+        let (msg_sender, msg_receiver) = mpsc::channel(1);
+        let (node_id_sender, mut node_id_receiver) = mpsc::channel(1);
+
+        let mut core_node = 0;
+        let minimum_network_size = 1;
+        tokio::spawn(async move {
+            let _ = run::<TestBackend, _, _>(
+                membership(&[core_node], None),
+                ReceiverStream::new(session_receiver),
+                ReceiverStream::new(msg_receiver),
+                &settings(10, minimum_network_size, node_id_sender),
+                &overwatch_handle(),
+            )
+            .await;
+        });
+
+        // A message should be forwarded to the core node 0.
+        msg_sender.send(vec![0]).await.expect("channel opened");
+        assert_eq!(
+            node_id_receiver.recv().await.expect("channel opened"),
+            core_node
+        );
+
+        // Send a new session with another core node 1.
+        core_node = 1;
+        session_sender
+            .send(SessionEvent::NewSession(membership(&[core_node], None)))
+            .await
+            .expect("channel opened");
+        sleep(Duration::from_millis(100)).await;
+
+        // A message should be forwarded to the core node 1.
+        msg_sender.send(vec![0]).await.expect("channel opened");
+        assert_eq!(
+            node_id_receiver.recv().await.expect("channel opened"),
+            core_node
+        );
+
+        // Send a TransitionPeriodExpired that should be ignored.
+        session_sender
+            .send(SessionEvent::TransitionPeriodExpired)
+            .await
+            .expect("channel opened");
+        sleep(Duration::from_millis(100)).await;
+        msg_sender.send(vec![0]).await.expect("channel opened");
+        assert_eq!(
+            node_id_receiver.recv().await.expect("channel opened"),
+            core_node
+        );
+
+        // Send a new session with an empty membership (smaller than the min size).
+        session_sender
+            .send(SessionEvent::NewSession(membership(&[], None)))
+            .await
+            .expect("channel opened");
+        sleep(Duration::from_millis(100)).await;
+
+        // A message should be ignored.
+        msg_sender.send(vec![0]).await.expect("channel opened");
+        sleep(Duration::from_millis(100)).await;
+        assert!(matches!(
+            node_id_receiver.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn run_with_small_initial_membership() {
+        let (session_sender, session_receiver) = mpsc::channel(1);
+        let (msg_sender, msg_receiver) = mpsc::channel(1);
+        let (node_id_sender, mut node_id_receiver) = mpsc::channel(1);
+
+        let core_nodes = [0];
+        let minimum_network_size = 2;
+        tokio::spawn(async move {
+            let _ = run::<TestBackend, _, _>(
+                membership(&core_nodes, None),
+                ReceiverStream::new(session_receiver),
+                ReceiverStream::new(msg_receiver),
+                &settings(10, minimum_network_size, node_id_sender),
+                &overwatch_handle(),
+            )
+            .await;
+        });
+
+        // A message should be ignored as the network is small.
+        msg_sender.send(vec![0]).await.expect("channel opened");
+        sleep(Duration::from_millis(100)).await;
+        assert!(matches!(
+            node_id_receiver.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+
+        // Send a new session with more nodes.
+        let core_nodes = [0, 1];
+        session_sender
+            .send(SessionEvent::NewSession(membership(&core_nodes, None)))
+            .await
+            .expect("channel opened");
+        sleep(Duration::from_millis(100)).await;
+
+        // A message should be forwarded to one of the core nodes.
+        msg_sender.send(vec![0]).await.expect("channel opened");
+        assert!(core_nodes.contains(&node_id_receiver.recv().await.expect("channel opened")));
+    }
+
+    fn membership(ids: &[NodeId], local_id: Option<NodeId>) -> Membership<NodeId> {
+        Membership::new(
+            &ids.iter()
+                .map(|id| Node {
+                    id: *id,
+                    address: Multiaddr::empty(),
+                    public_key: key(*id).1,
+                })
+                .collect::<Vec<_>>(),
+            local_id.map(|id| key(id).1).as_ref(),
+        )
+    }
+
+    fn key(id: NodeId) -> (Ed25519PrivateKey, Ed25519PublicKey) {
+        let private_key = Ed25519PrivateKey::from([id; 32]);
+        let public_key = private_key.public_key();
+        (private_key, public_key)
+    }
+
+    fn settings(
+        local_id: NodeId,
+        minimum_network_size: u64,
+        msg_sender: NodeIdSender,
+    ) -> BlendConfig<NodeIdSender, NodeId> {
+        BlendConfig {
+            membership: Vec::new(),
+            time: TimingSettings {
+                rounds_per_session: NonZeroU64::new(1).unwrap(),
+                rounds_per_interval: NonZeroU64::new(1).unwrap(),
+                round_duration: Duration::from_secs(1),
+                rounds_per_observation_window: NonZeroU64::new(1).unwrap(),
+                rounds_per_session_transition_period: NonZeroU64::new(1).unwrap(),
+            },
+            crypto: CryptographicProcessorSettings {
+                signing_private_key: key(local_id).0,
+                num_blend_layers: 1,
+            },
+            backend: msg_sender,
+            minimum_network_size: NonZeroU64::new(minimum_network_size).unwrap(),
+        }
+    }
+
+    type NodeId = u8;
+    type NodeIdSender = mpsc::Sender<NodeId>;
+
+    struct TestBackend {
+        membership: Membership<NodeId>,
+        sender: NodeIdSender,
+    }
+
+    #[async_trait::async_trait]
+    impl<RuntimeServiceId> BlendBackend<NodeId, RuntimeServiceId> for TestBackend
+    where
+        NodeId: Clone,
+        RuntimeServiceId: Debug + Sync + Display,
+    {
+        type Settings = NodeIdSender;
+
+        fn new<Rng>(
+            settings: Self::Settings,
+            _: OverwatchHandle<RuntimeServiceId>,
+            membership: Membership<NodeId>,
+            _: Rng,
+        ) -> Self
+        where
+            Rng: RngCore + Send + 'static,
+        {
+            Self {
+                membership,
+                sender: settings,
+            }
+        }
+
+        fn shutdown(self) {}
+
+        async fn send(&self, _: EncapsulatedMessage) {
+            let node_id = self
+                .membership
+                .choose_remote_nodes(&mut OsRng, 1)
+                .next()
+                .expect("Membership should not be empty")
+                .id;
+            self.sender.send(node_id).await.unwrap();
+        }
+    }
+
+    fn overwatch_handle() -> OverwatchHandle<usize> {
+        let (sender, _) = mpsc::channel::<OverwatchCommand<usize>>(1);
+        OverwatchHandle::new(tokio::runtime::Handle::current(), sender)
+    }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1534.

Integrated the session transition to the edge service.

As discussed, we drop the backend if the new session is too small.
Also, for simplicity, we recreate the backend whenever a new session is arrived, if it is not too small.
In that way, we don't need to pass a session stream to the backend, because the lifetime of the backend is just one session.
I think this approach is reasonable because the cost of initializing the backend is not heavy and the session duration is not too short. Also, the backend doesn't listen on any port.

I fixed handling the `inbound_relay` if the network is too small. Previously, we didn't poll the `inbound_relay` in that case. Now, we always poll it, but simply ignore the messages if the network is small, to avoid saturating the relay.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @madxor @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
