### PR TITLE
feat(blend): session transition for core service

### DIFF
--- a/nomos-services/blend/src/core/backends/libp2p/mod.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/mod.rs
@@ -7,7 +7,7 @@ use futures::{
 };
 use libp2p::PeerId;
 use nomos_blend_network::EncapsulatedMessageWithValidatedPublicHeader;
-use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
+use nomos_blend_scheduling::{membership::Membership, session::SessionEvent, EncapsulatedMessage};
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
 use tokio::sync::{broadcast, mpsc};
@@ -56,7 +56,7 @@ where
     fn new(
         config: BlendConfig<Self::Settings, PeerId>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<PeerId>> + Send>>,
+        session_stream: Pin<Box<dyn Stream<Item = SessionEvent<Membership<PeerId>>> + Send>>,
         rng: Rng,
     ) -> Self {
         let (swarm_message_sender, swarm_message_receiver) = mpsc::channel(CHANNEL_SIZE);

--- a/nomos-services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -19,7 +19,10 @@ use nomos_blend_network::{
     },
     EncapsulatedMessageWithValidatedPublicHeader,
 };
-use nomos_blend_scheduling::membership::{Membership, Node};
+use nomos_blend_scheduling::{
+    membership::{Membership, Node},
+    session::SessionEvent,
+};
 use nomos_libp2p::{Protocol, SwarmEvent};
 use nomos_utils::blake_rng::BlakeRng;
 use rand::SeedableRng as _;
@@ -38,7 +41,11 @@ use crate::{
 };
 
 pub struct TestSwarm {
-    pub swarm: BlendSwarm<Pending<Membership<PeerId>>, BlakeRng, TestObservationWindowProvider>,
+    pub swarm: BlendSwarm<
+        Pending<SessionEvent<Membership<PeerId>>>,
+        BlakeRng,
+        TestObservationWindowProvider,
+    >,
     pub swarm_message_sender: mpsc::Sender<BlendSwarmMessage>,
     pub incoming_message_receiver:
         broadcast::Receiver<EncapsulatedMessageWithValidatedPublicHeader>,

--- a/nomos-services/blend/src/core/backends/mod.rs
+++ b/nomos-services/blend/src/core/backends/mod.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, pin::Pin};
 
 use futures::Stream;
 use nomos_blend_network::EncapsulatedMessageWithValidatedPublicHeader;
-use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
+use nomos_blend_scheduling::{membership::Membership, session::SessionEvent, EncapsulatedMessage};
 use overwatch::overwatch::handle::OverwatchHandle;
 
 use crate::core::settings::BlendConfig;
@@ -18,7 +18,7 @@ pub trait BlendBackend<NodeId, Rng, RuntimeServiceId> {
     fn new(
         service_config: BlendConfig<Self::Settings, NodeId>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<NodeId>> + Send>>,
+        session_stream: Pin<Box<dyn Stream<Item = SessionEvent<Membership<NodeId>>> + Send>>,
         rng: Rng,
     ) -> Self;
     fn shutdown(self);


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1533

Integrated the session transition to the core service.

As discussed, (unlike the edge service), we initialize the backend at start-up and keep it forever. 

Whenever a new session is received, we recreate a membership and a crypto processor, so that we can build next messages with the new membership.
Also, we forward the new session to the backend, so that it can call the corresponding methods of the behaviour.

I fixed handling the `inbound_relay` if the network is too small. Previously, we didn't poll the `inbound_relay` in that case. Now, we always poll it, but simply ignore the messages if the network is small, to avoid saturating the relay.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
