### PR TITLE
feat(chain): skip blob validation for old blocks

### DIFF
--- a/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
@@ -606,12 +606,13 @@ mod tests {
 
         tokio::spawn(async move { downloader_swarm.loop_on_next().await });
 
-        let Tip { tip, slot } = receiver.await.unwrap().unwrap() else {
+        let Tip { tip, slot, height } = receiver.await.unwrap().unwrap() else {
             panic!("Expected a tip response");
         };
 
         assert_eq!(tip, HeaderId::from([0; 32]));
         assert_eq!(slot, Slot::from(0));
+        assert_eq!(height, 0);
     }
 
     #[tokio::test]
@@ -751,6 +752,7 @@ mod tests {
             ProviderResponse::Available(Tip {
                 tip: HeaderId::from([0; 32]),
                 slot: Slot::from(0),
+                height: 0,
             })
         }
 
@@ -791,6 +793,7 @@ mod tests {
             ProviderResponse::Available(Tip {
                 tip: HeaderId::from([0; 32]),
                 slot: Slot::from(0),
+                height: 0,
             })
         }
 

--- a/consensus/cryptarchia-sync/src/libp2p/downloader.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/downloader.rs
@@ -72,7 +72,9 @@ impl Downloader {
         })?
         .map_err(|e| ChainSyncError::from((peer_id, e)))
         .and_then(|response| match response {
-            GetTipResponse::Tip { tip, slot } => Ok(GetTipResponse::Tip { tip, slot }),
+            GetTipResponse::Tip { tip, slot, height } => {
+                Ok(GetTipResponse::Tip { tip, slot, height })
+            }
             GetTipResponse::Failure(reason) => Err(ChainSyncError {
                 peer: peer_id,
                 kind: ChainSyncErrorKind::RequestTipError(reason),

--- a/consensus/cryptarchia-sync/src/messages.rs
+++ b/consensus/cryptarchia-sync/src/messages.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use bytes::Bytes;
 use cryptarchia_engine::Slot;
-use nomos_core::header::HeaderId;
+use nomos_core::{block::Height, header::HeaderId};
 use serde::{Deserialize, Serialize};
 
 /// Blocks are serialized using nomos-core's wire format.
@@ -68,7 +68,11 @@ pub enum DownloadBlocksResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum GetTipResponse {
     /// A response containing the tip and slot of the peer.
-    Tip { tip: HeaderId, slot: Slot },
+    Tip {
+        tip: HeaderId,
+        slot: Slot,
+        height: Height,
+    },
     /// A response indicating that the request failed.
     Failure(String),
 }

--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -163,6 +163,9 @@ time:
 cryptarchia:
   transaction_selector_settings: null
   blob_selector_settings: null
+  da_settings:
+    availability_window_in_sessions: 2
+    session_length_in_blocks: 4320
   config:
     epoch_config:
       epoch_stake_distribution_stabilization: 3

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -154,6 +154,9 @@ time:
 cryptarchia:
   transaction_selector_settings: null
   blob_selector_settings: null
+  da_settings:
+    availability_window_in_sessions: 2
+    session_length_in_blocks: 4320
   config:
     epoch_config:
       epoch_stake_distribution_stabilization: 3

--- a/nomos-core/chain-defs/src/block/mod.rs
+++ b/nomos-core/chain-defs/src/block/mod.rs
@@ -8,6 +8,7 @@ use crate::{header::Header, wire};
 pub type TxHash = [u8; 32];
 
 pub type BlockNumber = u64;
+pub type Height = BlockNumber;
 
 pub type SessionNumber = u64;
 

--- a/nomos-services/chain-service/src/da.rs
+++ b/nomos-services/chain-service/src/da.rs
@@ -1,0 +1,82 @@
+use nomos_core::block::{Height, SessionNumber};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy)]
+pub enum BlobValidationPolicy {
+    Skip,
+    SkipOlderThan(Height),
+}
+
+impl BlobValidationPolicy {
+    pub const fn skip_old(settings: &Settings, max_known_height: Height) -> Self {
+        Self::SkipOlderThan(max_known_height.saturating_sub(settings.da_window_in_blocks()))
+    }
+
+    pub const fn should_validate(&self, height: Height) -> bool {
+        match self {
+            Self::Skip => false,
+            Self::SkipOlderThan(min_height) => height >= *min_height,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Settings {
+    /// The number of sessions for which DA nodes store blobs.
+    pub availability_window_in_sessions: SessionNumber,
+    /// The length of a session in blocks.
+    /// Later, this should be included in the genesis block.
+    pub session_length_in_blocks: Height,
+}
+
+impl Settings {
+    #[must_use]
+    pub const fn da_window_in_blocks(&self) -> Height {
+        self.availability_window_in_sessions
+            .checked_mul(self.session_length_in_blocks)
+            .expect("Shouldn't overflow")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skip_old_policy() {
+        let settings = Settings {
+            availability_window_in_sessions: 2,
+            session_length_in_blocks: 10,
+        };
+
+        let policy = BlobValidationPolicy::skip_old(&settings, 100);
+        assert!(
+            matches!(policy, BlobValidationPolicy::SkipOlderThan(80)),
+            "{policy:?}"
+        );
+
+        let policy = BlobValidationPolicy::skip_old(&settings, 20);
+        assert!(
+            matches!(policy, BlobValidationPolicy::SkipOlderThan(0)),
+            "{policy:?}"
+        );
+
+        let policy = BlobValidationPolicy::skip_old(&settings, 10);
+        assert!(
+            matches!(policy, BlobValidationPolicy::SkipOlderThan(0)),
+            "{policy:?}"
+        );
+    }
+
+    #[test]
+    fn test_should_validate() {
+        let policy = BlobValidationPolicy::Skip;
+        assert!(!policy.should_validate(0));
+        assert!(!policy.should_validate(100));
+
+        let policy = BlobValidationPolicy::SkipOlderThan(50);
+        assert!(!policy.should_validate(49));
+        assert!(policy.should_validate(50));
+        assert!(policy.should_validate(51));
+    }
+}

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use chain_service::{CryptarchiaInfo, CryptarchiaSettings, OrphanConfig, SyncConfig};
+use chain_service::{CryptarchiaInfo, CryptarchiaSettings, DaSettings, OrphanConfig, SyncConfig};
 use common_http_client::CommonHttpClient;
 use cryptarchia_engine::time::SlotConfig;
 use futures::Stream;
@@ -391,6 +391,10 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
             genesis_state: config.consensus_config.genesis_state,
             transaction_selector_settings: (),
             blob_selector_settings: (),
+            da_settings: DaSettings {
+                availability_window_in_sessions: 2,
+                session_length_in_blocks: 4320,
+            },
             network_adapter_settings:
                 chain_service::network::adapters::libp2p::LibP2pAdapterSettings {
                     topic: String::from(nomos_node::CONSENSUS_TOPIC),

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use chain_service::{CryptarchiaInfo, CryptarchiaSettings, OrphanConfig, SyncConfig};
+use chain_service::{CryptarchiaInfo, CryptarchiaSettings, DaSettings, OrphanConfig, SyncConfig};
 use common_http_client::CommonHttpClient;
 use cryptarchia_engine::time::SlotConfig;
 use futures::Stream;
@@ -416,6 +416,10 @@ pub fn create_validator_config(config: GeneralConfig) -> Config {
             genesis_state: config.consensus_config.genesis_state,
             transaction_selector_settings: (),
             blob_selector_settings: (),
+            da_settings: DaSettings {
+                availability_window_in_sessions: 2,
+                session_length_in_blocks: 4320,
+            },
             network_adapter_settings:
                 chain_service::network::adapters::libp2p::LibP2pAdapterSettings {
                     topic: String::from(nomos_node::CONSENSUS_TOPIC),


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #1479 

**Now we skip the blob validation if a block is too old.** 

DA nodes are not going to retain blobs forever. If we request to validate/sample blobs which are too old, it will fail. 
Therefore, this PR modifies the chain service to skip validating blobs if the block (which contains those blobs) is too old.

**How do we check if a block is too old?** 
We compare its height against the max height we've seen (aka. `max_known_height`).
If `max_known_height - availability_window > block.height`, we skip the blob validation because the block is outside the blob availability window.

**What is the `max_known_height`?**
In normal operations, the `max_known_height` is the local tip height. 
But, during bootstrapping (i.e. IBD), the local tip height might be too low compared to other nodes. So, we take the max tip heights from the `ibd_peers`. 
Still, the `max_known_height` may not perfectly reflect the true maximum height of the entire network, which most DA nodes follow. However, as long as DA operates solely based on block heights, there is little we can do about it. The best we can do is to carefully select healthy peers for IBD.

During recovery (loading blocks from storage), we skip the blob validation regardless of the block height, because we already know that those blocks were already validated.



## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@zeegomo @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
