### PR TITLE
feat(blend): DRAFT: session transition for edge service

### DIFF
--- a/nodes/nomos-executor/executor/src/lib.rs
+++ b/nodes/nomos-executor/executor/src/lib.rs
@@ -66,12 +66,15 @@ pub(crate) type BlendEdgeService = nomos_blend_service::edge::BlendService<
     <BlendNetworkAdapter<RuntimeServiceId> as nomos_blend_service::core::network::NetworkAdapter<
         RuntimeServiceId,
     >>::BroadcastSettings,
-    BlendMembershipAdapter<MembershipService<RuntimeServiceId>, PeerId>,
     RuntimeServiceId,
 >;
 
-pub(crate) type BlendService =
-    nomos_blend_service::BlendService<BlendCoreService, BlendEdgeService, RuntimeServiceId>;
+pub(crate) type BlendService = nomos_blend_service::BlendService<
+    BlendCoreService,
+    BlendEdgeService,
+    BlendMembershipAdapter<MembershipService<RuntimeServiceId>, PeerId>,
+    RuntimeServiceId,
+>;
 
 pub(crate) type DaDispersalService = DispersalService<
     DispersalKZGRSBackend<

--- a/nodes/nomos-node/node/src/config/blend.rs
+++ b/nodes/nomos-node/node/src/config/blend.rs
@@ -40,7 +40,6 @@ impl BlendConfig {
                     .expect("Edge message replication factor cannot be zero."),
             },
             crypto: self.0.crypto.clone(),
-            time: self.0.time.clone(),
             membership: self.0.membership.clone(),
             minimum_network_size: self.0.minimum_network_size,
         }

--- a/nodes/nomos-node/node/src/generic_services.rs
+++ b/nodes/nomos-node/node/src/generic_services.rs
@@ -56,9 +56,9 @@ pub type BlendService<RuntimeServiceId> = nomos_blend_service::BlendService<
         nomos_blend_service::edge::backends::libp2p::Libp2pBlendBackend,
         PeerId,
         <nomos_blend_service::core::network::libp2p::Libp2pAdapter<RuntimeServiceId> as nomos_blend_service::core::network::NetworkAdapter<RuntimeServiceId>>::BroadcastSettings,
-        BlendMembershipAdapter<RuntimeServiceId>,
         RuntimeServiceId
     >,
+    BlendMembershipAdapter<RuntimeServiceId>,
     RuntimeServiceId,
 >;
 

--- a/nodes/nomos-node/node/src/lib.rs
+++ b/nodes/nomos-node/node/src/lib.rs
@@ -108,12 +108,15 @@ pub(crate) type BlendEdgeService = nomos_blend_service::edge::BlendService<
     <BlendNetworkAdapter<RuntimeServiceId> as nomos_blend_service::core::network::NetworkAdapter<
         RuntimeServiceId,
     >>::BroadcastSettings,
-    BlendMembershipAdapter<MembershipService<RuntimeServiceId>, PeerId>,
     RuntimeServiceId,
 >;
 
-pub(crate) type BlendService =
-    nomos_blend_service::BlendService<BlendCoreService, BlendEdgeService, RuntimeServiceId>;
+pub(crate) type BlendService = nomos_blend_service::BlendService<
+    BlendCoreService,
+    BlendEdgeService,
+    BlendMembershipAdapter<MembershipService<RuntimeServiceId>, PeerId>,
+    RuntimeServiceId,
+>;
 
 pub(crate) type DaVerifierService = generic_services::DaVerifierService<
     VerifierNetworkAdapter<

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -157,6 +157,6 @@ pub fn build_memberships<Behaviour: NetworkBehaviour>(
         .collect::<Vec<_>>();
     nodes
         .iter()
-        .map(|node| Membership::new(&nodes, Some(&node.public_key)))
+        .map(|node| Membership::new(&nodes, &node.public_key))
         .collect()
 }

--- a/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/nomos-blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -53,7 +53,7 @@ impl BehaviourBuilder {
                     })
                     .collect::<Vec<_>>()
                     .as_ref(),
-                None,
+                &Ed25519PrivateKey::generate().public_key(),
             ))
         };
         Behaviour {

--- a/nomos-blend/scheduling/src/membership.rs
+++ b/nomos-blend/scheduling/src/membership.rs
@@ -44,13 +44,13 @@ where
     NodeId: Clone + Hash + Eq,
 {
     #[must_use]
-    pub fn new(nodes: &[Node<NodeId>], local_public_key: Option<&Ed25519PublicKey>) -> Self {
+    pub fn new(nodes: &[Node<NodeId>], local_public_key: &Ed25519PublicKey) -> Self {
         let mut core_nodes = HashMap::with_capacity(nodes.len());
         let mut remote_core_nodes = Vec::with_capacity(nodes.len());
         let mut local_node = None;
         for node in nodes {
             core_nodes.insert(node.id.clone(), node.clone());
-            if matches!(local_public_key, Some(key) if node.public_key == *key) {
+            if node.public_key == *local_public_key {
                 local_node = Some(node.id.clone());
             } else {
                 remote_core_nodes.push(node.id.clone());
@@ -130,7 +130,7 @@ mod tests {
         let nodes = vec![node(1, 1), node(2, 2), node(3, 3)];
         let local_key = key(2);
 
-        let membership = Membership::new(&nodes, Some(&local_key));
+        let membership = Membership::new(&nodes, &local_key);
 
         assert_eq!(membership.size(), 3);
         assert_eq!(membership.remote_nodes.len(), 2);
@@ -143,8 +143,9 @@ mod tests {
     #[test]
     fn test_membership_new_without_local_node() {
         let nodes = vec![node(1, 1), node(2, 2), node(3, 3)];
+        let local_key = key(99);
 
-        let membership = Membership::new(&nodes, None);
+        let membership = Membership::new(&nodes, &local_key);
 
         assert_eq!(membership.size(), 3);
         assert_eq!(membership.remote_nodes.len(), 3);
@@ -156,14 +157,15 @@ mod tests {
 
     #[test]
     fn test_membership_new_empty() {
-        let membership = Membership::<u32>::new(&[], None);
+        let membership = Membership::<u32>::new(&[], &key(99));
         assert_eq!(membership.size(), 0);
     }
 
     #[test]
     fn test_choose_remote_nodes() {
         let nodes = vec![node(1, 1), node(2, 2), node(3, 3), node(4, 4)];
-        let membership = Membership::new(&nodes, None);
+        let local_key = key(99);
+        let membership = Membership::new(&nodes, &local_key);
 
         let chosen: HashSet<_> = membership
             .choose_remote_nodes(&mut OsRng, 2)
@@ -175,7 +177,8 @@ mod tests {
     #[test]
     fn test_choose_remote_nodes_more_than_available() {
         let nodes = vec![node(1, 1), node(2, 2)];
-        let membership = Membership::new(&nodes, None);
+        let local_key = key(99);
+        let membership = Membership::new(&nodes, &local_key);
 
         let chosen: HashSet<_> = membership
             .choose_remote_nodes(&mut OsRng, 5)
@@ -187,7 +190,8 @@ mod tests {
     #[test]
     fn test_choose_remote_nodes_zero() {
         let nodes = vec![node(1, 1), node(2, 2)];
-        let membership = Membership::new(&nodes, None);
+        let local_key = key(99);
+        let membership = Membership::new(&nodes, &local_key);
 
         let mut chosen = membership.choose_remote_nodes(&mut OsRng, 0);
         assert!(chosen.next().is_none());
@@ -196,7 +200,8 @@ mod tests {
     #[test]
     fn test_filter_and_choose_remote_nodes() {
         let nodes = vec![node(1, 1), node(2, 2), node(3, 3)];
-        let membership = Membership::new(&nodes, None);
+        let local_key = key(99);
+        let membership = Membership::new(&nodes, &local_key);
         let exclude_peers = HashSet::from([3]);
 
         let chosen: HashSet<_> = membership
@@ -209,7 +214,8 @@ mod tests {
     #[test]
     fn test_filter_and_choose_remote_nodes_all_excluded() {
         let nodes = vec![node(1, 1), node(2, 2)];
-        let membership = Membership::new(&nodes, None);
+        let local_key = key(99);
+        let membership = Membership::new(&nodes, &local_key);
         let exclude_peers = HashSet::from([1, 2]);
 
         let chosen: HashSet<_> = membership
@@ -222,7 +228,8 @@ mod tests {
     #[test]
     fn test_contains() {
         let nodes = vec![node(1, 1)];
-        let membership = Membership::new(&nodes, None);
+        let local_key = key(99);
+        let membership = Membership::new(&nodes, &local_key);
 
         assert!(membership.contains(&1));
         assert!(!membership.contains(&2));

--- a/nomos-services/api/src/http/consensus/cryptarchia.rs
+++ b/nomos-services/api/src/http/consensus/cryptarchia.rs
@@ -71,9 +71,9 @@ type BlendService<RuntimeServiceId> = nomos_blend_service::BlendService<
         nomos_blend_service::edge::backends::libp2p::Libp2pBlendBackend,
         PeerId,
         <nomos_blend_service::core::network::libp2p::Libp2pAdapter<RuntimeServiceId> as nomos_blend_service::core::network::NetworkAdapter<RuntimeServiceId>>::BroadcastSettings,
-        BlendMembershipAdapter<RuntimeServiceId>,
         RuntimeServiceId
     >,
+    BlendMembershipAdapter<RuntimeServiceId>,
     RuntimeServiceId,
 >;
 

--- a/nomos-services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
@@ -37,7 +37,7 @@ async fn on_unhealthy_peer() {
                 public_key: Ed25519PrivateKey::generate().public_key(),
             },
         ],
-        None,
+        &Ed25519PrivateKey::generate().public_key(),
     );
     let TestSwarm {
         swarm: mut listening_swarm,
@@ -131,7 +131,7 @@ async fn on_malicious_peer() {
                 public_key: Ed25519PrivateKey::generate().public_key(),
             },
         ],
-        None,
+        &Ed25519PrivateKey::generate().public_key(),
     );
     let TestSwarm {
         swarm: mut listening_swarm,

--- a/nomos-services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -1,6 +1,7 @@
 use core::{slice::from_ref, time::Duration};
 
 use libp2p::{Multiaddr, PeerId};
+use nomos_blend_message::crypto::Ed25519PrivateKey;
 use nomos_blend_scheduling::membership::Membership;
 use nomos_libp2p::{Protocol, SwarmEvent};
 use test_log::test;
@@ -88,7 +89,10 @@ async fn core_redial_different_peer_after_redial_limit() {
     let (membership_entry, _) = listening_swarm
         .listen_and_return_membership_entry(None)
         .await;
-    let membership = Membership::new(from_ref(&membership_entry), None);
+    let membership = Membership::new(
+        from_ref(&membership_entry),
+        &Ed25519PrivateKey::generate().public_key(),
+    );
     let listening_peer_id = membership_entry.id;
 
     // Build dialing swarm with the listening info of the listening swarm.

--- a/nomos-services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -64,7 +64,7 @@ impl SwarmBuilder {
                 id: PeerId::random(),
                 public_key: Ed25519PrivateKey::generate().public_key(),
             }],
-            None,
+            &Ed25519PrivateKey::generate().public_key(),
         ));
         self
     }
@@ -84,8 +84,9 @@ impl SwarmBuilder {
             swarm_message_receiver,
             incoming_message_sender,
             pending(),
-            self.membership
-                .unwrap_or_else(|| Membership::new(&[], None)),
+            self.membership.unwrap_or_else(|| {
+                Membership::new(&[], &Ed25519PrivateKey::generate().public_key())
+            }),
             BlakeRng::from_entropy(),
             3u64.try_into().unwrap(),
             1usize.try_into().unwrap(),
@@ -128,7 +129,7 @@ impl BlendBehaviourBuilder {
                 id: PeerId::random(),
                 public_key: Ed25519PrivateKey::generate().public_key(),
             }],
-            None,
+            &Ed25519PrivateKey::generate().public_key(),
         ));
         self
     }

--- a/nomos-services/blend/src/core/settings.rs
+++ b/nomos-services/blend/src/core/settings.rs
@@ -77,7 +77,7 @@ where
 {
     pub(super) fn membership(&self) -> Membership<NodeId> {
         let local_signing_pubkey = self.crypto.signing_private_key.public_key();
-        Membership::new(&self.membership, Some(&local_signing_pubkey))
+        Membership::new(&self.membership, &local_signing_pubkey)
     }
 }
 

--- a/nomos-services/blend/src/edge/backends/libp2p/mod.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/mod.rs
@@ -1,12 +1,7 @@
 mod settings;
 mod swarm;
 
-use std::pin::Pin;
-
-use futures::{
-    future::{AbortHandle, Abortable},
-    Stream,
-};
+use futures::future::{AbortHandle, Abortable};
 use libp2p::PeerId;
 use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
 use overwatch::overwatch::OverwatchHandle;
@@ -36,8 +31,7 @@ impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBac
     fn new<Rng>(
         settings: Self::Settings,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<PeerId>> + Send>>,
-        current_membership: Option<Membership<PeerId>>,
+        membership: Membership<PeerId>,
         rng: Rng,
     ) -> Self
     where
@@ -46,8 +40,7 @@ impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBac
         let (swarm_command_sender, swarm_command_receiver) = mpsc::channel(CHANNEL_SIZE);
         let swarm = BlendSwarm::new(
             &settings,
-            session_stream,
-            current_membership,
+            membership,
             rng,
             swarm_command_receiver,
             settings.protocol_name.clone().into_inner(),

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -24,16 +24,15 @@ async fn edge_redial_same_peer() {
     let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
 
     // Configure swarm with an unreachable member.
-    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::default()
-        .with_membership(Membership::new(
-            from_ref(&Node {
-                address: empty_multiaddr.clone(),
-                id: random_peer_id,
-                public_key: Ed25519PrivateKey::generate().public_key(),
-            }),
-            None,
-        ))
-        .build();
+    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(Membership::new(
+        from_ref(&Node {
+            address: empty_multiaddr.clone(),
+            id: random_peer_id,
+            public_key: Ed25519PrivateKey::generate().public_key(),
+        }),
+        &Ed25519PrivateKey::generate().public_key(),
+    ))
+    .build();
     let message = TestEncapsulatedMessage::new(b"test-payload");
     swarm.send_message(&message);
 
@@ -143,14 +142,12 @@ async fn edge_redial_different_peer_after_redial_limit() {
                 public_key: Ed25519PrivateKey::generate().public_key(),
             },
         ],
-        None,
+        &Ed25519PrivateKey::generate().public_key(),
     );
     let EdgeTestSwarm {
         swarm: mut edge_swarm,
         ..
-    } = EdgeSwarmBuilder::default()
-        .with_membership(edge_membership)
-        .build();
+    } = EdgeSwarmBuilder::new(edge_membership).build();
 
     let message = TestEncapsulatedMessage::new(b"test-payload");
 

--- a/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/tests/utils.rs
@@ -1,6 +1,5 @@
 use core::num::NonZeroUsize;
 
-use futures::stream::{pending, Pending};
 use libp2p::PeerId;
 use nomos_blend_scheduling::membership::Membership;
 use nomos_utils::blake_rng::BlakeRng;
@@ -13,20 +12,21 @@ use crate::{
 };
 
 pub struct TestSwarm {
-    pub swarm: BlendSwarm<Pending<Membership<PeerId>>, BlakeRng>,
+    pub swarm: BlendSwarm<BlakeRng>,
     pub command_sender: mpsc::Sender<Command>,
 }
 
-#[derive(Default)]
 pub struct SwarmBuilder {
-    membership: Option<Membership<PeerId>>,
+    membership: Membership<PeerId>,
     replication_factor: Option<NonZeroUsize>,
 }
 
 impl SwarmBuilder {
-    pub fn with_membership(mut self, membership: Membership<PeerId>) -> Self {
-        self.membership = Some(membership);
-        self
+    pub fn new(membership: Membership<PeerId>) -> Self {
+        Self {
+            membership,
+            replication_factor: None,
+        }
     }
 
     pub fn with_replication_factor(mut self, replication_factor: usize) -> Self {
@@ -42,7 +42,6 @@ impl SwarmBuilder {
             command_receiver,
             3u64.try_into().unwrap(),
             BlakeRng::from_entropy(),
-            pending(),
             PROTOCOL_NAME,
             self.replication_factor
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),

--- a/nomos-services/blend/src/edge/backends/mod.rs
+++ b/nomos-services/blend/src/edge/backends/mod.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "libp2p")]
 pub mod libp2p;
 
-use std::pin::Pin;
-
-use futures::Stream;
 use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
@@ -19,8 +16,7 @@ where
     fn new<Rng>(
         settings: Self::Settings,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<NodeId>> + Send>>,
-        current_membership: Option<Membership<NodeId>>,
+        membership: Membership<NodeId>,
         rng: Rng,
     ) -> Self
     where

--- a/nomos-services/blend/src/edge/mod.rs
+++ b/nomos-services/blend/src/edge/mod.rs
@@ -5,18 +5,18 @@ pub mod settings;
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
-    marker::PhantomData,
-    time::Duration,
 };
 
 use backends::BlendBackend;
+use futures::StreamExt as _;
 use nomos_blend_scheduling::{
-    message_blend::crypto::CryptographicProcessor, session::SessionEventStream,
+    membership::Membership, message_blend::crypto::CryptographicProcessor,
 };
 use nomos_core::wire;
 use nomos_utils::blake_rng::BlakeRng;
 use overwatch::{
     services::{
+        resources::ServiceResourcesHandle,
         state::{NoOperator, NoState},
         AsServiceId, ServiceCore, ServiceData,
     },
@@ -25,26 +25,32 @@ use overwatch::{
 use rand::{RngCore, SeedableRng as _};
 use serde::Serialize;
 pub(crate) use service_components::ServiceComponents;
-use services_utils::wait_until_services_are_ready;
 use settings::BlendConfig;
-use tokio::time::interval;
-use tokio_stream::{wrappers::IntervalStream, StreamExt as _};
+use tracing::{error, info};
 
-use crate::{membership, message::ServiceMessage};
+use crate::message::ServiceMessage;
 
 const LOG_TARGET: &str = "blend::service::edge";
 
-pub struct BlendService<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId>
+/// Edge service that establishes a one-shot connection to one of core nodes
+/// each time a message needs to be sent.
+///
+/// # Panics
+/// This service should be started only when the following conditions are met.
+/// Otherwise, it will panic during initialization.
+/// - The Blend network is larger than the minimal network size.
+/// - The local node is not one of the core nodes in the Blend network.
+pub struct BlendService<Backend, NodeId, BroadcastSettings, RuntimeServiceId>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone,
 {
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-    _phantom: PhantomData<MembershipAdapter>,
+    membership: Membership<NodeId>,
 }
 
-impl<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId> ServiceData
-    for BlendService<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId>
+impl<Backend, NodeId, BroadcastSettings, RuntimeServiceId> ServiceData
+    for BlendService<Backend, NodeId, BroadcastSettings, RuntimeServiceId>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone,
@@ -56,126 +62,75 @@ where
 }
 
 #[async_trait::async_trait]
-impl<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId>
-    ServiceCore<RuntimeServiceId>
-    for BlendService<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId>
+impl<Backend, NodeId, BroadcastSettings, RuntimeServiceId> ServiceCore<RuntimeServiceId>
+    for BlendService<Backend, NodeId, BroadcastSettings, RuntimeServiceId>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Send + Sync,
     NodeId: Clone + Eq + Hash + Send + Sync + 'static,
     BroadcastSettings: Serialize + Send,
-    MembershipAdapter: membership::Adapter + Send,
-    membership::ServiceMessage<MembershipAdapter>: Send + Sync + 'static,
-    <MembershipAdapter as membership::Adapter>::Error: Send + Sync + 'static,
-    RuntimeServiceId: AsServiceId<<MembershipAdapter as membership::Adapter>::Service>
-        + AsServiceId<Self>
-        + Display
-        + Debug
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    RuntimeServiceId: AsServiceId<Self> + Display + Debug + Clone + Send + Sync + 'static,
 {
     fn init(
         service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
         _initial_state: Self::State,
     ) -> Result<Self, overwatch::DynError> {
-        Ok(Self {
-            service_resources_handle,
-            _phantom: PhantomData,
-        })
-    }
-
-    async fn run(mut self) -> Result<(), overwatch::DynError> {
-        let Self {
-            service_resources_handle,
-            ..
-        } = self;
-
         let settings = service_resources_handle
             .settings_handle
             .notifier()
             .get_updated_settings();
         let membership = settings.membership();
-        let current_membership = Some(membership.clone());
-        let minimum_network_size = settings.minimum_network_size;
+        if membership.size() < settings.minimum_network_size.get() as usize {
+            panic!("Blend network size is smaller than the required minimum. Edge service should not be started.");
+        } else if membership.contains_local() {
+            panic!("Local node is one of core nodes in the Blend network. Edge service should not be started.");
+        }
 
-        let membership_adapter = MembershipAdapter::new(
-            service_resources_handle
-                .overwatch_handle
-                .relay::<<MembershipAdapter as membership::Adapter>::Service>()
-                .await?,
-            settings.crypto.signing_private_key.public_key(),
+        Ok(Self {
+            service_resources_handle,
+            membership,
+        })
+    }
+
+    async fn run(mut self) -> Result<(), overwatch::DynError> {
+        let Self {
+            service_resources_handle:
+                ServiceResourcesHandle {
+                    inbound_relay,
+                    overwatch_handle,
+                    settings_handle,
+                    status_updater,
+                    ..
+                },
+            membership,
+        } = self;
+
+        let settings = settings_handle.notifier().get_updated_settings();
+
+        let mut cryptoraphic_processor = CryptographicProcessor::new(
+            settings.crypto.clone(),
+            membership.clone(),
+            BlakeRng::from_entropy(),
         );
-        let mut _session_stream = SessionEventStream::new(
-            membership_adapter.subscribe().await?,
-            settings.time.session_transition_period(),
+        let mut messages_to_blend = inbound_relay.map(|ServiceMessage::Blend(message)| {
+            wire::serialize(&message)
+                .expect("Message from internal services should not fail to serialize")
+        });
+        let backend = <Backend as BlendBackend<NodeId, RuntimeServiceId>>::new(
+            settings.backend,
+            overwatch_handle.clone(),
+            membership,
+            BlakeRng::from_entropy(),
         );
-        // TODO: Use session_stream: https://github.com/logos-co/nomos/issues/1532
 
-        wait_until_services_are_ready!(
-            &service_resources_handle.overwatch_handle,
-            Some(Duration::from_secs(60)),
-            <MembershipAdapter as membership::Adapter>::Service
-        )
-        .await?;
+        status_updater.notify_ready();
+        info!(
+            target: LOG_TARGET,
+            "Service '{}' is ready.",
+            <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
+        );
 
-        // TODO: Add logic to try process new sessions. I.e:
-        // * If the old session membership was too small and the new one is large
-        //   enough, create a new backend and start blending incoming messages.
-        // * If the old and new session membership are both too small, do nothing.
-        // * If the old session membership was large and the new one too small, simply
-        //   drop the backend.
-        // * If the old and new session membership are both large enough, perform
-        //   session rotation logic and maintain the swarm backend.
-        // Ideally, this service would be stopped altogether by the proxy service when a
-        // session is too small. Yet, the service itself must be resilient in case of
-        // bugs where the proxy service does not do that, hence the need for this
-        // additional logic.
-        if membership.size() < minimum_network_size.get() as usize {
-            tracing::warn!(target: LOG_TARGET, "Blend network size is smaller than the required minimum. Not starting swarm, hence no messages will be blended in this session.");
-            // We still mark the service as ready, albeit other services won't be able to
-            // interact with this service by sending messages to it, and it indeed should
-            // not happen, as all interactions should happen via the proxy service.
-            service_resources_handle.status_updater.notify_ready();
-            tracing::info!(
-                target: LOG_TARGET,
-                "Service '{}' is ready.",
-                <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
-            );
-        } else {
-            let mut cryptoraphic_processor = CryptographicProcessor::new(
-                settings.crypto.clone(),
-                settings.membership(),
-                BlakeRng::from_entropy(),
-            );
-            let mut messages_to_blend =
-                service_resources_handle
-                    .inbound_relay
-                    .map(|ServiceMessage::Blend(message)| {
-                        wire::serialize(&message)
-                            .expect("Message from internal services should not fail to serialize")
-                    });
-            let backend = <Backend as BlendBackend<NodeId, RuntimeServiceId>>::new(
-                settings.backend,
-                service_resources_handle.overwatch_handle.clone(),
-                Box::pin(
-                    IntervalStream::new(interval(settings.time.session_duration()))
-                        .map(move |_| membership.clone()),
-                ),
-                current_membership,
-                BlakeRng::from_entropy(),
-            );
-
-            service_resources_handle.status_updater.notify_ready();
-            tracing::info!(
-                target: LOG_TARGET,
-                "Service '{}' is ready.",
-                <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
-            );
-
-            while let Some(message) = messages_to_blend.next().await {
-                handle_messages_to_blend(message, &mut cryptoraphic_processor, &backend).await;
-            }
+        while let Some(message) = messages_to_blend.next().await {
+            handle_messages_to_blend(message, &mut cryptoraphic_processor, &backend).await;
         }
 
         Ok(())
@@ -195,10 +150,125 @@ async fn handle_messages_to_blend<NodeId, Rng, Backend, RuntimeServiceId>(
     let Ok(message) = cryptographic_processor
         .encapsulate_data_payload(&message)
         .inspect_err(|e| {
-            tracing::error!(target: LOG_TARGET, "Failed to encapsulate message: {e:?}");
+            error!(target: LOG_TARGET, "Failed to encapsulate message: {e:?}");
         })
     else {
         return;
     };
     backend.send(message).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use nomos_blend_message::crypto::Ed25519PrivateKey;
+    use nomos_blend_scheduling::{
+        membership::Node, message_blend::CryptographicProcessorSettings, EncapsulatedMessage,
+    };
+    use overwatch::overwatch::{OverwatchHandle, OverwatchRunner};
+    use services_utils::wait_until_services_are_ready;
+
+    use super::*;
+    use crate::instance::tests::{key, nodes, NodeId};
+
+    #[test]
+    fn successful_init_as_edge_node() {
+        let settings = settings(nodes(&[1]), key(99).0, 1);
+        let app = OverwatchRunner::<Services>::run(settings, None).unwrap();
+        app.runtime().handle().block_on(async {
+            app.handle().start_all_services().await.unwrap();
+            wait_until_services_are_ready!(app.handle(), Some(Duration::from_secs(1)), TestService)
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn init_panics_if_core_node() {
+        let settings = settings(nodes(&[1, 2]), key(1).0, 1);
+        let app = OverwatchRunner::<Services>::run(settings, None).unwrap();
+        app.runtime().handle().block_on(async {
+            app.handle().start_all_services().await.unwrap();
+            // Since the panic happens in a separate 'Overwatch' thread,
+            // we cannot catch it here.
+            // Instead, we check if the service fails to become ready.
+            let result = wait_until_services_are_ready!(
+                app.handle(),
+                Some(Duration::from_secs(1)),
+                TestService
+            )
+            .await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn init_panics_if_network_is_small() {
+        let settings = settings(nodes(&[1]), key(99).0, 2);
+        let app = OverwatchRunner::<Services>::run(settings, None).unwrap();
+        app.runtime().handle().block_on(async {
+            app.handle().start_all_services().await.unwrap();
+            // Since the panic happens in a separate 'Overwatch' thread,
+            // we cannot catch it here.
+            // Instead, we check if the service fails to become ready.
+            let result = wait_until_services_are_ready!(
+                app.handle(),
+                Some(Duration::from_secs(1)),
+                TestService
+            )
+            .await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[overwatch::derive_services]
+    struct Services {
+        edge: TestService,
+    }
+
+    type TestService = BlendService<TestBackend, NodeId, BroadcastSettings, RuntimeServiceId>;
+
+    struct TestBackend;
+
+    #[async_trait::async_trait]
+    impl BlendBackend<NodeId, RuntimeServiceId> for TestBackend {
+        type Settings = ();
+
+        fn new<Rng>(
+            (): Self::Settings,
+            _: OverwatchHandle<RuntimeServiceId>,
+            _: Membership<NodeId>,
+            _: Rng,
+        ) -> Self
+        where
+            Rng: RngCore + Send + 'static,
+        {
+            Self
+        }
+
+        fn shutdown(self) {}
+
+        async fn send(&self, _: EncapsulatedMessage) {}
+    }
+
+    type BroadcastSettings = ();
+
+    fn settings(
+        membership: Vec<Node<NodeId>>,
+        signing_private_key: Ed25519PrivateKey,
+        minimal_network_size: u64,
+    ) -> ServicesServiceSettings {
+        ServicesServiceSettings {
+            edge: BlendConfig {
+                backend: (),
+                crypto: CryptographicProcessorSettings {
+                    signing_private_key,
+                    num_blend_layers: 1,
+                },
+                minimum_network_size: minimal_network_size.try_into().unwrap(),
+                membership,
+            },
+        }
+    }
 }

--- a/nomos-services/blend/src/edge/service_components.rs
+++ b/nomos-services/blend/src/edge/service_components.rs
@@ -6,16 +6,13 @@ pub trait ServiceComponents {
     /// Settings for broadcasting messages that have passed through the blend
     /// network.
     type BroadcastSettings;
-    /// Adapter for membership service.
-    type MembershipAdapter;
 }
 
-impl<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId> ServiceComponents
-    for BlendService<Backend, NodeId, BroadcastSettings, MembershipAdapter, RuntimeServiceId>
+impl<Backend, NodeId, BroadcastSettings, RuntimeServiceId> ServiceComponents
+    for BlendService<Backend, NodeId, BroadcastSettings, RuntimeServiceId>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone,
 {
     type BroadcastSettings = BroadcastSettings;
-    type MembershipAdapter = MembershipAdapter;
 }

--- a/nomos-services/blend/src/edge/settings.rs
+++ b/nomos-services/blend/src/edge/settings.rs
@@ -7,13 +7,10 @@ use nomos_blend_scheduling::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::settings::TimingSettings;
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BlendConfig<BackendSettings, NodeId> {
     pub backend: BackendSettings,
     pub crypto: CryptographicProcessorSettings,
-    pub time: TimingSettings,
     pub membership: Vec<Node<NodeId>>,
     pub minimum_network_size: NonZeroU64,
 }
@@ -23,6 +20,7 @@ where
     NodeId: Clone + Eq + Hash,
 {
     pub fn membership(&self) -> Membership<NodeId> {
-        Membership::new(&self.membership, None)
+        let local_signing_pubkey = self.crypto.signing_private_key.public_key();
+        Membership::new(&self.membership, &local_signing_pubkey)
     }
 }

--- a/nomos-services/blend/src/membership/service.rs
+++ b/nomos-services/blend/src/membership/service.rs
@@ -65,7 +65,7 @@ where
                         })
                         .collect::<Vec<_>>()
                 })
-                .map(move |nodes| Membership::new(&nodes, Some(&signing_public_key))),
+                .map(move |nodes| Membership::new(&nodes, &signing_public_key)),
         ))
     }
 }

--- a/nomos-services/blend/src/service_components.rs
+++ b/nomos-services/blend/src/service_components.rs
@@ -10,8 +10,8 @@ pub trait ServiceComponents {
     type BroadcastSettings;
 }
 
-impl<CoreService, EdgeService, RuntimeServiceId> ServiceComponents
-    for BlendService<CoreService, EdgeService, RuntimeServiceId>
+impl<CoreService, EdgeService, MemebershipAdapter, RuntimeServiceId> ServiceComponents
+    for BlendService<CoreService, EdgeService, MemebershipAdapter, RuntimeServiceId>
 where
     CoreService: ServiceData + core::service_components::ServiceComponents<RuntimeServiceId>,
     EdgeService: ServiceData + edge::service_components::ServiceComponents,

--- a/nomos-services/blend/src/settings.rs
+++ b/nomos-services/blend/src/settings.rs
@@ -24,7 +24,7 @@ where
 {
     pub(crate) fn membership(&self) -> Membership<NodeId> {
         let local_signing_pubkey = self.crypto.signing_private_key.public_key();
-        Membership::new(&self.membership, Some(&local_signing_pubkey))
+        Membership::new(&self.membership, &local_signing_pubkey)
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

This is an incremental PR based on the PR #1611.

Now we don't need to pass a session stream to the edge service, because we will create/drop the edge service on demand through the proxy service. The session stream may be necessary if we want to make the edge service usable without the proxy service, but we discussed that's not what we want.
So, I removed all the session-related code from the edge service and its backend.

Also, as we discussed, now the edge service panics if the network is small or if the local node is a core node.

Plus, I made a small change on the `Membership` struct.
```diff
--- a/nomos-blend/scheduling/src/membership.rs
+++ b/nomos-blend/scheduling/src/membership.rs
@@ -44,13 +44,13 @@ where
     NodeId: Clone + Hash + Eq,
 {
     #[must_use]
-    pub fn new(nodes: &[Node<NodeId>], local_public_key: Option<&Ed25519PublicKey>) -> Self {
+    pub fn new(nodes: &[Node<NodeId>], local_public_key: &Ed25519PublicKey) -> Self {
```
The `local_public_key` doesn't need to be optional, which causes potential misuses.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
