### PR TITLE
feat(da): let stream to dial if no connection

### DIFF
--- a/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
@@ -418,7 +418,6 @@ where
         let members = self.membership.members_of(&subnetwork_id);
         let peers: Vec<_> = members
             .iter()
-            .filter(|peer_id| self.connected_peers.contains_key(peer_id))
             .filter(|peer_id| !self.pending_peer_open_stream_requests.contains(peer_id))
             .collect();
 


### PR DESCRIPTION
## 1. What does this PR implement?

It seems that current `poll_pending_shares` function may give up too eagerly. If understand correctly the design, even if peer is not connected, stream still tries to Dial and can find address from address book if it exists.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
