### PR TITLE
refactor(test): random ports

### DIFF
--- a/nomos-da/network/core/Cargo.toml
+++ b/nomos-da/network/core/Cargo.toml
@@ -36,6 +36,7 @@ kzgrs              = { workspace = true }
 kzgrs-backend      = { features = ["testutils"], workspace = true }
 libp2p             = { features = ["plaintext", "yamux"], workspace = true }
 libp2p-swarm-test  = { default-features = false, features = ["tokio"], version = "0.5.0" }
+nomos-utils        = { workspace = true }
 rstest             = { default-features = false, version = "0.25" }
 tokio              = { default-features = false, version = "1" }
 tracing-subscriber = { default-features = false, features = ["env-filter", "fmt", "std"], version = "0.3" }

--- a/nomos-da/network/core/src/protocols/replication/mod.rs
+++ b/nomos-da/network/core/src/protocols/replication/mod.rs
@@ -14,9 +14,10 @@ mod test {
     use kzgrs_backend::testutils;
     use libp2p::{
         identity::{Keypair, PublicKey},
+        multiaddr::multiaddr,
         quic,
         swarm::SwarmEvent,
-        Multiaddr, PeerId, Swarm,
+        PeerId, Swarm,
     };
     use libp2p_swarm_test::SwarmExt as _;
     use log::info;
@@ -35,7 +36,7 @@ mod test {
         common::Share,
         replication::{ReplicationRequest, ReplicationResponseId},
     };
-    use rand::{thread_rng, Rng as _};
+    use nomos_utils::net::get_available_udp_port;
     use tokio::sync::mpsc;
     use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 
@@ -68,15 +69,6 @@ mod test {
             .unwrap()
             .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(10)))
             .build()
-    }
-
-    fn random_quic_addr() -> Multiaddr {
-        format!(
-            "/ip4/127.0.0.1/udp/{}/quic-v1",
-            thread_rng().gen_range(49152..65535)
-        )
-        .parse()
-        .unwrap()
     }
 
     fn make_neighbours(keys: &[&Keypair]) -> AllNeighbours {
@@ -181,9 +173,16 @@ mod test {
         let (done_2_tx, mut done_2_rx) = mpsc::channel::<()>(1);
         let (done_3_tx, mut done_3_rx) = mpsc::channel::<()>(1);
 
-        let addr1 = random_quic_addr();
-        let addr3 = random_quic_addr();
-
+        let addr1 = multiaddr!(
+            Ip4([127, 0, 0, 1]),
+            Udp(get_available_udp_port().unwrap()),
+            QuicV1
+        );
+        let addr3 = multiaddr!(
+            Ip4([127, 0, 0, 1]),
+            Udp(get_available_udp_port().unwrap()),
+            QuicV1
+        );
         swarm_1.listen_on(addr1.clone()).unwrap();
         swarm_3.listen_on(addr3.clone()).unwrap();
 
@@ -248,7 +247,11 @@ mod test {
 
         let msg_count = 10usize;
 
-        let addr = random_quic_addr();
+        let addr = multiaddr!(
+            Ip4([127, 0, 0, 1]),
+            Udp(get_available_udp_port().unwrap()),
+            QuicV1
+        );
         swarm_1.listen_on(addr.clone()).unwrap();
 
         // future that listens for messages and collects `msg_count` of them, then
@@ -356,7 +359,11 @@ mod test {
             mantle_tx: base_mantle_tx,
         };
 
-        let addr1 = random_quic_addr();
+        let addr1 = multiaddr!(
+            Ip4([127, 0, 0, 1]),
+            Udp(get_available_udp_port().unwrap()),
+            QuicV1
+        );
         swarm1.listen_on(addr1.clone()).unwrap();
 
         let task1 = async move {

--- a/nomos-services/network/Cargo.toml
+++ b/nomos-services/network/Cargo.toml
@@ -23,6 +23,7 @@ utoipa           = { optional = true, workspace = true }
 
 [dev-dependencies]
 chrono             = { default-features = false, features = ["now"], version = "0.4" }
+nomos-utils        = { workspace = true }
 tokio              = { default-features = false, version = "1" }
 tracing-subscriber = { default-features = false, features = ["env-filter", "fmt", "std"], version = "0.3" }
 

--- a/nomos-services/network/src/backends/libp2p/swarm/mod.rs
+++ b/nomos-services/network/src/backends/libp2p/swarm/mod.rs
@@ -263,16 +263,12 @@ mod tests {
     use std::{net::Ipv4Addr, sync::Once, time::Instant};
 
     use nomos_libp2p::{protocol_name::ProtocolName, Protocol};
-    use rand::{thread_rng, Rng as _};
+    use nomos_utils::net::get_available_udp_port;
     use tracing_subscriber::EnvFilter;
 
     use super::*;
 
     static INIT: Once = Once::new();
-
-    fn random_port() -> u16 {
-        thread_rng().gen_range(49152..65535)
-    }
 
     fn init_tracing() {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
@@ -319,7 +315,7 @@ mod tests {
         let (pubsub_events_tx, _) = broadcast::channel(10);
         let (chainsync_events_tx, _) = broadcast::channel(10);
 
-        let config = create_libp2p_config(vec![], random_port());
+        let config = create_libp2p_config(vec![], get_available_udp_port().unwrap());
         let mut bootstrap_node = SwarmHandler::new(
             config,
             tx1.clone(),
@@ -372,7 +368,10 @@ mod tests {
             let (pubsub_events_tx, _) = broadcast::channel(10);
             let (chainsync_events_tx, _) = broadcast::channel(10);
 
-            let config = create_libp2p_config(vec![bootstrap_addr.clone()], random_port());
+            let config = create_libp2p_config(
+                vec![bootstrap_addr.clone()],
+                get_available_udp_port().unwrap(),
+            );
             let mut handler = SwarmHandler::new(
                 config,
                 tx.clone(),

--- a/nomos-services/time/Cargo.toml
+++ b/nomos-services/time/Cargo.toml
@@ -25,7 +25,7 @@ tokio-stream       = { default-features = false, version = "0.1" }
 tracing            = { default-features = false, version = "0.1" }
 
 [dev-dependencies]
-rand = { default-features = false, workspace = true }
+nomos-utils = { workspace = true }
 
 [features]
 ntp       = ["dep:sntpc", "dep:thiserror", "tokio/net"]

--- a/nomos-services/time/src/backends/ntp/testutils.rs
+++ b/nomos-services/time/src/backends/ntp/testutils.rs
@@ -186,7 +186,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use log::trace;
-    use rand::{thread_rng, Rng as _};
+    use nomos_utils::net::get_available_tcp_port;
 
     use super::*;
     use crate::backends::ntp::async_client::{AsyncNTPClient, NTPClientSettings};
@@ -194,7 +194,7 @@ mod tests {
     #[tokio::test]
     async fn test_fake_ntp_server() {
         let server_ip_address = "127.0.0.1";
-        let server_port = thread_rng().gen_range(49152..65535);
+        let server_port = get_available_tcp_port().unwrap();
         let parsed_server_ip_address: Ipv4Addr = server_ip_address.parse().unwrap();
         let server_socket_address =
             SocketAddr::new(IpAddr::from(parsed_server_ip_address), server_port);

--- a/nomos-utils/src/lib.rs
+++ b/nomos-utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod fisheryates;
 pub mod math;
+pub mod net;
 pub mod noop_service;
 
 #[cfg(feature = "rng")]

--- a/nomos-utils/src/net.rs
+++ b/nomos-utils/src/net.rs
@@ -1,0 +1,52 @@
+use std::{
+    collections::HashSet,
+    net::{TcpListener, UdpSocket},
+    sync::{LazyLock, Mutex},
+};
+
+static USED_TCP_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+static USED_UDP_PORTS: LazyLock<Mutex<HashSet<u16>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Get an available TCP port from the OS by binding to port 0.
+///
+/// Returns the actual port number assigned by the OS, or None if unable to get
+/// one. Keeps track of used TCP ports to ensure no reuse within the same test
+/// run.
+pub fn get_available_tcp_port() -> Option<u16> {
+    for _ in 0..100 {
+        // Limit retries to avoid infinite loop
+        let port = TcpListener::bind("127.0.0.1:0")
+            .ok()?
+            .local_addr()
+            .ok()?
+            .port();
+
+        let mut used_ports = USED_TCP_PORTS.lock().ok()?;
+        if used_ports.insert(port) {
+            return Some(port);
+        }
+    }
+    None
+}
+
+/// Get an available UDP port from the OS by binding to port 0.
+///
+/// Returns the actual port number assigned by the OS, or None if unable to get
+/// one. Keeps track of used UDP ports to ensure no reuse within the same test
+/// run.
+pub fn get_available_udp_port() -> Option<u16> {
+    for _ in 0..100 {
+        // Limit retries to avoid infinite loop
+        let port = UdpSocket::bind("127.0.0.1:0")
+            .ok()?
+            .local_addr()
+            .ok()?
+            .port();
+
+        let mut used_ports = USED_UDP_PORTS.lock().ok()?;
+        if used_ports.insert(port) {
+            return Some(port);
+        }
+    }
+    None
+}

--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -10,9 +10,10 @@ use nomos_core::sdp::{Locator, ServiceType};
 use nomos_libp2p::{ed25519, multiaddr, Multiaddr, PeerId};
 use nomos_membership::{backends::mock::MockMembershipBackendSettings, MembershipServiceSettings};
 use nomos_tracing_service::{LoggerLayer, MetricsLayer, TracingLayer, TracingSettings};
+use nomos_utils::net::get_available_udp_port;
 use rand::{thread_rng, Rng as _};
 use tests::{
-    get_available_port, secret_key_to_provider_id,
+    secret_key_to_provider_id,
     topology::configs::{
         api::GeneralApiConfig,
         blend::create_blend_configs,
@@ -85,7 +86,7 @@ pub fn create_node_configs(
     let mut ports = vec![];
     for id in &mut ids {
         thread_rng().fill(id);
-        ports.push(get_available_port());
+        ports.push(get_available_udp_port().unwrap());
     }
 
     let consensus_configs = create_consensus_configs(&ids, consensus_params);

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,22 +3,9 @@ pub mod common;
 pub mod nodes;
 pub mod topology;
 
-use std::{
-    env,
-    net::TcpListener,
-    ops::Mul as _,
-    sync::{
-        atomic::{AtomicU16, Ordering},
-        LazyLock,
-    },
-    time::Duration,
-};
+use std::{env, ops::Mul as _, sync::LazyLock, time::Duration};
 
 use nomos_libp2p::{multiaddr, Multiaddr, PeerId};
-use rand::{thread_rng, Rng as _};
-
-static NET_PORT: LazyLock<AtomicU16> =
-    LazyLock::new(|| AtomicU16::new(thread_rng().gen_range(8000..10000)));
 
 static IS_SLOW_TEST_ENV: LazyLock<bool> =
     LazyLock::new(|| env::var("SLOW_TEST_ENV").is_ok_and(|s| s == "true"));
@@ -39,15 +26,6 @@ pub static GLOBAL_PARAMS_PATH: LazyLock<String> = LazyLock::new(|| {
 pub static IS_DEBUG_TRACING: LazyLock<bool> = LazyLock::new(|| {
     env::var("NOMOS_TESTS_TRACING").is_ok_and(|val| val.eq_ignore_ascii_case("true"))
 });
-
-pub fn get_available_port() -> u16 {
-    loop {
-        let port = NET_PORT.fetch_add(1, Ordering::SeqCst);
-        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
-            return port;
-        }
-    }
-}
 
 /// In slow test environments like Codecov, use 2x timeout.
 #[must_use]

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -68,14 +68,13 @@ use nomos_time::{
 };
 use nomos_tracing::logging::local::FileConfig;
 use nomos_tracing_service::LoggerLayer;
-use nomos_utils::math::NonNegativeF64;
+use nomos_utils::{math::NonNegativeF64, net::get_available_tcp_port};
 use reqwest::Url;
 use tempfile::NamedTempFile;
 
 use super::{create_tempdir, persist_tempdir, CLIENT};
 use crate::{
-    adjust_timeout, get_available_port, nodes::LOGS_PREFIX, topology::configs::GeneralConfig,
-    IS_DEBUG_TRACING,
+    adjust_timeout, nodes::LOGS_PREFIX, topology::configs::GeneralConfig, IS_DEBUG_TRACING,
 };
 
 const BIN_PATH: &str = "../target/debug/nomos-executor";
@@ -338,7 +337,7 @@ impl Executor {
 #[must_use]
 #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
 pub fn create_executor_config(config: GeneralConfig) -> Config {
-    let testing_http_address = format!("127.0.0.1:{}", get_available_port())
+    let testing_http_address = format!("127.0.0.1:{}", get_available_tcp_port().unwrap())
         .parse()
         .unwrap();
 

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -55,15 +55,14 @@ use nomos_time::{
 };
 use nomos_tracing::logging::local::FileConfig;
 use nomos_tracing_service::LoggerLayer;
-use nomos_utils::math::NonNegativeF64;
+use nomos_utils::{math::NonNegativeF64, net::get_available_tcp_port};
 use reqwest::Url;
 use tempfile::NamedTempFile;
 use tokio::time::error::Elapsed;
 
 use super::{create_tempdir, persist_tempdir, CLIENT};
 use crate::{
-    adjust_timeout, get_available_port, nodes::LOGS_PREFIX, topology::configs::GeneralConfig,
-    IS_DEBUG_TRACING,
+    adjust_timeout, nodes::LOGS_PREFIX, topology::configs::GeneralConfig, IS_DEBUG_TRACING,
 };
 
 const BIN_PATH: &str = "../target/debug/nomos-node";
@@ -362,7 +361,7 @@ impl Validator {
 #[must_use]
 #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
 pub fn create_validator_config(config: GeneralConfig) -> Config {
-    let testing_http_address = format!("127.0.0.1:{}", get_available_port())
+    let testing_http_address = format!("127.0.0.1:{}", get_available_tcp_port().unwrap())
         .parse()
         .unwrap();
 

--- a/tests/src/tests/membership/disperse.rs
+++ b/tests/src/tests/membership/disperse.rs
@@ -6,11 +6,11 @@ use nomos_core::{
     da::BlobId,
     sdp::{FinalizedBlockEvent, FinalizedBlockEventUpdate, ProviderId},
 };
+use nomos_utils::net::get_available_udp_port;
 use rand::{thread_rng, Rng as _};
 use serial_test::serial;
 use tests::{
     common::da::{disseminate_with_metadata, wait_for_blob_onchain, APP_ID},
-    get_available_port,
     nodes::{executor::Executor, validator::Validator},
     topology::{
         configs::membership::{create_membership_configs, GeneralMembershipConfig},
@@ -45,7 +45,7 @@ fn generate_test_ids_and_ports(n_participants: usize) -> (Vec<[u8; 32]>, Vec<u16
 
     for id in &mut ids {
         thread_rng().fill(id);
-        ports.push(get_available_port());
+        ports.push(get_available_udp_port().unwrap());
     }
 
     (ids, ports)

--- a/tests/src/topology/configs/api.rs
+++ b/tests/src/topology/configs/api.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use crate::get_available_port;
+use nomos_utils::net::get_available_tcp_port;
 
 #[derive(Clone)]
 pub struct GeneralApiConfig {
@@ -11,7 +11,7 @@ pub struct GeneralApiConfig {
 pub fn create_api_configs(ids: &[[u8; 32]]) -> Vec<GeneralApiConfig> {
     ids.iter()
         .map(|_| GeneralApiConfig {
-            address: format!("127.0.0.1:{}", get_available_port())
+            address: format!("127.0.0.1:{}", get_available_tcp_port().unwrap())
                 .parse()
                 .unwrap(),
         })

--- a/tests/src/topology/configs/blend.rs
+++ b/tests/src/topology/configs/blend.rs
@@ -10,8 +10,7 @@ use nomos_libp2p::{
     protocol_name::StreamProtocol,
     Multiaddr, PeerId,
 };
-
-use crate::get_available_port;
+use nomos_utils::net::get_available_udp_port;
 
 #[derive(Clone)]
 pub struct GeneralBlendConfig {
@@ -33,7 +32,7 @@ pub fn create_blend_configs(ids: &[[u8; 32]]) -> Vec<GeneralBlendConfig> {
                 backend: Libp2pBlendBackendSettings {
                     listening_address: Multiaddr::from_str(&format!(
                         "/ip4/127.0.0.1/udp/{}/quic-v1",
-                        get_available_port(),
+                        get_available_udp_port().unwrap(),
                     ))
                     .unwrap(),
                     node_key,

--- a/tests/src/topology/configs/mod.rs
+++ b/tests/src/topology/configs/mod.rs
@@ -16,16 +16,14 @@ use blend::GeneralBlendConfig;
 use consensus::GeneralConsensusConfig;
 use da::GeneralDaConfig;
 use network::GeneralNetworkConfig;
+use nomos_utils::net::get_available_udp_port;
 use rand::{thread_rng, Rng as _};
 use tracing::GeneralTracingConfig;
 
-use crate::{
-    get_available_port,
-    topology::configs::{
-        api::GeneralApiConfig, bootstrap::GeneralBootstrapConfig, consensus::ConsensusParams,
-        da::DaParams, membership::GeneralMembershipConfig, network::NetworkParams,
-        time::GeneralTimeConfig,
-    },
+use crate::topology::configs::{
+    api::GeneralApiConfig, bootstrap::GeneralBootstrapConfig, consensus::ConsensusParams,
+    da::DaParams, membership::GeneralMembershipConfig, network::NetworkParams,
+    time::GeneralTimeConfig,
 };
 
 #[derive(Clone)]
@@ -56,7 +54,7 @@ pub fn create_general_configs_with_network(
 
     for id in &mut ids {
         thread_rng().fill(id);
-        ports.push(get_available_port());
+        ports.push(get_available_udp_port().unwrap());
     }
 
     let consensus_params = ConsensusParams::default_for_participants(n_nodes);

--- a/tests/src/topology/configs/network.rs
+++ b/tests/src/topology/configs/network.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
 use nomos_libp2p::{ed25519, Multiaddr, SwarmConfig};
+use nomos_utils::net::get_available_udp_port;
 
-use crate::{get_available_port, node_address_from_port};
+use crate::node_address_from_port;
 
 #[derive(Default)]
 pub enum Libp2pNetworkLayout {
@@ -37,7 +38,7 @@ pub fn create_network_configs(
 
             SwarmConfig {
                 node_key,
-                port: get_available_port(),
+                port: get_available_udp_port().unwrap(),
                 chain_sync_config: cryptarchia_sync::Config {
                     peer_response_timeout: Duration::from_secs(60),
                 },

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -9,10 +9,10 @@ use configs::{
     GeneralConfig,
 };
 use nomos_da_network_core::swarm::DAConnectionPolicySettings;
+use nomos_utils::net::get_available_udp_port;
 use rand::{thread_rng, Rng as _};
 
 use crate::{
-    get_available_port,
     nodes::{
         executor::{create_executor_config, Executor},
         validator::{create_validator_config, Validator},
@@ -120,7 +120,7 @@ impl Topology {
         let mut ports = vec![];
         for id in &mut ids {
             thread_rng().fill(id);
-            ports.push(get_available_port());
+            ports.push(get_available_udp_port().unwrap());
         }
 
         let consensus_configs = create_consensus_configs(&ids, &config.consensus_params);


### PR DESCRIPTION
## 1. What does this PR implement?

Use random ports in tests to avoid port already in use. 

```
ailures:

---- backends::libp2p::swarm::tests::test_kademlia_bootstrap stdout ----

thread 'backends::libp2p::swarm::tests::test_kademlia_bootstrap' panicked at nomos-services/network/src/backends/libp2p/swarm/mod.rs:67:48:
called `Result::unwrap()` on an `Err` value: Other(Custom { kind: Other, error: Other(Transport(Right(Io(Os { code: 48, kind: AddrInUse, message: "Address already in use" })))) })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
