### PR TITLE
feat(blend): pass SessionEvent stream to core backend

### DIFF
--- a/nomos-services/blend/Cargo.toml
+++ b/nomos-services/blend/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 async-trait            = "0.1"
+fork_stream            = { workspace = true }
 futures                = { default-features = false, version = "0.3" }
 libp2p                 = { optional = true, workspace = true }
 libp2p-stream          = { optional = true, workspace = true }

--- a/nomos-services/blend/src/core/backends/libp2p/mod.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/mod.rs
@@ -7,7 +7,7 @@ use futures::{
 };
 use libp2p::PeerId;
 use nomos_blend_network::EncapsulatedMessageWithValidatedPublicHeader;
-use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
+use nomos_blend_scheduling::{membership::Membership, session::SessionEvent, EncapsulatedMessage};
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
 use tokio::sync::{broadcast, mpsc};
@@ -56,7 +56,8 @@ where
     fn new(
         config: BlendConfig<Self::Settings, PeerId>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<PeerId>> + Send>>,
+        current_membership: Membership<PeerId>,
+        session_stream: Pin<Box<dyn Stream<Item = SessionEvent<Membership<PeerId>>> + Send>>,
         rng: Rng,
     ) -> Self {
         let (swarm_message_sender, swarm_message_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -65,6 +66,7 @@ where
 
         let swarm = BlendSwarm::<_, _, ObservationWindowTokioIntervalProvider>::new(
             config,
+            current_membership,
             session_stream,
             rng,
             swarm_message_receiver,

--- a/nomos-services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -19,7 +19,10 @@ use nomos_blend_network::{
     },
     EncapsulatedMessageWithValidatedPublicHeader,
 };
-use nomos_blend_scheduling::membership::{Membership, Node};
+use nomos_blend_scheduling::{
+    membership::{Membership, Node},
+    session::SessionEvent,
+};
 use nomos_libp2p::{Protocol, SwarmEvent};
 use nomos_utils::blake_rng::BlakeRng;
 use rand::SeedableRng as _;
@@ -38,7 +41,11 @@ use crate::{
 };
 
 pub struct TestSwarm {
-    pub swarm: BlendSwarm<Pending<Membership<PeerId>>, BlakeRng, TestObservationWindowProvider>,
+    pub swarm: BlendSwarm<
+        Pending<SessionEvent<Membership<PeerId>>>,
+        BlakeRng,
+        TestObservationWindowProvider,
+    >,
     pub swarm_message_sender: mpsc::Sender<BlendSwarmMessage>,
     pub incoming_message_receiver:
         broadcast::Receiver<EncapsulatedMessageWithValidatedPublicHeader>,

--- a/nomos-services/blend/src/core/backends/mod.rs
+++ b/nomos-services/blend/src/core/backends/mod.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, pin::Pin};
 
 use futures::Stream;
 use nomos_blend_network::EncapsulatedMessageWithValidatedPublicHeader;
-use nomos_blend_scheduling::{membership::Membership, EncapsulatedMessage};
+use nomos_blend_scheduling::{membership::Membership, session::SessionEvent, EncapsulatedMessage};
 use overwatch::overwatch::handle::OverwatchHandle;
 
 use crate::core::settings::BlendConfig;
@@ -18,7 +18,8 @@ pub trait BlendBackend<NodeId, Rng, RuntimeServiceId> {
     fn new(
         service_config: BlendConfig<Self::Settings, NodeId>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-        session_stream: Pin<Box<dyn Stream<Item = Membership<NodeId>> + Send>>,
+        current_membership: Membership<NodeId>,
+        session_stream: Pin<Box<dyn Stream<Item = SessionEvent<Membership<NodeId>>> + Send>>,
         rng: Rng,
     ) -> Self;
     fn shutdown(self);

--- a/nomos-services/blend/src/core/settings.rs
+++ b/nomos-services/blend/src/core/settings.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use futures::{Stream, StreamExt as _};
 use nomos_blend_scheduling::{
@@ -18,6 +18,7 @@ pub struct BlendConfig<BackendSettings, NodeId> {
     pub crypto: CryptographicProcessorSettings,
     pub scheduler: SchedulerSettingsExt,
     pub time: TimingSettings,
+    // TODO: Remove this and use the membership service stream instead: https://github.com/logos-co/nomos/issues/1532
     pub membership: Vec<Node<NodeId>>,
     pub minimum_network_size: NonZeroU64,
 }
@@ -68,16 +69,6 @@ impl CoverTrafficSettingsExt {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MessageDelayerSettingsExt {
     pub maximum_release_delay_in_rounds: NonZeroU64,
-}
-
-impl<BackendSettings, NodeId> BlendConfig<BackendSettings, NodeId>
-where
-    NodeId: Eq + Hash + Clone,
-{
-    pub(super) fn membership(&self) -> Membership<NodeId> {
-        let local_signing_pubkey = self.crypto.signing_private_key.public_key();
-        Membership::new(&self.membership, &local_signing_pubkey)
-    }
 }
 
 impl<BackendSettings, NodeId> BlendConfig<BackendSettings, NodeId> {

--- a/nomos-services/blend/src/edge/mod.rs
+++ b/nomos-services/blend/src/edge/mod.rs
@@ -189,6 +189,7 @@ where
 {
     // Read the initial membership, expecting it to be yielded immediately.
     // We use 1s timeout to tolerate small delays.
+    // TODO: Refactor this to a separate struct.
     let SessionEvent::NewSession(membership) =
         timeout(Duration::from_secs(1), session_stream.next())
             .await


### PR DESCRIPTION
## 1. What does this PR implement?

This is the `2/N`-th PR for https://github.com/logos-co/nomos/issues/1533.

Previously, when initializing the core service, we created the backend with a stream built from the static membership specified in the settings.

This PR:
- Changes the flow so that the backend is created only after subscribing to a stream of `SessionEvent`s provided by the membership adapter (though we're yet using the static membership instead of the stream from the membership adapter).
- Modifies the backend to notify new sessions to the underlying swarm.

Next PRs are coming soon. (Checking new sessions in the service level)


## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @ntn-x2 @madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
