### PR TITLE
chore: remove blocknumber from da assignation storage

### DIFF
--- a/nomos-services/storage/src/api/da/mod.rs
+++ b/nomos-services/storage/src/api/da/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use multiaddr::Multiaddr;
-use nomos_core::{block::BlockNumber, da::blob::Share};
+use nomos_core::{block::SessionNumber, da::blob::Share};
 
 pub mod requests;
 
@@ -112,14 +112,14 @@ pub trait StorageDaApi {
 
     async fn store_assignations(
         &mut self,
-        block_number: BlockNumber,
+        session_id: SessionNumber,
         assignations: HashMap<Self::NetworkId, HashSet<Self::Id>>,
     ) -> Result<(), Self::Error>;
 
     async fn get_assignations(
         &mut self,
-        block_number: BlockNumber,
-    ) -> Result<HashMap<Self::NetworkId, HashSet<Self::Id>>, Self::Error>;
+        session_id: SessionNumber,
+    ) -> Result<Option<HashMap<Self::NetworkId, HashSet<Self::Id>>>, Self::Error>;
 
     async fn store_addresses(
         &mut self,

--- a/nomos-services/storage/src/backends/mock.rs
+++ b/nomos-services/storage/src/backends/mock.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use cryptarchia_engine::Slot;
 use libp2p_identity::PeerId;
 use multiaddr::Multiaddr;
-use nomos_core::{block::BlockNumber, header::HeaderId};
+use nomos_core::{block::SessionNumber, header::HeaderId};
 use thiserror::Error;
 
 use super::{StorageBackend, StorageSerde, StorageTransaction};
@@ -211,7 +211,7 @@ impl<SerdeOp: StorageSerde + Send + Sync + 'static> StorageDaApi for MockStorage
 
     async fn store_assignations(
         &mut self,
-        _block_number: BlockNumber,
+        _session_id: SessionNumber,
         _assignations: HashMap<Self::NetworkId, HashSet<Self::Id>>,
     ) -> Result<(), Self::Error> {
         unimplemented!()
@@ -219,8 +219,8 @@ impl<SerdeOp: StorageSerde + Send + Sync + 'static> StorageDaApi for MockStorage
 
     async fn get_assignations(
         &mut self,
-        _block_number: BlockNumber,
-    ) -> Result<HashMap<Self::NetworkId, HashSet<Self::Id>>, Self::Error> {
+        _session_id: SessionNumber,
+    ) -> Result<Option<HashMap<Self::NetworkId, HashSet<Self::Id>>>, Self::Error> {
         unimplemented!()
     }
 


### PR DESCRIPTION
## 1. What does this PR implement?
This PR removes block number leftovers in storage da. It was left when we were replacing it with session. 
It also fixes a small bug when getting assignations, when assignations are not found.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @pradovic 

## 4. Is the specification accurate and complete?
Yes
## 5. Does the implementation introduce changes in the specification?

Yes

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
