### PR TITLE
DRAFT: feat(chain): mark chain service ready after bootstrapping

### DIFF
--- a/testnet/cfgsync/src/config.rs
+++ b/testnet/cfgsync/src/config.rs
@@ -89,7 +89,7 @@ pub fn create_node_configs(
     }
 
     let consensus_configs = create_consensus_configs(&ids, consensus_params);
-    let bootstrap_configs = create_bootstrap_configs(&ids, Duration::from_secs(60));
+    let bootstrap_configs = create_bootstrap_configs(&ids, Duration::from_secs(3));
     let da_configs = create_da_configs(&ids, da_params, &ports);
     let network_configs = create_network_configs(&ids, &NetworkParams::default());
     let membership_configs = create_membership_configs(&ids, &hosts);

--- a/tests/src/topology/configs/mod.rs
+++ b/tests/src/topology/configs/mod.rs
@@ -61,7 +61,7 @@ pub fn create_general_configs_with_network(
 
     let consensus_params = ConsensusParams::default_for_participants(n_nodes);
     let consensus_configs = consensus::create_consensus_configs(&ids, &consensus_params);
-    let bootstrap_config = bootstrap::create_bootstrap_configs(&ids, Duration::from_secs(20));
+    let bootstrap_config = bootstrap::create_bootstrap_configs(&ids, Duration::from_secs(3));
     let network_configs = network::create_network_configs(&ids, network_params);
     let da_configs = da::create_da_configs(&ids, &DaParams::default(), &da_ports);
     let api_configs = api::create_api_configs(&ids);

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -126,7 +126,7 @@ impl Topology {
         }
 
         let consensus_configs = create_consensus_configs(&ids, &config.consensus_params);
-        let bootstrapping_config = create_bootstrap_configs(&ids, Duration::from_secs(30));
+        let bootstrapping_config = create_bootstrap_configs(&ids, Duration::from_secs(3));
         let da_configs = create_da_configs(&ids, &config.da_params, &da_ports);
         let membership_configs = create_membership_configs(ids.as_slice(), &da_ports, &blend_ports);
         let network_configs = create_network_configs(&ids, &config.network_params);
@@ -170,7 +170,7 @@ impl Topology {
         let n_participants = config.n_validators + config.n_executors;
 
         let consensus_configs = create_consensus_configs(ids, &config.consensus_params);
-        let bootstrapping_config = create_bootstrap_configs(ids, Duration::from_secs(60));
+        let bootstrapping_config = create_bootstrap_configs(ids, Duration::from_secs(3));
         let da_configs = create_da_configs(ids, &config.da_params, da_ports);
         let network_configs = create_network_configs(ids, &config.network_params);
         let blend_configs = create_blend_configs(ids, blend_ports);


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1656. All details can be found in the root issue https://github.com/logos-co/nomos/issues/1479.

This is a stacked PR based on https://github.com/logos-co/nomos/pull/1657.

Now, the chain service doesn't need to wait for the Blend and DA sampling services,
- because blob validation is disabled for most of the bootstrapping period.
- because proposing block is disabled until bootstrapping is done.

So, in this PR, the chain service doesn't wait for them at startup.

Instead, after bootstrapping is done, the chain service checks if they're ready, and notifies Overwatch that it's finally ready.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @zeegomo 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
