### PR TITLE
refactor(cryptarchia): define Length type

### DIFF
--- a/nomos-services/chain/broadcast-service/Cargo.toml
+++ b/nomos-services/chain/broadcast-service/Cargo.toml
@@ -8,9 +8,10 @@ version = "0.1.0"
 workspace = true
 
 [dependencies]
-async-trait = "0.1"
-nomos-core  = { workspace = true }
-overwatch   = { workspace = true }
-serde       = { features = ["derive"], version = "1.0" }
-tokio       = { default-features = false, version = "1" }
-tracing     = { workspace = true }
+async-trait        = "0.1"
+cryptarchia-engine = { workspace = true }
+nomos-core         = { workspace = true }
+overwatch          = { workspace = true }
+serde              = { features = ["derive"], version = "1.0" }
+tokio              = { default-features = false, version = "1" }
+tracing            = { workspace = true }

--- a/nomos-services/chain/broadcast-service/src/lib.rs
+++ b/nomos-services/chain/broadcast-service/src/lib.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
+use cryptarchia_engine::Length;
 use nomos_core::header::HeaderId;
 use overwatch::{
     OpaqueServiceResourcesHandle,
@@ -17,7 +18,7 @@ const BROADCAST_CHANNEL_SIZE: usize = 128;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockInfo {
-    pub height: u64,
+    pub height: Length,
     pub header_id: HeaderId,
 }
 

--- a/nomos-services/chain/chain-service/src/lib.rs
+++ b/nomos-services/chain/chain-service/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use broadcast_service::{BlockBroadcastMsg, BlockBroadcastService, BlockInfo};
-use cryptarchia_engine::{PrunedBlocks, Slot};
+use cryptarchia_engine::{Length, PrunedBlocks, Slot};
 use cryptarchia_sync::{GetTipResponse, ProviderResponse};
 use futures::{StreamExt as _, TryFutureExt as _};
 pub use leadership::LeaderConfig;
@@ -127,7 +127,7 @@ pub struct CryptarchiaInfo {
     pub lib: HeaderId,
     pub tip: HeaderId,
     pub slot: Slot,
-    pub height: u64,
+    pub height: Length,
     pub mode: cryptarchia_engine::State,
 }
 

--- a/nomos-services/chain/chain-service/src/states.rs
+++ b/nomos-services/chain/chain-service/src/states.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, hash::Hash, marker::PhantomData, time::SystemTime};
 
+use cryptarchia_engine::Length;
 use nomos_core::{header::HeaderId, mantle::Utxo};
 use nomos_ledger::LedgerState;
 use overwatch::{services::state::ServiceState, DynError};
@@ -13,7 +14,7 @@ pub struct CryptarchiaConsensusState<TxS, NodeId, NetworkAdapterSettings, BlendA
     pub lib: HeaderId,
     pub lib_ledger_state: LedgerState,
     pub lib_leader_utxos: Vec<Utxo>,
-    pub lib_block_length: u64,
+    pub lib_block_length: Length,
     /// Set of blocks that have been pruned from the engine but have not yet
     /// been deleted from the persistence layer because of some unexpected
     /// error.
@@ -80,7 +81,7 @@ where
                 lib: settings.genesis_id,
                 lib_ledger_state: settings.genesis_state.clone(),
                 lib_leader_utxos: settings.leader_config.utxos.clone(),
-                lib_block_length: 0,
+                lib_block_length: 0u64.into(),
                 storage_blocks_to_remove: HashSet::new(),
                 last_engine_state: None,
                 _markers: PhantomData,

--- a/tests/src/tests/cryptarchia/orphan.rs
+++ b/tests/src/tests/cryptarchia/orphan.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use cryptarchia_engine::Length;
 use futures::stream::{self, StreamExt as _};
 use serial_test::serial;
 use tests::{
@@ -46,7 +47,7 @@ async fn test_orphan_handling() {
 
     let behind_node = vec![Validator::spawn(config).await.unwrap()];
 
-    let mut behind_node_height = 0;
+    let mut behind_node_height = Length::from(0u64);
 
     // Most of the time late node receives an orphan block within a few seconds.
     // But sometimes it takes longer, 20 seconds seems safe.


### PR DESCRIPTION
## 1. What does this PR implement?

We've been using `u64` to represent chain length, height, and depth.
This PR defines the `Length(u64)` type for them.

That's useful since now we deal with it in many places outside of the cryptarchia engine (such as in `chain/broadcast_service` and, in the near future, chain sync).

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
@zeegomo @youngjoon-lee 

## 4. Is the specification accurate and complete?
n/a

## 5. Does the implementation introduce changes in the specification?
n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
