### PR TITLE
feat(chainsync): add height to the TipResponse

### DIFF
--- a/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
@@ -607,12 +607,13 @@ mod tests {
 
         tokio::spawn(async move { downloader_swarm.loop_on_next().await });
 
-        let Tip { tip, slot } = receiver.await.unwrap().unwrap() else {
+        let Tip { tip, slot, height } = receiver.await.unwrap().unwrap() else {
             panic!("Expected a tip response");
         };
 
         assert_eq!(tip, HeaderId::from([0; 32]));
         assert_eq!(slot, Slot::from(0));
+        assert_eq!(height, 0);
     }
 
     #[tokio::test]
@@ -752,6 +753,7 @@ mod tests {
             ProviderResponse::Available(Tip {
                 tip: HeaderId::from([0; 32]),
                 slot: Slot::from(0),
+                height: 0,
             })
         }
 
@@ -792,6 +794,7 @@ mod tests {
             ProviderResponse::Available(Tip {
                 tip: HeaderId::from([0; 32]),
                 slot: Slot::from(0),
+                height: 0,
             })
         }
 

--- a/consensus/cryptarchia-sync/src/libp2p/downloader.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/downloader.rs
@@ -70,7 +70,7 @@ impl Downloader {
         })?
         .map_err(|e| ChainSyncError::from((peer_id, e)))
         .and_then(|response| match response {
-            GetTipResponse::Tip { tip, slot } => Ok(GetTipResponse::Tip { tip, slot }),
+            tip @ GetTipResponse::Tip { .. } => Ok(tip),
             GetTipResponse::Failure(reason) => Err(ChainSyncError {
                 peer: peer_id,
                 kind: ChainSyncErrorKind::RequestTipError(reason),

--- a/consensus/cryptarchia-sync/src/messages.rs
+++ b/consensus/cryptarchia-sync/src/messages.rs
@@ -8,8 +8,12 @@ pub type SerialisedBlock = Bytes;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum GetTipResponse {
-    /// A response containing the tip and slot of the peer.
-    Tip { tip: HeaderId, slot: Slot },
+    /// A success response.
+    Tip {
+        tip: HeaderId,
+        slot: Slot,
+        height: u64,
+    },
     /// A response indicating that the request failed.
     Failure(String),
 }

--- a/nomos-services/chain/chain-service/src/bootstrap/ibd.rs
+++ b/nomos-services/chain/chain-service/src/bootstrap/ibd.rs
@@ -338,10 +338,10 @@ mod tests {
         let peer = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
             ],
-            Ok(Block::new(2, 1, 2)),
+            Ok(Block::new(2, 1, 2, 2)),
             2,
             false,
         );
@@ -363,11 +363,11 @@ mod tests {
         let peer = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
-                Block::new(3, 2, 3),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
+                Block::new(3, 2, 3, 3),
             ],
-            Ok(Block::new(3, 2, 3)),
+            Ok(Block::new(3, 2, 3, 3)),
             2,
             false,
         );
@@ -389,21 +389,21 @@ mod tests {
         let peer0 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
             ],
-            Ok(Block::new(2, 1, 2)),
+            Ok(Block::new(2, 1, 2, 2)),
             2,
             false,
         );
         let peer1 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(3, GENESIS_ID, 3),
-                Block::new(4, 3, 4),
-                Block::new(5, 4, 5),
+                Block::new(3, GENESIS_ID, 3, 1),
+                Block::new(4, 3, 4, 2),
+                Block::new(5, 4, 5, 3),
             ],
-            Ok(Block::new(5, 4, 5)),
+            Ok(Block::new(5, 4, 5, 3)),
             2,
             false,
         );
@@ -432,21 +432,21 @@ mod tests {
         let peer0 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
             ],
-            Ok(Block::new(2, 1, 2)),
+            Ok(Block::new(2, 1, 2, 2)),
             2,
             true, // Return error while streaming blocks
         );
         let peer1 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(3, GENESIS_ID, 3),
-                Block::new(4, 3, 4),
-                Block::new(5, 4, 5),
+                Block::new(3, GENESIS_ID, 3, 1),
+                Block::new(4, 3, 4, 2),
+                Block::new(5, 4, 5, 3),
             ],
-            Ok(Block::new(5, 4, 5)),
+            Ok(Block::new(5, 4, 5, 3)),
             2,
             false,
         );
@@ -474,21 +474,21 @@ mod tests {
         let peer0 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
             ],
-            Ok(Block::new(2, 1, 2)),
+            Ok(Block::new(2, 1, 2, 2)),
             2,
             true, // Return error while streaming blocks
         );
         let peer1 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(3, GENESIS_ID, 3),
-                Block::new(4, 3, 4),
-                Block::new(5, 4, 5),
+                Block::new(3, GENESIS_ID, 3, 1),
+                Block::new(4, 3, 4, 2),
+                Block::new(5, 4, 5, 3),
             ],
-            Ok(Block::new(5, 4, 5)),
+            Ok(Block::new(5, 4, 5, 3)),
             2,
             true, // Return error while streaming blocks
         );
@@ -514,8 +514,8 @@ mod tests {
         let peer0 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
             ],
             Err(()), // Return error while initiating download
             2,
@@ -524,11 +524,11 @@ mod tests {
         let peer1 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(3, GENESIS_ID, 3),
-                Block::new(4, 3, 4),
-                Block::new(5, 4, 5),
+                Block::new(3, GENESIS_ID, 3, 1),
+                Block::new(4, 3, 4, 2),
+                Block::new(5, 4, 5, 3),
             ],
-            Ok(Block::new(5, 4, 5)),
+            Ok(Block::new(5, 4, 5, 3)),
             2,
             false,
         );
@@ -556,8 +556,8 @@ mod tests {
         let peer0 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(1, GENESIS_ID, 1),
-                Block::new(2, 1, 2),
+                Block::new(1, GENESIS_ID, 1, 1),
+                Block::new(2, 1, 2, 2),
             ],
             Err(()), // Return error while initiating download
             2,
@@ -566,9 +566,9 @@ mod tests {
         let peer1 = BlockProvider::new(
             vec![
                 Block::genesis(),
-                Block::new(3, GENESIS_ID, 3),
-                Block::new(4, 3, 4),
-                Block::new(5, 4, 5),
+                Block::new(3, GENESIS_ID, 3, 1),
+                Block::new(4, 3, 4, 2),
+                Block::new(5, 4, 5, 3),
             ],
             Err(()), // Return error while initiating download
             2,
@@ -625,14 +625,16 @@ mod tests {
         id: HeaderId,
         parent: HeaderId,
         slot: Slot,
+        height: u64,
     }
 
     impl Block {
-        fn new(id: u8, parent: u8, slot: u64) -> Self {
+        fn new(id: u8, parent: u8, slot: u64, height: u64) -> Self {
             Self {
                 id: [id; 32].into(),
                 parent: [parent; 32].into(),
                 slot: slot.into(),
+                height,
             }
         }
 
@@ -641,6 +643,7 @@ mod tests {
                 id: [GENESIS_ID; 32].into(),
                 parent: [GENESIS_ID; 32].into(),
                 slot: Slot::genesis(),
+                height: 0,
             }
         }
     }
@@ -740,6 +743,7 @@ mod tests {
                 Ok(tip) => Ok(GetTipResponse::Tip {
                     tip: tip.id,
                     slot: tip.slot,
+                    height: tip.height,
                 }),
                 Err(()) => Err(DynError::from("Cannot provide tip")),
             }

--- a/nomos-services/chain/chain-service/src/lib.rs
+++ b/nomos-services/chain/chain-service/src/lib.rs
@@ -1541,6 +1541,7 @@ where
                 let response = ProviderResponse::Available(GetTipResponse::Tip {
                     tip: tip.id(),
                     slot: tip.slot(),
+                    height: tip.length(),
                 });
 
                 info!("Sending tip response: {response:?}");


### PR DESCRIPTION
## 1. What does this PR implement?

(stacked on PR #1715 )

Added `height` to the `TipResponse`.
It's necessary for IBD in the near future, since the node must enable blob validation during IBD once it enters the DA window (e.g. 8640 blocks). In other words, it should enable the blob validation once it reaches the 8640-deep block from the peer's tip. (See details in https://github.com/logos-co/nomos/issues/1479). This PR is a preparation for it.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @zeegomo 

## 4. Is the specification accurate and complete?

no

## 5. Does the implementation introduce changes in the specification?

we should add `height` to the spec.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
