### PR TITLE
feat(chain): introduce `subscribe` API for winning slot PoL info

### DIFF
--- a/nomos-core/chain-defs/src/proofs/leader_proof.rs
+++ b/nomos-core/chain-defs/src/proofs/leader_proof.rs
@@ -32,12 +32,13 @@ pub enum Error {
 }
 
 impl Groth16LeaderProof {
-    pub fn prove(witness: &LeaderPrivate, voucher_cm: VoucherCm) -> Result<Self, Error> {
+    pub fn prove(witness: LeaderPrivate, voucher_cm: VoucherCm) -> Result<Self, Error> {
         let start_t = std::time::Instant::now();
+        #[cfg(feature = "pol-dev-mode")]
+        let witness_public = witness.public;
+        let leader_key = witness.pk;
         let (proof, entropy_contribution) = Self::generate_proof(witness)?;
         tracing::debug!("groth16 prover time: {:.2?}", start_t.elapsed(),);
-
-        let leader_key = witness.pk;
 
         Ok(Self {
             proof,
@@ -45,11 +46,11 @@ impl Groth16LeaderProof {
             leader_key,
             voucher_cm,
             #[cfg(feature = "pol-dev-mode")]
-            public: witness.public,
+            public: witness_public,
         })
     }
 
-    fn generate_proof(private: &LeaderPrivate) -> Result<(pol::PoLProof, Fr), Error> {
+    fn generate_proof(private: LeaderPrivate) -> Result<(pol::PoLProof, Fr), Error> {
         if cfg!(feature = "pol-dev-mode") && std::env::var(POL_PROOF_DEV_MODE).is_ok() {
             tracing::warn!(
                 "Proofs are being generated in dev mode. This should never be used in production."
@@ -62,7 +63,8 @@ impl Groth16LeaderProof {
 
             return Ok((proof, Fr::ZERO));
         }
-        let (proof, verif_inputs) = pol::prove(&private.input).map_err(Error::PoLProofFailed)?;
+        let (proof, verif_inputs) =
+            pol::prove(&private.input.into()).map_err(Error::PoLProofFailed)?;
         Ok((proof, verif_inputs.entropy_contribution.into_inner()))
     }
 
@@ -215,7 +217,7 @@ impl LeaderPublic {
 
 #[derive(Debug, Clone)]
 pub struct LeaderPrivate {
-    input: pol::PolWitnessInputs,
+    input: pol::PolWitnessInputsData,
     pk: ed25519_dalek::VerifyingKey,
     #[cfg(feature = "pol-dev-mode")]
     public: LeaderPublic,
@@ -260,7 +262,7 @@ impl LeaderPrivate {
             slot_secret_path: vec![], // TODO: implement
             starting_slot,
         };
-        let input = pol::PolWitnessInputs::from_chain_and_wallet_data(chain, wallet);
+        let input = pol::PolWitnessInputsData::from_chain_and_wallet_data(chain, wallet);
         Self {
             input,
             pk: public_key,

--- a/nomos-services/chain/chain-service/src/leadership.rs
+++ b/nomos-services/chain/chain-service/src/leadership.rs
@@ -101,7 +101,7 @@ impl Leader {
                 );
                 let res = tokio::task::spawn_blocking(move || {
                     Groth16LeaderProof::prove(
-                        &private_inputs,
+                        private_inputs,
                         VoucherCm::default(), // TODO: use actual voucher commitment
                     )
                 })

--- a/nomos-services/chain/chain-service/src/leadership.rs
+++ b/nomos-services/chain/chain-service/src/leadership.rs
@@ -48,7 +48,7 @@ impl Leader {
         latest_tree: &UtxoTree,
         epoch_state: &EpochState,
         slot: Slot,
-        winning_slot_pol_info_sender: &Sender<(LeaderPublic, LeaderPrivate)>,
+        winning_slot_pol_info_sender: &Sender<(LeaderPublic, LeaderPrivate, SecretKey)>,
     ) -> Option<Groth16LeaderProof> {
         for utxo in &self.utxos {
             let Some(_aged_witness) = aged_tree.witness(&utxo.id()) else {
@@ -101,9 +101,11 @@ impl Leader {
                     starting_slot,
                     &leader_pk,
                 );
-                if let Err(e) =
-                    winning_slot_pol_info_sender.send((public_inputs, private_inputs.clone()))
-                {
+                if let Err(e) = winning_slot_pol_info_sender.send((
+                    public_inputs,
+                    private_inputs.clone(),
+                    self.sk,
+                )) {
                     tracing::error!("Failed to send winning slot PoL info to subscribers: {e:?}");
                 }
                 let res = tokio::task::spawn_blocking(move || {

--- a/nomos-services/chain/chain-service/src/lib.rs
+++ b/nomos-services/chain/chain-service/src/lib.rs
@@ -31,8 +31,8 @@ use nomos_core::{
     da,
     header::{Header, HeaderId},
     mantle::{
-        gas::MainnetGasConstants, ops::leader_claim::VoucherCm, AuthenticatedMantleTx, Op,
-        SignedMantleTx, Transaction, TxHash, TxSelect,
+        gas::MainnetGasConstants, keys::SecretKey, ops::leader_claim::VoucherCm,
+        AuthenticatedMantleTx, Op, SignedMantleTx, Transaction, TxHash, TxSelect,
     },
     proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate, LeaderPublic},
 };
@@ -101,7 +101,7 @@ pub enum Error {
 }
 
 pub type WinningSlotPolInfoStream =
-    Pin<Box<dyn Stream<Item = (LeaderPublic, LeaderPrivate)> + Send + Sync + Unpin>>;
+    Pin<Box<dyn Stream<Item = (LeaderPublic, LeaderPrivate, SecretKey)> + Send + Sync + Unpin>>;
 
 pub enum ConsensusMsg {
     Info {
@@ -350,7 +350,7 @@ pub struct CryptarchiaConsensus<
     new_block_subscription_sender: broadcast::Sender<HeaderId>,
     lib_subscription_sender: broadcast::Sender<LibUpdate>,
     initial_state: <Self as ServiceData>::State,
-    winning_slot_pol_info_sender: broadcast::Sender<(LeaderPublic, LeaderPrivate)>,
+    winning_slot_pol_info_sender: broadcast::Sender<(LeaderPublic, LeaderPrivate, SecretKey)>,
 }
 
 impl<
@@ -965,7 +965,7 @@ where
         cryptarchia: &Cryptarchia,
         new_block_channel: &broadcast::Sender<HeaderId>,
         lib_channel: &broadcast::Sender<LibUpdate>,
-        winning_slot_pol_info_sender: &broadcast::Sender<(LeaderPublic, LeaderPrivate)>,
+        winning_slot_pol_info_sender: &broadcast::Sender<(LeaderPublic, LeaderPrivate, SecretKey)>,
         msg: ConsensusMsg,
     ) {
         match msg {

--- a/nomos-services/chain/chain-service/src/sync/block_provider.rs
+++ b/nomos-services/chain/chain-service/src/sync/block_provider.rs
@@ -968,7 +968,7 @@ mod tests {
             );
 
             nomos_core::proofs::leader_proof::Groth16LeaderProof::prove(
-                &private_inputs,
+                private_inputs,
                 nomos_core::mantle::ops::leader_claim::VoucherCm::default(),
             )
             .expect("Proof generation should succeed")

--- a/zk/proofs/pol/src/inputs.rs
+++ b/zk/proofs/pol/src/inputs.rs
@@ -17,14 +17,36 @@ pub struct PolWitnessInputs {
 
 impl PolWitnessInputs {
     #[must_use]
-    pub fn from_chain_and_wallet_data(
+    pub const fn from_chain_and_wallet_inputs(
+        chain: PolChainInputs,
+        wallet: PolWalletInputs,
+    ) -> Self {
+        Self { wallet, chain }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PolWitnessInputsData {
+    pub wallet: PolWalletInputsData,
+    pub chain: PolChainInputsData,
+}
+
+impl From<PolWitnessInputsData> for PolWitnessInputs {
+    fn from(data: PolWitnessInputsData) -> Self {
+        Self {
+            wallet: data.wallet.into(),
+            chain: data.chain.into(),
+        }
+    }
+}
+
+impl PolWitnessInputsData {
+    #[must_use]
+    pub const fn from_chain_and_wallet_data(
         chain: PolChainInputsData,
         wallet: PolWalletInputsData,
     ) -> Self {
-        Self {
-            wallet: wallet.into(),
-            chain: chain.into(),
-        }
+        Self { wallet, chain }
     }
 }
 

--- a/zk/proofs/pol/src/lib.rs
+++ b/zk/proofs/pol/src/lib.rs
@@ -303,9 +303,10 @@ mod tests {
             .collect(),
             starting_slot: 16,
         };
-        let witness_inputs = PolWitnessInputs::from_chain_and_wallet_data(chain_data, wallet_data);
+        let witness_inputs =
+            PolWitnessInputsData::from_chain_and_wallet_data(chain_data, wallet_data);
 
-        let (proof, inputs) = prove(&witness_inputs).unwrap();
+        let (proof, inputs) = prove(&witness_inputs.into()).unwrap();
         assert!(verify(&proof, &inputs).unwrap());
     }
 }

--- a/zk/proofs/pol/src/lib.rs
+++ b/zk/proofs/pol/src/lib.rs
@@ -40,7 +40,7 @@ pub use chain_inputs::{PolChainInputs, PolChainInputsData};
 use groth16::{
     CompressedGroth16Proof, Groth16Input, Groth16InputDeser, Groth16Proof, Groth16ProofJsonDeser,
 };
-pub use inputs::{PolVerifierInput, PolWitnessInputs};
+pub use inputs::{PolVerifierInput, PolWitnessInputs, PolWitnessInputsData};
 use thiserror::Error;
 pub use wallet_inputs::{PolWalletInputs, PolWalletInputsData};
 pub use witness::Witness;


### PR DESCRIPTION
## 1. What does this PR implement?

This PR introduces a new `subscribe` API for other services to get winning PoL slot info from chain service whenever a new winning slot is computed. This API will be used by Blend, to start pre-computing all the leadership quota proofs as soon as the first winning slot for an epoch is made available by the chain service. I also refactored the leader public and private inputs to take the user-friendlier `InputsData`, so that the same is sent over the new API, while they are converted to their lower-level counterparts only upon actual proof generation.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
