### PR TITLE
feat(nat): use NewListenAddr

### DIFF
--- a/nomos-libp2p/src/behaviour/nat/inner.rs
+++ b/nomos-libp2p/src/behaviour/nat/inner.rs
@@ -183,6 +183,10 @@ where
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm) {
+        if let FromSwarm::NewListenAddr(addr_event) = &event {
+            self.local_address = Some(addr_event.addr.clone());
+        }
+
         self.state_machine.on_event(event);
         self.autonat_client_behaviour.on_swarm_event(event);
     }
@@ -203,7 +207,11 @@ where
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Poll::Ready(to_swarm) = self.autonat_client_behaviour.poll(cx) {
             if let ToSwarm::GenerateEvent(event) = &to_swarm {
-                self.state_machine.on_event(event);
+                if let Some(ref local_addr) = self.local_address {
+                    if &event.tested_addr == local_addr {
+                        self.state_machine.on_event(event);
+                    }
+                }
             }
 
             return Poll::Ready(to_swarm.map_out(Either::Left));

--- a/nomos-libp2p/src/behaviour/nat/state_machine/event.rs
+++ b/nomos-libp2p/src/behaviour/nat/state_machine/event.rs
@@ -1,6 +1,6 @@
 use libp2p::{
     autonat,
-    swarm::{behaviour::ExternalAddrConfirmed, FromSwarm, NewExternalAddrCandidate},
+    swarm::{behaviour::ExternalAddrConfirmed, FromSwarm, NewListenAddr},
     Multiaddr,
 };
 
@@ -21,7 +21,7 @@ pub enum Event {
     },
     ExternalAddressConfirmed(Multiaddr),
     LocalAddressChanged(Multiaddr),
-    NewExternalAddressCandidate(Multiaddr),
+    NewListenAddress(Multiaddr),
     NewExternalMappedAddress {
         local_address: Multiaddr,
         external_address: Multiaddr,
@@ -83,8 +83,8 @@ impl TryFrom<FromSwarm<'_>> for Event {
 
     fn try_from(event: FromSwarm<'_>) -> Result<Self, Self::Error> {
         match event {
-            FromSwarm::NewExternalAddrCandidate(NewExternalAddrCandidate { addr }) => {
-                Ok(Self::NewExternalAddressCandidate(addr.clone()))
+            FromSwarm::NewListenAddr(NewListenAddr { addr, .. }) => {
+                Ok(Self::NewListenAddress(addr.clone()))
             }
             FromSwarm::ExternalAddrConfirmed(ExternalAddrConfirmed { addr }) => {
                 Ok(Self::ExternalAddressConfirmed(addr.clone()))

--- a/nomos-libp2p/src/behaviour/nat/state_machine/transitions/uninitialized.rs
+++ b/nomos-libp2p/src/behaviour/nat/state_machine/transitions/uninitialized.rs
@@ -3,15 +3,13 @@ use crate::behaviour::nat::state_machine::{
 };
 
 /// The `Uninitialized` state is the starting point of the NAT state machine. In
-/// this state, the state machine is waiting for an external address candidate
-/// to be provided. Once it receives a candidate, it transitions to the
+/// this state, the state machine is waiting for a listening address
+/// to be provided. Once it receives a listening address, it transitions to the
 /// `TestIfPublic` state to verify if the address is public or not.
 impl OnEvent for State<Uninitialized> {
     fn on_event(self: Box<Self>, event: Event, _: &CommandTx) -> Box<dyn OnEvent> {
         match event {
-            Event::NewExternalAddressCandidate(addr) => {
-                self.boxed(|state| state.into_test_if_public(addr))
-            }
+            Event::NewListenAddress(addr) => self.boxed(|state| state.into_test_if_public(addr)),
             _ => self,
         }
     }
@@ -23,15 +21,15 @@ mod tests {
 
     use crate::behaviour::nat::state_machine::{
         states::{TestIfPublic, Uninitialized},
-        transitions::fixtures::{all_events, new_external_address_candidate, ADDR},
+        transitions::fixtures::{all_events, new_listen_address, ADDR},
         StateMachine,
     };
 
     #[test]
-    fn new_external_address_candidate_event_causes_transition() {
+    fn new_listen_address_event_causes_transition() {
         let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
-        let event = new_external_address_candidate();
+        let event = new_listen_address();
         state_machine.on_test_event(event);
         assert_eq!(
             state_machine.inner.as_ref().unwrap(),
@@ -45,7 +43,7 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         let mut other_events = all_events();
-        other_events.remove(&new_external_address_candidate());
+        other_events.remove(&new_listen_address());
         for event in other_events {
             state_machine.on_test_event(event);
             assert_eq!(


### PR DESCRIPTION
## 1. What does this PR implement?

This PR changes how NAT is triggered. Instead of listening `NewExternalAddrCandidate` events, it listens `NewListenAddr` events. Given that our goal is verify if listening address is publicly visible, this approach should have the same outcome. 

Most of the time we can assume single listening address, so this solution helps with the concurrency issue discussed in [Discord](https://discord.com/channels/1111286067413405788/1418557596641656843/1419619641982193664). 

Ideally we still support multiple listening addresses but this is much larger refactoring work and can be done later.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
