### PR TITLE
chore(zk): Derive pk from sk in mantle key

### DIFF
--- a/nomos-core/chain-defs/src/mantle/keys.rs
+++ b/nomos-core/chain-defs/src/mantle/keys.rs
@@ -1,10 +1,16 @@
+use std::sync::LazyLock;
+
 use groth16::{Fr, serde::serde_fr};
 use num_bigint::BigUint;
+use poseidon2::{Digest as _, Poseidon2Bn254Hasher};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SecretKey(#[serde(with = "serde_fr")] Fr);
+
+static NOMOS_KDF_V1: LazyLock<Fr> =
+    LazyLock::new(|| BigUint::from_bytes_le(b"NOMOS_KDF_V1").into());
 
 impl SecretKey {
     #[must_use]
@@ -19,7 +25,7 @@ impl SecretKey {
 
     #[must_use]
     pub fn to_public_key(&self) -> PublicKey {
-        unimplemented!("Conversion from SecretKey to PublicKey is not implemented yet")
+        PublicKey(Poseidon2Bn254Hasher::digest(&[*NOMOS_KDF_V1, self.0]))
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?
This implements public key derivation from zk private keys as per the [specs](https://www.notion.so/nomos-tech/Wallet-Technical-Standard-215261aa09df80e9884ad7cf039e2c57?source=copy_link#215261aa09df80a290c1c8872e0f4470)

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@zeegomo @danielSanchezQ 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
