### PR TITLE
feat(chain): change logic for pre-computing winning slots

### DIFF
--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -25,12 +25,22 @@ impl Epoch {
     pub const fn new(inner: u32) -> Self {
         Self(inner)
     }
+
+    #[must_use]
+    pub const fn into_inner(self) -> u32 {
+        self.0
+    }
 }
 
 impl Slot {
     #[must_use]
     pub const fn new(inner: u64) -> Self {
         Self(inner)
+    }
+
+    #[must_use]
+    pub const fn into_inner(self) -> u64 {
+        self.0
     }
 
     #[must_use]


### PR DESCRIPTION
## 1. What does this PR implement?

Since Blend sessions are not aligned with epochs, it is very likely the case that Blend services can start/stop at session changes, and need information about the current ongoing epoch. Since there can be potentially a lot of winning slots, I changed the design of the subscribe API to pre-compute the first winning slot of the epoch when the chain leader is started or when a new epoch starts. Then, for subsequent slots we piggy-back on the existing block proposal logic. To support subscribers joining mid-epoch, I changed the channel type from broadcast to watch, so the latest computed slot, if any, is returned automatically to new subscribers.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
