### PR TITLE
chore(blend): switch from membership service to chain broadcast for session subscription

### DIFF
--- a/nodes/nomos-node/node/src/generic_services/blend.rs
+++ b/nodes/nomos-node/node/src/generic_services/blend.rs
@@ -7,6 +7,7 @@ use core::{
 };
 
 use async_trait::async_trait;
+use broadcast_service::BlockBroadcastService;
 use chain_leader::LeaderMsg;
 use futures::{Stream, StreamExt as _};
 use nomos_blend_message::crypto::{
@@ -33,9 +34,7 @@ use services_utils::wait_until_services_are_ready;
 use tokio::sync::oneshot::channel;
 use tokio_stream::wrappers::BroadcastStream;
 
-use crate::generic_services::{
-    CryptarchiaLeaderService, CryptarchiaService, MembershipService, WalletService,
-};
+use crate::generic_services::{CryptarchiaLeaderService, CryptarchiaService, WalletService};
 
 // TODO: Replace this with the actual verifier once the verification inputs are
 // successfully fetched by the Blend service.
@@ -137,7 +136,7 @@ fn loop_until_valid_proof(
 }
 
 pub type BlendMembershipAdapter<RuntimeServiceId> =
-    Adapter<MembershipService<RuntimeServiceId>, PeerId>;
+    Adapter<BlockBroadcastService<RuntimeServiceId>, PeerId>;
 pub type BlendCoreService<SamplingAdapter, RuntimeServiceId> =
     nomos_blend_service::core::BlendService<
         nomos_blend_service::core::backends::libp2p::Libp2pBlendBackend,

--- a/nomos-services/blend/Cargo.toml
+++ b/nomos-services/blend/Cargo.toml
@@ -8,33 +8,33 @@ version = "0.1.0"
 workspace = true
 
 [dependencies]
-async-trait              = "0.1"
-chain-service            = { workspace = true }
-cryptarchia-engine       = { workspace = true }
-fork_stream              = { workspace = true }
-futures                  = { default-features = false, version = "0.3" }
-groth16                  = { default-features = false, workspace = true }
-libp2p                   = { optional = true, workspace = true }
-libp2p-stream            = { optional = true, workspace = true }
-nomos-blend-message      = { workspace = true }
-nomos-blend-network      = { workspace = true }
-nomos-blend-scheduling   = { workspace = true }
-nomos-core               = { workspace = true }
-nomos-ledger             = { workspace = true }
-nomos-libp2p             = { optional = true, workspace = true }
-nomos-membership-service = { workspace = true }
-nomos-network            = { workspace = true }
-nomos-time               = { workspace = true }
-nomos-utils              = { features = ["serde"], workspace = true }
-overwatch                = { workspace = true }
-rand                     = { workspace = true }
-serde                    = { default-features = false, version = "1.0" }
-serde_with               = { workspace = true }
-services-utils           = { workspace = true }
-thiserror                = { default-features = false, version = "1" }
-tokio                    = { default-features = false, version = "1" }
-tokio-stream             = { default-features = false, version = "0.1" }
-tracing                  = { workspace = true }
+async-trait            = "0.1"
+broadcast-service      = { workspace = true }
+chain-service          = { workspace = true }
+cryptarchia-engine     = { workspace = true }
+fork_stream            = { workspace = true }
+futures                = { default-features = false, version = "0.3" }
+groth16                = { default-features = false, workspace = true }
+libp2p                 = { optional = true, workspace = true }
+libp2p-stream          = { optional = true, workspace = true }
+nomos-blend-message    = { workspace = true }
+nomos-blend-network    = { workspace = true }
+nomos-blend-scheduling = { workspace = true }
+nomos-core             = { workspace = true }
+nomos-ledger           = { workspace = true }
+nomos-libp2p           = { optional = true, workspace = true }
+nomos-network          = { workspace = true }
+nomos-time             = { workspace = true }
+nomos-utils            = { features = ["serde"], workspace = true }
+overwatch              = { workspace = true }
+rand                   = { workspace = true }
+serde                  = { default-features = false, version = "1.0" }
+serde_with             = { workspace = true }
+services-utils         = { workspace = true }
+thiserror              = { default-features = false, version = "1" }
+tokio                  = { default-features = false, version = "1" }
+tokio-stream           = { default-features = false, version = "0.1" }
+tracing                = { workspace = true }
 
 [dev-dependencies]
 libp2p                 = { default-features = false, features = ["plaintext", "tcp", "yamux"], workspace = true }

--- a/nomos-services/blend/src/edge/mod.rs
+++ b/nomos-services/blend/src/edge/mod.rs
@@ -223,7 +223,10 @@ where
         // Stream combining the membership stream with the stream yielding PoQ
         // generation and verification material.
         let aggregated_session_stream = membership_stream.zip(poq_input_stream).map(
-            |(membership, (poq_public_inputs, poq_private_inputs))| {
+            |(
+                membership::SessionInfo { membership, .. },
+                (poq_public_inputs, poq_private_inputs),
+            )| {
                 let local_node_index = membership.local_index();
                 let membership_size = membership.size();
 

--- a/nomos-services/blend/src/lib.rs
+++ b/nomos-services/blend/src/lib.rs
@@ -37,7 +37,7 @@ use crate::{
         },
     },
     instance::{Instance, Mode},
-    membership::Adapter as _,
+    membership::{Adapter as _, SessionInfo},
     settings::{FIRST_SESSION_READY_TIMEOUT, Settings},
 };
 
@@ -163,14 +163,15 @@ where
         .subscribe()
         .await?;
 
-        let (membership, mut session_stream) = UninitializedSessionEventStream::new(
-            membership_stream,
-            FIRST_SESSION_READY_TIMEOUT,
-            settings.time.session_transition_period(),
-        )
-        .await_first_ready()
-        .await
-        .expect("The current session must be ready");
+        let (SessionInfo { membership, .. }, mut session_stream) =
+            UninitializedSessionEventStream::new(
+                membership_stream,
+                FIRST_SESSION_READY_TIMEOUT,
+                settings.time.session_transition_period(),
+            )
+            .await_first_ready()
+            .await
+            .expect("The current session must be ready");
 
         info!(
             target: LOG_TARGET,

--- a/nomos-services/blend/src/membership/mod.rs
+++ b/nomos-services/blend/src/membership/mod.rs
@@ -8,8 +8,27 @@ use nomos_blend_message::crypto::keys::Ed25519PublicKey;
 use nomos_blend_scheduling::membership::Membership;
 use overwatch::services::{ServiceData, relay::OutboundRelay};
 
+#[derive(Clone, Debug)]
+/// All information about core nodes available for each session.
+pub struct SessionInfo<NodeId> {
+    /// The list of core nodes and their public information.
+    pub membership: Membership<NodeId>,
+    /// The session number.
+    pub session_number: u64,
+}
+
+#[cfg(test)]
+impl<NodeId> From<Membership<NodeId>> for SessionInfo<NodeId> {
+    fn from(value: Membership<NodeId>) -> Self {
+        Self {
+            membership: value,
+            session_number: 1,
+        }
+    }
+}
+
 pub type MembershipStream<NodeId> =
-    Pin<Box<dyn Stream<Item = Membership<NodeId>> + Send + Sync + 'static>>;
+    Pin<Box<dyn Stream<Item = SessionInfo<NodeId>> + Send + Sync + 'static>>;
 
 pub type ServiceMessage<MembershipAdapter> =
     <<MembershipAdapter as Adapter>::Service as ServiceData>::Message;


### PR DESCRIPTION
## 1. What does this PR implement?

The changeset of this PR is also part of the overarching [epoch transition PR](https://github.com/logos-co/nomos/pull/1793). Nevertheless, that PR might take a while to be merged, and this is a small change, so I thought to open a separate PR for it that maintains the current behaviour and just changes the source of the session ticks. Proper processing of the new information (i.e., session numbers and zk keys) will still be done in the bigger PR linked above.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
