### PR TITLE
chore: Fix build

### DIFF
--- a/nomos-core/chain-defs/src/mantle/encoding.rs
+++ b/nomos-core/chain-defs/src/mantle/encoding.rs
@@ -53,9 +53,13 @@ pub fn decode_signed_mantle_tx(input: &[u8]) -> IResult<&[u8], SignedMantleTx> {
     // In release mode without test/debug, we need to verify
     #[cfg(not(any(test, debug_assertions)))]
     {
-        SignedMantleTx::new(mantle_tx, ops_proofs, ledger_tx_proof)
-            .map(|tx| (input, tx))
-            .map_err(|_| nom::Err::Error(Error::new(input, ErrorKind::Verify)))
+        SignedMantleTx::new(
+            mantle_tx,
+            ops_proofs.into_iter().map(Some).collect(),
+            ledger_tx_proof,
+        )
+        .map(|tx| (input, tx))
+        .map_err(|_| nom::Err::Error(Error::new(input, ErrorKind::Verify)))
     }
 }
 


### PR DESCRIPTION
```bash
$ cargo build --bin nomos-node --release

error[E0308]: mismatched types
   --> nomos-core/chain-defs/src/mantle/encoding.rs:56:40
    |
 56 |         SignedMantleTx::new(mantle_tx, ops_proofs, ledger_tx_proof)
    |         -------------------            ^^^^^^^^^^ expected `Vec<Option<OpProof>>`, found `Vec<OpProof>`
    |         |
    |         arguments to this function are incorrect
    |
    = note: expected struct `Vec<std::option::Option<OpProof>>`
               found struct `Vec<OpProof>`
note: associated function defined here
   --> nomos-core/chain-defs/src/mantle/tx.rs:149:12
    |
149 |     pub fn new(
    |            ^^^
150 |         mantle_tx: MantleTx,
151 |         ops_proofs: Vec<Option<OpProof>>,
    |         --------------------------------
```