### PR TITLE
chore: fix tauri dep

### DIFF
--- a/nomos-bundler/Cargo.toml
+++ b/nomos-bundler/Cargo.toml
@@ -12,8 +12,8 @@ clap          = { default-features = false, version = "4.5.27", features = ["der
 env_logger    = { default-features = false, version = "0.11.6" }
 log           = "0.4.22"
 serde_json    = { default-features = false, version = "1.0.135" }
-tauri-bundler = { default-features = false, version = "2.4.0" }
-tauri-utils   = "2.1.1"
+tauri-bundler = { default-features = false, version = "=2.6.1" }
+tauri-utils   = "=2.7.0"
 
 [[bin]]
 name = "bundle-nomos-node"


### PR DESCRIPTION
## 1. What does this PR implement?

`tauri-bundler` is broken on macos runner.

```
Compiling tauri-bundler v2.7.0
error[E0412]: cannot find type `Error` in crate `tauri_macos_sign`
Error:    --> /Users/github/github-runner-node-02/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-bundler-2.7.0/src/error.rs:171:47
    |
171 |   AppleCodesign(#[from] Box<tauri_macos_sign::Error>),
    |                                               ^^^^^ not found in `tauri_macos_sign`
    |
help: consider importing one of these items
    |
  6 + use crate::Error;
    |
  6 + use crate::error::io::Error;
    |
  6 + use std::error::Error;
    |
  6 + use std::fmt::Error;
    |
    = and 21 other candidates
help: if you import `Error`, refer to it directly
    |
171 -   AppleCodesign(#[from] Box<tauri_macos_sign::Error>),
171 +   AppleCodesign(#[from] Box<Error>),
```

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
