### PR TITLE
chore: add deny allow rules

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -13,6 +13,11 @@ ignore = [
   { id = "RUSTSEC-2024-0388", reason = "`derivative` is unmaintained; consider using an alternative. Use `cargo tree -p derivative -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2024-0436", reason = "`paste` has a security vulnerability; consider using an alternative. Use `cargo tree -p paste -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2025-0055", reason = "`tracing-subscriber` v0.2.25 pulled in by ark-relations v0.4.0 - will be addressed before mainnet" },
+  { id = "RUSTSEC-2025-0075", reason = "`unic-char-range` is unmaintained; inherited via `tauri-utils` -> `urlpattern`. Pending upstream replacement." },
+  { id = "RUSTSEC-2025-0080", reason = "`unic-common` is unmaintained; inherited via `tauri-utils` -> `urlpattern`. Pending upstream replacement." },
+  { id = "RUSTSEC-2025-0081", reason = "`unic-char-property` is unmaintained; inherited via `tauri-utils` -> `urlpattern`. Pending upstream replacement." },
+  { id = "RUSTSEC-2025-0098", reason = "`unic-ucd-version` is unmaintained; inherited via `tauri-utils` -> `urlpattern`. Pending upstream replacement." },
+  { id = "RUSTSEC-2025-0100", reason = "`unic-ucd-ident` is unmaintained; inherited via `tauri-utils` -> `urlpattern`. Pending upstream replacement." },
 ]
 yanked = "deny"
 


### PR DESCRIPTION
## 1. What does this PR implement?

1h ago `rustsec` committed new rules that broke our cargo deny - https://github.com/rustsec/advisory-db/commit/d47b07c5ee38355ce7534af904ac50d47d6d8a61

Until `tauri` gets rid of these deps, we probably just need to allow.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
