### PR TITLE
feat(blend): delay shutting down core service when session transition ends

### DIFF
--- a/nomos-services/blend/src/instance.rs
+++ b/nomos-services/blend/src/instance.rs
@@ -239,17 +239,14 @@ where
 
     /// Handles the expiration of the transition period,
     /// by shutting down the previous Core mode if exists.
-    // TODO: Before shutting down the previous Core mode, notify it to submit
-    // activity proof in case it terminates before detecting the end of the
-    // transition period.
     async fn handle_transition_period_expired(self) -> Self {
         match self {
             Self::EdgeAfterCore { mode, prev } => {
-                prev.shutdown().await;
+                prev.graceful_shutdown().await;
                 Self::Edge(mode)
             }
             Self::BroadcastAfterCore { mode, prev } => {
-                prev.shutdown().await;
+                prev.graceful_shutdown().await;
                 Self::Broadcast(mode)
             }
             _ => self,

--- a/nomos-services/blend/src/modes/core.rs
+++ b/nomos-services/blend/src/modes/core.rs
@@ -1,9 +1,13 @@
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    time::Duration,
+};
 
 use overwatch::{
     overwatch::OverwatchHandle,
     services::{AsServiceId, ServiceData},
 };
+use tokio::time::sleep;
 
 use crate::modes::{Error, ondemand::OnDemandServiceMode};
 
@@ -26,5 +30,18 @@ where
 
     pub async fn shutdown(self) {
         self.0.shutdown().await;
+    }
+
+    pub async fn graceful_shutdown(self) {
+        // Give the core service time to detect/handle the end of session transition
+        // period.
+        // TODO: Replace with a sophisticated mechanism:
+        // - Deprecate Mode and Instance by letting services handle their own state
+        //   transitions. Then, they can run their cleanup logic before spawning
+        //   (switching to) a new service.
+        // - Or, add graceful shutdown to Overwatch: Notify a service so that it can run
+        //   its cleanup logic before shutting down.
+        sleep(Duration::from_millis(500)).await;
+        self.shutdown().await;
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This is the 3rd PR for rewarding.

This is a temporary workaround. I've tried some other ways, but none of them was not perfect without refactoring (which may involve breaking changes against what Antonio's working on). So, I'd like to introduce this workaround for now, considering the dev time we have. 

### Background

As implemented in https://github.com/logos-co/nomos/pull/1822, the core service computes and submits an activity message when the session transition period has passed. It's good.
But, the upper layer (`instance.rs`) shuts down the core service as soon as the session transition period ends (when it's in `EdgeAfterCore` or `BroadcastAfterCore` mode), and switches to other modes (`Edge` or `Broadcast`). Then, the core service may not have time to detect the end of session transition before shutdown. In this case, no activity token will be submitted.

### An workaround

In this PR, we simply sleep 500ms before shutting down the core service, to give it time to detect the end of session transition and to compute/submit an activity proof.
This approach is not perfect, but is maybe the simplest one we can take right now. 
I have more sophisticated ideas but want to discuss about them before making breaking changes. I left my idea in a TODO comment. Let's talk in Discord.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @ntn-x2 @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
