### PR TITLE
feat(chain): conditionally enable blob validation by block slot

### DIFF
--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -78,6 +78,11 @@ impl Slot {
             )
         }
     }
+
+    #[must_use]
+    pub const fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
 }
 
 impl From<u32> for Epoch {

--- a/nomos-services/chain/chain-service/src/blob.rs
+++ b/nomos-services/chain/chain-service/src/blob.rs
@@ -1,46 +1,111 @@
-use std::{collections::BTreeSet, fmt::Debug};
+use std::{collections::BTreeSet, fmt::Debug, marker::PhantomData, num::NonZero};
 
+use cryptarchia_engine::Slot;
 use nomos_core::{
     block::Block,
     da,
     mantle::{AuthenticatedMantleTx, Op},
 };
 use nomos_da_sampling::DaSamplingServiceMsg;
-use overwatch::DynError;
+use nomos_time::TimeServiceMessage;
 use tokio::sync::oneshot;
 use tracing::debug;
 
-use crate::{LOG_TARGET, SamplingRelay};
+use crate::{LOG_TARGET, SamplingRelay, relays::TimeRelay};
 
-/// Blob validation strategy.
-#[async_trait::async_trait]
-pub trait BlobValidation<BlobId, Tx> {
-    /// Validates all the blobs in the given block.
-    async fn validate(&self, block: &Block<Tx>) -> Result<(), Error>;
+/// An instance for validating blobs in blocks.
+pub struct Validation<S: Strategy> {
+    consensus_base_period_length: NonZero<u64>,
+    sampling_relay: SamplingRelay<da::BlobId>,
+    time_relay: TimeRelay,
+    _phantom: PhantomData<S>,
 }
 
-/// Checks if blobs have been sampled/validated by the sampling service
-/// recently.
-pub struct RecentBlobValidation<BlobId> {
-    sampling_relay: SamplingRelay<BlobId>,
-}
-
-impl<BlobId> RecentBlobValidation<BlobId> {
-    pub const fn new(sampling_relay: SamplingRelay<BlobId>) -> Self {
-        Self { sampling_relay }
+impl<S: Strategy> Validation<S> {
+    pub const fn new(
+        consensus_base_period_length: NonZero<u64>,
+        sampling_relay: SamplingRelay<da::BlobId>,
+        time_relay: TimeRelay,
+    ) -> Self {
+        Self {
+            consensus_base_period_length,
+            sampling_relay,
+            time_relay,
+            _phantom: PhantomData,
+        }
     }
 }
 
+impl<S: Strategy + Sync> Validation<S> {
+    /// Validate blobs in the given block.
+    ///
+    /// If the block is outside the blob validation window, which is calculated
+    /// based on the current slot and the consensus base period length,
+    /// no validation is performed and `Ok(())` is returned.
+    pub async fn validate<Tx>(&self, block: &Block<Tx>) -> Result<(), Error>
+    where
+        Tx: AuthenticatedMantleTx + Sync,
+    {
+        if !should_validate_blobs(
+            block.header().slot(),
+            get_current_slot(&self.time_relay).await?,
+            self.consensus_base_period_length,
+        ) {
+            return Ok(());
+        }
+
+        S::validate(block, &self.sampling_relay).await
+    }
+}
+
+async fn get_current_slot(time_relay: &TimeRelay) -> Result<Slot, Error> {
+    let (sender, receiver) = oneshot::channel();
+    time_relay
+        .send(TimeServiceMessage::CurrentSlot { sender })
+        .await
+        .map_err(|(e, _)| e)?;
+    Ok(receiver.await?.slot)
+}
+
+fn should_validate_blobs(
+    block_slot: Slot,
+    current_slot: Slot,
+    consensus_base_period_length: NonZero<u64>,
+) -> bool {
+    current_slot.saturating_sub(block_slot)
+        <= blob_validation_window_in_slots(consensus_base_period_length)
+}
+
+const fn blob_validation_window_in_slots(consensus_base_period_length: NonZero<u64>) -> Slot {
+    Slot::new(consensus_base_period_length.get() / 2)
+}
+
 #[async_trait::async_trait]
-impl<Tx> BlobValidation<da::BlobId, Tx> for RecentBlobValidation<da::BlobId>
-where
-    Tx: AuthenticatedMantleTx + Sync,
-{
-    async fn validate(&self, block: &Block<Tx>) -> Result<(), Error> {
+pub trait Strategy {
+    async fn validate<Tx>(
+        block: &Block<Tx>,
+        sampling_relay: &SamplingRelay<da::BlobId>,
+    ) -> Result<(), Error>
+    where
+        Tx: AuthenticatedMantleTx + Sync;
+}
+
+/// Validation strategy for blobs in blocks received through recent block
+/// propagation, under the assumption that the DA sampling service has already
+/// sampled and validated the blobs.
+pub struct RecentBlobStrategy;
+
+#[async_trait::async_trait]
+impl Strategy for RecentBlobStrategy {
+    async fn validate<Tx>(
+        block: &Block<Tx>,
+        sampling_relay: &SamplingRelay<da::BlobId>,
+    ) -> Result<(), Error>
+    where
+        Tx: AuthenticatedMantleTx + Sync,
+    {
         debug!(target = LOG_TARGET, "Validating recent blobs");
-        let sampled_blobs = get_sampled_blobs(&self.sampling_relay)
-            .await
-            .map_err(|_| Error::RelayError)?;
+        let sampled_blobs = get_sampled_blobs(sampling_relay).await?;
         let all_blobs_sampled = block
             .transactions()
             .flat_map(|tx| tx.mantle_tx().ops.iter())
@@ -60,29 +125,40 @@ where
     }
 }
 
-/// Skips blob validation.
-pub struct SkipBlobValidation;
+/// Validation strategy for blobs in blocks retrieved manually (e.g. chain
+/// bootstrapping or orphan handling), under the assumption that the DA sampling
+/// service has not yet sampled and validated the blobs.
+pub struct HistoricBlobStrategy;
 
 #[async_trait::async_trait]
-impl<BlobId, Tx> BlobValidation<BlobId, Tx> for SkipBlobValidation {
-    async fn validate(&self, _: &Block<Tx>) -> Result<(), Error> {
-        debug!(target = LOG_TARGET, "Skipping blob validation");
+impl Strategy for HistoricBlobStrategy {
+    async fn validate<Tx>(
+        _block: &Block<Tx>,
+        _sampling_relay: &SamplingRelay<da::BlobId>,
+    ) -> Result<(), Error>
+    where
+        Tx: AuthenticatedMantleTx + Sync,
+    {
+        debug!(target = LOG_TARGET, "Validating historic blobs");
+        // TODO: trigger historic sampling and wait for completion: https://github.com/logos-co/nomos/issues/1838
         Ok(())
     }
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Block contains invalid blobs")]
     InvalidBlobs,
-    #[error("Relay error")]
-    RelayError,
+    #[error("Relay error: {0}")]
+    Relay(#[from] overwatch::services::relay::RelayError),
+    #[error("Reply channel error: {0}")]
+    ReplyRecv(#[from] oneshot::error::RecvError),
 }
 
 /// Retrieves all the blobs that have been sampled by the sampling service.
 pub async fn get_sampled_blobs<BlobId>(
     sampling_relay: &SamplingRelay<BlobId>,
-) -> Result<BTreeSet<BlobId>, DynError>
+) -> Result<BTreeSet<BlobId>, Error>
 where
     BlobId: Send,
 {
@@ -92,6 +168,55 @@ where
             reply_channel: sender,
         })
         .await
-        .map_err(|(e, _)| Box::new(e) as DynError)?;
-    receiver.await.map_err(|e| Box::new(e) as DynError)
+        .map_err(|(e, _)| e)?;
+    Ok(receiver.await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blob_validation_window_in_slots() {
+        assert_eq!(
+            blob_validation_window_in_slots(10.try_into().unwrap()),
+            5.into()
+        );
+        assert_eq!(
+            blob_validation_window_in_slots(7.try_into().unwrap()),
+            3.into() // Should round down
+        );
+        assert_eq!(
+            blob_validation_window_in_slots(1.try_into().unwrap()),
+            0.into() // Should round down
+        );
+    }
+
+    #[test]
+    fn test_should_validate_blobs() {
+        // (103 - 100) <= (10 / 2)
+        assert!(should_validate_blobs(
+            100.into(),
+            103.into(),
+            10.try_into().unwrap()
+        ));
+        // (105 - 100) <= (10 / 2)
+        assert!(should_validate_blobs(
+            100.into(),
+            105.into(),
+            10.try_into().unwrap()
+        ));
+        // (106 - 100) > (10 / 2)
+        assert!(!should_validate_blobs(
+            100.into(),
+            106.into(),
+            10.try_into().unwrap()
+        ));
+        // saturating(100 - 101) <= (10 / 2)
+        assert!(should_validate_blobs(
+            101.into(),
+            100.into(),
+            10.try_into().unwrap()
+        ));
+    }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1675

As we discussed, this PR implements enabling blob validation during bootstrapping.

Now we decide on whether to perform blob validation or not for each block, by comparing `block.slot` with `current_slot`.
If `(current_slot - block.slot) > blob_validation_window`, we skip blob validation because DA nodes may already prune the blobs.
This logic is applied to the `ChainService::process_block`, so that we can use this logic for all scenarios.

The `current_slot` is retrieved from the time service. 

The `blob_validation_window` is currently `0.5 * k/f`. You can find the rationale from https://github.com/logos-co/nomos/issues/1675.

Also, this PR introduces two strategies for blob validation. One is `Recent` (that we've already had), and the other is `Historic`. You can find details from their doc comments.


## 2. Does the code have enough context to be clearly understood?

I believe so.

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @zeegomo 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
