### PR TITLE
feat(time): add CurrentSlot message

### DIFF
--- a/nomos-services/time/src/backends/common.rs
+++ b/nomos-services/time/src/backends/common.rs
@@ -10,24 +10,37 @@ use tokio_stream::wrappers::IntervalStream;
 
 use crate::{EpochSlotTickStream, SlotTick};
 
+/// Returns the current [`SlotTick`] and a stream of future [`SlotTick`]s
+/// that ticks at the start of each slot, starting from the next slot.
 pub fn slot_timer(
     slot_config: SlotConfig,
     datetime: OffsetDateTime,
     current_slot: Slot,
     epoch_config: EpochConfig,
     base_period_length: NonZero<u64>,
-) -> EpochSlotTickStream {
-    Pin::new(Box::new(
-        IntervalStream::new(SlotTimer::new(slot_config).slot_interval(datetime))
-            .zip(futures::stream::iter(std::iter::successors(
-                Some(current_slot + 1), // +1 because `slot_interval` ticks from the next slot
-                |&slot| Some(slot + 1),
-            )))
-            .map(move |(_, slot)| SlotTick {
-                epoch: epoch_config.epoch(slot, base_period_length),
-                slot,
-            }),
-    ))
+) -> (SlotTick, EpochSlotTickStream) {
+    (
+        new_slot_tick(current_slot, epoch_config, base_period_length),
+        Pin::new(Box::new(
+            IntervalStream::new(SlotTimer::new(slot_config).slot_interval(datetime))
+                .zip(futures::stream::iter(std::iter::successors(
+                    Some(current_slot + 1), // +1 because `slot_interval` ticks from the next slot
+                    |&slot| Some(slot + 1),
+                )))
+                .map(move |(_, slot)| new_slot_tick(slot, epoch_config, base_period_length)),
+        )),
+    )
+}
+
+fn new_slot_tick(
+    slot: Slot,
+    epoch_config: EpochConfig,
+    base_period_length: NonZero<u64>,
+) -> SlotTick {
+    SlotTick {
+        epoch: epoch_config.epoch(slot, base_period_length),
+        slot,
+    }
 }
 
 #[cfg(test)]
@@ -38,13 +51,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_slot_timer() {
-        let (mut timer, slot_config) = timer();
+        let (current_slot_tick, mut timer, slot_config) = timer();
 
-        // The first tick will be the next slot after the timer was created.
-        let tick = timer.next().await;
         // Calculate the expected slot based on the current time.
         let mut expected_slot =
             Slot::from_offset_and_config(OffsetDateTime::now_utc(), slot_config);
+        assert_eq!(current_slot_tick.slot, expected_slot);
+
+        // The first tick will be the next slot after the timer was created.
+        let tick = timer.next().await;
+        // Slots should increment by 1 for each tick.
+        expected_slot = expected_slot + 1;
         assert_eq!(tick.unwrap().slot, expected_slot);
 
         // Slots should increment by 1 for each tick.
@@ -53,25 +70,23 @@ mod tests {
         assert_eq!(tick.unwrap().slot, expected_slot);
     }
 
-    fn timer() -> (EpochSlotTickStream, SlotConfig) {
+    fn timer() -> (SlotTick, EpochSlotTickStream, SlotConfig) {
         let now = OffsetDateTime::now_utc();
         let slot_config = SlotConfig {
             slot_duration: Duration::from_secs(1),
             chain_start_time: now,
         };
-        (
-            slot_timer(
-                slot_config,
-                now,
-                Slot::from(0),
-                EpochConfig {
-                    epoch_stake_distribution_stabilization: NonZero::new(1).unwrap(),
-                    epoch_period_nonce_buffer: NonZero::new(1).unwrap(),
-                    epoch_period_nonce_stabilization: NonZero::new(1).unwrap(),
-                },
-                NonZero::new(1).unwrap(),
-            ),
+        let (current_slot_tick, timer) = slot_timer(
             slot_config,
-        )
+            now,
+            Slot::from(0),
+            EpochConfig {
+                epoch_stake_distribution_stabilization: NonZero::new(1).unwrap(),
+                epoch_period_nonce_buffer: NonZero::new(1).unwrap(),
+                epoch_period_nonce_stabilization: NonZero::new(1).unwrap(),
+            },
+            NonZero::new(1).unwrap(),
+        );
+        (current_slot_tick, timer, slot_config)
     }
 }

--- a/nomos-services/time/src/backends/mod.rs
+++ b/nomos-services/time/src/backends/mod.rs
@@ -7,11 +7,15 @@ pub mod system_time;
 pub use ntp::{NtpTimeBackend, NtpTimeBackendSettings};
 pub use system_time::{SystemTimeBackend, SystemTimeBackendSettings};
 
-use crate::EpochSlotTickStream;
+use crate::{EpochSlotTickStream, SlotTick};
 
 /// Abstraction over slot ticking systems
 pub trait TimeBackend {
     type Settings;
+
     fn init(settings: Self::Settings) -> Self;
-    fn tick_stream(self) -> EpochSlotTickStream;
+
+    /// Returns the current [`SlotTick`] and a stream of future [`SlotTick`]s
+    /// that ticks at the start of each slot, starting from the next slot.
+    fn tick_stream(self) -> (SlotTick, EpochSlotTickStream);
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds a new API `CurrentSlot` to the time service.

It will be useful for the chain service that needs to get the current slot whenever processing a block (to determine whether to validate blobs). I tried another approach for it in the PR #1839 but we discussed that it's better to have the `CurrentSlot` API in the time service. 

This PR is simple, but I left two comments below to help reviewers.



## 2. Does the code have enough context to be clearly understood?
I believe so.

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee  @danielSanchezQ

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
