### PR TITLE
fix(test): revert the panic check to persist tempdir in tests

### DIFF
--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -91,7 +91,9 @@ pub struct Validator {
 
 impl Drop for Validator {
     fn drop(&mut self) {
-        if let Err(e) = persist_tempdir(&mut self.tempdir, "nomos-node") {
+        if std::thread::panicking()
+            && let Err(e) = persist_tempdir(&mut self.tempdir, "nomos-node")
+        {
             println!("failed to persist tempdir: {e}");
         }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Sorry. I accidentally removed the panic check in https://github.com/logos-co/nomos/commit/0646adaae66e96a0e0db55153fd83919fee6e3fc#diff-bccee03db893949350f3cf6d4d66f1b06ab2dff29aa68a67e4cffa5e59b77074. 🙈 
I'm reverting it.


## 2. Does the code have enough context to be clearly understood?
yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
