### PR TITLE
chore(blend): remove core redundancy parameter

### DIFF
--- a/nodes/nomos-executor/config.yaml
+++ b/nodes/nomos-executor/config.yaml
@@ -46,7 +46,6 @@ blend:
     scheduler:
       intervals_for_safety_buffer: 100
       message_frequency_per_round: 1.0
-      redundancy_parameter: 0
       maximum_release_delay_in_rounds: 3
     zk:
       secret_key: 32e4b52b78e0e8273f31e2ae0826d09b0348d4c66824af4f51ec4ef338082211

--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -46,7 +46,6 @@ blend:
     scheduler:
       intervals_for_safety_buffer: 100
       message_frequency_per_round: 1.0
-      redundancy_parameter: 0
       maximum_release_delay_in_rounds: 3
     zk:
       secret_key: 32e4b52b78e0e8273f31e2ae0826d09b0348d4c66824af4f51ec4ef338082211

--- a/nomos-services/blend/src/core/settings.rs
+++ b/nomos-services/blend/src/core/settings.rs
@@ -55,8 +55,6 @@ pub struct SchedulerSettings {
 pub struct CoverTrafficSettings {
     /// `F_c`: frequency at which cover messages are generated per round.
     pub message_frequency_per_round: NonNegativeF64,
-    /// `R_c`: redundancy parameter for cover messages.
-    pub redundancy_parameter: u64,
     // `max`: safety buffer length, expressed in intervals
     pub intervals_for_safety_buffer: u64,
 }
@@ -67,7 +65,6 @@ impl Default for CoverTrafficSettings {
         Self {
             intervals_for_safety_buffer: 1,
             message_frequency_per_round: 1.try_into().unwrap(),
-            redundancy_parameter: 1,
         }
     }
 }
@@ -85,11 +82,10 @@ impl CoverTrafficSettings {
         let expected_number_of_session_messages =
             timings.rounds_per_session.get() as f64 * self.message_frequency_per_round.get();
 
-        // `Q_c`: Messaging allowance that can be used by a core node during a
-        // single session.
-        let core_quota = ((expected_number_of_session_messages
-            * (crypto.num_blend_layers + self.redundancy_parameter * crypto.num_blend_layers)
-                as f64)
+        // `Q_c`: Messaging allowance that can be used by a core node during a single
+        // session. We assume `R_c` to be `0` for now, hence `Q_c = ceil(C * (ß_c
+        // + 0 * ß_c)) / N = ceil(C * ß_c) / N`.
+        let core_quota = ((expected_number_of_session_messages * crypto.num_blend_layers as f64)
             / membership_size as f64)
             .ceil();
 

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -403,7 +403,6 @@ pub fn create_executor_config(config: GeneralConfig) -> Config {
                         intervals_for_safety_buffer: 100,
                         message_frequency_per_round: NonNegativeF64::try_from(1f64)
                             .expect("Message frequency per round cannot be negative."),
-                        redundancy_parameter: 0,
                     },
                     delayer: MessageDelayerSettings {
                         maximum_release_delay_in_rounds: NonZeroU64::try_from(3u64)

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -441,7 +441,6 @@ pub fn create_validator_config(config: GeneralConfig) -> Config {
                         intervals_for_safety_buffer: 100,
                         message_frequency_per_round: NonNegativeF64::try_from(1f64)
                             .expect("Message frequency per round cannot be negative."),
-                        redundancy_parameter: 0,
                     },
                     delayer: MessageDelayerSettings {
                         maximum_release_delay_in_rounds: NonZeroU64::try_from(3u64)


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes https://github.com/logos-co/nomos/issues/1868. We currently only use `R_c` to compute the total core quota. We don't process it in any other way. This parameter is also "disabled" for now, meaning the spec does not really say much about it and should not have a value different than `0`. Hence, let's remove all mentions of it and assume it's `0` when we compute the core quota.

For more context, please check the Discord discussion linked to the linked issue.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

* @ntn-x2 - dev
* @madxor spec writer
* @youngjoon-lee - reviewer

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
