### PR TITLE
fix(tests): Serialize blob and session hashmap as vec

### DIFF
--- a/nodes/nomos-node/node/Cargo.toml
+++ b/nodes/nomos-node/node/Cargo.toml
@@ -37,7 +37,7 @@ nomos-da-network-core    = { workspace = true }
 nomos-da-network-service = { workspace = true }
 nomos-da-sampling        = { features = ["libp2p", "rocksdb-backend"], workspace = true }
 nomos-da-verifier        = { features = ["libp2p"], workspace = true }
-nomos-http-api-common    = { workspace = true, features = ["profiling"] }
+nomos-http-api-common    = { features = ["profiling"], workspace = true }
 nomos-libp2p             = { workspace = true }
 nomos-network            = { workspace = true }
 nomos-sdp                = { workspace = true }
@@ -47,7 +47,7 @@ nomos-time               = { features = ["ntp", "serde"], workspace = true }
 nomos-tracing            = { workspace = true }
 nomos-tracing-service    = { workspace = true }
 nomos-wallet             = { workspace = true }
-num-bigint               = { version = "0.4", default-features = false }
+num-bigint               = { default-features = false, version = "0.4" }
 overwatch                = { workspace = true }
 pol                      = { workspace = true }
 poq                      = { workspace = true }

--- a/nodes/nomos-node/node/src/api/testing/handlers.rs
+++ b/nodes/nomos-node/node/src/api/testing/handlers.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fmt::{Debug, Display},
     hash::Hash,
 };
@@ -72,7 +71,7 @@ where
     BlobId: Eq + Hash,
 {
     pub block_id: HeaderId,
-    pub blob_ids: HashMap<BlobId, SessionNumber>,
+    pub blob_ids: Vec<(BlobId, SessionNumber)>,
 }
 
 pub async fn da_historic_sampling<
@@ -110,5 +109,9 @@ where
         SamplingStorage,
         SamplingMempoolAdapter,
         RuntimeServiceId,
-    >(handle, request.block_id, request.blob_ids))
+    >(
+        handle,
+        request.block_id,
+        request.blob_ids.into_iter().collect()
+    ))
 }

--- a/tests/src/nodes/executor.rs
+++ b/tests/src/nodes/executor.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     net::SocketAddr,
     num::{NonZeroU64, NonZeroUsize},
     path::PathBuf,
@@ -322,7 +322,7 @@ impl Executor {
     pub async fn da_historic_sampling(
         &self,
         block_id: HeaderId,
-        blob_ids: HashMap<BlobId, SessionNumber>,
+        blob_ids: Vec<(BlobId, SessionNumber)>,
     ) -> Result<bool, reqwest::Error> {
         let request = HistoricSamplingRequest { block_id, blob_ids };
 

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     net::SocketAddr,
     num::{NonZeroU64, NonZeroUsize},
     path::PathBuf,
@@ -242,7 +242,7 @@ impl Validator {
     pub async fn da_historic_sampling(
         &self,
         block_id: HeaderId,
-        blob_ids: HashMap<BlobId, SessionNumber>,
+        blob_ids: Vec<(BlobId, SessionNumber)>,
     ) -> Result<bool, reqwest::Error> {
         let request = HistoricSamplingRequest { block_id, blob_ids };
 

--- a/tests/src/tests/da/historic_sampling.rs
+++ b/tests/src/tests/da/historic_sampling.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use futures::StreamExt as _;
 use nomos_core::{da::BlobId, sdp::SessionNumber};
 use tests::{
@@ -55,7 +53,7 @@ async fn test_sampling_scenarios(executor: &Executor, blob_ids: &[BlobId]) {
 
     // Test 1: Valid blobs - all from session 0
     let valid_future = async {
-        let blob_ids_map: HashMap<BlobId, SessionNumber> =
+        let blob_ids_map: Vec<(BlobId, SessionNumber)> =
             blob_ids.iter().map(|&blob_id| (blob_id, 0)).collect();
 
         let result = executor
@@ -74,7 +72,7 @@ async fn test_sampling_scenarios(executor: &Executor, blob_ids: &[BlobId]) {
         let mut mixed_blob_ids = blob_ids.to_vec();
         mixed_blob_ids[0] = [99u8; 32];
 
-        let blob_ids_map: HashMap<BlobId, SessionNumber> =
+        let blob_ids_map: Vec<(BlobId, SessionNumber)> =
             mixed_blob_ids.iter().map(|&blob_id| (blob_id, 0)).collect();
 
         let result = executor


### PR DESCRIPTION
## 1. What does this PR implement?

In https://github.com/logos-co/nomos/commit/a29aa048a3279a28c3ce693821a9c4637ce57392 historical sampling test was unignored, and in https://github.com/logos-co/nomos/pull/1899 it was changed to a request type that contain blob id as hashmap key, json does not allow non strings as a map key and test started failing.

The workaround is to encode historical sampling post request as a `Vec<(blob_id, session)>`.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
