### PR TITLE
fix(blend): collect old session tokens with the correct collector

### DIFF
--- a/nomos-blend/message/src/reward/session.rs
+++ b/nomos-blend/message/src/reward/session.rs
@@ -49,6 +49,11 @@ impl SessionInfo {
             activity_threshold,
         })
     }
+
+    #[must_use]
+    pub const fn session_randomness(&self) -> SessionRandomness {
+        self.session_randomness
+    }
 }
 
 /// Deterministic unbiased randomness for a session.

--- a/nomos-services/blend/src/core/tests/utils.rs
+++ b/nomos-services/blend/src/core/tests/utils.rs
@@ -19,7 +19,7 @@ use nomos_blend_message::{
         },
     },
     encap::ProofsVerifier,
-    reward::{self, BlendingTokenCollector},
+    reward::{self, SessionBlendingTokenCollector, SessionRandomness},
 };
 use nomos_blend_scheduling::{
     EncapsulatedMessage,
@@ -328,21 +328,23 @@ pub fn new_poq_core_quota_inputs() -> ProofOfCoreQuotaInputs {
 pub fn new_blending_token_collector(
     public_info: &PublicInfo<NodeId>,
     message_frequency_per_round: NonNegativeF64,
-) -> BlendingTokenCollector {
-    BlendingTokenCollector::new(
-        &reward::SessionInfo::new(
-            public_info.session.session_number,
-            &public_info.epoch.pol_epoch_nonce,
-            public_info
-                .session
-                .membership
-                .size()
-                .try_into()
-                .expect("num_core_nodes must fit into u64"),
-            public_info.session.core_public_inputs.quota,
-            message_frequency_per_round,
-        )
-        .expect("session info must be created successfully"),
+) -> (SessionBlendingTokenCollector, SessionRandomness) {
+    let session_info = reward::SessionInfo::new(
+        public_info.session.session_number,
+        &public_info.epoch.pol_epoch_nonce,
+        public_info
+            .session
+            .membership
+            .size()
+            .try_into()
+            .expect("num_core_nodes must fit into u64"),
+        public_info.session.core_public_inputs.quota,
+        message_frequency_per_round,
+    )
+    .expect("session info must be created successfully");
+    (
+        SessionBlendingTokenCollector::new(&session_info),
+        session_info.session_randomness(),
     )
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1854
(Stacked on the PR https://github.com/logos-co/nomos/pull/1902).

Previously, blending tokens from the old session have been collected to the set for the new session.

This PR fixed it by refactoring the `BlendingTokenCollector` into two separate structs (`SessionBlendingTokenCollector` and `OldSessionBlendingTokenCollector`), which are intuitive and follow the same pattern introduced in other PRs (https://github.com/logos-co/nomos/pull/1902 and https://github.com/logos-co/nomos/pull/1913).

You may feel that the `run_event_loop` is verbose. I will refactor it by introducing state machine or any other way soon.

## 2. Does the code have enough context to be clearly understood?

I believe so.

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee @ntn-x2 @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
