### PR TITLE
test(blend): wait for inbound upgrades as well

### DIFF
--- a/nomos-blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
@@ -30,7 +30,7 @@ async fn detect_spammy_peer() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     // We let the first observation clock tick.
@@ -88,7 +88,7 @@ async fn detect_unhealthy_peer() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     // Do not send any message from dialing to listening swarm.
@@ -149,7 +149,7 @@ async fn restore_healthy_peer() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     // Let the connection turn unhealthy.

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -33,7 +33,7 @@ async fn message_sending_and_reception() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     // Send one message, which is within the range of expected messages.
@@ -99,7 +99,7 @@ async fn undeserializable_message_received() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     dialing_swarm
@@ -148,7 +148,7 @@ async fn duplicate_message_received() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     let test_message = TestEncapsulatedMessage::new(b"msg");
@@ -207,7 +207,7 @@ async fn invalid_public_header_message_received() {
 
     listening_swarm.listen().with_memory_addr_external().await;
     dialing_swarm
-        .connect_and_wait_for_outbound_upgrade(&mut listening_swarm)
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
         .await;
 
     let invalid_public_header_message = TestEncapsulatedMessage::new_with_invalid_signature(b"");

--- a/nomos-blend/network/src/core/with_core/behaviour/tests/session.rs
+++ b/nomos-blend/network/src/core/with_core/behaviour/tests/session.rs
@@ -36,9 +36,7 @@ async fn publish_message() {
     });
 
     listener.listen().with_memory_addr_external().await;
-    dialer
-        .connect_and_wait_for_outbound_upgrade(&mut listener)
-        .await;
+    dialer.connect_and_wait_for_upgrade(&mut listener).await;
 
     // Start a new session before sending any message through the connection.
     session += 1;
@@ -61,9 +59,7 @@ async fn publish_message() {
     assert_eq!(result, Err(Error::NoPeers));
 
     // Establish a connection for the new session.
-    dialer
-        .connect_and_wait_for_outbound_upgrade(&mut listener)
-        .await;
+    dialer.connect_and_wait_for_upgrade(&mut listener).await;
 
     // Now we can send the message successfully.
     dialer
@@ -117,12 +113,8 @@ async fn forward_message() {
     receiver2.listen().with_memory_addr_external().await;
 
     // Connect 3 nodes: sender -> forwarder -> receiver1
-    sender
-        .connect_and_wait_for_outbound_upgrade(&mut forwarder)
-        .await;
-    forwarder
-        .connect_and_wait_for_outbound_upgrade(&mut receiver1)
-        .await;
+    sender.connect_and_wait_for_upgrade(&mut forwarder).await;
+    forwarder.connect_and_wait_for_upgrade(&mut receiver1).await;
 
     // Before sending any message, start a new session
     // only for the forwarder, receiver1, and receiver2.
@@ -144,9 +136,7 @@ async fn forward_message() {
         memberships[3].clone(),
         SessionBasedMockProofsVerifier(new_session),
     );
-    forwarder
-        .connect_and_wait_for_outbound_upgrade(&mut receiver2)
-        .await;
+    forwarder.connect_and_wait_for_upgrade(&mut receiver2).await;
 
     // The sender publishes a message built with the old session to the forwarder.
     let test_message = TestEncapsulatedMessageWithSession::new(old_session, b"msg").into_inner();
@@ -184,9 +174,7 @@ async fn forward_message() {
         memberships[0].clone(),
         SessionBasedMockProofsVerifier(new_session),
     );
-    sender
-        .connect_and_wait_for_outbound_upgrade(&mut forwarder)
-        .await;
+    sender.connect_and_wait_for_upgrade(&mut forwarder).await;
 
     // The sender publishes a new message built with the new session to the
     // forwarder.
@@ -236,9 +224,7 @@ async fn finish_session_transition() {
     });
 
     listener.listen().with_memory_addr_external().await;
-    dialer
-        .connect_and_wait_for_outbound_upgrade(&mut listener)
-        .await;
+    dialer.connect_and_wait_for_upgrade(&mut listener).await;
 
     // Start a new session.
     session += 1;

--- a/nomos-services/blend/src/core/backends/libp2p/swarm.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/swarm.rs
@@ -256,6 +256,12 @@ where
             nomos_blend_network::core::with_core::behaviour::Event::OutboundConnectionUpgradeSucceeded(peer_id) => {
                 assert!(self.ongoing_dials.remove(&peer_id).is_some(), "Peer ID for a successfully upgraded connection must be present in storage");
             }
+            nomos_blend_network::core::with_core::behaviour::Event::InboundConnectionUpgradeFailed(peer_id) => {
+                tracing::warn!(target: LOG_TARGET, "Inbound connection upgrade failed for {peer_id:?}");
+            }
+            nomos_blend_network::core::with_core::behaviour::Event::InboundConnectionUpgradeSucceeded(peer_id) => {
+                tracing::debug!(target: LOG_TARGET, "Inbound connection upgrade succeeded for {peer_id:?}");
+            }
         }
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes a test that runs forever in the PR https://github.com/logos-co/nomos/pull/1911. 
```
test core::with_core::behaviour::tests::session::forward_message has been running for over 60 seconds
```

Previously, the test was waiting for the outbound connection to be negotiated successfully after dialing to a peer. But, we also have to wait until the inbound connection (on the peer side) is upgraded successfully. If we start other jobs without waiting for it, we may observe unexpected behaviors.
In the test above, we send a new session info to all the swarms, right after the outbound connection was upgraded. But, at that time, the listening peer didn't get/handle the event of the inbound connection upgrade. When a new session starts, each swarm clears all the pending connection upgrades (HashMap). So, even if the listening peer receives the event lately, it ignores it because there's no corresponding pending upgrades that it manages in the HashMap.
So, I think it's much safer to wait until both ends are upgraded successfully.

p.s.
It was hard to find this edge case because the failure is not reproduced when we run only the single `forward_message` test. It is reproduced only when we run multiple tests, as below.
```
cargo test -p nomos-blend-network core::with_core::behaviour::tests::session --all-features -- --nocapture`
```
I still don't get why it's failed only in this case. I think the https://github.com/logos-co/nomos/pull/1911 doesn't change anything related to this test. But anyway, it's good to have this fix that I found from debugging.

## 2. Does the code have enough context to be clearly understood?
I believe so. 

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee @ntn-x2 @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
