### PR TITLE
fix(blend): wait for core service to be stopped before killing it

### DIFF
--- a/nomos-services/blend/src/modes/core.rs
+++ b/nomos-services/blend/src/modes/core.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    time::Duration,
+};
 
 use overwatch::{
     overwatch::OverwatchHandle,
@@ -24,7 +27,9 @@ where
         self.0.handle_inbound_message(message).await
     }
 
-    pub async fn shutdown(self) {
-        self.0.shutdown().await;
+    pub async fn wait_until_stopped_or_kill(self) {
+        self.0
+            .wait_until_stopped_or_kill(Duration::from_secs(3))
+            .await;
     }
 }

--- a/nomos-services/blend/src/modes/edge.rs
+++ b/nomos-services/blend/src/modes/edge.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    time::Duration,
+};
 
 use overwatch::{
     overwatch::OverwatchHandle,
@@ -24,7 +27,9 @@ where
         self.0.handle_inbound_message(message).await
     }
 
-    pub async fn shutdown(self) {
-        self.0.shutdown().await;
+    pub async fn wait_until_stopped_or_kill(self) {
+        self.0
+            .wait_until_stopped_or_kill(Duration::from_secs(1))
+            .await;
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1860

Please see the issue to understand a bug that this PR fixes.

In this PR, instead of killing the core service right after its last STP has passed, the proxy service waits 3s for the core service to be stopped by itself. If it's not stopped in time, we kill it forcefully in the end. 3s is for the core service to perform its tear-down logic (computing/submitting an activity proof). 
In most cases, the tear-down will be done very quickly. Even if it wouldn't, I think spending 3s is fine.

Unlike for the core service, we wait 1s for the edge service because it doesn't have any tear-down yet. 

Initially (as noted in the issue), I remember that we shortly discussed about changing the proxy service to not kill or wait for the underlying services at all, but just focusing on starting new services. But after some experiments, I realized that it's not that safe. 
In summary, I think it's better to make sure that all the unnecessary services are cleanly terminated before moving forward. If we just fire-and-forget about services, some services may persist for a long time. If we try to start the same service after some time, Overwatch will ignore our request and allow us to interact with the existing service (This is what I found by experiments. It might be different depending on Overwatch settings). If that service will stop soon, the entire logic will be broken. 
We could probably avoid those edge cases by strictly limiting the cases of transitions. Nevertheless, I want to explicitly make sure that the retired services doesn't exist anymore.





## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee @ntn-x2 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
