### PR TITLE
test(e2e): fix regression breaking `n_blend_core_nodes` when spawning nodes

### DIFF
--- a/tests/src/topology/configs/mod.rs
+++ b/tests/src/topology/configs/mod.rs
@@ -64,6 +64,8 @@ pub fn create_general_configs_with_network(
 #[must_use]
 pub fn create_general_configs_with_blend_core_subset(
     n_nodes: usize,
+    // TODO: Instead of this, define a config struct for each node.
+    // That would be also useful for non-even token distributions: https://github.com/logos-co/nomos/issues/1888
     n_blend_core_nodes: usize,
     network_params: &NetworkParams,
 ) -> Vec<GeneralConfig> {
@@ -98,6 +100,7 @@ pub fn create_general_configs_with_blend_core_subset(
     let providers: Vec<_> = blend_configs
         .iter()
         .enumerate()
+        .take(n_blend_core_nodes)
         .map(|(i, blend_conf)| ProviderInfo {
             service_type: ServiceType::BlendNetwork,
             provider_id: ProviderId(blend_conf.signer.verifying_key()),


### PR DESCRIPTION
## 1. What does this PR implement?

Closes https://github.com/logos-co/nomos/issues/1889.  Please see details in the issue.

In short, there are some cases where we want to configure only a subset of all nodes to participate as a Blend provider, in the tests. I added it before, but removed at some point. This PR revives it.

## 2. Does the code have enough context to be clearly understood?
I believe so. 

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
