### PR TITLE
chore(blend): remove node_key in favor of cryptographic processor key

### DIFF
--- a/nodes/nomos-node/config.yaml
+++ b/nodes/nomos-node/config.yaml
@@ -30,7 +30,6 @@ blend:
   core:
     backend:
       listening_address: /ip4/127.0.0.1/udp/3001/quic-v1
-      node_key: ea1e1dcc31612bd20987f017f0ca435cd2a59a4bd9fd6e14883b4803ae3b803d
       conn_monitor: null
       minimum_messages_coefficient: 3
       normalization_constant: 1.03
@@ -51,7 +50,6 @@ blend:
       secret_key: 32e4b52b78e0e8273f31e2ae0826d09b0348d4c66824af4f51ec4ef338082211
   edge:
     backend:
-      node_key: ea1e1dcc31612bd20987f017f0ca435cd2a59a4bd9fd6e14883b4803ae3b803d
       max_dial_attempts_per_peer_per_message: 1
       replication_factor: 1
       protocol_name: /nomos/blend/1.0.0

--- a/nodes/nomos-node/node/src/config/blend.rs
+++ b/nodes/nomos-node/node/src/config/blend.rs
@@ -1,4 +1,4 @@
-use nomos_libp2p::{Multiaddr, ed25519::SecretKey};
+use nomos_libp2p::Multiaddr;
 use overwatch::services::ServiceData;
 use serde::{Deserialize, Serialize};
 
@@ -23,11 +23,6 @@ impl BlendConfig {
 
     pub fn set_listening_address(&mut self, listening_address: Multiaddr) {
         self.0.core.backend.listening_address = listening_address;
-    }
-
-    pub fn set_node_key(&mut self, key: SecretKey) {
-        self.0.core.backend.node_key = key.clone();
-        self.0.edge.backend.node_key = key;
     }
 
     pub const fn set_blend_layers(&mut self, layers: u64) {

--- a/nodes/nomos-node/node/src/config/mod.rs
+++ b/nodes/nomos-node/node/src/config/mod.rs
@@ -162,11 +162,6 @@ pub struct NetworkArgs {
 pub struct BlendArgs {
     #[clap(long = "blend-addr", env = "BLEND_ADDR")]
     blend_addr: Option<Multiaddr>,
-
-    // TODO: Use either the raw bytes or the key type directly to delegate error handling to clap
-    #[clap(long = "blend-node-key", env = "BLEND_NODE_KEY")]
-    blend_node_key: Option<String>,
-
     #[clap(long = "blend-num-blend-layers", env = "BLEND_NUM_BLEND_LAYERS")]
     blend_num_blend_layers: Option<usize>,
     #[clap(long = "blend-service-group", action)]
@@ -323,18 +318,12 @@ pub fn update_network<RuntimeServiceId>(
 pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) -> Result<()> {
     let BlendArgs {
         blend_addr,
-        blend_node_key,
         blend_num_blend_layers,
         ..
     } = blend_args;
 
     if let Some(addr) = blend_addr {
         blend.set_listening_address(addr);
-    }
-
-    if let Some(node_key) = blend_node_key {
-        let mut key_bytes = hex::decode(node_key)?;
-        blend.set_node_key(SecretKey::try_from_bytes(key_bytes.as_mut_slice())?);
     }
 
     if let Some(num_blend_layers) = blend_num_blend_layers {

--- a/nomos-services/blend/src/core/backends/libp2p/behaviour.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/behaviour.rs
@@ -49,7 +49,7 @@ where
                 },
                 observation_window_interval_provider,
                 current_membership,
-                config.backend.peer_id(),
+                config.peer_id(),
                 config.backend.protocol_name.clone().into_inner(),
                 poq_verifier,
             ),

--- a/nomos-services/blend/src/core/backends/libp2p/settings.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/settings.rs
@@ -2,20 +2,16 @@ use core::time::Duration;
 use std::{num::NonZeroU64, ops::RangeInclusive};
 
 use libp2p::{Multiaddr, PeerId, identity::Keypair};
-use nomos_libp2p::{ed25519, protocol_name::StreamProtocol};
+use nomos_libp2p::protocol_name::StreamProtocol;
 use nomos_utils::math::NonNegativeF64;
 use serde::{Deserialize, Serialize};
+
+use crate::core::settings::BlendConfig;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde_with::serde_as]
 pub struct Libp2pBlendBackendSettings {
     pub listening_address: Multiaddr,
-    // A key for deriving PeerId and establishing secure connections (TLS 1.3 by QUIC)
-    #[serde(
-        with = "nomos_libp2p::secret_key_serde",
-        default = "ed25519::SecretKey::generate"
-    )]
-    pub node_key: ed25519::SecretKey,
     pub core_peering_degree: RangeInclusive<u64>,
     pub minimum_messages_coefficient: NonZeroU64,
     pub normalization_constant: NonNegativeF64,
@@ -28,10 +24,12 @@ pub struct Libp2pBlendBackendSettings {
     pub protocol_name: StreamProtocol,
 }
 
-impl Libp2pBlendBackendSettings {
+impl BlendConfig<Libp2pBlendBackendSettings> {
     #[must_use]
     pub fn keypair(&self) -> Keypair {
-        Keypair::from(ed25519::Keypair::from(self.node_key.clone()))
+        let mut secret_key_bytes = *self.crypto.non_ephemeral_signing_key.as_bytes();
+        Keypair::ed25519_from_bytes(&mut secret_key_bytes)
+            .expect("Cryptographic secret key should be a valid Ed25519 private key.")
     }
 
     #[must_use]

--- a/nomos-services/blend/src/core/backends/libp2p/swarm.rs
+++ b/nomos-services/blend/src/core/backends/libp2p/swarm.rs
@@ -119,9 +119,8 @@ where
             minimum_network_size,
         }: SwarmParams<Rng>,
     ) -> Self {
-        let keypair = config.backend.keypair();
         let listening_address = config.backend.listening_address.clone();
-        let mut swarm = SwarmBuilder::with_existing_identity(keypair)
+        let mut swarm = SwarmBuilder::with_existing_identity(config.keypair())
             .with_tokio()
             .with_quic()
             .with_behaviour(|_| {

--- a/nomos-services/blend/src/edge/backends/libp2p/mod.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/mod.rs
@@ -11,6 +11,7 @@ use swarm::BlendSwarm;
 use tokio::sync::mpsc;
 
 use super::BlendBackend;
+use crate::edge::settings::BlendConfig;
 
 const LOG_TARGET: &str = "blend::service::edge::backend::libp2p";
 
@@ -29,7 +30,7 @@ impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBac
     type Settings = Libp2pBlendBackendSettings;
 
     fn new<Rng>(
-        settings: Self::Settings,
+        settings: BlendConfig<Self::Settings>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
         membership: Membership<PeerId>,
         rng: Rng,
@@ -43,7 +44,7 @@ impl<RuntimeServiceId> BlendBackend<PeerId, RuntimeServiceId> for Libp2pBlendBac
             membership,
             rng,
             swarm_command_receiver,
-            settings.protocol_name.clone().into_inner(),
+            settings.backend.protocol_name.clone().into_inner(),
         );
 
         let (swarm_task_abort_handle, swarm_task_abort_registration) = AbortHandle::new_pair();

--- a/nomos-services/blend/src/edge/backends/libp2p/settings.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/settings.rs
@@ -1,18 +1,14 @@
 use core::num::NonZeroU64;
 
 use libp2p::identity::Keypair;
-use nomos_libp2p::{ed25519, protocol_name::StreamProtocol};
+use nomos_libp2p::protocol_name::StreamProtocol;
 use serde::{Deserialize, Serialize};
+
+use crate::edge::settings::BlendConfig;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde_with::serde_as]
 pub struct Libp2pBlendBackendSettings {
-    // A key for deriving PeerId and establishing secure connections (TLS 1.3 by QUIC)
-    #[serde(
-        with = "nomos_libp2p::secret_key_serde",
-        default = "ed25519::SecretKey::generate"
-    )]
-    pub node_key: ed25519::SecretKey,
     pub max_dial_attempts_per_peer_per_message: NonZeroU64,
     pub protocol_name: StreamProtocol,
     // $\Phi_{EC}$: the minimum number of connections that the edge node establishes with
@@ -20,9 +16,11 @@ pub struct Libp2pBlendBackendSettings {
     pub replication_factor: NonZeroU64,
 }
 
-impl Libp2pBlendBackendSettings {
+impl BlendConfig<Libp2pBlendBackendSettings> {
     #[must_use]
     pub fn keypair(&self) -> Keypair {
-        Keypair::from(ed25519::Keypair::from(self.node_key.clone()))
+        let mut secret_key_bytes = *self.crypto.non_ephemeral_signing_key.as_bytes();
+        Keypair::ed25519_from_bytes(&mut secret_key_bytes)
+            .expect("Cryptographic secret key should be a valid Ed25519 private key.")
     }
 }

--- a/nomos-services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/nomos-services/blend/src/edge/backends/libp2p/swarm.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 
 use super::settings::Libp2pBlendBackendSettings;
-use crate::edge::backends::libp2p::LOG_TARGET;
+use crate::edge::{backends::libp2p::LOG_TARGET, settings::BlendConfig};
 
 #[derive(Debug)]
 pub struct DialAttempt {
@@ -77,7 +77,7 @@ where
     Rng: RngCore + 'static,
 {
     pub(super) fn new(
-        settings: &Libp2pBlendBackendSettings,
+        settings: &BlendConfig<Libp2pBlendBackendSettings>,
         membership: Membership<PeerId>,
         rng: Rng,
         command_receiver: mpsc::Receiver<Command>,
@@ -97,7 +97,8 @@ where
             .build();
         let stream_control = swarm.behaviour().new_control();
 
-        let replication_factor: NonZeroUsize = settings.replication_factor.try_into().unwrap();
+        let replication_factor: NonZeroUsize =
+            settings.backend.replication_factor.try_into().unwrap();
         let membership_size = membership.size();
 
         if membership_size < replication_factor.get() {
@@ -111,7 +112,9 @@ where
             membership,
             rng,
             pending_dials: HashMap::new(),
-            max_dial_attempts_per_connection: settings.max_dial_attempts_per_peer_per_message,
+            max_dial_attempts_per_connection: settings
+                .backend
+                .max_dial_attempts_per_peer_per_message,
             protocol_name,
             replication_factor,
         }

--- a/nomos-services/blend/src/edge/backends/mod.rs
+++ b/nomos-services/blend/src/edge/backends/mod.rs
@@ -5,6 +5,8 @@ use nomos_blend_scheduling::{EncapsulatedMessage, membership::Membership};
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
 
+use crate::edge::settings::BlendConfig;
+
 /// A trait for blend backends that send messages to the blend network.
 #[async_trait::async_trait]
 pub trait BlendBackend<NodeId, RuntimeServiceId>
@@ -14,7 +16,7 @@ where
     type Settings: Clone + Send + Sync + 'static;
 
     fn new<Rng>(
-        settings: Self::Settings,
+        settings: BlendConfig<Self::Settings>,
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
         membership: Membership<NodeId>,
         rng: Rng,

--- a/nomos-services/blend/src/edge/handlers.rs
+++ b/nomos-services/blend/src/edge/handlers.rs
@@ -75,7 +75,7 @@ where
             private_info,
         );
         let backend = Backend::new(
-            settings.backend.clone(),
+            settings.clone(),
             overwatch_handle,
             membership,
             BlakeRng::from_entropy(),

--- a/nomos-services/blend/src/edge/tests/utils.rs
+++ b/nomos-services/blend/src/edge/tests/utils.rs
@@ -165,7 +165,7 @@ where
     type Settings = NodeIdSender;
 
     fn new<Rng>(
-        settings: Self::Settings,
+        settings: BlendConfig<Self::Settings>,
         _: OverwatchHandle<RuntimeServiceId>,
         membership: Membership<NodeId>,
         _: Rng,
@@ -175,7 +175,7 @@ where
     {
         Self {
             membership,
-            sender: settings,
+            sender: settings.backend,
         }
     }
 

--- a/tests/src/topology/configs/blend.rs
+++ b/tests/src/topology/configs/blend.rs
@@ -7,11 +7,7 @@ use nomos_blend_service::{
     core::backends::libp2p::Libp2pBlendBackendSettings as Libp2pCoreBlendBackendSettings,
     edge::backends::libp2p::Libp2pBlendBackendSettings as Libp2pEdgeBlendBackendSettings,
 };
-use nomos_libp2p::{
-    Multiaddr,
-    ed25519::{self},
-    protocol_name::StreamProtocol,
-};
+use nomos_libp2p::{Multiaddr, protocol_name::StreamProtocol};
 use num_bigint::BigUint;
 use zksign::SecretKey;
 
@@ -29,9 +25,6 @@ pub fn create_blend_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<GeneralBlend
     ids.iter()
         .zip(ports)
         .map(|(id, port)| {
-            let mut node_key_bytes = *id;
-            let node_key = ed25519::SecretKey::try_from_bytes(&mut node_key_bytes)
-                .expect("Failed to generate secret key from bytes");
             let signer = SigningKey::from_bytes(id);
 
             let private_key = Ed25519PrivateKey::from(*id);
@@ -46,7 +39,6 @@ pub fn create_blend_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<GeneralBlend
                         "/ip4/127.0.0.1/udp/{port}/quic-v1",
                     ))
                     .unwrap(),
-                    node_key: node_key.clone(),
                     core_peering_degree: 1..=3,
                     minimum_messages_coefficient: NonZeroU64::try_from(1)
                         .expect("Minimum messages coefficient cannot be zero."),
@@ -61,7 +53,6 @@ pub fn create_blend_configs(ids: &[[u8; 32]], ports: &[u16]) -> Vec<GeneralBlend
                 },
                 backend_edge: Libp2pEdgeBlendBackendSettings {
                     max_dial_attempts_per_peer_per_message: 1.try_into().unwrap(),
-                    node_key,
                     protocol_name: StreamProtocol::new("/blend/integration-tests"),
                     replication_factor: 1.try_into().unwrap(),
                 },


### PR DESCRIPTION
## 1. What does this PR implement?

Tests were passing by chance since we were using the same seed for both keys, but in reality `node_key` is not needed, since using a different value than the cryptographic processor would result in a different peer ID and hence in failed handshakes. I tested that locally, by using a different `node_key` value compared to the crypto processor and that's the result.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
