### PR TITLE
chore(kms): let operators consume self

### DIFF
--- a/nomos-services/key-management-system/src/backend/preload.rs
+++ b/nomos-services/key-management-system/src/backend/preload.rs
@@ -140,7 +140,7 @@ mod tests {
         type Key = Key;
         type Error = Error;
 
-        async fn execute(&mut self, _key: &Self::Key) -> Result<(), Self::Error> {
+        async fn execute(self: Box<Self>, _key: &Self::Key) -> Result<(), Self::Error> {
             Ok(())
         }
     }

--- a/nomos-services/key-management-system/src/keys/mod.rs
+++ b/nomos-services/key-management-system/src/keys/mod.rs
@@ -8,7 +8,6 @@ use key_management_system_macros::KmsEnumKey;
 use serde::{Deserialize, Serialize};
 use zeroize::ZeroizeOnDrop;
 
-use crate::keys::errors::KeyError;
 pub use crate::keys::{ed25519::Ed25519Key, zk::ZkKey};
 
 /// Entity that gathers all keys provided by the KMS crate.

--- a/nomos-services/key-management-system/src/keys/secured_key.rs
+++ b/nomos-services/key-management-system/src/keys/secured_key.rs
@@ -6,7 +6,7 @@ use zeroize::ZeroizeOnDrop;
 pub trait SecureKeyOperator {
     type Key;
     type Error;
-    async fn execute(&mut self, key: &Self::Key) -> Result<(), Self::Error>;
+    async fn execute(self: Box<Self>, key: &Self::Key) -> Result<(), Self::Error>;
 }
 
 pub trait DebugSecureKeyOperator: SecureKeyOperator + Debug {}
@@ -32,10 +32,10 @@ pub trait SecuredKey: ZeroizeOnDrop {
         Self: Sized;
     fn as_public_key(&self) -> Self::PublicKey;
 
-    async fn execute<Operation>(&self, mut operator: Operation) -> Result<(), Self::Error>
+    async fn execute<Operation>(&self, operator: Operation) -> Result<(), Self::Error>
     where
         Operation: SecureKeyOperator<Key = Self, Error = Self::Error> + Send + Debug,
     {
-        operator.execute(self).await
+        Box::new(operator).execute(self).await
     }
 }

--- a/nomos-services/key-management-system/src/operators/blend/poq.rs
+++ b/nomos-services/key-management-system/src/operators/blend/poq.rs
@@ -21,7 +21,7 @@ pub struct PoQOperator {
     core_path_and_selectors: CorePathAndSelectors,
     public_inputs: PublicInputs,
     key_index: u64,
-    response_channel: Option<oneshot::Sender<Result<(ProofOfQuota, ZkHash), quota::Error>>>,
+    response_channel: oneshot::Sender<Result<(ProofOfQuota, ZkHash), quota::Error>>,
 }
 
 impl Debug for PoQOperator {
@@ -42,7 +42,7 @@ impl PoQOperator {
             core_path_and_selectors,
             public_inputs,
             key_index,
-            response_channel: Some(response_channel),
+            response_channel,
         }
     }
 }
@@ -52,7 +52,7 @@ impl SecureKeyOperator for PoQOperator {
     type Key = ZkKey;
     type Error = <ZkKey as SecuredKey>::Error;
 
-    async fn execute(&mut self, key: &Self::Key) -> Result<(), Self::Error> {
+    async fn execute(mut self: Box<Self>, key: &Self::Key) -> Result<(), Self::Error> {
         let private_inputs = PrivateInputs::new_proof_of_core_quota_inputs(
             self.key_index,
             ProofOfCoreQuotaInputs {
@@ -66,12 +66,7 @@ impl SecureKeyOperator for PoQOperator {
         let poq_result = spawn_blocking(move || ProofOfQuota::new(&public_inputs, private_inputs))
             .await
             .map_err(Self::Error::FailedOperatorCall)?;
-        if let Err(e) = self
-            .response_channel
-            .take()
-            .expect("Channel to be available")
-            .send(poq_result)
-        {
+        if let Err(e) = self.response_channel.send(poq_result) {
             error!("Error building proof of quota: {e:?}");
         }
         Ok(())


### PR DESCRIPTION
## 1. What does this PR implement?

Operators are meant to be one-off operations, so they should consume self. For PoQ, that means we can use a oneshot channel without wrapping it in an `Option`, resulting in cleaner code.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2  @danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
