### PR TITLE
fix(da-network): remove pending open stream requests on error

### DIFF
--- a/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
+++ b/nomos-da/network/core/src/protocols/dispersal/executor/behaviour.rs
@@ -545,7 +545,12 @@ where
                     );
                     None
                 }
-                Err(error) => Some(DispersalExecutorEvent::DispersalError { error }),
+                Err(error) => {
+                    if let Some(peer_id) = error.peer_id() {
+                        self.pending_peer_open_stream_requests.remove(peer_id);
+                    }
+                    Some(DispersalExecutorEvent::DispersalError { error })
+                }
             }
         } else {
             None


### PR DESCRIPTION
## 1. What does this PR implement?

We were only removing pending open stream requests on success, which allows for scenario that peer is never removed and always filtered when getting members.

This PR introduces a trivial fix to remove peer from open stream requests  on error.

## 2. Does the code have enough context to be clearly understood?

Yes
## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes
## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
