### PR TITLE
fix(block): Remove rewards from blocks

### DIFF
--- a/nomos-services/chain/chain-leader/src/lib.rs
+++ b/nomos-services/chain/chain-leader/src/lib.rs
@@ -648,7 +648,7 @@ where
         // TODO: use PoL signing key
         let dummy_signing_key = SigningKey::from_bytes(&[0u8; 32]);
 
-        let block = Block::create(parent, slot, proof, txs, None, &dummy_signing_key)?;
+        let block = Block::create(parent, slot, proof, txs, &dummy_signing_key)?;
 
         info!(
             "proposed block with id {:?} containing {} transactions ({} removed)",

--- a/nomos-services/chain/chain-network/src/lib.rs
+++ b/nomos-services/chain/chain-network/src/lib.rs
@@ -787,21 +787,13 @@ where
         )));
     }
 
-    // TODO: recover service reward
-    let service_reward = None;
-
     let reconstructed_transactions = mempool_response.into_found();
 
     let header = proposal.header().clone();
     let signature = *proposal.signature();
 
-    let block = Block::reconstruct(
-        header,
-        reconstructed_transactions,
-        service_reward,
-        signature,
-    )
-    .map_err(|e| Error::InvalidBlock(format!("Invalid block: {e}")))?;
+    let block = Block::reconstruct(header, reconstructed_transactions, signature)
+        .map_err(|e| Error::InvalidBlock(format!("Invalid block: {e}")))?;
 
     Ok(block)
 }

--- a/nomos-services/chain/chain-service/src/sync/block_provider.rs
+++ b/nomos-services/chain/chain-service/src/sync/block_provider.rs
@@ -823,7 +823,6 @@ mod tests {
                 slot,
                 self.proof.clone(),
                 vec![],
-                None,
                 &dummy_signing_key,
             )
             .ok()


### PR DESCRIPTION
## 1. What does this PR implement?
Remove the leftover reward field in block structure
## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@madxor @thomaslavaur
## 4. Is the specification accurate and complete?
https://www.notion.so/nomos-tech/Block-Construction-Validation-and-Execution-Specification-215261aa09df8164b5a9f0783c0e99b9 is now outdated after having implemented https://www.notion.so/nomos-tech/v1-2-Service-Reward-Distribution-Protocol-26b261aa09df8032861dddf01182e242

## 5. Does the implementation introduce changes in the specification?
Yes, removing the reward fields that is made useless by the new service reward distribution protocol
## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
