### PR TITLE
chore(ci): Add rustls-pem to cargo deny file

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -18,6 +18,7 @@ ignore = [
   { id = "RUSTSEC-2025-0081", reason = "`unic-char-property` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2025-0098", reason = "`unic-ucd-version` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2025-0100", reason = "`unic-ucd-ident` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
+  { id = "RUSTSEC-2025-0134", reason = "`rusttls-pemfile` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
 ]
 yanked = "deny"
 


### PR DESCRIPTION
## 1. What does this PR implement?

The rustls-pemfile crate is no longer maintained. 

## 2. Does the code have enough context to be clearly understood?

We don't use this dependency directly, will most likely be updated in the future.

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
