### PR TITLE
chore(ci): Bump cargo deny

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2  # Version 4.2.2
       - name: Run `cargo deny`
-        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # Version 2.0.11
+        uses: EmbarkStudios/cargo-deny-action@76cd80eb775d7bbbd2d80292136d74d39e1b4918 # Version 2.0.14
         with:
           arguments: "--locked"
           command-arguments: "--hide-inclusion-graph -c .cargo-deny.toml --show-stats -D warnings"


### PR DESCRIPTION
## 1. What does this PR implement?

Previous cargo deny version couldn't parse new RustSec Advisory Database version string.

## 2. Does the code have enough context to be clearly understood?

Couple of failing jobs:
- https://github.com/logos-blockchain/logos-blockchain/actions/runs/20456636353/job/58780063041
- https://github.com/logos-blockchain/logos-blockchain/actions/runs/20665411011/job/59336513024

## 3. Who are the specification authors and who is accountable for this PR?

@bacv 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
