### PR TITLE
chore(ci): add more ignore rules for cargo deny

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -19,6 +19,8 @@ ignore = [
   { id = "RUSTSEC-2025-0098", reason = "`unic-ucd-version` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2025-0100", reason = "`unic-ucd-ident` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
   { id = "RUSTSEC-2025-0134", reason = "`rusttls-pemfile` is unmaintained; consider using an alternative. Use `cargo tree -p difference -i > tmp.txt` to check the dependency tree." },
+  { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
+  { id = "RUSTSEC-2026-0002", reason = "`lru` v0.12.5 is unsound but required by libp2p v0.55.0 - will upgrade libp2p once it's ready." },
 ]
 yanked = "deny"
 


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes the following errors from `cargo deny`, by adding them into the `ignore` rules.

```
error[unmaintained]: Bincode is unmaintained
   ┌─ /github/workspace/Cargo.lock:91:1
   │
91 │ bincode 1.3.3 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2025-0141
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0141
   ├ Due to a doxxing and harassment incident, the bincode team has taken the decision to cease development permanently.
     
     The team considers version 1.3.3 a complete version of bincode that is not in need of any updates.
     
     ## Alternatives to consider
     
         * [wincode](https://crates.io/crates/wincode)
     
         * [postcard](https://crates.io/crates/postcard)
     
         * [bitcode](https://crates.io/crates/bitcode)
     
         * [rkyv](https://crates.io/crates/rkyv)
   ├ Announcement: https://git.sr.ht/~stygianentity/bincode/tree/v3.0/item/README.md
   ├ Solution: No safe upgrade is available!

error[unsound]: `IterMut` violates Stacked Borrows by invalidating internal pointer
    ┌─ /github/workspace/Cargo.lock:438:1
    │
438 │ lru 0.12.5 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2026-0002
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0002
    ├ Affected versions of this crate contain a soundness issue in the `IterMut`
      iterator implementation. The `IterMut::next` and `IterMut::next_back`
      methods temporarily create an exclusive reference to the key when
      dereferencing the internal node pointer.
      
      This invalidates the shared pointer held by the internal `HashMap`,
      violating Stacked Borrows rules.
    ├ Announcement: https://github.com/jeromefroe/lru-rs/pull/224
    ├ Solution: Upgrade to >=0.16.3 (try `cargo update -p lru`)

 advisories FAILED: 2 errors, 0 warnings, 26 notes
```

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 

## 4. Is the specification accurate and complete?
n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
