### PR TITLE
ci: remove extra test step for PoL

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -201,27 +201,17 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Cargo test all except PoL and end-to-end integration tests
+      - name: Cargo test all except end-to-end integration tests
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
           CONSENSUS_SLOT_TIME: 5
         with:
           command: nextest
           # - We don't test benches as they take 6h+, leading to a timeout
-          # - We aslo do not test end-to-end integration tests here as those are run in a dedicated step below
+          # - We also do not test end-to-end integration tests here as those are run in a dedicated step below
           args: >-
             run --workspace --locked --lib --bins --examples --tests --retries 2
             --all-features --no-fail-fast --exclude logos-blockchain-tests
-
-      - name: Cargo test PoL proof generation and verification
-        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
-        with:
-          command: nextest
-          # TODO: Enable all tests after adapting them to PoL
-          args: >-
-            run --locked --lib --bins --examples --tests --retries 2
-            -p logos-blockchain-chain-leader-service -p logos-blockchain-pol 
-            --no-fail-fast
 
       - name: Clean up build artifacts
         if: success() || failure()


### PR DESCRIPTION
## 1. What does this PR implement?

I forgot to update CI in the PR https://github.com/logos-blockchain/logos-blockchain/pull/2077, which I already merged.
Now that we can run all tests with PoL enabled, we don't need an extra step in CI which ran only PoL-specific tests.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
