### PR TITLE
refactor(wallet): remove unnecessary field: `WalletState::claimable_vouchers`

### DIFF
--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -829,10 +829,9 @@ where
         storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
         cryptarchia_api: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
     ) {
-        let Ok((block, ledger)) = Self::load_block_and_ledger(
+        let Ok(block) = Self::load_block(
             header_id,
             storage_adapter,
-            cryptarchia_api,
         )
         .await
         .inspect_err(|e| {
@@ -842,7 +841,7 @@ where
         };
 
         let wallet_block = WalletBlock::from(block);
-        match state.apply_block(&wallet_block, &ledger) {
+        match state.apply_block(&wallet_block) {
             Ok(()) => {
                 trace!(block_id=?wallet_block.id, "Applied block to wallet");
             }
@@ -865,20 +864,14 @@ where
         }
     }
 
-    async fn load_block_and_ledger(
+    async fn load_block(
         header_id: HeaderId,
         storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-        cryptarchia_api: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
-    ) -> Result<(Block<Tx>, LedgerState), WalletServiceError> {
-        let block = storage_adapter
+    ) -> Result<Block<Tx>, WalletServiceError> {
+        storage_adapter
             .get_block(&header_id)
             .await
-            .ok_or(WalletServiceError::BlockNotFoundInStorage(header_id))?;
-        let ledger = cryptarchia_api
-            .get_ledger_state(header_id)
-            .await?
-            .ok_or(WalletServiceError::LedgerStateNotFound(header_id))?;
-        Ok((block, ledger))
+            .ok_or(WalletServiceError::BlockNotFoundInStorage(header_id))
     }
 
     fn handle_lib_update(lib_update: &LibUpdate, state: &mut ServiceState<'_>) {
@@ -912,10 +905,9 @@ where
                 continue;
             }
 
-            let (block, ledger) =
-                Self::load_block_and_ledger(header_id, storage_adapter, cryptarchia_api).await?;
+            let block = Self::load_block(header_id, storage_adapter).await?;
 
-            if let Err(e) = state.apply_block(&block.into(), &ledger) {
+            if let Err(e) = state.apply_block(&block.into()) {
                 error!(
                     block_id = ?header_id,
                     err = %e,

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -74,12 +74,8 @@ impl<'u> ServiceState<'u> {
         self.update_state();
     }
 
-    pub fn apply_block(
-        &mut self,
-        block: &WalletBlock,
-        ledger: &LedgerState,
-    ) -> Result<(), WalletError> {
-        self.wallet.apply_block(block, ledger)?;
+    pub fn apply_block(&mut self, block: &WalletBlock) -> Result<(), WalletError> {
+        self.wallet.apply_block(block)?;
         self.update_state();
         Ok(())
     }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -46,15 +46,11 @@ impl<Tx: AuthenticatedMantleTx> From<Block<Tx>> for WalletBlock {
 pub struct WalletState {
     pub utxos: rpds::HashTrieMapSync<NoteId, Utxo>,
     pub pk_index: rpds::HashTrieMapSync<ZkPublicKey, rpds::HashTrieSetSync<NoteId>>,
-    /// Claimable vouchers in the corresponding ledger state.
-    /// When building `LEADER_CLAIM` ops, vouchers must be picked from this.
-    pub claimable_vouchers: rpds::HashTrieSetSync<VoucherCm>,
 }
 
 impl WalletState {
     pub fn from_ledger<KeyId>(
         known_keys: &HashMap<ZkPublicKey, KeyId>,
-        known_vouchers: impl Iterator<Item = VoucherCm>,
         ledger: &LedgerState,
     ) -> Self {
         let mut utxos = rpds::HashTrieMapSync::new_sync();
@@ -74,13 +70,7 @@ impl WalletState {
             }
         }
 
-        let claimable_vouchers = Self::filter_claimable_known_vouchers(known_vouchers, ledger);
-
-        Self {
-            utxos,
-            pk_index,
-            claimable_vouchers,
-        }
+        Self { utxos, pk_index }
     }
 
     pub fn utxos_owned_by_pks(
@@ -154,9 +144,7 @@ impl WalletState {
     pub fn apply_block<KeyId>(
         &self,
         known_keys: &HashMap<ZkPublicKey, KeyId>,
-        known_vouchers: impl Iterator<Item = VoucherCm>,
         block: &WalletBlock,
-        ledger: &LedgerState,
     ) -> Self {
         let mut utxos = self.utxos.clone();
         let mut pk_index = self.pk_index.clone();
@@ -196,27 +184,7 @@ impl WalletState {
             }
         }
 
-        // Update the known claimable voucher list.
-        // We need the ledger because block doesn't contain the list of vouchers
-        // that have newly become claimable.
-        let claimable_vouchers = Self::filter_claimable_known_vouchers(known_vouchers, ledger);
-
-        Self {
-            utxos,
-            pk_index,
-            claimable_vouchers,
-        }
-    }
-
-    /// Filter the known voucher secrets to only those that are claimable in the
-    /// given ledger state.
-    fn filter_claimable_known_vouchers(
-        known_vouchers: impl Iterator<Item = VoucherCm>,
-        ledger: &LedgerState,
-    ) -> rpds::HashTrieSetSync<VoucherCm> {
-        known_vouchers
-            .filter(|known_voucher| ledger.mantle_ledger().has_claimable_voucher(known_voucher))
-            .collect()
+        Self { utxos, pk_index }
     }
 }
 
@@ -235,8 +203,7 @@ impl<KeyId, VoucherId> Wallet<KeyId, VoucherId> {
         ledger: &LedgerState,
     ) -> Self {
         let known_keys = known_keys.into_iter().collect();
-        let wallet_state =
-            WalletState::from_ledger(&known_keys, known_vouchers.commitments().copied(), ledger);
+        let wallet_state = WalletState::from_ledger(&known_keys, ledger);
 
         Self {
             known_keys,
@@ -269,22 +236,15 @@ impl<KeyId, VoucherId> Wallet<KeyId, VoucherId> {
         self.wallet_states.contains_key(&block_id)
     }
 
-    pub fn apply_block(
-        &mut self,
-        block: &WalletBlock,
-        ledger: &LedgerState,
-    ) -> Result<(), WalletError> {
+    pub fn apply_block(&mut self, block: &WalletBlock) -> Result<(), WalletError> {
         if self.wallet_states.contains_key(&block.id) {
             // Already processed this block
             return Ok(());
         }
 
-        let block_wallet_state = self.wallet_state_at(block.parent)?.apply_block(
-            &self.known_keys,
-            self.known_vouchers.commitments().copied(),
-            block,
-            ledger,
-        );
+        let block_wallet_state = self
+            .wallet_state_at(block.parent)?
+            .apply_block(&self.known_keys, block);
         self.wallet_states.insert(block.id, block_wallet_state);
         Ok(())
     }
@@ -403,13 +363,7 @@ mod tests {
         );
         assert_eq!(wallet.balance(genesis, alice).unwrap(), None);
         assert_eq!(wallet.balance(genesis, bob).unwrap(), None);
-        assert!(
-            !wallet
-                .wallet_state_at(genesis)
-                .unwrap()
-                .claimable_vouchers
-                .contains(&voucher_cm)
-        );
+        assert!(wallet.vouchers().get(&voucher_cm).is_none());
 
         let wallet = Wallet::from_lib(
             [(alice, 1)],
@@ -420,13 +374,7 @@ mod tests {
         assert_eq!(wallet.balance(genesis, alice).unwrap(), Some(104));
         assert_eq!(wallet.balance(genesis, bob).unwrap(), None);
         // we know the voucher, but it is not claimable (doesn't exist) in the ledger
-        assert!(
-            !wallet
-                .wallet_state_at(genesis)
-                .unwrap()
-                .claimable_vouchers
-                .contains(&voucher_cm)
-        );
+        assert!(wallet.vouchers().get(&voucher_cm).is_none());
 
         let wallet =
             Wallet::<_, TestVoucherId>::from_lib([(bob, 2)], Vouchers::default(), genesis, &ledger);
@@ -472,7 +420,7 @@ mod tests {
             ledger_txs: vec![tx1.clone()],
         };
 
-        wallet.apply_block(&block_1, &genesis_ledger).unwrap();
+        wallet.apply_block(&block_1).unwrap();
 
         // Block 2
         //  - alice spends 100 NMO utxo, sending 20 NMO to bob and 80 to herself
@@ -486,7 +434,7 @@ mod tests {
                 outputs: vec![Note::new(20, bob), Note::new(80, alice)],
             }],
         };
-        wallet.apply_block(&block_2, &genesis_ledger).unwrap();
+        wallet.apply_block(&block_2).unwrap();
 
         // Query the balance of for each pk at different points in the blockchain
         assert_eq!(wallet.balance(genesis, alice).unwrap(), None);
@@ -506,7 +454,6 @@ mod tests {
 
         let wallet_state = WalletState::from_ledger(
             &HashMap::from_iter([(alice, 1)]),
-            empty(),
             &LedgerState::from_utxos([alice_utxo], &ledger_config()),
         );
 
@@ -543,7 +490,6 @@ mod tests {
 
         let wallet_state = WalletState::from_ledger(
             &HashMap::from_iter([(alice, 1)]),
-            empty(),
             &LedgerState::from_utxos(
                 [
                     Utxo::new(tx_hash(0), 0, Note::new(100, alice)),
@@ -574,7 +520,6 @@ mod tests {
 
         let wallet_state = WalletState::from_ledger(
             &HashMap::from_iter([(alice, 1)]),
-            empty(),
             &LedgerState::from_utxos([], &ledger_config()),
         );
 
@@ -597,7 +542,6 @@ mod tests {
 
         let wallet_state = WalletState::from_ledger(
             &HashMap::from_iter([(alice, 1), (bob, 2)]),
-            empty(),
             &LedgerState::from_utxos(
                 [Utxo::new(tx_hash(0), 0, Note::new(1_000_000, bob))],
                 &ledger_config(),
@@ -643,7 +587,6 @@ mod tests {
         // note
         let wallet_state = WalletState::from_ledger(
             &HashMap::from_iter([(alice, 1)]),
-            empty(),
             &LedgerState::from_utxos(
                 [Utxo::new(tx_hash(0), 0, Note::new(2884, alice))],
                 &ledger_config(),
@@ -674,7 +617,6 @@ mod tests {
             // note
             let wallet_state = WalletState::from_ledger(
                 &HashMap::from_iter([(alice, 1)]),
-                empty(),
                 &LedgerState::from_utxos(
                     [Utxo::new(tx_hash(0), 0, Note::new(value, alice))],
                     &ledger_config(),
@@ -692,7 +634,6 @@ mod tests {
         // We can fund the tx if the note value exceeds gas cost with change note
         let wallet_state = WalletState::from_ledger(
             &HashMap::from_iter([(alice, 1)]),
-            empty(),
             &LedgerState::from_utxos(
                 [Utxo::new(tx_hash(0), 0, Note::new(2925, alice))],
                 &ledger_config(),

--- a/wallet/src/voucher.rs
+++ b/wallet/src/voucher.rs
@@ -40,8 +40,4 @@ impl<Id> Vouchers<Id> {
     pub(crate) fn get_by_nullifier(&self, nf: &VoucherNullifier) -> Option<&Id> {
         self.get(self.voucher_nullifiers.get(nf)?)
     }
-
-    pub(crate) fn commitments(&self) -> impl Iterator<Item = &VoucherCm> {
-        self.vouchers.keys()
-    }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

The `WalletState::claimable_vouchers` field is not necessary. 

Initially, I thought it's necessary for implementing the `LEADER_CLAIM` API, but I took a different approach for it: [`Wallet::get_claimable_voucher(tip, ...)`](https://github.com/logos-blockchain/logos-blockchain/pull/2108/changes#diff-62a78ce0f936dc088d182f747639011e010fd70b34899475b85fd16ce3f13b1c) in PR https://github.com/logos-blockchain/logos-blockchain/pull/2108.
So, this PR removed the unnecessary field.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
