### PR TITLE
test: decrease blend max delay: 3s -> 1s

### DIFF
--- a/tests/src/topology/configs/deployment.rs
+++ b/tests/src/topology/configs/deployment.rs
@@ -67,7 +67,7 @@ pub fn default_e2e_deployment_settings() -> DeploymentSettings {
                             .expect("Message frequency per round cannot be negative."),
                     },
                     delayer: MessageDelayerSettings {
-                        maximum_release_delay_in_rounds: NonZeroU64::try_from(3u64)
+                        maximum_release_delay_in_rounds: NonZeroU64::try_from(1u64)
                             .expect("Maximum release delay between rounds cannot be zero."),
                     },
                 },


### PR DESCRIPTION
## 1. What does this PR implement?

(based on PR https://github.com/logos-blockchain/logos-blockchain/pull/2130)

Now that we are enabling blend network and PoQ, block propagation is a bit slower than before. To finish e2e tests without increasing timeout, this PR decreases the blend max release delay from 3s to 1s. 

two_nodes_happy in CI Linux
- PoQ disabled: 230s
- PoQ enabled: > 600s (timed out)
- [real latest utxo tree](https://github.com/logos-blockchain/logos-blockchain/pull/2130): >600s (sometimes 379s)
- [1s blend max delay](https://github.com/logos-blockchain/logos-blockchain/pull/2131): 215s

In this PR, I focused on only making CI green. Another PR https://github.com/logos-blockchain/logos-blockchain/pull/2136 introduces the automatic timeout adjustment.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
