### PR TITLE
test: remove SLOW_TEST_ENV

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,24 +4,15 @@ pub mod cucumber;
 pub mod nodes;
 pub mod topology;
 
-use std::{env, ops::Mul as _, sync::LazyLock, time::Duration};
+use std::{env, sync::LazyLock};
 
 use lb_libp2p::{Multiaddr, PeerId, multiaddr};
-
-static IS_SLOW_TEST_ENV: LazyLock<bool> =
-    LazyLock::new(|| env::var("SLOW_TEST_ENV").is_ok_and(|s| s == "true"));
 
 /// Global flag indicating whether debug tracing configuration is enabled to
 /// send traces to local grafana stack.
 pub static IS_DEBUG_TRACING: LazyLock<bool> = LazyLock::new(|| {
     env::var("LOGOS_BLOCKCHAIN_TESTS_TRACING").is_ok_and(|val| val.eq_ignore_ascii_case("true"))
 });
-
-/// In slow test environments like Codecov, use 2x timeout.
-#[must_use]
-pub fn adjust_timeout(d: Duration) -> Duration {
-    if *IS_SLOW_TEST_ENV { d.mul(2) } else { d }
-}
 
 fn node_address_from_port(port: u16) -> Multiaddr {
     multiaddr(std::net::Ipv4Addr::LOCALHOST, port)

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -39,7 +39,7 @@ use tokio::time::error::Elapsed;
 
 use super::{CLIENT, create_tempdir, get_exe_path, persist_tempdir};
 use crate::{
-    IS_DEBUG_TRACING, adjust_timeout, common::kms::key_id_for_preload_backend, nodes::LOGS_PREFIX,
+    IS_DEBUG_TRACING, common::kms::key_id_for_preload_backend, nodes::LOGS_PREFIX,
     topology::configs::GeneralConfig,
 };
 
@@ -133,7 +133,7 @@ impl Validator {
             http_client: CommonHttpClient::new_with_client(CLIENT.clone(), None),
         };
 
-        tokio::time::timeout(adjust_timeout(Duration::from_secs(10)), async {
+        tokio::time::timeout(Duration::from_secs(10), async {
             node.wait_online().await;
         })
         .await?;

--- a/tests/src/tests/cryptarchia/bootstrap.rs
+++ b/tests/src/tests/cryptarchia/bootstrap.rs
@@ -7,7 +7,6 @@ use futures::stream::{self, StreamExt as _};
 use lb_libp2p::PeerId;
 use lb_pol::slot_activation_coefficient;
 use logos_blockchain_tests::{
-    adjust_timeout,
     common::{
         sync::{wait_for_validators_mode, wait_for_validators_mode_and_height},
         time::max_block_propagation_time,
@@ -59,12 +58,12 @@ async fn test_ibd_behind_nodes() {
         &initial_validators,
         lb_cryptarchia_engine::State::Online,
         minimum_height.into(),
-        adjust_timeout(max_block_propagation_time(
+        max_block_propagation_time(
             minimum_height,
             initial_validators.len().try_into().unwrap(),
             &initial_validators[0].config().deployment,
             2.0,
-        )),
+        ),
     )
     .await;
 
@@ -106,7 +105,7 @@ async fn test_ibd_behind_nodes() {
     wait_for_validators_mode(
         &[&behind_node],
         lb_cryptarchia_engine::State::Online,
-        adjust_timeout(Duration::from_secs(10)),
+        Duration::from_secs(10),
     )
     .await;
 

--- a/tests/src/tests/cryptarchia/happy.rs
+++ b/tests/src/tests/cryptarchia/happy.rs
@@ -2,7 +2,6 @@ use std::{collections::HashSet, time::Duration};
 
 use futures::stream::{self, StreamExt as _};
 use logos_blockchain_tests::{
-    adjust_timeout,
     common::time::max_block_propagation_time,
     topology::{Topology, TopologyConfig},
 };
@@ -17,12 +16,12 @@ async fn happy_test(topology: &Topology) {
     let config = nodes[0].config();
 
     let n_blocks = config.deployment.cryptarchia.security_param.get() * CHAIN_LENGTH_MULTIPLIER;
-    let timeout = adjust_timeout(max_block_propagation_time(
+    let timeout = max_block_propagation_time(
         n_blocks,
         nodes.len().try_into().unwrap(),
         &config.deployment,
         3.0,
-    ));
+    );
     println!("waiting for {n_blocks} blocks: timeout:{timeout:?}");
     let timeout = tokio::time::sleep(timeout);
     {

--- a/tests/src/tests/cryptarchia/immutable_blocks.rs
+++ b/tests/src/tests/cryptarchia/immutable_blocks.rs
@@ -2,9 +2,8 @@ use std::{num::NonZero, time::Duration};
 
 use futures_util::StreamExt as _;
 use logos_blockchain_tests::{
-    adjust_timeout,
     common::time::max_block_propagation_time,
-    nodes::validator::{Validator, create_validator_config},
+    nodes::{Validator, create_validator_config},
     topology::configs::{create_general_configs, deployment::default_e2e_deployment_settings},
 };
 use serial_test::serial;
@@ -58,7 +57,7 @@ async fn immutable_blocks_two_nodes() {
     tokio::pin!(stream1);
     tokio::pin!(stream2);
 
-    let timeout = tokio::time::sleep(adjust_timeout(timeout));
+    let timeout = tokio::time::sleep(timeout);
 
     tokio::select! {
         () = timeout => panic!("Timed out waiting for matching LIBs"),

--- a/tests/src/tests/cryptarchia/orphan.rs
+++ b/tests/src/tests/cryptarchia/orphan.rs
@@ -2,7 +2,6 @@ use std::{slice, time::Duration};
 
 use futures::stream::{self, StreamExt as _};
 use logos_blockchain_tests::{
-    adjust_timeout,
     common::{
         sync::{format_cryptarhica_info, wait_for_validators_mode_and_height},
         time::max_block_propagation_time,
@@ -66,7 +65,7 @@ async fn test_orphan_handling() {
     // a new block and it is delivered to the behind node.
     // We set a timeout long enough, since there is a non-zero probability that the
     // behind node also proposes blocks (which wouldn't trigger orphan handling).
-    tokio::time::timeout(adjust_timeout(Duration::from_secs(300)), async {
+    tokio::time::timeout(Duration::from_secs(300), async {
         loop {
             let initial_nodes_info: Vec<_> = stream::iter(&validators)
                 .then(async |n| n.consensus_info(false).await)

--- a/tests/src/tests/mantle/sdp_ops.rs
+++ b/tests/src/tests/mantle/sdp_ops.rs
@@ -11,7 +11,6 @@ use lb_core::{
 };
 use lb_key_management_system_service::keys::{Ed25519Key, ZkKey};
 use logos_blockchain_tests::{
-    adjust_timeout,
     common::mantle_tx::{create_sdp_active_tx, create_sdp_declare_tx, create_sdp_withdraw_tx},
     nodes::validator::Validator,
     topology::{GenesisNoteSpec, Topology, TopologyConfig},
@@ -44,7 +43,7 @@ async fn sdp_ops_e2e() {
 
     let validator = &topology.validators()[0];
 
-    wait_for_height(validator, 1, adjust_timeout(Duration::from_secs(30)))
+    wait_for_height(validator, 1, Duration::from_secs(30))
         .await
         .expect("validator should produce the first block before submitting declare");
 
@@ -117,8 +116,7 @@ async fn sdp_ops_e2e() {
         .get(&ServiceType::BlendNetwork)
         .expect("blend network parameters must exist")
         .lock_period;
-    let height_timeout =
-        adjust_timeout(Duration::from_secs(lock_period.saturating_mul(12).max(90)));
+    let height_timeout = Duration::from_secs(lock_period.saturating_mul(12).max(90));
 
     let created_height = declaration_state.created;
     let initial_active = declaration_state.active;

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -1,6 +1,6 @@
 pub mod configs;
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use configs::{
     GeneralConfig,
@@ -18,7 +18,6 @@ use lb_utils::net::get_available_udp_port;
 use rand::{Rng as _, thread_rng};
 
 use crate::{
-    adjust_timeout,
     common::kms::key_id_for_preload_backend,
     nodes::validator::{Validator, create_validator_config},
     topology::configs::{
@@ -269,14 +268,13 @@ trait ReadinessCheck<'a> {
     fn timeout_message(&self, data: Self::Data) -> String;
 
     async fn wait(&'a self) {
-        let timeout_duration = adjust_timeout(std::time::Duration::from_secs(60));
-        let timeout = tokio::time::timeout(timeout_duration, async {
+        let timeout = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 let data = self.collect().await;
                 if self.is_ready(&data) {
                     return;
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
         });
 


### PR DESCRIPTION
## 1. What does this PR implement?

Removed an unnecessary env var: `SLOW_TEST_ENV`. We added at the very beginning to increase test timeouts in slow CI environments. But we're not using it anywhere, and we don't need it anymore because we're already mulitplying the enough safety margin to the timeouts.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n /a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
