### PR TITLE
fix(explorer): delay explorer startup to allow node to start

### DIFF
--- a/compose.static.yml
+++ b/compose.static.yml
@@ -4,7 +4,7 @@ services:
 
   explorer:
     container_name: explorer
-    image: logos-blockchain
+    image: ghcr.io/logos-blockchain/logos-blockchain:devnet
     depends_on:
       - logos-blockchain-node-0
     environment:
@@ -12,7 +12,7 @@ services:
       - NBE_NODE_API_PORT=${NODE0_API_PORT}
     ports:
       - "8000:8000/tcp"
-    entrypoint: /opt/scripts/run_explorer.sh
+    entrypoint: [/bin/sh, '-c', "sleep 10 && /opt/scripts/run_explorer.sh"]
 
   cfgsync:
     container_name: cfgsync


### PR DESCRIPTION
## 1. What does this PR implement?

explorer is not retrying connections to the node if it is down (need to fix this) but for now we can just delay the explorer startup a little bit to allow the node to start

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

NA

## 4. Is the specification accurate and complete?

NA

## 5. Does the implementation introduce changes in the specification?

NA

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
