### PR TITLE
feat(blend): reduce blend net inactivity and retention period to 1

### DIFF
--- a/ledger/src/config.rs
+++ b/ledger/src/config.rs
@@ -77,8 +77,8 @@ mod tests {
                         ServiceType::BlendNetwork,
                         ServiceParameters {
                             lock_period: 10,
-                            inactivity_period: 20,
-                            retention_period: 100,
+                            inactivity_period: 1,
+                            retention_period: 1,
                             timestamp: 0,
                             session_duration: 10,
                         },
@@ -123,8 +123,8 @@ mod tests {
                         ServiceType::BlendNetwork,
                         ServiceParameters {
                             lock_period: 10,
-                            inactivity_period: 20,
-                            retention_period: 100,
+                            inactivity_period: 1,
+                            retention_period: 1,
                             timestamp: 0,
                             session_duration: 10,
                         },

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -577,8 +577,8 @@ pub mod tests {
             lb_core::sdp::ServiceType::BlendNetwork,
             ServiceParameters {
                 lock_period: 10,
-                inactivity_period: 20,
-                retention_period: 100,
+                inactivity_period: 1,
+                retention_period: 1,
                 timestamp: 0,
                 session_duration: 10,
             },

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -647,9 +647,9 @@ mod tests {
         params.insert(
             ServiceType::BlendNetwork,
             ServiceParameters {
-                inactivity_period: 20,
+                inactivity_period: 1,
                 lock_period: 10,
-                retention_period: 1000,
+                retention_period: 1,
                 timestamp: 0,
                 session_duration: 10,
             },

--- a/ledger/src/mantle/sdp/rewards/test_utils.rs
+++ b/ledger/src/mantle/sdp/rewards/test_utils.rs
@@ -44,8 +44,8 @@ pub fn create_provider_id(byte: u8) -> ProviderId {
 pub fn create_service_parameters() -> ServiceParameters {
     ServiceParameters {
         lock_period: 10,
-        inactivity_period: 20,
-        retention_period: 100,
+        inactivity_period: 1,
+        retention_period: 1,
         timestamp: 0,
         session_duration: 10,
     }

--- a/nodes/node/binary/src/config/cryptarchia/deployment.rs
+++ b/nodes/node/binary/src/config/cryptarchia/deployment.rs
@@ -72,9 +72,9 @@ fn devnet_settings() -> Settings {
             service_params: [(
                 ServiceType::BlendNetwork,
                 ServiceParameters {
-                    inactivity_period: 20,
+                    inactivity_period: 1,
                     lock_period: 10,
-                    retention_period: 100,
+                    retention_period: 1,
                     timestamp: 0,
                 },
             )]

--- a/nodes/node/standalone-deployment-config.yaml
+++ b/nodes/node/standalone-deployment-config.yaml
@@ -35,8 +35,8 @@ cryptarchia:
     service_params:
       BN:
         lock_period: 10
-        inactivity_period: 20
-        retention_period: 100
+        inactivity_period: 1
+        retention_period: 1
         timestamp: 0
     min_stake:
       threshold: 1

--- a/tests/src/topology/configs/deployment.rs
+++ b/tests/src/topology/configs/deployment.rs
@@ -102,8 +102,8 @@ pub fn e2e_deployment_settings_with_genesis_tx(genesis_tx: GenesisTx) -> Deploym
                     ServiceType::BlendNetwork,
                     ServiceParameters {
                         lock_period: 10,
-                        inactivity_period: 20,
-                        retention_period: 100,
+                        inactivity_period: 1,
+                        retention_period: 1,
                         timestamp: 0,
                     },
                 )]


### PR DESCRIPTION
## 1. What does this PR implement?

Reduces Blend inactivity and retention to 1 session, previous values were way too large (>2yrs with mainnet configuration)

Blend values are specified here: https://www.notion.so/nomos-tech/Service-Declaration-Protocol-1fd261aa09df819ca9f8eb2bdfd4ec1d?source=copy_link#303261aa09df800599e3d7f5ec2c2646

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
