### PR TITLE
fix(api): remove waiting service dependencies

### DIFF
--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -3,7 +3,6 @@
 use std::{
     fmt::{Debug, Display},
     marker::PhantomData,
-    time::Duration,
 };
 
 use axum::{
@@ -25,10 +24,9 @@ use lb_core::{
 use lb_http_api_common::paths;
 pub use lb_http_api_common::settings::AxumBackendSettings;
 use lb_sdp_service::{mempool::SdpMempoolAdapter, wallet::SdpWalletAdapter};
-use lb_services_utils::wait_until_services_are_ready;
 use lb_storage_service::{StorageService, backends::rocksdb::RocksBackend};
 use lb_tx_service::{TxMempoolService, backend::Mempool};
-use overwatch::{DynError, overwatch::handle::OverwatchHandle, services::AsServiceId};
+use overwatch::{overwatch::handle::OverwatchHandle, services::AsServiceId};
 use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
@@ -157,23 +155,6 @@ where
             settings,
             _phantom: PhantomData,
         })
-    }
-
-    async fn wait_until_ready(
-        &mut self,
-        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-    ) -> Result<(), DynError> {
-        wait_until_services_are_ready!(
-            &overwatch_handle,
-            Some(Duration::from_secs(60)),
-            Cryptarchia<_>,
-            ChainLeader,
-            lb_network_service::NetworkService<_, _>,
-            BlockStorageService<_>,
-            TxMempoolService<_, _, _,  _>
-        )
-        .await?;
-        Ok(())
     }
 
     #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]

--- a/nodes/node/binary/src/api/testing/backend.rs
+++ b/nodes/node/binary/src/api/testing/backend.rs
@@ -11,7 +11,7 @@ use axum::{
 use lb_api_service::Backend;
 use lb_http_api_common::paths::MANTLE_SDP_DECLARATIONS;
 pub use lb_network_service::backends::libp2p::Libp2p as NetworkBackend;
-use overwatch::{DynError, overwatch::handle::OverwatchHandle, services::AsServiceId};
+use overwatch::{overwatch::handle::OverwatchHandle, services::AsServiceId};
 use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
@@ -57,13 +57,6 @@ where
         Self: Sized,
     {
         Ok(Self { settings })
-    }
-
-    async fn wait_until_ready(
-        &mut self,
-        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-    ) -> Result<(), DynError> {
-        Ok(())
     }
 
     async fn serve(self, handle: OverwatchHandle<RuntimeServiceId>) -> Result<(), Self::Error> {

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -22,34 +22,6 @@ pub trait Backend<RuntimeServiceId> {
     where
         Self: Sized;
 
-    /// Wait until the backend is ready to serve requests.
-    ///
-    /// # Notes
-    ///
-    /// * Because this method is async and takes a `self` reference, it would
-    ///   need to propagate `Sync` traits. To avoid this, we use a `&mut self`
-    ///   reference. In addition, this also covers potential use-cases where the
-    ///   backend might need to perform some `mut` operations when checking
-    ///   readiness, such as sending/receiving messages.
-    ///
-    /// # Arguments
-    ///
-    /// * `overwatch_handle` - A handle to Overwatch. This is mainly used to
-    ///   retrieve the
-    ///   [`StatusWatcher`](overwatch::services::status::StatusWatcher) to read
-    ///   the [`ServiceStatus`](overwatch::services::status::ServiceStatus) of
-    ///   `Services` we depend on.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` indicating:
-    /// * `Ok(())` if the backend is ready.
-    /// * `Err(DynError)` if there was an error while waiting for readiness.
-    async fn wait_until_ready(
-        &mut self,
-        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-    ) -> Result<(), DynError>;
-
     async fn serve(self, handle: OverwatchHandle<RuntimeServiceId>) -> Result<(), Self::Error>;
 }
 
@@ -95,18 +67,14 @@ where
     }
 
     /// Service main loop
-    async fn run(mut self) -> Result<(), DynError> {
-        let mut endpoint = B::new(self.settings.backend_settings).await?;
+    async fn run(self) -> Result<(), DynError> {
+        let endpoint = B::new(self.settings.backend_settings).await?;
 
         self.service_resources_handle.status_updater.notify_ready();
         tracing::info!(
             "Service '{}' is ready.",
             <RuntimeServiceId as AsServiceId<Self>>::SERVICE_ID
         );
-
-        endpoint
-            .wait_until_ready(self.service_resources_handle.overwatch_handle.clone())
-            .await?;
 
         endpoint
             .serve(self.service_resources_handle.overwatch_handle)

--- a/services/api/tests/todo.rs
+++ b/services/api/tests/todo.rs
@@ -10,7 +10,7 @@ use std::{
 use axum::{Router, routing};
 use logos_blockchain_api_service::{ApiService, ApiServiceSettings, Backend};
 use overwatch::{
-    DynError, derive_services,
+    derive_services,
     overwatch::{OverwatchRunner, handle::OverwatchHandle},
 };
 use utoipa::{
@@ -73,13 +73,6 @@ impl Backend<RuntimeServiceId> for WebServer {
         Self: Sized,
     {
         Ok(Self { addr: settings })
-    }
-
-    async fn wait_until_ready(
-        &mut self,
-        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
-    ) -> Result<(), DynError> {
-        Ok(())
     }
 
     async fn serve(self, _handle: OverwatchHandle<RuntimeServiceId>) -> Result<(), Self::Error> {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR removes `wait_until_services_are_ready!` from the API service.

Previously, API service was waiting for Network, Storage, Mempool, Chain, and ChainLeader service. But, the ChainLeader service becomes ready only after the chain enters the Online mode. It takes time depending on [IBD and PBP](https://www.notion.so/nomos-tech/Cryptarchia-v1-Bootstrapping-Synchronization-1fd261aa09df81ac94b5fb6a4eff32a6?source=copy_link#1fd261aa09df8113baa7c8c751f7d8e3). Because of that, we were not able to use basic APIs (e.g. `cryptarchia/info`) during the chain Bootstrapping mode. 

To fix it, we now do not wait for service dependencies. API service becomes ready immediately. Instead, we rely on the [timeout middleware](https://github.com/logos-blockchain/logos-blockchain/blob/4b481023e3c1753da5b226b54c22200fbfa6f56e/nodes/node/binary/src/api/backend.rs#L281) we've already had. The API service tries to send a request to the other service via the Overwatch relay, regardless of whether it is ready or not. If it is failed to send a request in time, or if the service didn't respond in time, the API service returns `408: Request Timeout` to the end user.

The video below shows this scenario. I set 20s to PBP and 3s to API timeout. 

https://github.com/user-attachments/assets/2dcd0a4c-4d59-4cc2-807c-570e9f69c38e


### Future work

In a next PR, we can probably improve API service to introduce the on-demand service dependency check. 
Now that we are not waiting for service dependencies, the request messages will be stacked on the Overwatch relay (with buffer=16 hardcoded). It is not an issue for immutable operations (e.g. GET) but may be little tricky for POST operations.

For example, if a user calls `POST /leader/claim` during bootstrapping, the request will be timed out but will be stuck in the relay. Once the ChainLeader becomes ready, it will read the request from the relay, process it, and tries to send the response back. Sending the response will be failed because `oneshot::Sender` is already dropped by the requester. But, the ChainLeader already claimed the leader reward by processing the request. 

I believe this is not a big issue, because afaik, it's fine that a request is processed by the server, even if the user gets a timeout error, as long as the server state is consistent. But, I'm just mentioning that we can consider an improvement: We can check whether service dependencies are ready whenever we process an API request, and can return `503 Service Unavailable` (or any other) if they are not ready.

We can merge this PR first to unblock enabling IBD in devnet, and discuss about this improvement separately.

## 2. Does the code have enough context to be clearly understood?

I believe so

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
