### PR TITLE
chore: tar binaries in release

### DIFF
--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -21,7 +21,7 @@ After generating the node config file to fit your needs, you can untar and run t
 
 To untar the binary, run:
 
-`tar -xf logos-blockchain-node-{your_architecture}-{binary_version}.tar`, for instance `tar -xf logos-blockchain-node-macos-aarch64-0.0.1.tar`.
+`tar -xzf logos-blockchain-node-{your_architecture}-{binary_version}.tar.gz`, for instance `tar -xzf logos-blockchain-node-macos-aarch64-0.0.1.tar.gz`.
 
 The operation will give you the `logos-blockchain-node` binary, which you can now run. See the repo's `README.md` for more info.
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -76,13 +76,13 @@ jobs:
         run: cargo build -p logos-blockchain-node --features high-active-slot-coefficient --release --target ${{ matrix.platform.target_triple }}
 
       - name: Tar node binary
-        run: tar -cf logos-blockchain-node-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ needs.configure-version.outputs.version }}.tar -C target/${{ matrix.platform.target_triple }}/release logos-blockchain-node
+        run: tar -czf logos-blockchain-node-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ needs.configure-version.outputs.version }}.tar.gz -C target/${{ matrix.platform.target_triple }}/release logos-blockchain-node
 
       - name: Upload binary tar (${{ matrix.platform.arch }})
         uses: actions/upload-artifact@6027e3dd177782cd8ab9af838c04fd81a07f1d47 # Version 4.6.2
         with:
           name: logos-blockchain-node-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ needs.configure-version.outputs.version }}
-          path: logos-blockchain-node-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ needs.configure-version.outputs.version }}.tar
+          path: logos-blockchain-node-${{ matrix.platform.os }}-${{ matrix.platform.arch }}-${{ needs.configure-version.outputs.version }}.tar.gz
           if-no-files-found: error
 
   create-draft-release:
@@ -146,6 +146,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ${{ env.DOWNLOAD_DIRECTORY }}/${{ env.BINARY_NAME }}.tar
-          asset_name: ${{ env.BINARY_NAME }}.tar
-          asset_content_type: application/x-tar
+          asset_path: ${{ env.DOWNLOAD_DIRECTORY }}/${{ env.BINARY_NAME }}.tar.gz
+          asset_name: ${{ env.BINARY_NAME }}.tar.gz
+          asset_content_type: application/gzip


### PR DESCRIPTION
## 1. What does this PR implement?

Let's tar the binaries so that 1. the unwrapped binary is always called `logos-blockchain-node`, and 2. the executable flag is already set, so no need to run `chmod +x` on it.

Successful test run: https://github.com/logos-blockchain/logos-blockchain/actions/runs/22064967451/job/63756018340.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
