### PR TITLE
chore(Readme): Shorten prolonged bootstrap period in standalone param

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,14 @@ cargo build --all-features --all-targets
 target/debug/logos-blockchain-node nodes/node/standalone-node-config.yaml
 ```
 
-Node stores its state inside the `db` directory. If there are any issues when restarting the node, please try removing 
-`db` directory.
+Node stores its state inside the `store` directory. If there are any issues when restarting the node, please try removing 
+`store` directory.
+
+If you would like to test a node with a more frequent blocks per slot, please usea `--features high-active-slot-coefficient` feature flag when building:
+```bash
+cargo build --all-features --all-targets --features high-active-slot-coefficient
+```
+
 
 #### Running Logos Blockchain Node with integration test
 

--- a/nodes/node/standalone-node-config.yaml
+++ b/nodes/node/standalone-node-config.yaml
@@ -4,6 +4,9 @@ blend:
     zk:
       secret_key_kms_id: 64249c75c2cb813578b75d05b215fc95f67cea5862fff047228183f22e63460e
 cryptarchia:
+  service:
+    bootstrap:
+      prolonged_bootstrap_period: '1.000000000'
   leader:
     wallet:
       funding_pk: "2e03b2eff5a45478e7e79668d2a146cf2c5c7925bce927f2b1c67f2ab4fc0d26"


### PR DESCRIPTION
## 1. What does this PR implement?

Prolonged bootstrap period set to `1` in standalone user config.
Readme has a note about  `--features high-active-slot-coefficient` feature flag.

## 2. Does the code have enough context to be clearly understood?

N/A

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
