### PR TITLE
fix(system-sig): prevent CTRL+C shutdown hang

### DIFF
--- a/services/system-sig/src/lib.rs
+++ b/services/system-sig/src/lib.rs
@@ -18,7 +18,6 @@ where
     RuntimeServiceId: Debug + Display + Sync,
 {
     async fn ctrl_c_signal_received(overwatch_handle: &OverwatchHandle<RuntimeServiceId>) {
-        drop(overwatch_handle.stop_all_services().await);
         drop(overwatch_handle.shutdown().await);
     }
 }


### PR DESCRIPTION
## Problem

When the user presses Ctrl+C, `SystemSig` calls `stop_all_services()` followed by `shutdown()`. However, `stop_all_services()` aborts **all** services — including `SystemSig` itself. This means the task running `ctrl_c_signal_received` gets aborted before `shutdown()` is ever called, leaving the process hanging indefinitely.

## Fix

Call `shutdown()` directly instead of `stop_all_services()` + `shutdown()`. The `shutdown()` method already stops all services internally, so no functionality is lost — and since it runs as a single call, it completes before `SystemSig`'s task can be aborted.

## Change

One line removed from `services/system-sig/src/lib.rs` — no new dependencies.