### PR TITLE
fix(cryptarchia): use epoch schedule for total stake inference

### DIFF
--- a/ledger/src/config.rs
+++ b/ledger/src/config.rs
@@ -33,17 +33,32 @@ impl Config {
 
     #[must_use]
     pub fn nonce_snapshot(&self, epoch: Epoch) -> Slot {
-        let offset = self.base_period_length().get().saturating_mul(
+        let offset = self.nonce_contribution_period();
+        let base =
+            u64::from(u32::from(epoch).saturating_sub(1)).saturating_mul(self.epoch_length());
+        base.saturating_add(offset).into()
+    }
+
+    #[must_use]
+    pub fn nonce_contribution_period(&self) -> u64 {
+        self.base_period_length().get().saturating_mul(
             u64::from(NonZeroU64::from(
                 self.epoch_config.epoch_period_nonce_buffer,
             ))
             .saturating_add(u64::from(NonZeroU64::from(
                 self.epoch_config.epoch_stake_distribution_stabilization,
             ))),
-        );
-        let base =
-            u64::from(u32::from(epoch).saturating_sub(1)).saturating_mul(self.epoch_length());
-        base.saturating_add(offset).into()
+        )
+    }
+
+    #[must_use]
+    pub fn total_stake_snapshot(&self, epoch: Epoch) -> Slot {
+        self.nonce_snapshot(epoch)
+    }
+
+    #[must_use]
+    pub fn total_stake_inference_period(&self) -> u64 {
+        self.nonce_contribution_period()
     }
 
     #[must_use]

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -441,7 +441,7 @@ impl LedgerState {
         let stake_inference = Arc::new(StakeInference::new(
             config.consensus_config.stake_inference_learning_rate(),
             config.consensus_config.slot_activation_coeff().as_f64(),
-            config.consensus_config.security_param().get().into(),
+            config.total_stake_inference_period(),
         ));
         let block_density = BlockDensity::new(stake_inference.period(), slot);
         Self {
@@ -683,7 +683,7 @@ pub mod tests {
         let stake_inference = Arc::new(StakeInference::new(
             config.consensus_config.stake_inference_learning_rate(),
             config.consensus_config.slot_activation_coeff().as_f64(),
-            config.consensus_config.security_param().get().into(),
+            config.total_stake_inference_period(),
         ));
         let block_density_inference = BlockDensity::new(stake_inference.period(), 0.into());
         LedgerState {

--- a/ledger/src/cryptarchia/stake.rs
+++ b/ledger/src/cryptarchia/stake.rs
@@ -1,5 +1,3 @@
-use std::ops::Div as _;
-
 pub const PRECISION: u64 = 1000;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -7,28 +5,20 @@ pub const PRECISION: u64 = 1000;
 pub struct StakeInference {
     learning_rate: f64,
     slot_activation_coefficient: f64,
-    security_parameter: u64,
+    period: u64,
 }
 
 impl StakeInference {
-    pub const fn new(
-        learning_rate: f64,
-        slot_activation_coefficient: f64,
-        security_parameter: u64,
-    ) -> Self {
+    pub const fn new(learning_rate: f64, slot_activation_coefficient: f64, period: u64) -> Self {
         Self {
             learning_rate,
             slot_activation_coefficient,
-            security_parameter,
+            period,
         }
     }
 
-    pub fn period(&self) -> u64 {
-        const PERIOD_CONSTANT: u64 = 6;
-        (self.security_parameter as f64)
-            .div(self.slot_activation_coefficient)
-            .floor() as u64
-            * PERIOD_CONSTANT
+    pub const fn period(&self) -> u64 {
+        self.period
     }
 
     pub fn total_stake_inference<const PRECISION: u64>(
@@ -76,31 +66,24 @@ impl StakeInference {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{collections::HashMap, sync::Arc};
 
+    use lb_core::sdp::MinStake;
+    use lb_utils::math::NonNegativeRatio;
+
+    use super::*;
+    use crate::{
+        Config,
+        mantle::sdp::{ServiceRewardsParameters, rewards::blend},
+    };
+
+    const SECURITY_PARAM: u32 = 10;
     const LEARNING_RATE: f64 = 1f64;
 
     #[test]
-    fn test_period_calculation_with_different_security_params() {
-        let inference1 = StakeInference::new(LEARNING_RATE, 1.0, 5);
-        assert_eq!(inference1.period(), 30);
-
-        let inference2 = StakeInference::new(LEARNING_RATE, 1.0, 20);
-        assert_eq!(inference2.period(), 120);
-    }
-
-    #[test]
-    fn test_period_calculation_with_fractional_results() {
-        let inference = StakeInference::new(LEARNING_RATE, 1.0, 7);
-        assert_eq!(inference.period(), 42); // 7 * 6 / 1
-
-        let inference2 = StakeInference::new(LEARNING_RATE, 0.9, 10);
-        assert_eq!(inference2.period(), 66); // 10 * 6 / 0.9
-    }
-
-    #[test]
     fn test_total_stake_inference_zero_block_density() {
-        let inference = StakeInference::new(LEARNING_RATE, 1.0, 10);
+        let config = config(NonNegativeRatio::new(1, 2.try_into().unwrap()));
+        let inference = stake_inference_from(&config);
         let total_stake_estimate = 1000u64;
         let period_block_density = 0u64;
 
@@ -112,42 +95,115 @@ mod tests {
     }
 
     #[test]
-    fn test_total_stake_inference_max_block_density() {
-        let inference = StakeInference::new(LEARNING_RATE, 1.0, 10);
+    fn test_total_stake_inference_high_block_density() {
+        let config = config(NonNegativeRatio::new(1, 2.try_into().unwrap()));
+        let inference = stake_inference_from(&config);
         let total_stake_estimate = 1000u64;
-        let period = inference.period(); // 10
-        let period_block_density = period;
+        let measured_block_density = expected_density(&inference) * 2;
 
         let result = inference
-            .total_stake_inference::<PRECISION>(total_stake_estimate, period_block_density);
+            .total_stake_inference::<PRECISION>(total_stake_estimate, measured_block_density);
 
+        // total stake should decrease because blocks more than expected were produced
+        assert!(
+            result > total_stake_estimate,
+            "result({result}) must be > total_stake_estimate({total_stake_estimate})"
+        );
+    }
+
+    #[test]
+    fn test_total_stake_inference_exact_block_density() {
+        let config = config(NonNegativeRatio::new(1, 2.try_into().unwrap()));
+        let inference = stake_inference_from(&config);
+        let total_stake_estimate = 1000u64;
+        let measured_block_density = expected_density(&inference);
+
+        let result = inference
+            .total_stake_inference::<PRECISION>(total_stake_estimate, measured_block_density);
+
+        // total stake shouldn't change because the measured density matches the
+        // expected one
         assert_eq!(result, total_stake_estimate);
     }
 
     #[test]
     fn test_total_stake_inference_intermediate_block_density() {
-        let inference = StakeInference::new(LEARNING_RATE, 1.0, 10);
+        let config = config(NonNegativeRatio::new(1, 2.try_into().unwrap()));
+        let inference = stake_inference_from(&config);
         let total_stake_estimate = 1000u64;
-        let period_block_density = inference.period() / 2;
+        let measured_block_density = expected_density(&inference) / 2;
 
         let result = inference
-            .total_stake_inference::<PRECISION>(total_stake_estimate, period_block_density);
+            .total_stake_inference::<PRECISION>(total_stake_estimate, measured_block_density);
 
         // With intermediate density, result should be between 0 and
         // total_stake_estimate
-        assert!(result < total_stake_estimate);
+        assert!(
+            result < total_stake_estimate,
+            "result({result}) must be < total_stake_estimate({total_stake_estimate})"
+        );
     }
 
     #[test]
     fn test_total_stake_inference_very_high_stake() {
-        let inference = StakeInference::new(LEARNING_RATE, 1.0, 10);
-        let total_stake_estimate = u64::MAX; //maximum stake suported is half
-        let period_block_density = inference.period();
+        let config = config(NonNegativeRatio::new(1, 2.try_into().unwrap()));
+        let inference = stake_inference_from(&config);
+        let total_stake_estimate = u64::MAX; //maximum stake supported is half
+        let measured_block_density = expected_density(&inference) / 2;
 
         let result = inference
-            .total_stake_inference::<PRECISION>(total_stake_estimate, period_block_density);
+            .total_stake_inference::<PRECISION>(total_stake_estimate, measured_block_density);
 
         // Should handle large numbers without overflow
-        assert!(result <= total_stake_estimate);
+        assert!(
+            result <= total_stake_estimate,
+            "result({result}) must be <= total_stake_estimate({total_stake_estimate})"
+        );
+    }
+
+    fn stake_inference_from(config: &Config) -> StakeInference {
+        StakeInference::new(
+            config.consensus_config.stake_inference_learning_rate(),
+            config.consensus_config.slot_activation_coeff().as_f64(),
+            config.total_stake_inference_period(),
+        )
+    }
+
+    fn config(slot_activation_coeff: NonNegativeRatio) -> Config {
+        Config {
+            epoch_config: lb_cryptarchia_engine::EpochConfig {
+                epoch_stake_distribution_stabilization: 3.try_into().unwrap(),
+                epoch_period_nonce_buffer: 3.try_into().unwrap(),
+                epoch_period_nonce_stabilization: 4.try_into().unwrap(),
+            },
+            consensus_config: lb_cryptarchia_engine::Config::new(
+                SECURITY_PARAM.try_into().unwrap(),
+                slot_activation_coeff,
+                LEARNING_RATE.try_into().unwrap(),
+            ),
+            // Not used in the tests
+            sdp_config: crate::mantle::sdp::Config {
+                service_params: Arc::new(HashMap::new()),
+                service_rewards_params: ServiceRewardsParameters {
+                    blend: blend::RewardsParameters {
+                        rounds_per_session: 10.try_into().unwrap(),
+                        message_frequency_per_round: 1.0.try_into().unwrap(),
+                        num_blend_layers: 1.try_into().unwrap(),
+                        data_replication_factor: 0,
+                        minimum_network_size: 1.try_into().unwrap(),
+                        activity_threshold_sensitivity: 1,
+                    },
+                },
+                min_stake: MinStake {
+                    threshold: 0,
+                    timestamp: 0,
+                },
+            },
+            faucet_pk: None,
+        }
+    }
+
+    fn expected_density(inference: &StakeInference) -> u64 {
+        (inference.period() as f64 * inference.slot_activation_coefficient).floor() as u64
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #2231

Details are written in the issue #2231. 
This PR removes the `PERIOD` constant for the total stake inference.
Now the period is calculated by `ledger::Config`, similar as other properties such as `nonce_contribution_period`.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

spec: @davidrusu 
dev: @youngjoon-lee @danielSanchezQ 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
