### PR TITLE
fix(cryptarchia): use existing `update_epoch_state` for `epoch_state_for_slot`

### DIFF
--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -126,6 +126,11 @@ pub struct LedgerState {
 }
 
 impl LedgerState {
+    /// Synthesizes the epoch state for the given slot.
+    ///
+    /// This function must be called before any other function that updates
+    /// [`LedgerState`]. Otherwise, previously accumulated values (e.g. nonce
+    /// and block density) will be lost.
     fn update_epoch_state<Id>(self, slot: Slot, config: &Config) -> Result<Self, LedgerError<Id>> {
         if slot <= self.slot {
             return Err(LedgerError::InvalidSlot {
@@ -134,26 +139,16 @@ impl LedgerState {
             });
         }
 
-        // increment density for new slot
-        let mut block_density_inference = self.block_density.clone();
-        block_density_inference.increment_block_density(slot);
-        // infere new total stake
-        let total_stake = self.stake_inference.total_stake_inference::<PRECISION>(
-            self.epoch_state.total_stake,
-            block_density_inference.current_block_density(),
-        );
-        let (lottery_0, lottery_1) = config
-            .lottery_constants()
-            .compute_lottery_values(total_stake);
         let current_epoch = config.epoch(self.slot);
         let new_epoch = config.epoch(slot);
 
-        // there are 3 cases to consider:
-        // 1. we are in the same epoch as the parent state: update the next epoch state
-        // 2. we are in the next epoch use the next epoch state as the current epoch:
+        // There are 3 cases to consider:
+        // 1. We are in the same epoch as the parent state: Update the next epoch state
+        // 2. We are in the next epoch: Use the next epoch state as the current epoch
         //    state and reset next epoch state
-        // 3. we are in the next-next or later epoch: use the parent state as the epoch
-        //    state and reset next epoch state
+        // 3. We are in the next-next or later epoch: Use the parent state as the epoch
+        //    state and reset next epoch state. Total stake should be adjusted with zero
+        //    block density for skipped epochs.
         if current_epoch == new_epoch {
             // case 1)
             let next_epoch_state = self
@@ -163,11 +158,20 @@ impl LedgerState {
             Ok(Self {
                 slot,
                 next_epoch_state,
-                block_density: block_density_inference,
                 ..self
             })
         } else if new_epoch == current_epoch + 1 {
             // case 2)
+
+            // infer new total stake
+            let total_stake = self.stake_inference.total_stake_inference::<PRECISION>(
+                self.epoch_state.total_stake,
+                self.block_density.current_block_density(),
+            );
+            let (lottery_0, lottery_1) = config
+                .lottery_constants()
+                .compute_lottery_values(total_stake);
+
             tracing::info!(
                 old_epoch = ?current_epoch,
                 new_epoch = ?new_epoch,
@@ -195,11 +199,28 @@ impl LedgerState {
             })
         } else {
             // case 3)
+
+            // First, infer total stake using block density of the current epoch
+            let mut total_stake = self.stake_inference.total_stake_inference::<PRECISION>(
+                self.epoch_state.total_stake,
+                self.block_density.current_block_density(),
+            );
+            // Adjust total stake with zero block density for skipped epochs
+            for _ in u32::from(self.next_epoch_state.epoch())..u32::from(new_epoch) {
+                total_stake = self
+                    .stake_inference
+                    .total_stake_inference::<PRECISION>(total_stake, 0);
+            }
+            let (lottery_0, lottery_1) = config
+                .lottery_constants()
+                .compute_lottery_values(total_stake);
+
             tracing::warn!(
                 old_epoch = ?current_epoch,
                 new_epoch = ?new_epoch,
                 epochs_skipped = u32::from(new_epoch) - u32::from(current_epoch) - 1,
-                total_stake = total_stake,
+                old_total_stake = self.epoch_state.total_stake,
+                new_total_stake = total_stake,
                 slot = ?slot,
                 "skipped epochs"
             );
@@ -264,10 +285,14 @@ impl LedgerState {
     where
         LeaderProof: leader_proof::LeaderProof,
     {
+        // First, synthesize epoch state for `slot` before update the ledger state.
+        // Then, apply the proof and update the nonce. Finally, increment block density
+        // since this function is called for a new block.
         Ok(self
             .update_epoch_state(slot, config)?
             .try_apply_proof(slot, proof, config)?
-            .update_nonce(&proof.entropy(), slot))
+            .update_nonce(&proof.entropy(), slot)
+            .increment_block_density(slot))
     }
 
     pub fn try_apply_tx<Id, Constants: GasConstants>(
@@ -325,6 +350,15 @@ impl LedgerState {
         Self { nonce, ..self }
     }
 
+    fn increment_block_density(self, slot: Slot) -> Self {
+        let mut block_density = self.block_density.clone();
+        block_density.increment_block_density(slot);
+        Self {
+            block_density,
+            ..self
+        }
+    }
+
     #[must_use]
     pub const fn slot(&self) -> Slot {
         self.slot
@@ -350,58 +384,23 @@ impl LedgerState {
         &self.epoch_state.utxos
     }
 
-    /// Computes the epoch state for a given slot.
+    /// Synthesizes the epoch state for a given slot.
     ///
     /// This handles the case where epochs have been skipped (no blocks
-    /// produced). When the requested epoch is ahead of the stored epoch
-    /// states, it synthesizes an epoch state with adjusted total stake
-    /// using 0 block density for each skipped epoch.
+    /// produced). Details can be found in [`Self::update_epoch_state`].
     ///
-    /// Returns `None` if the requested epoch is in the past (before current
-    /// `epoch_state`).
-    #[must_use]
-    pub fn epoch_state_for_slot(&self, slot: Slot, config: &Config) -> Option<EpochState> {
-        let requested_epoch = config.epoch(slot);
-
-        if self.epoch_state.epoch() == requested_epoch {
-            Some(self.epoch_state.clone())
-        } else if self.next_epoch_state.epoch() == requested_epoch {
-            Some(self.next_epoch_state.clone())
-        } else if requested_epoch > self.next_epoch_state.epoch() {
-            // Epochs were skipped - synthesize epoch state with adjusted total stake.
-            // Use 0 density since no blocks were produced in the skipped epochs.
-            let mut total_stake = self.epoch_state.total_stake;
-
-            for _ in u32::from(self.next_epoch_state.epoch())..u32::from(requested_epoch) {
-                total_stake = self
-                    .stake_inference
-                    .total_stake_inference::<PRECISION>(total_stake, 0);
-            }
-
-            tracing::warn!(
-                "EpochState skipping epochs {}..{}, adjusting total stake: {} -> {}",
-                u32::from(self.next_epoch_state.epoch()),
-                u32::from(requested_epoch),
-                self.epoch_state.total_stake,
-                total_stake
-            );
-
-            let (lottery_0, lottery_1) = config
-                .lottery_constants()
-                .compute_lottery_values(total_stake);
-
-            Some(EpochState {
-                epoch: requested_epoch,
-                nonce: self.nonce,
-                utxos: self.utxos.clone(),
-                total_stake,
-                lottery_0,
-                lottery_1,
-            })
-        } else {
-            // Requested epoch is in the past
-            None
-        }
+    /// Returns [`LedgerError::InvalidSlot`] if the slot is in the past before
+    /// the current ledger state.
+    pub fn epoch_state_for_slot<Id>(
+        &self,
+        slot: Slot,
+        config: &Config,
+    ) -> Result<EpochState, LedgerError<Id>> {
+        Ok(self
+            .clone()
+            .update_epoch_state(slot, config)?
+            .epoch_state()
+            .clone())
     }
 
     pub fn from_genesis_tx<Id>(
@@ -1150,7 +1149,7 @@ pub mod tests {
         // Query for epoch 0 (current epoch) - should return epoch_state
         let epoch_0_slot: Slot = (epoch_length - 1).into();
         let epoch_0_state = ledger_state
-            .epoch_state_for_slot(epoch_0_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_0_slot, &config)
             .expect("Should return epoch state for current epoch");
         assert_eq!(epoch_0_state.epoch, 0.into());
         assert_eq!(epoch_0_state.total_stake, initial_total_stake);
@@ -1158,7 +1157,7 @@ pub mod tests {
         // Query for epoch 1 (next epoch) - should return next_epoch_state
         let epoch_1_slot: Slot = (epoch_length + 1).into();
         let epoch_1_state = ledger_state
-            .epoch_state_for_slot(epoch_1_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_1_slot, &config)
             .expect("Should return epoch state for next epoch");
         assert_eq!(epoch_1_state.epoch, 1.into());
         assert_eq!(epoch_1_state.total_stake, initial_total_stake);
@@ -1167,7 +1166,7 @@ pub mod tests {
         // stake
         let epoch_2_slot: Slot = (2 * epoch_length + 1).into();
         let epoch_2_state = ledger_state
-            .epoch_state_for_slot(epoch_2_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_2_slot, &config)
             .expect("Should synthesize epoch state for skipped epoch");
         assert_eq!(epoch_2_state.epoch, 2.into());
         // With 0 density and LEARNING_RATE=1, total stake drops to minimum (1)
@@ -1179,7 +1178,7 @@ pub mod tests {
         // Query for epoch 3 (multiple skipped epochs) - stake stays at minimum
         let epoch_3_slot: Slot = (3 * epoch_length + 1).into();
         let epoch_3_state = ledger_state
-            .epoch_state_for_slot(epoch_3_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_3_slot, &config)
             .expect("Should synthesize epoch state for multiple skipped epochs");
         assert_eq!(epoch_3_state.epoch, 3.into());
         assert_eq!(
@@ -1190,5 +1189,47 @@ pub mod tests {
         // Verify nonce and utxos are preserved from current state
         assert_eq!(epoch_3_state.nonce, ledger_state.nonce);
         assert_eq!(epoch_3_state.utxos, ledger_state.utxos);
+    }
+
+    /// Test that a proof built from the jumped (synthesized) epoch state can be
+    /// applied successfully
+    #[test]
+    fn test_try_apply_header_with_proof_from_jumped_epoch() {
+        let utxo = utxo();
+        let config = config();
+        let genesis_state = genesis_state(&[utxo]);
+
+        // First, apply a header from epoch 0 to increase block density
+        let slot = Slot::from(1);
+        assert_eq!(config.epoch(slot), 0.into());
+        let proof = generate_proof(&genesis_state, &utxo, slot);
+        let ledger_state_1 = genesis_state
+            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &config)
+            .unwrap();
+
+        // Now, apply a header from the 2nd slot of epoch 2
+        let slot = Slot::from(config.epoch_length() * 2 + 1);
+        assert_eq!(config.epoch(slot), 2.into());
+
+        // First, synthesize epoch state for epoch 2
+        let synthesized_ledger_state = ledger_state_1
+            .clone()
+            .update_epoch_state::<HeaderId>(slot, &config)
+            .unwrap();
+        assert_eq!(synthesized_ledger_state.slot, slot);
+
+        // Build a proof with the synthesized epoch state
+        let proof = generate_proof(&synthesized_ledger_state, &utxo, slot);
+
+        // Apply it to `ledger_state_1`.
+        // Must succeed if epoch state in `ledger_state_1` is jumped
+        // correctly to epoch 2 as the same as `synthesized_ledger_state`.
+        let ledger_state_2 = ledger_state_1
+            .clone()
+            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &config)
+            .unwrap();
+        assert_eq!(ledger_state_2.slot, slot);
+        assert_ne!(ledger_state_2.nonce, ledger_state_1.nonce); // advanced
+        assert_eq!(ledger_state_2.epoch_state.epoch, 2.into());
     }
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -268,9 +268,15 @@ impl LedgerState {
     /// Computes the epoch state for a given slot.
     ///
     /// This handles the case where epochs have been skipped (no blocks
-    /// produced). Returns `None` if the requested epoch is in the past.
-    #[must_use]
-    pub fn epoch_state_for_slot(&self, slot: Slot, config: &Config) -> Option<EpochState> {
+    /// produced).
+    ///
+    /// Returns [`LedgerError::InvalidSlot`] if the slot is in the past before
+    /// the current ledger state.
+    pub fn epoch_state_for_slot<Id>(
+        &self,
+        slot: Slot,
+        config: &Config,
+    ) -> Result<EpochState, LedgerError<Id>> {
         self.cryptarchia_ledger.epoch_state_for_slot(slot, config)
     }
 

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -412,13 +412,13 @@ where
                         let latest_tree = tip_state.latest_utxos();
 
                         let epoch_state = match cryptarchia_api.get_epoch_state(slot).await {
-                            Ok(Some(state)) => state,
-                            Ok(None) => {
-                                error!("trying to propose a block for slot {} but epoch state is not available", u64::from(slot));
+                            Ok(Ok(state)) => state,
+                            Ok(Err(e)) => {
+                                error!("trying to propose a block for slot {} but epoch state is not available: {e}", u64::from(slot));
                                 continue;
                             }
                             Err(e) => {
-                                error!("Failed to get epoch state: {:?}", e);
+                                error!("Failed to get epoch state: {e}");
                                 continue;
                             }
                         };

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -170,7 +170,7 @@ where
     pub async fn get_epoch_state(
         &self,
         slot: lb_cryptarchia_engine::Slot,
-    ) -> Result<Option<lb_ledger::EpochState>, ApiError> {
+    ) -> Result<Result<lb_ledger::EpochState, crate::Error>, ApiError> {
         let (tx, rx) = oneshot::channel();
 
         self.relay

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -124,7 +124,7 @@ pub enum ConsensusMsg<Tx> {
     },
     GetEpochState {
         slot: Slot,
-        tx: oneshot::Sender<Option<EpochState>>,
+        tx: oneshot::Sender<Result<EpochState, Error>>,
     },
     /// Apply a block to the chain,
     /// and return the tip and reorged txs if successful.
@@ -326,10 +326,10 @@ impl Cryptarchia {
         Ok((cryptarchia, pruned_blocks, reorged_blocks))
     }
 
-    fn epoch_state_for_slot(&self, slot: Slot) -> Option<EpochState> {
+    fn epoch_state_for_slot(&self, slot: Slot) -> Result<EpochState, Error> {
         let tip = self.tip();
         let state = self.ledger.state(&tip).expect("no state for tip");
-        state.epoch_state_for_slot(slot, self.ledger.config())
+        Ok(state.epoch_state_for_slot(slot, self.ledger.config())?)
     }
 
     /// Remove the ledger states associated with blocks that have been pruned by
@@ -804,8 +804,8 @@ where
                 });
             }
             ConsensusMsg::GetEpochState { slot, tx } => {
-                let epoch_state = cryptarchia.epoch_state_for_slot(slot);
-                tx.send(epoch_state).unwrap_or_else(|_| {
+                let result = cryptarchia.epoch_state_for_slot(slot);
+                tx.send(result).unwrap_or_else(|_| {
                     error!("Could not send epoch state through channel");
                 });
             }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #2229 

### Background

Recently, we implemented `LedgerState::epoch_state_for_slot` #2076 to query the epoch state for a given slot, supporting skipping empty epochs. It is very useful, but I realized that we already have `LedgerState::update_epoch_state` which is a superset of `epoch_state_for_slot`.

Moreover, each function had its own bugs. 
- `epoch_state_for_slot`
  - It was ignoring the block density accumulated so far for the current epoch.
- `update_epoch_state`
  - It was not adjusting total stake with zero density for the skipped epochs.

### Solution 

I replaced the function body of `epoch_state_for_slot` with a function call of `update_epoch_state`, because it is what we have heavily used. This technique has been already used in the tests. I guess this is what is intended by the original author. https://github.com/logos-blockchain/logos-blockchain/blob/60ed77d5779af5c4d9c977e6dfbeced8cc48d8b3/ledger/src/cryptarchia/mod.rs#L574

You may be worried about the name `update_...`, but it's fine because all functions in the module create a fresh object.

I also fixed `update_epoch_state` to adjust total stake with zero density for skipped epochs.

### Note

As I mentioned in the issue #2229, this bug can prevent block proposals. 
We use `epoch_state_for_slot` for building a PoL. But, we use `update_epoch_state` for applying the block header (i.e., verifying the PoL). If those two functions return different epoch states, PoL verification will be failed.
In this PR, I added a test for this case.

Also, `cryptarchia::LedgerState` is not so easy to read. I have an idea for refactoring (after Lisbon).

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

spec: @davidrusu 
dev: @youngjoon-lee 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
