### PR TITLE
chore(binary): add missing feature gate for InitArgs

### DIFF
--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -125,6 +125,7 @@ pub struct InitArgs {
     pub state_path: Option<PathBuf>,
 }
 
+#[cfg(feature = "config-gen")]
 impl Default for InitArgs {
     fn default() -> Self {
         Self::parse_from::<Vec<String>, String>(vec![])


### PR DESCRIPTION
## 1. What does this PR implement?

All `InitArgs`-related codes should be guarded by the `config-gen` feature gate.
This fixes the CI failure (`Check packages feature combinations`): https://github.com/logos-blockchain/logos-blockchain/actions/runs/22196215075/job/64197139430.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
