### PR TITLE
feat(cfgsync): increase `max_orphan_cache_size` to 1000

### DIFF
--- a/testnet/cfgsync/src/config/consensus.rs
+++ b/testnet/cfgsync/src/config/consensus.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use lb_core::mantle::{Note, Utxo, genesis_tx::GenesisTx};
 use lb_key_management_system_service::keys::{ZkKey, ZkPublicKey};
@@ -19,6 +19,7 @@ pub struct FaucetInfo {
 pub fn create_consensus_configs(
     ids: &[[u8; 32]],
     prolonged_bootstrap_period: Duration,
+    max_orphan_cache_size: NonZeroUsize,
     faucet_settings: &FaucetSettings,
 ) -> (Vec<GeneralConsensusConfig>, Option<FaucetInfo>, GenesisTx) {
     let mut regular_note_keys = Vec::new();
@@ -47,6 +48,7 @@ pub fn create_consensus_configs(
                 funding_pk,
                 other_keys: Vec::new(),
                 prolonged_bootstrap_period,
+                max_orphan_cache_size,
             }
         })
         .collect();

--- a/testnet/cfgsync/src/config/mod.rs
+++ b/testnet/cfgsync/src/config/mod.rs
@@ -16,8 +16,8 @@ use lb_tests::topology::configs::{
     api::GeneralApiConfig,
     blend::GeneralBlendConfig,
     consensus::{
-        GeneralConsensusConfig, ProviderInfo, SHORT_PROLONGED_BOOTSTRAP_PERIOD,
-        create_genesis_tx_with_declarations,
+        BIG_MAX_ORPHAN_CACHE_SIZE, GeneralConsensusConfig, ProviderInfo,
+        SHORT_PROLONGED_BOOTSTRAP_PERIOD, create_genesis_tx_with_declarations,
     },
     network::{NetworkParams, create_network_configs},
     time::default_time_config,
@@ -61,8 +61,12 @@ pub fn create_node_configs(
     // > observable difference for this data type. [stable_sort_primitive]
     ids.sort_unstable();
 
-    let (consensus_configs, faucet_info, genesis_tx) =
-        create_consensus_configs(&ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD, faucet_settings);
+    let (consensus_configs, faucet_info, genesis_tx) = create_consensus_configs(
+        &ids,
+        SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+        BIG_MAX_ORPHAN_CACHE_SIZE,
+        faucet_settings,
+    );
     let faucet_pk = faucet_info.as_ref().map(|f| f.pk);
     let network_configs = create_network_configs(&ids, &NetworkParams::default());
     let blend_configs = create_blend_configs(
@@ -160,6 +164,7 @@ pub fn create_node_config_from_template(
     let (consensus_configs, _, _) = create_consensus_configs(
         &ids,
         SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+        BIG_MAX_ORPHAN_CACHE_SIZE,
         &FaucetSettings::default(),
     );
     let network_configs = create_network_configs(&ids, &NetworkParams::default());

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -343,6 +343,8 @@ pub fn create_validator_config(
             });
         base_config.service.bootstrap.prolonged_bootstrap_period =
             config.consensus_config.prolonged_bootstrap_period;
+        base_config.network.sync.orphan.max_orphan_cache_size =
+            config.consensus_config.max_orphan_cache_size;
         base_config
     };
 

--- a/tests/src/topology/configs/consensus.rs
+++ b/tests/src/topology/configs/consensus.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+use std::num::NonZeroUsize;
 
 use lb_core::{
     mantle::{
@@ -18,6 +19,7 @@ use lb_node::{SignedMantleTx, Transaction as _};
 use num_bigint::BigUint;
 
 pub const SHORT_PROLONGED_BOOTSTRAP_PERIOD: Duration = Duration::from_secs(1);
+pub const BIG_MAX_ORPHAN_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
 
 #[derive(Clone)]
 pub struct ProviderInfo {
@@ -50,6 +52,7 @@ pub struct GeneralConsensusConfig {
     pub funding_pk: ZkPublicKey,
     pub other_keys: Vec<ZkKey>,
     pub prolonged_bootstrap_period: Duration,
+    pub max_orphan_cache_size: NonZeroUsize,
 }
 
 #[derive(Clone, Debug)]
@@ -95,6 +98,7 @@ pub fn create_genesis_tx(utxos: &[Utxo]) -> GenesisTx {
 pub fn create_consensus_configs(
     ids: &[[u8; 32]],
     prolonged_bootstrap_period: Duration,
+    max_orphan_cache_size: NonZeroUsize,
 ) -> (Vec<GeneralConsensusConfig>, GenesisTx) {
     let mut regular_note_keys = Vec::new();
     let mut blend_notes = Vec::new();
@@ -123,6 +127,7 @@ pub fn create_consensus_configs(
                     funding_pk,
                     other_keys: Vec::new(),
                     prolonged_bootstrap_period,
+                    max_orphan_cache_size,
                 }
             })
             .collect(),

--- a/tests/src/topology/configs/mod.rs
+++ b/tests/src/topology/configs/mod.rs
@@ -21,7 +21,9 @@ use tracing::GeneralTracingConfig;
 use crate::{
     common::kms::key_id_for_preload_backend,
     topology::configs::{
-        api::GeneralApiConfig, consensus::SHORT_PROLONGED_BOOTSTRAP_PERIOD, network::NetworkParams,
+        api::GeneralApiConfig,
+        consensus::{BIG_MAX_ORPHAN_CACHE_SIZE, SHORT_PROLONGED_BOOTSTRAP_PERIOD},
+        network::NetworkParams,
         time::GeneralTimeConfig,
     },
 };
@@ -73,8 +75,11 @@ pub fn create_general_configs_with_blend_core_subset(
         blend_ports.push(get_available_udp_port().unwrap());
     }
 
-    let (consensus_configs, genesis_tx) =
-        consensus::create_consensus_configs(&ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
+    let (consensus_configs, genesis_tx) = consensus::create_consensus_configs(
+        &ids,
+        SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+        BIG_MAX_ORPHAN_CACHE_SIZE,
+    );
     let network_configs = network::create_network_configs(&ids, network_params);
     let api_configs = api::create_api_configs(&ids);
     let blend_configs = blend::create_blend_configs(&ids, &blend_ports);

--- a/tests/src/topology/mod.rs
+++ b/tests/src/topology/mod.rs
@@ -24,7 +24,9 @@ use crate::{
     topology::configs::{
         api::create_api_configs,
         blend::{GeneralBlendConfig, create_blend_configs},
-        consensus::{SHORT_PROLONGED_BOOTSTRAP_PERIOD, create_consensus_configs},
+        consensus::{
+            BIG_MAX_ORPHAN_CACHE_SIZE, SHORT_PROLONGED_BOOTSTRAP_PERIOD, create_consensus_configs,
+        },
         deployment::e2e_deployment_settings_with_genesis_tx,
         time::default_time_config,
     },
@@ -94,8 +96,11 @@ impl Topology {
             blend_ports.push(get_available_udp_port().unwrap());
         }
 
-        let (consensus_configs, genesis_tx) =
-            create_consensus_configs(&ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
+        let (consensus_configs, genesis_tx) = create_consensus_configs(
+            &ids,
+            SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+            BIG_MAX_ORPHAN_CACHE_SIZE,
+        );
         let network_configs = create_network_configs(&ids, &config.network_params);
         let blend_configs = create_blend_configs(&ids, &blend_ports);
         let api_configs = create_api_configs(&ids);

--- a/tests/testing_framework/src/node/configs/dynamic.rs
+++ b/tests/testing_framework/src/node/configs/dynamic.rs
@@ -6,7 +6,9 @@ use thiserror::Error;
 use super::node_configs::{
     self, GeneralConfig as Config,
     blend::GeneralBlendConfig,
-    consensus::{GeneralConsensusConfig, SHORT_PROLONGED_BOOTSTRAP_PERIOD},
+    consensus::{
+        BIG_MAX_ORPHAN_CACHE_SIZE, GeneralConsensusConfig, SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+    },
     network::NetworkParams,
     time::GeneralTimeConfig,
 };
@@ -75,8 +77,11 @@ fn build_consensus_config_for_node(
     id: [u8; 32],
     base: &GeneralConsensusConfig,
 ) -> Result<GeneralConsensusConfig, DynamicConfigBuildError> {
-    let (mut configs, _) =
-        node_configs::consensus::create_consensus_configs(&[id], SHORT_PROLONGED_BOOTSTRAP_PERIOD);
+    let (mut configs, _) = node_configs::consensus::create_consensus_configs(
+        &[id],
+        SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+        BIG_MAX_ORPHAN_CACHE_SIZE,
+    );
     let mut config = configs.pop().ok_or(DynamicConfigBuildError::Consensus)?;
     config.blend_notes.clone_from(&base.blend_notes);
 

--- a/tests/testing_framework/src/node/configs/node_configs.rs
+++ b/tests/testing_framework/src/node/configs/node_configs.rs
@@ -29,7 +29,9 @@ use network::GeneralNetworkConfig;
 use tracing::GeneralTracingConfig;
 
 use self::{
-    api::GeneralApiConfig, consensus::SHORT_PROLONGED_BOOTSTRAP_PERIOD, network::NetworkParams,
+    api::GeneralApiConfig,
+    consensus::{BIG_MAX_ORPHAN_CACHE_SIZE, SHORT_PROLONGED_BOOTSTRAP_PERIOD},
+    network::NetworkParams,
     time::GeneralTimeConfig,
 };
 use crate::common::kms::key_id_for_preload_backend;
@@ -67,8 +69,11 @@ pub fn create_general_configs_from_ids(
         ids.len()
     );
 
-    let (consensus_configs, genesis_tx) =
-        consensus::create_consensus_configs(ids, SHORT_PROLONGED_BOOTSTRAP_PERIOD);
+    let (consensus_configs, genesis_tx) = consensus::create_consensus_configs(
+        ids,
+        SHORT_PROLONGED_BOOTSTRAP_PERIOD,
+        BIG_MAX_ORPHAN_CACHE_SIZE,
+    );
     let network_configs = network::create_network_configs(ids, network_params);
     let api_configs = api::create_api_configs(ids);
     let blend_configs = blend::create_blend_configs(ids, blend_ports);


### PR DESCRIPTION
## 1. What does this PR implement?

As discussed in [Discord](https://discord.com/channels/973324189794697286/1474296507707560081/1474301892245848147), this PR adds a `max_orphan_cache_size` to the `GeneralConsensusConfig` and set 1000 to it, allowing nodes to backfill more orphan blocks (sequentially).

Please review if I configured cfgsync correctly, since it's my first time.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?
n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
