### PR TITLE
chore(chain-network): increase default `max_orphan_cache_size` to 1000

### DIFF
--- a/nodes/node/binary/src/config/cryptarchia/serde/network.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/network.rs
@@ -54,7 +54,7 @@ pub struct OrphanConfig {
 impl Default for OrphanConfig {
     fn default() -> Self {
         Self {
-            max_orphan_cache_size: NonZeroUsize::new(5).unwrap(),
+            max_orphan_cache_size: NonZeroUsize::new(1000).unwrap(),
         }
     }
 }

--- a/services/chain/chain-network/src/sync/config.rs
+++ b/services/chain/chain-network/src/sync/config.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use serde::{Deserialize, Serialize};
 
 const MAX_ORPHAN_CACHE_SIZE: NonZeroUsize =
-    NonZeroUsize::new(5).expect("MAX_ORPHAN_CACHE_SIZE must be non-zero");
+    NonZeroUsize::new(1000).expect("MAX_ORPHAN_CACHE_SIZE must be non-zero");
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SyncConfig {


### PR DESCRIPTION
## 1. What does this PR implement?

As discussed in [Discord](https://discord.com/channels/973324189794697286/1474296507707560081/1474301892245848147), this PR increases the default value of `max_orphan_cache_size` from 5 to 1000.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?
n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
