### PR TITLE
fix(libp2p): don't update static address in static mode

### DIFF
--- a/libp2p/src/behaviour/nat/mod.rs
+++ b/libp2p/src/behaviour/nat/mod.rs
@@ -5,8 +5,8 @@ use libp2p::{
     Multiaddr, PeerId, autonat,
     core::{Endpoint, transport::PortUse},
     swarm::{
-        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, NewListenAddr, THandler,
-        THandlerInEvent, THandlerOutEvent, ToSwarm,
+        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
+        THandlerOutEvent, ToSwarm,
         behaviour::toggle::{Toggle, ToggleConnectionHandler},
     },
 };
@@ -126,9 +126,9 @@ impl<Rng: RngCore + 'static> NetworkBehaviour for Behaviour<Rng> {
     fn on_swarm_event(&mut self, event: FromSwarm) {
         if let Some(inner_behaviour) = self.inner_behaviour.as_mut() {
             inner_behaviour.on_swarm_event(event);
-        } else if let FromSwarm::NewListenAddr(NewListenAddr { addr, .. }) = event {
-            self.static_listen_addr = Some(addr.clone());
         }
+        // Static mode: don't overwrite configured external_address with listen
+        // addresses.
     }
 
     fn on_connection_handler_event(


### PR DESCRIPTION
## 1. What does this PR implement?

It looks like we were overwriting the static external address in NAT static mode. This PR removes the branch where the external address was being overwritten, potentially by local address (if behind a NAT, for example). 

More context:
```
192.168.x.x (private LAN):
  Dialing address: /ip4/192.168.5.77/udp/3002/quic-v1/p2p/12D3KooWBGAS8KazCze9xukok6iFEVBZmro88rqY2kRZWGcAxFZJ
  Failed to dial using libp2p_core::transport::map::Map<libp2p_quic...

  127.0.0.1 (localhost):
  Dialing address: /ip4/127.0.0.1/udp/3000/quic-v1/p2p/12D3KooWNWgWAzkvH95ucQitsSmddm7JFtQAsufaBUVS7GB6s6qu
  Failed to dial using libp2p_core::transport::map::Map<libp2p_quic...

  100.x.x.x (CGNAT/Tailscale):
  Dialing address: /ip4/100.107.205.121/udp/3000/quic-v1/p2p/12D3KooWNWgWAzkvH95ucQitsSmddm7JFtQAsufaBUVS7GB6s6qu
  Failed to dial using libp2p_core::transport::map::Map<libp2p_quic...

  10.x.x.x (private):
  Dialing address: /ip4/10.114.0.3/udp/3000/quic-v1/p2p/12D3KooWNWgWAzkvH95ucQitsSmddm7JFtQAsufaBUVS7GB6s6qu
  Failed to dial using libp2p_core::transport::map::Map<libp2p_quic...

  WrongPeerId (connecting to self via localhost):
  Connection attempt to peer failed with WrongPeerId { obtained: PeerId("12D3KooWJzcJ78thxyFyDbda7L5fkj5R2KdEmPveWSME6snyjd1A"), endpoint: Dialer { address: /ip4/127.0.0.1/udp/3000/quic-v1/p2p/12D3KooWKbgpSnw98ru3XgwFscwv4dYSkQnYXfq9tAwYtE6J2tZt
  ```
  
  Nodes were advertising their local addresses along with the public one. This should fix local peer advertisement noise.

## 2. Does the code have enough context to be clearly understood?

Yes
## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes
## 5. Does the implementation introduce changes in the specification?
No
## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
