### PR TITLE
fix(tracing): Reduce otlp logs and node logs

### DIFF
--- a/testnet/cfgsync.yaml
+++ b/testnet/cfgsync.yaml
@@ -16,7 +16,7 @@ tracing_settings:
     otlp:
       endpoint: "http://otel:4317"
       service_name: "init_node"
-    stdout: true
+    stdout: false
     stderr: false
     file:
       directory: "./state/logs"

--- a/testnet/tracing/otel.yaml
+++ b/testnet/tracing/otel.yaml
@@ -12,11 +12,8 @@ exporters:
     tls:
       insecure: true
 
-  debug:
-    verbosity: detailed
-
 service:
   pipelines:
     logs:
       receivers: [otlp]
-      exporters: [otlp_http/loki, debug]
+      exporters: [otlp_http/loki]


### PR DESCRIPTION
## 1. What does this PR implement?

Node was logging to stdout (and in turn to journalctl of docker service), to a file in a container and to the grafana. Now it's reduced to log to a file and to the grafana.

Otel debug logging was removed completely, as node logs are appearing in grafana.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
