### PR TITLE
fix(nat): ignore address mismatch events in confirmed states

### DIFF
--- a/libp2p/src/behaviour/nat/state_machine/transitions/mapped_public.rs
+++ b/libp2p/src/behaviour/nat/state_machine/transitions/mapped_public.rs
@@ -1,3 +1,5 @@
+use tracing::warn;
+
 use crate::behaviour::nat::state_machine::{
     Command, CommandTx, OnEvent, State, event::Event, states::MappedPublic,
 };
@@ -8,11 +10,6 @@ use crate::behaviour::nat::state_machine::{
 /// client to ensure it remains valid. If the address is found to be
 /// unreachable, the state machine transitions to the `TestIfMappedPublic` state
 /// to re-evaluate the address.
-///
-/// ### Panics
-///
-/// This state will panic if it receives an event that does not match the
-/// expected address to test.
 impl OnEvent for State<MappedPublic> {
     fn on_event(self: Box<Self>, event: Event, command_tx: &CommandTx) -> Box<dyn OnEvent> {
         match event {
@@ -37,18 +34,28 @@ impl OnEvent for State<MappedPublic> {
                 }
             }
             Event::ExternalAddressConfirmed(addr) => {
-                panic!(
-                    "State<MappedPublic>: Swarm confirmed external address {}, but {} was expected",
+                warn!(
+                    "State<MappedPublic>: ignoring external address confirmation for {} (expected {}).",
                     addr,
                     self.state.external_address(),
                 );
+                self
             }
-            Event::AutonatClientTestOk(addr) | Event::AutonatClientTestFailed(addr) => {
-                panic!(
-                    "State<MappedPublic>: Autonat client reported address {}, but {} was expected",
+            Event::AutonatClientTestOk(addr) => {
+                warn!(
+                    "State<MappedPublic>: ignoring autonat success for {} (expected {}).",
                     addr,
                     self.state.external_address(),
                 );
+                self
+            }
+            Event::AutonatClientTestFailed(addr) => {
+                warn!(
+                    "State<MappedPublic>: Ignoring failed autonat test for mismatched address {} (expected {}).",
+                    addr,
+                    self.state.external_address(),
+                );
+                self
             }
             _ => self,
         }
@@ -132,34 +139,43 @@ mod tests {
         assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
-    #[should_panic = "State<MappedPublic>: Swarm confirmed external address /memory/1, but /memory/0 was expected"]
     #[test]
-    fn address_mismatch_in_external_address_confirmed_event_causes_panic() {
-        let (tx, _) = unbounded_channel();
+    fn address_mismatch_in_external_address_confirmed_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         state_machine.inner = Some(MappedPublic::for_test(ADDR.clone()));
-        let event = external_address_confirmed_address_mismatch();
-        state_machine.on_test_event(event);
+        state_machine.on_test_event(external_address_confirmed_address_mismatch());
+        assert_eq!(
+            state_machine.inner.as_ref().unwrap(),
+            &MappedPublic::for_test(ADDR.clone())
+        );
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
-    #[should_panic = "State<MappedPublic>: Autonat client reported address /memory/1, but /memory/0 was expected"]
     #[test]
-    fn address_mismatch_in_autonat_ok_event_causes_panic() {
-        let (tx, _) = unbounded_channel();
+    fn address_mismatch_in_autonat_ok_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         state_machine.inner = Some(MappedPublic::for_test(ADDR.clone()));
-        let event = autonat_ok_address_mismatch();
-        state_machine.on_test_event(event);
+        state_machine.on_test_event(autonat_ok_address_mismatch());
+        assert_eq!(
+            state_machine.inner.as_ref().unwrap(),
+            &MappedPublic::for_test(ADDR.clone())
+        );
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
-    #[should_panic = "State<MappedPublic>: Autonat client reported address /memory/1, but /memory/0 was expected"]
     #[test]
-    fn address_mismatch_in_autonat_failed_event_causes_panic() {
-        let (tx, _) = unbounded_channel();
+    fn address_mismatch_in_autonat_failed_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         state_machine.inner = Some(MappedPublic::for_test(ADDR.clone()));
-        let event = autonat_failed_address_mismatch();
-        state_machine.on_test_event(event);
+        state_machine.on_test_event(autonat_failed_address_mismatch());
+        assert_eq!(
+            state_machine.inner.as_ref().unwrap(),
+            &MappedPublic::for_test(ADDR.clone())
+        );
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
     #[test]

--- a/libp2p/src/behaviour/nat/state_machine/transitions/public.rs
+++ b/libp2p/src/behaviour/nat/state_machine/transitions/public.rs
@@ -1,3 +1,5 @@
+use tracing::warn;
+
 use crate::behaviour::nat::state_machine::{
     Command, CommandTx, OnEvent, State, event::Event, states::Public,
 };
@@ -7,11 +9,6 @@ use crate::behaviour::nat::state_machine::{
 /// periodically tested by the `autonat` client to ensure it remains valid. If
 /// the address is found to be unreachable, the state machine transitions to the
 /// `TestIfPublic` state to re-evaluate the address.
-///
-/// ### Panics
-///
-/// This state will panic if it receives an event that does not match the
-/// expected address to test.
 impl OnEvent for State<Public> {
     fn on_event(self: Box<Self>, event: Event, command_tx: &CommandTx) -> Box<dyn OnEvent> {
         match event {
@@ -36,18 +33,28 @@ impl OnEvent for State<Public> {
                 }
             }
             Event::ExternalAddressConfirmed(addr) => {
-                panic!(
-                    "State<Public>: Swarm confirmed external address {}, but {} was expected",
+                warn!(
+                    "State<Public>: ignoring external address confirmation for {} (expected {}).",
                     addr,
                     self.state.address(),
                 );
+                self
             }
-            Event::AutonatClientTestOk(addr) | Event::AutonatClientTestFailed(addr) => {
-                panic!(
-                    "State<Public>: Autonat client reported address {}, but {} was expected",
+            Event::AutonatClientTestOk(addr) => {
+                warn!(
+                    "State<Public>: ignoring autonat success for {} (expected {}).",
                     addr,
                     self.state.address(),
                 );
+                self
+            }
+            Event::AutonatClientTestFailed(addr) => {
+                warn!(
+                    "State<Public>: Ignoring failed autonat test for mismatched address {} (expected {}).",
+                    addr,
+                    self.state.address(),
+                );
+                self
             }
             _ => self,
         }
@@ -131,34 +138,43 @@ mod tests {
         assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
-    #[should_panic = "State<Public>: Swarm confirmed external address /memory/1, but /memory/0 was expected"]
     #[test]
-    fn address_mismatch_in_external_address_confirmed_event_causes_panic() {
-        let (tx, _) = unbounded_channel();
+    fn address_mismatch_in_external_address_confirmed_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         state_machine.inner = Some(Public::for_test(ADDR.clone()));
-        let event = external_address_confirmed_address_mismatch();
-        state_machine.on_test_event(event);
+        state_machine.on_test_event(external_address_confirmed_address_mismatch());
+        assert_eq!(
+            state_machine.inner.as_ref().unwrap(),
+            &Public::for_test(ADDR.clone())
+        );
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
-    #[should_panic = "State<Public>: Autonat client reported address /memory/1, but /memory/0 was expected"]
     #[test]
-    fn address_mismatch_in_autonat_ok_event_causes_panic() {
-        let (tx, _) = unbounded_channel();
+    fn address_mismatch_in_autonat_ok_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         state_machine.inner = Some(Public::for_test(ADDR.clone()));
-        let event = autonat_ok_address_mismatch();
-        state_machine.on_test_event(event);
+        state_machine.on_test_event(autonat_ok_address_mismatch());
+        assert_eq!(
+            state_machine.inner.as_ref().unwrap(),
+            &Public::for_test(ADDR.clone())
+        );
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
-    #[should_panic = "State<Public>: Autonat client reported address /memory/1, but /memory/0 was expected"]
     #[test]
-    fn address_mismatch_in_autonat_failed_event_causes_panic() {
-        let (tx, _) = unbounded_channel();
+    fn address_mismatch_in_autonat_failed_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
         let mut state_machine = StateMachine::new(tx);
         state_machine.inner = Some(Public::for_test(ADDR.clone()));
-        let event = autonat_failed_address_mismatch();
-        state_machine.on_test_event(event);
+        state_machine.on_test_event(autonat_failed_address_mismatch());
+        assert_eq!(
+            state_machine.inner.as_ref().unwrap(),
+            &Public::for_test(ADDR.clone())
+        );
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

Fix follow-up for NAT mismatch handling in confirmed states.

After the previous change made `TestIfPublic` / `TestIfMappedPublic` tolerant, `Public` / `MappedPublic` could still panic on mismatch events (`ExternalAddressConfirmed` / AutoNAT results). In multi-interface environments this still caused network task failure.

Changes:

- `Public` / `MappedPublic`: downgrade mismatch panics to `warn! + ignore` for:
  - `ExternalAddressConfirmed`
  - `AutonatClientTestOk`
  - `AutonatClientTestFailed`
- update transition tests to assert mismatch events are ignored (state unchanged), instead of panic.

No behavior changes to `Uninitialized`, `Private`, or `TryMapAddress`.


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
