### PR TITLE
chore(blend): do not panic on unexpected case and add more logs to proof generation and verification for easier matching

### DIFF
--- a/blend/message/src/crypto/proofs.rs
+++ b/blend/message/src/crypto/proofs.rs
@@ -104,6 +104,9 @@ impl ProofsVerifier for RealProofsVerifier {
 
         // Try with current input, and if it fails, try with the previous one, if any
         // (i.e., within the epoch transition period).
+        tracing::debug!(
+            "Verifying proof of quota {proof:?} with session {session:?}, public core inputs: {core:?}, leader inputs: {leader:?} and signing key: {signing_key:?}."
+        );
         proof
             .verify(&PublicInputs {
                 core,
@@ -116,6 +119,9 @@ impl ProofsVerifier for RealProofsVerifier {
                     tracing::debug!("Input proof invalid and no previous epoch to try with.");
                     return Err(Error::ProofOfQuota(quota::Error::InvalidProof));
                 };
+                tracing::debug!(
+                    "Verifying same proof of quota with previous epoch leader inputs: {previous_epoch_inputs:?}."
+                );
                 proof
                     .verify(&PublicInputs {
                         core,

--- a/blend/proofs/src/quota/mod.rs
+++ b/blend/proofs/src/quota/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt::{self, Debug, Formatter};
 use std::sync::LazyLock;
 
 use ::serde::{Deserialize, Serialize};
@@ -43,12 +44,24 @@ pub enum Error {
 }
 
 /// A Proof of Quota as described in the Blend v1 spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#26a261aa09df80f4b119f900fbb36f3f>.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ProofOfQuota {
     #[serde(with = "lb_groth16::serde::serde_fr")]
     key_nullifier: ZkHash,
     #[serde(with = "self::serde::proof::SerializablePoQProof")]
     proof: PoQProof,
+}
+
+impl Debug for ProofOfQuota {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProofOfQuota")
+            .field(
+                "key_nullifier",
+                &hex::encode(fr_to_bytes(&self.key_nullifier)),
+            )
+            .field("proof", &hex::encode(self.proof.to_bytes()))
+            .finish()
+    }
 }
 
 impl ProofOfQuota {

--- a/blend/scheduling/src/message_blend/provers/core_and_leader/mod.rs
+++ b/blend/scheduling/src/message_blend/provers/core_and_leader/mod.rs
@@ -164,13 +164,17 @@ where
     }
 
     async fn get_next_core_proof(&mut self) -> Option<BlendLayerProof> {
-        self.core_proofs_generator.get_next_proof().await
+        let proof = self.core_proofs_generator.get_next_proof().await?;
+        tracing::debug!(target: LOG_TARGET, "Generated core PoQ {:?} with settings: {:?}, epoch: {:?} and signing key: {:?}", proof.proof_of_quota, self.core_proofs_generator.settings, self.core_proofs_generator.settings.epoch, proof.ephemeral_signing_key.public_key());
+        Some(proof)
     }
 
     async fn get_next_leader_proof(&mut self) -> Option<BlendLayerProof> {
         let Some(leader_proofs_generator) = &mut self.leader_proofs_generator else {
             return None;
         };
-        Some(leader_proofs_generator.get_next_proof().await)
+        let proof = leader_proofs_generator.get_next_proof().await;
+        tracing::debug!(target: LOG_TARGET, "Generated leadership PoQ {:?} with settings: {:?}, epoch: {:?} and signing key: {:?}", proof.proof_of_quota, leader_proofs_generator.settings, leader_proofs_generator.settings.epoch, proof.ephemeral_signing_key.public_key());
+        Some(proof)
     }
 }

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -393,6 +393,7 @@ where
                 }
             }
             Some(message) = incoming_message_stream.next() => {
+                // TODO: Investigate why secret PoL info at times arrives after the block proposal.
                 let Some(handler) = current_pol_info_and_message_handler.as_mut().map(|(_, handler)| handler) else {
                     tracing::warn!(target: LOG_TARGET, "Received a message to blend, but no active message handler is available to process it because the secret PoL info for the current epoch is not yet available. Ignoring the message.");
                     continue;


### PR DESCRIPTION
## 1. What does this PR implement?

* Sometimes, counterintuitively, a block proposal can come in before the new epoch PoL info is received by Blend. We will investigate why this happens, but for now we avoid panicking in Blend edge and there will simply be no block proposed. This is a very narrow window that can happen if a node wins the lottery for a very early slot of a new epoch. Nevertheless, this will be investigated.
* Let's add some more logs (which we will remove or demote to trace later on) to print what inputs are being used when generating and verifying a PoQ, so that we can match exactly the flow of a proof and link them across nodes thanks to the key nullifier.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
