### PR TITLE
revert(libp2p): don't update static address in static mode

### DIFF
--- a/libp2p/src/behaviour/nat/mod.rs
+++ b/libp2p/src/behaviour/nat/mod.rs
@@ -5,8 +5,8 @@ use libp2p::{
     Multiaddr, PeerId, autonat,
     core::{Endpoint, transport::PortUse},
     swarm::{
-        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
-        THandlerOutEvent, ToSwarm,
+        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, NewListenAddr, THandler,
+        THandlerInEvent, THandlerOutEvent, ToSwarm,
         behaviour::toggle::{Toggle, ToggleConnectionHandler},
     },
 };
@@ -126,9 +126,9 @@ impl<Rng: RngCore + 'static> NetworkBehaviour for Behaviour<Rng> {
     fn on_swarm_event(&mut self, event: FromSwarm) {
         if let Some(inner_behaviour) = self.inner_behaviour.as_mut() {
             inner_behaviour.on_swarm_event(event);
+        } else if let FromSwarm::NewListenAddr(NewListenAddr { addr, .. }) = event {
+            self.static_listen_addr = Some(addr.clone());
         }
-        // Static mode: don't overwrite configured external_address with listen
-        // addresses.
     }
 
     fn on_connection_handler_event(


### PR DESCRIPTION
After observing logs from the devnet bootstrap nodes I identified that they initially connected (but through private addresses), but later all retries failed. So basically, all traffic went through outer nodes.  Retries were all on public addresses, so I think this fix was wrong for this use case (for bootnodes). It looks like our nodes could not reach themselves over public address.

I did see both addresses being advertised initially, but then the chain stopped for local ones. 

The quickest fix is to revert this change and accept that local addresses will be advertised as well when static address is set (this had some noise but was working in devnet setup).
