### PR TITLE
fix(devnet): Host and container port collision

### DIFF
--- a/compose.devnet.run.yml
+++ b/compose.devnet.run.yml
@@ -15,7 +15,7 @@ services:
       - NBE_NODE_API_PORT=${NODE0_API_PORT}
       - NBE_BASE_PATH=/web/explorer
     ports:
-      - "8000:8000/tcp"
+      - "13800:8000/tcp"
 
   # TODO: remove after /web/explorer is working
   explorerold:
@@ -28,7 +28,7 @@ services:
       - NBE_NODE_API_PORT=${NODE1_API_PORT}
       - NBE_BASE_PATH=/node/0/explorer
     ports:
-      - "8001:8000/tcp"
+      - "13801:8000/tcp"
 
   cfgsync:
     container_name: cfgsync


### PR DESCRIPTION
## 1. What does this PR implement?

During deployment of 0.1.8 "run" stage one container couldn't start because of a collision with an already occupied port.

## 2. Does the code have enough context to be clearly understood?

N/A

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist


* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
