### PR TITLE
fix(core): `DeclarationId` serde as string

### DIFF
--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -12,6 +12,7 @@ use strum::EnumIter;
 use crate::{
     block::BlockNumber,
     mantle::{NoteId, ops::channel::Ed25519PublicKey},
+    utils::serde_bytes_newtype,
 };
 
 pub type SessionNumber = u64;
@@ -110,8 +111,9 @@ impl Ord for ProviderId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct DeclarationId(pub [u8; 32]);
+serde_bytes_newtype!(DeclarationId, 32);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -241,7 +243,37 @@ fn parse_session_number(input: &[u8]) -> IResult<&[u8], SessionNumber> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use lb_key_management_system_keys::keys::Ed25519Key;
+    use rand::thread_rng;
+
     use super::*;
+    use crate::codec::DeserializeOp as _;
+
+    /// Test that [`DeclarationId`] can be serde-ed correctly
+    /// when used as a key in a HashMap.
+    #[test]
+    fn test_declaration_id_serde_string_key() {
+        let declarations = HashMap::from([(
+            DeclarationId([1; 32]),
+            Declaration {
+                service_type: ServiceType::BlendNetwork,
+                provider_id: ProviderId(Ed25519Key::generate(&mut thread_rng()).public_key()),
+                locked_note_id: NoteId::from_bytes(&[3; 32]).unwrap(),
+                locators: vec![Locator(Multiaddr::empty())],
+                zk_id: ZkPublicKey::from_bytes(&[4; 32]).unwrap(),
+                created: 5,
+                active: 6,
+                withdrawn: None,
+                nonce: 7,
+            },
+        )]);
+        let serialized = serde_json::to_string(&declarations).unwrap();
+        let deserialized: HashMap<DeclarationId, Declaration> =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(declarations, deserialized);
+    }
 
     #[test]
     fn test_activity_metadata_empty_bytes() {


### PR DESCRIPTION
## 1. What does this PR implement?

```
ERROR logos_blockchain_services_utils::overwatch::recovery::operators: key must be a string
```
This PR fixes this error.

This error occurs when serializing a map which has `DeclarationId([u8; 32])` as a key. It must be serialized as a string because JSON requires it, but it was being serialized like `[1, 0, 9, ...]`.

Because of this error, the chain service recovery state was not stored in disk successfully, until the initial declarations were kicked out from SDP because of their inactivity. That is why the error occurred for only the first 5~6 minutes approximately.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
