### PR TITLE
fix(chain-leader): don't wait on ChainNetwork with timeout

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -359,7 +359,6 @@ where
             TxMempoolService<_, _, _, _>,
             TimeService<_, _>,
             CryptarchiaService,
-            ChainNetwork,
             Wallet,
             PreloadKmsService<_>
         )

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -464,7 +464,7 @@ where
             Error::Cryptarchia(lb_chain_service::api::ApiError::ParentMissing { parent, info }) => {
                 orphan_downloader.enqueue_orphan(block_id, info.tip, info.lib);
 
-                error!(
+                info!(
                     target: LOG_TARGET, ?block_id, ?parent,
                     "Parent block missing, enqueued block for orphan processing",
                 );


### PR DESCRIPTION
## 1. What does this PR implement?

Chain-leader was waiting on chain-network twice, once with timeout, second time with no timeout.

Since we are joining a live testnet, IBD takes >20m and the first timeout will trigger causing the chain-leader to halt.

Fix is to remove the chain-network wait with timeout, only wait on chain-network with no timeout.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
