### PR TITLE
fix(tx-service): always gossip user txs, even if it's in mempool

### DIFF
--- a/services/tx-service/src/tx/service.rs
+++ b/services/tx-service/src/tx/service.rs
@@ -402,6 +402,17 @@ where
                     tx_broadcast,
                 );
             }
+            Err(MempoolError::ExistingItem) => {
+                // Tx already in pool, but since this came from a local submission
+                // (not gossip), re-gossip it so leader nodes can pick it up.
+                tokio::spawn(async move {
+                    let adapter = NetworkAdapter::new(settings, network_relay).await;
+                    adapter.send(item_for_broadcast).await;
+                });
+                if let Err(e) = reply_channel.send(Ok(())) {
+                    tracing::debug!("Failed to send add reply: {:?}", e);
+                }
+            }
             Err(e) => Self::handle_add_error(e, reply_channel),
         }
     }


### PR DESCRIPTION
## 1. What does this PR implement?

When a sequencer submits a tx to the local node's HTTP API and the tx is already in the mempool, `pool.add_item()` returns `Err(ExistingItem)`. The current code calls handle_add_error which just returns the error. So the tx is never gossiped.
Meanwhile, leader nodes may have already purged the tx from their mempools. The sequencer keeps resubmitting, but the tx never reaches leaders because the local node short-circuits on ExistingItem.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ

## 4. Is the specification accurate and complete?

NA

## 5. Does the implementation introduce changes in the specification?

NA

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
