### PR TITLE
fix(ledger): do not lose the latest nonce update when transitioning epoch

### DIFF
--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -149,7 +149,8 @@ impl LedgerState {
         // First, update the next epoch nonce using the ledger state
         // that was updated by the previous slot (block).
         // TODO: Refactor: Guarantee that `next_epoch_state` is always updated
-        // whenever `LedgerState` is updated before Lottery Constants Finalization period
+        // whenever `LedgerState` is updated before Lottery Constants Finalization
+        // period starts.
         let next_epoch_state = self
             .next_epoch_state
             .clone()


### PR DESCRIPTION
## 1. What does this PR implement?

### Background

There is an edge case that we haven't covered correctly for a long time. The scenario is:
1. In the epoch E, a block B is applied to the ledger at the slot 10. Assuming that the epoch length is 100 slots, this block is within the [Stake Distribution Snapshot](https://www.notion.so/nomos-tech/Cryptarchia-v1-Protocol-Specification-21c261aa09df810cb85eff1c76e5798c?source=copy_link#21c261aa09df81a6ad71e403bbc9fa4f). Therefore, it must contribute to the nonce for the next epoch E+1. 
2. But, if **no more block** is received during the rest of epoch E, the nonce contribution from the block B is lost, and the epoch N+1 is started. This is a **bug**. Whenever a block is received before the [Lottery Constants Finalization](https://www.notion.so/nomos-tech/Cryptarchia-v1-Protocol-Specification-21c261aa09df810cb85eff1c76e5798c?source=copy_link#21c261aa09df81a6ad71e403bbc9fa4f) period starts, its nonce contribution must be included in the next epoch.

This bug doesn't happen if at least one block is received during the Lottery Constants Finalization period. That's why it was not detected in the tests (though the tests were not enough).

### Solution

We should make sure that any block received before Lottery Constants Finalization must always update `LedgerState::next_epoch_state`. Unfortunately, the current code structure is not so easy to follow.
https://github.com/logos-blockchain/logos-blockchain/blob/ca022e416c216c9bf6458a8070ee4af74fce0213/ledger/src/cryptarchia/mod.rs#L304-L321
As above, we first synthesize the ledger state for the `slot`. In this step, we update `LedgerState::next_epoch_state` only when the epoch is **not** transitioning:
https://github.com/logos-blockchain/logos-blockchain/blob/ca022e416c216c9bf6458a8070ee4af74fce0213/ledger/src/cryptarchia/mod.rs#L152-L162
After that, we update `LedgerState::nonce` (in the 1st link of the code), and that's it. If the epoch E+1 starts without no more new block in the epoch E, the nonce, which was previously updated, is lost because we don't update `LedgerState::next_epoch_state` when the epoch is transitioning (in the 2nd link of the code).

**This PR fixes this bug by updating `LedgerState::next_epoch_state` for ALL cases when synthesizing the ledger state.**

Yeah, it's hard to explain the flow. It may be better to read the test change first. This is a quick fix just for easy reviews, but I will refactor this module substantially in a next PR (maybe after Devnet). The long three-branches in the `if` statement is not maintainable. We have been postponing it for a long time. I left TODO comments.


## 2. Does the code have enough context to be clearly understood?

I hope so.

## 3. Who are the specification authors and who is accountable for this PR?

spec: @davidrusu 
dev: @youngjoon-lee 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
