### PR TITLE
fix(sync): Upgrade buffers size in sync to support bigger msg sizes

### DIFF
--- a/consensus/cryptarchia-sync/src/libp2p/packing.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/packing.rs
@@ -7,9 +7,9 @@ use thiserror::Error;
 
 type Result<T> = std::result::Result<T, PackingError>;
 
-type LenType = u16;
+type LenType = u32;
 const MAX_MSG_LEN_BYTES: usize = size_of::<LenType>();
-const MAX_MSG_LEN: usize = LenType::MAX as usize;
+const MAX_MSG_LEN: usize = 16 * 1024 * 1024; // 16 MiB;
 
 #[derive(Debug, Error)]
 pub enum PackingError {


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes buffer sizes on sync now that we support bigger messages.

## 2. Does the code have enough context to be clearly understood?

Small change

## 3. Who are the specification authors and who is accountable for this PR?

@andrussal @youngjoon-lee @danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
