### PR TITLE
feat: persist banned Blend peers across restarts

### DIFF
--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -20,7 +20,7 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use crate::core::{
     backends::{
-        BlendBackend, PublicInfo, SessionInfo,
+        BlendBackend, PeerEvent, PublicInfo, SessionInfo,
         libp2p::{
             swarm::{BlendSwarm, BlendSwarmMessage, SwarmParams},
             tokio_provider::ObservationWindowTokioIntervalProvider,
@@ -47,6 +47,7 @@ pub struct Libp2pBlendBackend {
     swarm_task_abort_handle: AbortHandle,
     swarm_message_sender: mpsc::Sender<BlendSwarmMessage>,
     incoming_message_sender: broadcast::Sender<EncapsulatedMessageWithVerifiedPublicHeader>,
+    peer_event_sender: broadcast::Sender<PeerEvent<PeerId>>,
 }
 
 const CHANNEL_SIZE: usize = 64;
@@ -68,6 +69,7 @@ where
     ) -> Self {
         let (swarm_message_sender, swarm_message_receiver) = mpsc::channel(CHANNEL_SIZE);
         let (incoming_message_sender, _) = broadcast::channel(CHANNEL_SIZE);
+        let (peer_event_sender, _) = broadcast::channel(CHANNEL_SIZE);
         let minimum_network_size = config.minimum_network_size.try_into().unwrap();
 
         let swarm = BlendSwarm::<_, ProofsVerifier, ObservationWindowTokioIntervalProvider>::new(
@@ -75,6 +77,7 @@ where
                 config: &config,
                 current_public_info,
                 incoming_message_sender: incoming_message_sender.clone(),
+                peer_event_sender: peer_event_sender.clone(),
                 minimum_network_size,
                 rng,
                 swarm_message_receiver,
@@ -90,6 +93,7 @@ where
             swarm_task_abort_handle,
             swarm_message_sender,
             incoming_message_sender,
+            peer_event_sender,
         }
     }
 
@@ -152,6 +156,13 @@ where
     ) -> Pin<Box<dyn Stream<Item = EncapsulatedMessageWithVerifiedPublicHeader> + Send>> {
         Box::pin(
             BroadcastStream::new(self.incoming_message_sender.subscribe())
+                .filter_map(async |event| event.ok()),
+        )
+    }
+
+    fn listen_to_peer_events(&mut self) -> Pin<Box<dyn Stream<Item = PeerEvent<PeerId>> + Send>> {
+        Box::pin(
+            BroadcastStream::new(self.peer_event_sender.subscribe())
                 .filter_map(async |event| event.ok()),
         )
     }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -34,7 +34,7 @@ use tokio::sync::{broadcast, mpsc};
 
 use crate::core::{
     backends::{
-        PublicInfo, SessionInfo,
+        PeerEvent, PublicInfo, SessionInfo,
         libp2p::{
             LOG_TARGET, Libp2pBlendBackendSettings,
             behaviour::{BlendBehaviour, BlendBehaviourEvent},
@@ -79,6 +79,7 @@ where
     swarm: Swarm<BlendBehaviour<ProofsVerifier, ObservationWindowProvider>>,
     swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
     incoming_message_sender: broadcast::Sender<EncapsulatedMessageWithVerifiedPublicHeader>,
+    peer_event_sender: broadcast::Sender<PeerEvent<PeerId>>,
     public_info: PublicInfo<PeerId>,
     rng: Rng,
     max_dial_attempts_per_connection: NonZeroU64,
@@ -92,6 +93,7 @@ pub struct SwarmParams<'config, Rng> {
     pub rng: Rng,
     pub swarm_message_receiver: mpsc::Receiver<BlendSwarmMessage>,
     pub incoming_message_sender: broadcast::Sender<EncapsulatedMessageWithVerifiedPublicHeader>,
+    pub peer_event_sender: broadcast::Sender<PeerEvent<PeerId>>,
     pub minimum_network_size: NonZeroUsize,
 }
 
@@ -113,6 +115,7 @@ where
             rng,
             swarm_message_receiver: swarm_messages_receiver,
             incoming_message_sender,
+            peer_event_sender,
             minimum_network_size,
         }: SwarmParams<Rng>,
     ) -> Self {
@@ -144,6 +147,7 @@ where
             swarm,
             swarm_messages_receiver,
             incoming_message_sender,
+            peer_event_sender,
             public_info: current_public_info,
             rng,
             max_dial_attempts_per_connection: config.backend.max_dial_attempts_per_peer,
@@ -216,14 +220,22 @@ where
 
     fn handle_disconnected_peer(&mut self, peer_id: PeerId, peer_state: NegotiatedPeerState) {
         tracing::debug!(target: LOG_TARGET, "Peer {peer_id} disconnected with state {peer_state:?}.");
-        if peer_state.is_spammy() {
+        if let NegotiatedPeerState::Spammy(spam_reason) = peer_state {
             self.swarm.behaviour_mut().blocked_peers.block_peer(peer_id);
+            drop(self.peer_event_sender.send(PeerEvent::Banned {
+                id: peer_id,
+                reason: spam_reason,
+            }));
         }
         self.check_and_dial_new_peers_except(Some(peer_id));
     }
 
     fn handle_unhealthy_peer(&mut self, peer_id: PeerId) {
         tracing::debug!(target: LOG_TARGET, "Peer {peer_id} is unhealthy");
+        drop(
+            self.peer_event_sender
+                .send(PeerEvent::Unhealthy { id: peer_id }),
+        );
         self.check_and_dial_new_peers_except(Some(peer_id));
     }
 
@@ -239,7 +251,7 @@ where
                 self.handle_unhealthy_peer(peer_id);
             }
             lb_blend::network::core::with_core::behaviour::Event::HealthyPeer(peer_id) => {
-                Self::handle_healthy_peer(peer_id);
+                self.handle_healthy_peer(peer_id);
             }
             lb_blend::network::core::with_core::behaviour::Event::PeerDisconnected(
                 peer_id,
@@ -409,8 +421,12 @@ where
             .available_connection_slots()
     }
 
-    fn handle_healthy_peer(peer_id: PeerId) {
+    fn handle_healthy_peer(&self, peer_id: PeerId) {
         tracing::debug!(target: LOG_TARGET, "Peer {peer_id} is healthy again");
+        drop(
+            self.peer_event_sender
+                .send(PeerEvent::Healthy { id: peer_id }),
+        );
     }
 
     fn handle_blend_edge_behaviour_event(&mut self, blend_event: CoreToEdgeEvent) {
@@ -544,6 +560,7 @@ where
         behaviour_constructor: BehaviourConstructor,
         swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
         incoming_message_sender: broadcast::Sender<EncapsulatedMessageWithVerifiedPublicHeader>,
+        peer_event_sender: broadcast::Sender<PeerEvent<PeerId>>,
         current_public_info: PublicInfo<PeerId>,
         rng: Rng,
         max_dial_attempts_per_connection: NonZeroU64,
@@ -561,6 +578,7 @@ where
         let membership = current_public_info.session.membership.clone();
         Self {
             incoming_message_sender,
+            peer_event_sender,
             public_info: current_public_info,
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -125,12 +125,14 @@ impl SwarmBuilder {
     {
         let (swarm_message_sender, swarm_message_receiver) = mpsc::channel(100);
         let (incoming_message_sender, incoming_message_receiver) = broadcast::channel(100);
+        let (incoming_peer_event_sender, _incoming_peer_event_receiver) = broadcast::channel(100);
 
         let swarm = BlendSwarm::new_test(
             &self.identity,
             behaviour_constructor,
             swarm_message_receiver,
             incoming_message_sender,
+            incoming_peer_event_sender,
             self.public_info,
             BlakeRng::from_entropy(),
             3u64.try_into().unwrap(),

--- a/services/blend/src/core/backends/mod.rs
+++ b/services/blend/src/core/backends/mod.rs
@@ -9,6 +9,7 @@ use lb_blend::{
             validated::EncapsulatedMessageWithVerifiedPublicHeader,
         },
     },
+    network::core::with_core::behaviour::SpamReason,
     proofs::quota::inputs::prove::public::{CoreInputs, LeaderInputs},
     scheduling::{membership::Membership, session::SessionEvent},
 };
@@ -146,4 +147,16 @@ pub trait BlendBackend<NodeId, Rng, ProofsVerifier, RuntimeServiceId> {
     fn listen_to_incoming_messages(
         &mut self,
     ) -> Pin<Box<dyn Stream<Item = EncapsulatedMessageWithVerifiedPublicHeader> + Send>>;
+
+    fn listen_to_peer_events(&mut self) -> Pin<Box<dyn Stream<Item = PeerEvent<NodeId>> + Send>>;
+}
+
+#[derive(Debug, Clone)]
+pub enum PeerEvent<NodeId> {
+    // Node went from healthy to unhealthy.
+    Unhealthy { id: NodeId },
+    // Node went from unhealthy to healthy.
+    Healthy { id: NodeId },
+    // Node was banned for misbehavior (e.g., spamming).
+    Banned { id: NodeId, reason: SpamReason },
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -82,7 +82,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     core::{
-        backends::{PublicInfo, SessionInfo},
+        backends::{PeerEvent, PublicInfo, SessionInfo},
         kms::{KmsPoQAdapter, PreloadKMSBackendCorePoQGenerator},
         processor::{
             CoreCryptographicProcessor, DecapsulatedMessageType, Error,
@@ -141,9 +141,10 @@ pub struct BlendService<
 > where
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
+    NodeId: Eq + Hash,
 {
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-    last_saved_state: Option<ServiceState<Backend::Settings, Network::BroadcastSettings>>,
+    last_saved_state: Option<ServiceState<Backend::Settings, Network::BroadcastSettings, NodeId>>,
     _phantom: PhantomData<(
         Backend,
         MembershipAdapter,
@@ -184,12 +185,13 @@ impl<
 where
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
     Network: NetworkAdapter<RuntimeServiceId>,
+    NodeId: Eq + Hash,
 {
     type Settings = StartingBlendConfig<Backend::Settings>;
-    type State = RecoveryServiceState<Backend::Settings, Network::BroadcastSettings>;
+    type State = RecoveryServiceState<Backend::Settings, Network::BroadcastSettings, NodeId>;
     type StateOperator = RecoveryOperator<
         JsonFileBackend<
-            RecoveryServiceState<Backend::Settings, Network::BroadcastSettings>,
+            RecoveryServiceState<Backend::Settings, Network::BroadcastSettings, NodeId>,
             StartingBlendConfig<Backend::Settings>,
         >,
     >;
@@ -444,6 +446,7 @@ where
         let secret_pol_info_stream = post_initialize::<PolInfoProvider, _>(overwatch_handle).await;
 
         let mut blend_messages = backend.listen_to_incoming_messages();
+        let peer_events = backend.listen_to_peer_events();
 
         // Run the main event loop while the node is a core node across multiple
         // sessions. When the node becomes a non-core node in a new session, the
@@ -458,6 +461,7 @@ where
         ) = run_event_loop(
             inbound_relay,
             &mut blend_messages,
+            peer_events,
             &mut remaining_clock_stream,
             secret_pol_info_stream,
             &mut remaining_session_stream,
@@ -524,9 +528,11 @@ async fn initialize<
     overwatch_handle: OverwatchHandle<RuntimeServiceId>,
     kms_adapter: KmsAdapter,
     sdp_relay: &OutboundRelay<SdpMessage>,
-    mut last_saved_state: Option<ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>>,
+    mut last_saved_state: Option<
+        ServiceState<Backend::Settings, NetAdapter::BroadcastSettings, NodeId>,
+    >,
     state_updater: StateUpdater<
-        Option<RecoveryServiceState<Backend::Settings, NetAdapter::BroadcastSettings>>,
+        Option<RecoveryServiceState<Backend::Settings, NetAdapter::BroadcastSettings, NodeId>>,
     >,
 ) -> (
     impl Stream<Item = SessionEvent<MaybeEmptyCoreSessionInfo<NodeId, KmsAdapter::CorePoQGenerator>>>
@@ -542,7 +548,7 @@ async fn initialize<
         ProofsGenerator,
         ProofsVerifier,
     >,
-    ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>,
+    ServiceState<Backend::Settings, NetAdapter::BroadcastSettings, NodeId>,
     SchedulerWrapper<
         BlakeRng,
         ProcessedMessage<NetAdapter::BroadcastSettings>,
@@ -813,6 +819,7 @@ async fn run_event_loop<
     blend_messages: &mut (
              impl Stream<Item = EncapsulatedMessageWithVerifiedPublicHeader> + Send + Unpin + 'static
          ),
+    mut peer_events: impl Stream<Item = PeerEvent<NodeId>> + Send + Unpin + 'static,
     remaining_clock_stream: &mut (impl Stream<Item = SlotTick> + Send + Sync + Unpin + 'static),
     mut secret_pol_info_stream: impl Stream<Item = PolEpochInfo> + Unpin,
     remaining_session_stream: &mut (
@@ -840,7 +847,7 @@ async fn run_event_loop<
     >,
     mut public_info: PublicInfo<NodeId>,
     mut epoch: Epoch,
-    mut recovery_checkpoint: ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>,
+    mut recovery_checkpoint: ServiceState<Backend::Settings, NetAdapter::BroadcastSettings, NodeId>,
 ) -> (
     CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
     OldSessionMessageScheduler<Rng, ProcessedMessage<NetAdapter::BroadcastSettings>>,
@@ -892,6 +899,9 @@ where
             }
             Some(incoming_message) = blend_messages.next() => {
                 recovery_checkpoint = handle_incoming_blend_message(incoming_message, &mut message_scheduler, old_session_message_scheduler.as_mut(), &crypto_processor, old_session_crypto_processor.as_ref(),  recovery_checkpoint);
+            }
+            _ = peer_events.next() => {
+                unimplemented!()
             }
             Some(round_info) = message_scheduler.next() => {
                 recovery_checkpoint = handle_release_round(round_info, &mut crypto_processor, rng, backend, network_adapter,  recovery_checkpoint).await;
@@ -1065,7 +1075,7 @@ async fn handle_session_event<
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
     current_public_info: PublicInfo<NodeId>,
-    current_recovery_checkpoint: ServiceState<Backend::Settings, BroadcastSettings>,
+    current_recovery_checkpoint: ServiceState<Backend::Settings, BroadcastSettings, NodeId>,
     backend: &mut Backend,
     sdp_relay: &OutboundRelay<SdpMessage>,
     current_epoch: Epoch,
@@ -1097,7 +1107,7 @@ where
                     membership: new_membership,
                 },
         })) => {
-            let (_, _, _, _, current_session_blending_token_collector, _, state_updater) =
+            let (_, _, _, _, current_session_blending_token_collector, _, _, state_updater) =
                 current_recovery_checkpoint.into_components();
 
             let new_reward_session_info = reward::SessionInfo::new(
@@ -1185,7 +1195,7 @@ where
         }
         SessionEvent::NewSession(MaybeEmptyCoreSessionInfo::Empty { session }) => {
             tracing::info!(target: LOG_TARGET, "New session event received, but no session info is available due to empty membership set.");
-            let (_, _, _, _, current_session_blending_token_collector, _, _) =
+            let (_, _, _, _, current_session_blending_token_collector, _, _, _) =
                 current_recovery_checkpoint.into_components();
             let new_reward_session_info = reward::SessionInfo::new(
                 session,
@@ -1256,7 +1266,9 @@ enum HandleSessionEventOutput<
     BackendSettings,
     BroadcastSettings,
     CorePoQGenerator,
-> {
+> where
+    NodeId: Eq + Hash,
+{
     Transitioning {
         new_crypto_processor:
             CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
@@ -1269,7 +1281,7 @@ enum HandleSessionEventOutput<
         >,
         old_scheduler: OldSessionMessageScheduler<Rng, ProcessedMessage<BroadcastSettings>>,
         new_public_info: PublicInfo<NodeId>,
-        new_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
+        new_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
     },
     TransitionCompleted {
         current_crypto_processor:
@@ -1280,7 +1292,7 @@ enum HandleSessionEventOutput<
             EncapsulatedMessageWithVerifiedPublicHeader,
         >,
         current_public_info: PublicInfo<NodeId>,
-        new_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
+        new_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
     },
     Retiring {
         old_crypto_processor:
@@ -1318,10 +1330,10 @@ async fn handle_serialized_local_data_message<
         ProcessedMessage<BroadcastSettings>,
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
-    current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
-) -> ServiceState<BackendSettings, BroadcastSettings>
+    current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
+) -> ServiceState<BackendSettings, BroadcastSettings, NodeId>
 where
-    NodeId: Eq + Hash + Send + 'static,
+    NodeId: Eq + Hash + Clone + Send + 'static,
     Rng: RngCore + Clone + Send + Unpin,
     BackendSettings: Clone + Send + Sync,
     BroadcastSettings:
@@ -1431,10 +1443,10 @@ fn handle_incoming_blend_message<
     old_session_cryptographic_processor: Option<
         &CoreCryptographicProcessor<NodeId, CorePoQGenerator, ProofsGenerator, ProofsVerifier>,
     >,
-    current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
-) -> ServiceState<BackendSettings, BroadcastSettings>
+    current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
+) -> ServiceState<BackendSettings, BroadcastSettings, NodeId>
 where
-    NodeId: 'static,
+    NodeId: Eq + Hash + Clone + 'static,
     Rng: RngCore + Clone + Send + Unpin,
     BroadcastSettings: Serialize + for<'de> Deserialize<'de> + Debug + Eq + Hash + Clone + Send,
     BackendSettings: Clone,
@@ -1533,6 +1545,7 @@ fn handle_decapsulated_incoming_message_from_current_session<
     Rng,
     BroadcastSettings,
     BackendSettings,
+    NodeId,
 >(
     multi_layer_decapsulation_output: MultiLayerDecapsulationOutput,
     scheduler: &mut SessionMessageScheduler<
@@ -1540,11 +1553,12 @@ fn handle_decapsulated_incoming_message_from_current_session<
         ProcessedMessage<BroadcastSettings>,
         EncapsulatedMessageWithVerifiedPublicHeader,
     >,
-    current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
-) -> ServiceState<BackendSettings, BroadcastSettings>
+    current_recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
+) -> ServiceState<BackendSettings, BroadcastSettings, NodeId>
 where
     BroadcastSettings: Serialize + for<'de> Deserialize<'de> + Debug + Eq + Hash + Clone + Send,
     BackendSettings: Clone,
+    NodeId: Eq + Hash + Clone,
 {
     let mut state_updater = current_recovery_checkpoint.start_updating();
 
@@ -1565,14 +1579,20 @@ where
 /// and collects the blending tokens obtained from the decapsulation.
 ///
 /// It updates the recovery checkpoint by storing the collected tokens.
-fn handle_decapsulated_incoming_message_from_old_session<Rng, BroadcastSettings, BackendSettings>(
+fn handle_decapsulated_incoming_message_from_old_session<
+    Rng,
+    BroadcastSettings,
+    BackendSettings,
+    NodeId,
+>(
     multi_layer_decapsulation_output: MultiLayerDecapsulationOutput,
     scheduler: &mut OldSessionMessageScheduler<Rng, ProcessedMessage<BroadcastSettings>>,
-    recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings>,
-) -> ServiceState<BackendSettings, BroadcastSettings>
+    recovery_checkpoint: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
+) -> ServiceState<BackendSettings, BroadcastSettings, NodeId>
 where
     BroadcastSettings: Serialize + for<'de> Deserialize<'de> + Debug + Eq + Hash + Clone + Send,
     BackendSettings: Clone,
+    NodeId: Eq + Hash + Clone,
 {
     let (_, blending_tokens) =
         schedule_decapsulated_incoming_message(multi_layer_decapsulation_output, scheduler);
@@ -1670,10 +1690,14 @@ async fn handle_release_round<
     rng: &mut Rng,
     backend: &Backend,
     network_adapter: &NetAdapter,
-    current_recovery_checkpoint: ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>,
-) -> ServiceState<Backend::Settings, NetAdapter::BroadcastSettings>
+    current_recovery_checkpoint: ServiceState<
+        Backend::Settings,
+        NetAdapter::BroadcastSettings,
+        NodeId,
+    >,
+) -> ServiceState<Backend::Settings, NetAdapter::BroadcastSettings, NodeId>
 where
-    NodeId: Eq + Hash + 'static,
+    NodeId: Eq + Hash + Clone + 'static,
     Rng: RngCore + Send,
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId> + Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator>,
@@ -1779,7 +1803,7 @@ fn build_futures_to_release_processed_messages<
     backend: &'fut Backend,
     network_adapter: &'fut NetAdapter,
     mut state_updater: Option<
-        &mut ServiceStateUpdater<Backend::Settings, NetAdapter::BroadcastSettings>,
+        &mut ServiceStateUpdater<Backend::Settings, NetAdapter::BroadcastSettings, NodeId>,
     >,
 ) -> Vec<BoxFuture<'fut, ()>>
 where
@@ -1830,7 +1854,7 @@ async fn generate_and_try_to_decapsulate_cover_message<
         ProofsGenerator,
         ProofsVerifier,
     >,
-    state_updater: &mut state::StateUpdater<BackendSettings, BroadcastSettings>,
+    state_updater: &mut state::StateUpdater<BackendSettings, BroadcastSettings, NodeId>,
 ) -> Option<EncapsulatedMessage>
 where
     NodeId: Eq + Hash + 'static,

--- a/services/blend/src/core/service_components.rs
+++ b/services/blend/src/core/service_components.rs
@@ -1,3 +1,5 @@
+use core::hash::Hash;
+
 use lb_utils::blake_rng::BlakeRng;
 
 use crate::{
@@ -45,6 +47,7 @@ impl<
 where
     Backend: BlendBackend<NodeId, BlakeRng, ProofsVerifier, RuntimeServiceId>,
     Network: crate::core::network::NetworkAdapter<RuntimeServiceId>,
+    NodeId: Eq + Hash,
 {
     type NetworkAdapter = Network;
     type BackendSettings = Backend::Settings;

--- a/services/blend/src/core/state.rs
+++ b/services/blend/src/core/state.rs
@@ -1,4 +1,5 @@
 mod serde {
+    use core::hash::Hash;
     use std::collections::HashSet;
 
     use lb_blend::message::{
@@ -16,7 +17,10 @@ mod serde {
     /// Recovery state that is serialized and deserialized to file.
     ///
     /// For details about its fields, check [`ServiceState`].
-    pub struct SerializableServiceState<BroadcastSettings> {
+    pub struct SerializableServiceState<BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
         last_seen_session: u64,
         spent_core_quota: u64,
         #[serde(bound(
@@ -26,21 +30,26 @@ mod serde {
         unsent_data_messages: HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
         current_session_token_collector: SessionBlendingTokenCollector,
         old_session_token_collector: Option<OldSessionBlendingTokenCollector>,
+        banned_peers: HashSet<NodeId>,
     }
 
-    impl<BroadcastSettings> SerializableServiceState<BroadcastSettings> {
+    impl<BroadcastSettings, NodeId> SerializableServiceState<BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
         /// Consume the serializable state to create an actual state object, by
         /// passing it an Overwatch
         /// [`overwatch::services::state::StateUpdater`].
         pub fn try_into_state_with_state_updater<BackendSettings>(
             self,
             state_updater: overwatch::services::state::StateUpdater<
-                Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>,
+                Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>,
             >,
-        ) -> Result<ServiceState<BackendSettings, BroadcastSettings>, error::SessionMismatch>
+        ) -> Result<ServiceState<BackendSettings, BroadcastSettings, NodeId>, error::SessionMismatch>
         where
             BackendSettings: Clone,
             BroadcastSettings: Clone,
+            NodeId: Clone,
         {
             ServiceState::new(
                 self.last_seen_session,
@@ -49,15 +58,19 @@ mod serde {
                 self.unsent_data_messages,
                 self.current_session_token_collector,
                 self.old_session_token_collector,
+                self.banned_peers,
                 state_updater,
             )
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> From<ServiceState<BackendSettings, BroadcastSettings>>
-        for SerializableServiceState<BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        From<ServiceState<BackendSettings, BroadcastSettings, NodeId>>
+        for SerializableServiceState<BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
     {
-        fn from(value: ServiceState<BackendSettings, BroadcastSettings>) -> Self {
+        fn from(value: ServiceState<BackendSettings, BroadcastSettings, NodeId>) -> Self {
             let (
                 last_seen_session,
                 spent_core_quota,
@@ -65,6 +78,7 @@ mod serde {
                 unsent_data_messages,
                 current_session_token_collector,
                 old_session_token_collector,
+                banned_peers,
                 _,
             ) = value.into_components();
             Self {
@@ -74,6 +88,7 @@ mod serde {
                 unsent_data_messages,
                 current_session_token_collector,
                 old_session_token_collector,
+                banned_peers,
             }
         }
     }
@@ -99,7 +114,10 @@ mod service {
 
     #[derive(Clone)]
     /// Recovery state for Blend core service.
-    pub struct ServiceState<BackendSettings, BroadcastSettings> {
+    pub struct ServiceState<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
         /// The last session that was saved.
         last_seen_session: u64,
         /// The last value for the core quota allowance for the session that is
@@ -109,14 +127,17 @@ mod service {
         unsent_data_messages: HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
         current_session_token_collector: SessionBlendingTokenCollector,
         old_session_token_collector: Option<OldSessionBlendingTokenCollector>,
+        banned_peers: HashSet<NodeId>,
         state_updater: overwatch::services::state::StateUpdater<
-            Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>,
+            Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>,
         >,
     }
 
-    impl<BackendSettings, BroadcastSettings> Debug for ServiceState<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId> Debug
+        for ServiceState<BackendSettings, BroadcastSettings, NodeId>
     where
         BroadcastSettings: Debug,
+        NodeId: Eq + Hash + Debug,
     {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
             f.debug_struct("ServiceState")
@@ -132,17 +153,21 @@ mod service {
                     "old_session_token_collector",
                     &self.old_session_token_collector,
                 )
+                .field("banned_peers", &self.banned_peers)
                 .finish_non_exhaustive()
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> ServiceState<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        ServiceState<BackendSettings, BroadcastSettings, NodeId>
     where
         BackendSettings: Clone,
         BroadcastSettings: Clone,
+        NodeId: Eq + Hash + Clone,
     {
         // Creates a new instance with the provided fields, and saves it using
         // `state_updater`.
+        #[expect(clippy::too_many_arguments, reason = "TODO: Change into a struct.")]
         pub(super) fn new(
             last_seen_session: u64,
             spent_core_quota: u64,
@@ -150,8 +175,9 @@ mod service {
             unsent_data_messages: HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
             current_session_token_collector: SessionBlendingTokenCollector,
             old_session_token_collector: Option<OldSessionBlendingTokenCollector>,
+            banned_peers: HashSet<NodeId>,
             state_updater: overwatch::services::state::StateUpdater<
-                Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>,
+                Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>,
             >,
         ) -> Result<Self, error::SessionMismatch> {
             // Check if `current_session_token_collector` has the correct session number.
@@ -183,6 +209,7 @@ mod service {
                 unsent_data_messages,
                 current_session_token_collector,
                 old_session_token_collector,
+                banned_peers,
                 state_updater,
             };
             this.save();
@@ -201,7 +228,7 @@ mod service {
             current_session_token_collector: SessionBlendingTokenCollector,
             old_session_token_collector: Option<OldSessionBlendingTokenCollector>,
             state_updater: overwatch::services::state::StateUpdater<
-                Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>,
+                Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>,
             >,
         ) -> Result<Self, error::SessionMismatch> {
             Self::new(
@@ -211,6 +238,7 @@ mod service {
                 HashSet::new(),
                 current_session_token_collector,
                 old_session_token_collector,
+                HashSet::new(),
                 state_updater,
             )
         }
@@ -220,11 +248,17 @@ mod service {
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> ServiceState<BackendSettings, BroadcastSettings> {
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        ServiceState<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
         /// Consume `self` to return a [`StateUpdater`], which can be used to
         /// batch changes before they are stored using the underlying
         /// [`overwatch::services::state::StateUpdater`].
-        pub const fn start_updating(self) -> StateUpdater<BackendSettings, BroadcastSettings> {
+        pub const fn start_updating(
+            self,
+        ) -> StateUpdater<BackendSettings, BroadcastSettings, NodeId> {
             StateUpdater::new(self)
         }
 
@@ -293,8 +327,9 @@ mod service {
             HashSet<EncapsulatedMessageWithVerifiedPublicHeader>,
             SessionBlendingTokenCollector,
             Option<OldSessionBlendingTokenCollector>,
+            HashSet<NodeId>,
             overwatch::services::state::StateUpdater<
-                Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>,
+                Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>,
             >,
         ) {
             (
@@ -304,14 +339,17 @@ mod service {
                 self.unsent_data_messages,
                 self.current_session_token_collector,
                 self.old_session_token_collector,
+                self.banned_peers,
                 self.state_updater,
             )
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> ServiceState<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        ServiceState<BackendSettings, BroadcastSettings, NodeId>
     where
         BroadcastSettings: Eq + Hash,
+        NodeId: Eq + Hash,
     {
         pub(super) fn add_unsent_processed_message(
             &mut self,
@@ -389,22 +427,31 @@ mod state_updater {
     /// A state updater which gathers changes to the underlying [`ServiceState`]
     /// before committing them via the underlying
     /// [`overwatch::services::state::StateUpdater`].
-    pub struct StateUpdater<BackendSettings, BroadcastSettings> {
-        inner: ServiceState<BackendSettings, BroadcastSettings>,
+    pub struct StateUpdater<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
+        inner: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
         /// Flag indicating whether ANY changes happened since this object
         /// creation.
         changed: bool,
     }
 
-    impl<BackendSettings, BroadcastSettings> StateUpdater<BackendSettings, BroadcastSettings> {
-        pub(super) const fn new(inner: ServiceState<BackendSettings, BroadcastSettings>) -> Self {
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        StateUpdater<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
+        pub(super) const fn new(
+            inner: ServiceState<BackendSettings, BroadcastSettings, NodeId>,
+        ) -> Self {
             Self {
                 inner,
                 changed: false,
             }
         }
 
-        pub fn into_inner(self) -> ServiceState<BackendSettings, BroadcastSettings> {
+        pub fn into_inner(self) -> ServiceState<BackendSettings, BroadcastSettings, NodeId> {
             self.inner
         }
 
@@ -424,7 +471,7 @@ mod state_updater {
         /// before consuming it to produce this state updater instance.
         pub fn consume_without_committing(
             self,
-        ) -> ServiceState<BackendSettings, BroadcastSettings> {
+        ) -> ServiceState<BackendSettings, BroadcastSettings, NodeId> {
             self.inner
         }
 
@@ -452,15 +499,17 @@ mod state_updater {
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> StateUpdater<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        StateUpdater<BackendSettings, BroadcastSettings, NodeId>
     where
         BackendSettings: Clone,
         BroadcastSettings: Clone,
+        NodeId: Eq + Hash + Clone,
     {
         /// Consumes `self` and stores the latest state via the underlying
         /// `overwatch::services::state::StateUpdater`, returning the updated
         /// [`ServiceState`].
-        pub fn commit_changes(self) -> ServiceState<BackendSettings, BroadcastSettings> {
+        pub fn commit_changes(self) -> ServiceState<BackendSettings, BroadcastSettings, NodeId> {
             if self.changed {
                 self.inner.save();
             }
@@ -468,9 +517,11 @@ mod state_updater {
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> StateUpdater<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        StateUpdater<BackendSettings, BroadcastSettings, NodeId>
     where
         BroadcastSettings: Eq + Hash,
+        NodeId: Eq + Hash,
     {
         /// Mark a new [`ProcessedMessage`] as unsent, meaning that it has been
         /// decapsulated and scheduled for release but not yet released.
@@ -530,7 +581,7 @@ mod state_updater {
 
 pub use self::recovery_state::RecoveryServiceState;
 mod recovery_state {
-    use core::{convert::Infallible, marker::PhantomData};
+    use core::{convert::Infallible, hash::Hash, marker::PhantomData};
 
     use serde::{Deserialize, Serialize};
 
@@ -548,18 +599,24 @@ mod recovery_state {
     ///
     /// If Overwatch will start supporting optional states, this type will most
     /// likely go.
-    pub struct RecoveryServiceState<BackendSettings, BroadcastSettings> {
+    pub struct RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
+    {
         #[serde(bound(
-            deserialize = "BroadcastSettings: Deserialize<'de> + Eq + core::hash::Hash"
+            deserialize = "BroadcastSettings: Deserialize<'de> + Eq + core::hash::Hash, NodeId: Deserialize<'de>"
         ))]
-        pub service_state: Option<SerializableServiceState<BroadcastSettings>>,
+        pub service_state: Option<SerializableServiceState<BroadcastSettings, NodeId>>,
         _phantom: PhantomData<BackendSettings>,
     }
 
-    impl<BackendSettings, BroadcastSettings> From<ServiceState<BackendSettings, BroadcastSettings>>
-        for RecoveryServiceState<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId>
+        From<ServiceState<BackendSettings, BroadcastSettings, NodeId>>
+        for RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
     {
-        fn from(value: ServiceState<BackendSettings, BroadcastSettings>) -> Self {
+        fn from(value: ServiceState<BackendSettings, BroadcastSettings, NodeId>) -> Self {
             Self {
                 _phantom: PhantomData,
                 service_state: Some(value.into()),
@@ -567,8 +624,10 @@ mod recovery_state {
         }
     }
 
-    impl<BackendSettings, BroadcastSettings> overwatch::services::state::ServiceState
-        for RecoveryServiceState<BackendSettings, BroadcastSettings>
+    impl<BackendSettings, BroadcastSettings, NodeId> overwatch::services::state::ServiceState
+        for RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>
+    where
+        NodeId: Eq + Hash,
     {
         type Error = Infallible;
         type Settings = BlendConfig<BackendSettings>;

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -48,7 +48,7 @@ type RuntimeServiceId = ();
 #[test_log::test(tokio::test)]
 async fn test_handle_incoming_blend_message() {
     let (_, _, state_updater, _state_receiver) =
-        dummy_overwatch_resources::<(), (), RuntimeServiceId>();
+        dummy_overwatch_resources::<(), (), _, RuntimeServiceId>();
 
     // Prepare a encapsulated message.
     let mut session = 0;
@@ -125,7 +125,7 @@ async fn test_handle_incoming_blend_message() {
     );
     let (mut new_scheduler, mut scheduler) =
         scheduler.rotate_session(scheduler_session_info(&public_info), scheduler_settings);
-    let (_, _, _, _, current_token_collector, _, state_updater) =
+    let (_, _, _, _, current_token_collector, _, _, state_updater) =
         recovery_checkpoint.into_components();
     let (new_token_collector, old_token_collector) =
         current_token_collector.rotate_session(&reward_session_info(&public_info));
@@ -258,7 +258,7 @@ async fn test_handle_incoming_blend_message() {
 
 #[test_log::test(tokio::test)]
 async fn test_handle_session_transition_expired() {
-    let (overwatch_handle, _, _, _) = dummy_overwatch_resources::<(), (), RuntimeServiceId>();
+    let (overwatch_handle, _, _, _) = dummy_overwatch_resources::<(), (), (), RuntimeServiceId>();
 
     // Prepare settings.
     let session = 0;
@@ -339,7 +339,7 @@ async fn test_handle_session_event() {
     use lb_chain_service::Epoch;
 
     let (overwatch_handle, _overwatch_cmd_receiver, state_updater, _state_receiver) =
-        dummy_overwatch_resources::<(), (), RuntimeServiceId>();
+        dummy_overwatch_resources::<(), (), _, RuntimeServiceId>();
 
     // Prepare components for session event handling.
     let session = 0;
@@ -533,6 +533,7 @@ async fn complete_old_session_after_main_loop_done() {
     // Prepare streams.
     let (inbound_relay, _inbound_message_sender) = new_stream();
     let (mut blend_message_stream, _blend_message_sender) = new_stream();
+    let (blend_peer_event_stream, _) = new_stream();
     let (membership_stream, membership_sender) = new_stream();
     let (clock_stream, clock_sender) = new_stream();
 
@@ -624,6 +625,7 @@ async fn complete_old_session_after_main_loop_done() {
         ) = run_event_loop(
             inbound_relay,
             &mut blend_message_stream,
+            blend_peer_event_stream,
             &mut remaining_clock_stream,
             secret_pol_info_stream,
             &mut remaining_session_stream,
@@ -711,6 +713,7 @@ async fn stop_on_empty_session() {
     // Prepare streams.
     let (inbound_relay, _inbound_message_sender) = new_stream();
     let (mut blend_message_stream, _blend_message_sender) = new_stream();
+    let (blend_peer_event_stream, _) = new_stream();
     let (membership_stream, membership_sender) = new_stream();
     let (clock_stream, clock_sender) = new_stream();
 
@@ -802,6 +805,7 @@ async fn stop_on_empty_session() {
         ) = run_event_loop(
             inbound_relay,
             &mut blend_message_stream,
+            blend_peer_event_stream,
             &mut remaining_clock_stream,
             secret_pol_info_stream,
             &mut remaining_session_stream,

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -1,3 +1,4 @@
+use core::hash::Hash;
 use std::{num::NonZeroU64, pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
@@ -53,7 +54,7 @@ use tokio_stream::wrappers::{BroadcastStream, ReceiverStream};
 
 use crate::{
     core::{
-        backends::{BlendBackend, EpochInfo, PublicInfo, SessionInfo},
+        backends::{BlendBackend, EpochInfo, PeerEvent, PublicInfo, SessionInfo},
         kms::KmsPoQAdapter,
         network::NetworkAdapter,
         processor::CoreCryptographicProcessor,
@@ -192,6 +193,10 @@ where
     ) -> Pin<Box<dyn Stream<Item = EncapsulatedMessageWithVerifiedPublicHeader> + Send>> {
         unimplemented!()
     }
+
+    fn listen_to_peer_events(&mut self) -> Pin<Box<dyn Stream<Item = PeerEvent<NodeId>> + Send>> {
+        unimplemented!()
+    }
 }
 
 impl TestBlendBackend {
@@ -276,18 +281,21 @@ impl<RuntimeServiceId> NetworkBackend<RuntimeServiceId> for TestNetworkBackend {
 }
 
 #[expect(clippy::type_complexity, reason = "a test utility")]
-pub fn dummy_overwatch_resources<BackendSettings, BroadcastSettings, RuntimeServiceId>() -> (
+pub fn dummy_overwatch_resources<BackendSettings, BroadcastSettings, NodeId, RuntimeServiceId>() -> (
     OverwatchHandle<RuntimeServiceId>,
     mpsc::Receiver<OverwatchCommand<RuntimeServiceId>>,
-    StateUpdater<Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>>,
-    watch::Receiver<Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>>,
-) {
+    StateUpdater<Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>>,
+    watch::Receiver<Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>>,
+)
+where
+    NodeId: Eq + Hash,
+{
     let (cmd_sender, cmd_receiver) = mpsc::channel(CHANNEL_SIZE);
     let handle =
         OverwatchHandle::<RuntimeServiceId>::new(tokio::runtime::Handle::current(), cmd_sender);
     let (state_sender, state_receiver) = watch::channel(None);
     let state_updater = StateUpdater::<
-        Option<RecoveryServiceState<BackendSettings, BroadcastSettings>>,
+        Option<RecoveryServiceState<BackendSettings, BroadcastSettings, NodeId>>,
     >::new(Arc::new(state_sender));
 
     (handle, cmd_receiver, state_updater, state_receiver)


### PR DESCRIPTION
## 1. What does this PR implement?

As discussed at the offsite, we want to persist banned peers across restarts. In a separate discussion + PR, we will implement pruning logic to unban peers based on the reason why they were banned in the first place.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 implementation, @madxor spec writer

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
