### PR TITLE
fix(ledger): use rpds for pending vouchers in mantle ledger

### DIFF
--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -105,6 +105,9 @@ impl EpochState {
 
 /// Tracks bedrock transactions and minimal the state needed for consensus to
 /// work.
+///
+/// NOTE: Most collection fields in this struct should use `rpds`
+/// since we keep a copy of this state for each block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Derivative)]
 #[derivative(Clone, Eq, PartialEq)]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -128,6 +128,10 @@ where
     }
 }
 
+/// A ledger state
+///
+/// NOTE: Most collection fields in this struct should use `rpds`
+/// since we keep a copy of this state for each block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct LedgerState {

--- a/ledger/src/mantle/leader.rs
+++ b/ledger/src/mantle/leader.rs
@@ -9,10 +9,14 @@ use lb_core::{
 };
 use lb_cryptarchia_engine::Epoch;
 use lb_utxotree::{DynamicMerkleTree, MerklePath};
-use rpds::HashTrieMapSync;
+use rpds::{HashTrieMapSync, VectorSync};
 
 use crate::Balance;
 
+/// A leader state in the mantle ledger.
+///
+/// NOTE: Most collection fields in this struct should use `rpds`
+/// since we keep a copy of this state for each block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LeaderState {
@@ -37,7 +41,7 @@ pub struct LeaderState {
     claimable_voucher_indices: HashTrieMapSync<VoucherCm, usize>,
     // List of vouchers that are waiting to be added at the start of
     // the next epoch
-    pending_vouchers: Vec<VoucherCm>,
+    pending_vouchers: VectorSync<VoucherCm>,
 }
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -67,7 +71,7 @@ impl LeaderState {
             claimable_rewards: 0,
             claimable_vouchers: DynamicMerkleTree::new(),
             claimable_voucher_indices: HashTrieMapSync::new_sync(),
-            pending_vouchers: Vec::new(),
+            pending_vouchers: VectorSync::new_sync(),
         }
     }
 
@@ -96,7 +100,7 @@ impl LeaderState {
     /// Add a voucher to be included in the Merkle tree at the start of the
     /// next epoch
     fn add_pending_voucher(mut self, voucher_cm: VoucherCm) -> Self {
-        self.pending_vouchers.push(voucher_cm);
+        self.pending_vouchers.push_back_mut(voucher_cm);
         self
     }
 
@@ -109,7 +113,7 @@ impl LeaderState {
             self.claimable_voucher_indices =
                 self.claimable_voucher_indices.insert(voucher_cm, index);
         }
-        self.pending_vouchers = Vec::new();
+        self.pending_vouchers = VectorSync::new_sync();
         self.claimable_vouchers_root = self.claimable_vouchers.root().into();
         self.n_claimable_vouchers = self.claimable_vouchers.size() as u64;
         self

--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -38,7 +38,10 @@ pub enum Error {
     NoteNotFound(NoteId),
 }
 
-/// Tracks mantle ops
+/// A state of the mantle ledger
+///
+/// NOTE: Most collection fields in this struct should use `rpds`
+/// since we keep a copy of this state for each block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
 pub struct LedgerState {

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -373,6 +373,10 @@ impl<R: Rewards> ServiceState<R> {
     }
 }
 
+/// A SDP state of the mantle ledger
+///
+/// NOTE: Most collection fields in this struct should use `rpds`
+/// since we keep a copy of this state for each block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct SdpLedger {


### PR DESCRIPTION
## 1. What does this PR implement?
A ledger state should contain collections as [`rpds`](https://docs.rs/rpds/latest/rpds/) which supports structural sharing. Most of collection fields are already `rpds`, but only `pending_vouchers` is a plain `Vec`. Because of this, a node consumes lots of memory during bootstrapping, since it keeps a copy of ledger state for each block.

This PR fixes it by using `rdps::VectorSync`, which reduces memory consumption during bootstrapping from 800MiB -> 350MiB.
<img width="417" height="55" alt="image" src="https://github.com/user-attachments/assets/1d7c164a-6ada-4f41-b892-5fa5d3848ce4" />
<img width="396" height="49" alt="image" src="https://github.com/user-attachments/assets/547122fb-b20b-4875-be0f-8f2a8a4f66ab" />
(IBD downloaded blocks from the genesis to the tip at the height 18,000).


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

This is an implementation detail.

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
