### PR TITLE
fix(chain): make Ledger mutable to eliminate unnecessary clones

### DIFF
--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -593,7 +593,7 @@ pub mod tests {
             .unwrap();
         let id = make_id(parent, slot, utxo);
         let proof = generate_proof(&ledger_state, &utxo, slot);
-        *ledger = ledger.try_update::<_, MainnetGasConstants>(
+        ledger.try_update::<_, MainnetGasConstants>(
             id,
             parent,
             slot,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -70,16 +70,16 @@ where
         }
     }
 
-    /// Create a new [`Ledger`] with the updated state.
-    #[must_use = "Returns a new instance with the updated state, without modifying the original."]
+    /// Try to update the ledger state by applying the given proof and
+    /// transactions on top of the parent state.
     pub fn try_update<LeaderProof, Constants>(
-        &self,
+        &mut self,
         id: Id,
         parent_id: Id,
         slot: Slot,
         proof: &LeaderProof,
         txs: impl Iterator<Item = impl AuthenticatedMantleTx>,
-    ) -> Result<Self, LedgerError<Id>>
+    ) -> Result<(), LedgerError<Id>>
     where
         LeaderProof: leader_proof::LeaderProof,
         Constants: GasConstants,
@@ -94,12 +94,8 @@ where
                 .clone()
                 .try_update::<_, _, Constants>(slot, proof, txs, &self.config)?;
 
-        let mut states = self.states.clone();
-        states.insert(id, new_state);
-        Ok(Self {
-            states,
-            config: self.config.clone(),
-        })
+        self.states.insert(id, new_state);
+        Ok(())
     }
 
     pub fn state(&self, id: &Id) -> Option<&LedgerState> {
@@ -362,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_ledger_try_update_with_transaction() {
-        let (ledger, genesis_id, utxo) = create_test_ledger();
+        let (mut ledger, genesis_id, utxo) = create_test_ledger();
         let mut output_note = Note::new(1, ZkPublicKey::new(BigUint::from(1u8).into()));
         let sk = ZkKey::from(BigUint::from(0u8));
         // determine fees
@@ -384,7 +380,7 @@ mod tests {
         );
 
         let new_id = [1; 32];
-        let new_ledger = ledger
+        ledger
             .try_update::<_, MainnetGasConstants>(
                 new_id,
                 genesis_id,
@@ -395,7 +391,7 @@ mod tests {
             .unwrap();
 
         // Verify the transaction was applied
-        let new_state = new_ledger.state(&new_id).unwrap();
+        let new_state = ledger.state(&new_id).unwrap();
         assert!(!new_state.latest_utxos().contains(&utxo.id()));
 
         // Verify output was created

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -262,13 +262,12 @@ impl Cryptarchia {
         self.consensus.lib()
     }
 
-    /// Create a new [`Cryptarchia`] with the updated state.
-    #[must_use = "Returns a new instance with the updated state, without modifying the original."]
+    /// Try to apply a block to the chain.
     fn try_apply_block<Tx>(
-        &self,
+        &mut self,
         block: &Block<Tx>,
         current_slot: Slot,
-    ) -> Result<(Self, PrunedBlocks<HeaderId>, ReorgedBlocks<HeaderId>), Error>
+    ) -> Result<(PrunedBlocks<HeaderId>, ReorgedBlocks<HeaderId>), Error>
     where
         Tx: AuthenticatedMantleTx,
     {
@@ -286,8 +285,7 @@ impl Cryptarchia {
         }
 
         // A block number of this block if it's applied to the chain.
-        let ledger = self
-            .ledger
+        self.ledger
             .try_update::<_, MainnetGasConstants>(
                 id,
                 parent,
@@ -302,6 +300,7 @@ impl Cryptarchia {
                 },
                 err => Error::Ledger(err),
             })?;
+
         let UpdatedCryptarchia {
             cryptarchia: consensus,
             pruned_blocks,
@@ -316,16 +315,12 @@ impl Cryptarchia {
                 },
                 err => Error::Consensus(err),
             })?;
+        self.consensus = consensus;
 
-        let mut cryptarchia = Self {
-            ledger,
-            consensus,
-            genesis_id: self.genesis_id,
-        };
         // Prune the ledger states of all the pruned blocks.
-        cryptarchia.prune_ledger_states(pruned_blocks.all());
+        self.prune_ledger_states(pruned_blocks.all());
 
-        Ok((cryptarchia, pruned_blocks, reorged_blocks))
+        Ok((pruned_blocks, reorged_blocks))
     }
 
     fn epoch_state_for_slot(&self, slot: Slot) -> Result<EpochState, Error> {
@@ -896,7 +891,7 @@ where
     #[expect(clippy::allow_attributes_without_reason)]
     #[instrument(level = "debug", skip(cryptarchia, relays))]
     async fn process_block(
-        cryptarchia: Cryptarchia,
+        mut cryptarchia: Cryptarchia,
         block: Block<Tx>,
         current_slot: Slot,
         relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
@@ -915,8 +910,7 @@ where
             }
         };
 
-        let (cryptarchia, pruned_blocks, reorged_blocks) =
-            cryptarchia.try_apply_block(&block, current_slot)?;
+        let (pruned_blocks, reorged_blocks) = cryptarchia.try_apply_block(&block, current_slot)?;
         let new_lib = cryptarchia.lib();
 
         relays


### PR DESCRIPTION
## 1. What does this PR implement?
The `Ledger` struct that contains a set of `LedgerState`s doesn't need to be designed as an immutable data structure. Unlike `LedgerState`, it's better to define `Ledger` as mutable to eliminate unnecessary clones (even though clones were being dropped immediately).

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
