### PR TITLE
feat: add sequencer inscription lineage tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,6 +4819,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "tracing-appender",
  "tracing-subscriber 0.3.22",
 ]
 
@@ -4964,6 +4965,7 @@ name = "logos-blockchain-zone-sdk"
 version = "0.2.1"
 dependencies = [
  "futures",
+ "hex",
  "logos-blockchain-common-http-client",
  "logos-blockchain-core",
  "logos-blockchain-key-management-system-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ version = "0.2.1"
 dependencies = [
  "clap",
  "hex",
+ "logos-blockchain-common-http-client",
  "logos-blockchain-core",
  "logos-blockchain-key-management-system-service",
  "logos-blockchain-zone-sdk",

--- a/core/src/mantle/ops/channel/mod.rs
+++ b/core/src/mantle/ops/channel/mod.rs
@@ -19,6 +19,11 @@ impl MsgId {
     pub const fn root() -> Self {
         Self([0; 32])
     }
+
+    #[must_use]
+    pub fn as_hex(&self) -> String {
+        hex::encode(self.as_ref())
+    }
 }
 
 impl From<[u8; 32]> for MsgId {
@@ -53,5 +58,12 @@ impl AsRef<[u8; 32]> for ChannelId {
 impl From<ChannelId> for [u8; 32] {
     fn from(channel_id: ChannelId) -> Self {
         channel_id.0
+    }
+}
+
+impl ChannelId {
+    #[must_use]
+    pub fn as_hex(&self) -> String {
+        hex::encode(self.as_ref())
     }
 }

--- a/core/src/mantle/tx.rs
+++ b/core/src/mantle/tx.rs
@@ -11,6 +11,7 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
+    codec::SerializeOp as _,
     crypto::ZkHasher,
     mantle::{
         AuthenticatedMantleTx, Transaction, TransactionHasher,
@@ -75,6 +76,11 @@ impl TxHash {
     #[must_use]
     pub fn as_signing_bytes(&self) -> Bytes {
         self.0.0.0.iter().flat_map(|b| b.to_le_bytes()).collect()
+    }
+
+    #[must_use]
+    pub fn as_hex(&self) -> String {
+        hex::encode(self.to_bytes().unwrap_or_default())
     }
 }
 

--- a/nodes/node/http-client/Cargo.toml
+++ b/nodes/node/http-client/Cargo.toml
@@ -26,4 +26,3 @@ serde                         = { workspace = true }
 serde_json                    = { default-features = false, version = "1.0.140" }
 thiserror                     = "1.0"
 url                           = { default-features = false, version = "2.5.4" }
-

--- a/nodes/node/http-client/Cargo.toml
+++ b/nodes/node/http-client/Cargo.toml
@@ -26,3 +26,4 @@ serde                         = { workspace = true }
 serde_json                    = { default-features = false, version = "1.0.140" }
 thiserror                     = "1.0"
 url                           = { default-features = false, version = "2.5.4" }
+

--- a/testnet/tui-zone/Cargo.toml
+++ b/testnet/tui-zone/Cargo.toml
@@ -30,4 +30,5 @@ rand                             = { workspace = true }
 reqwest                          = { workspace = true }
 serde_json                       = { workspace = true }
 tokio                            = { default-features = false, features = ["macros", "rt-multi-thread", "signal", "sync"], version = "1" }
+tracing-appender                 = "0.2.4"
 tracing-subscriber               = { features = ["env-filter"], version = "0.3" }

--- a/testnet/tui-zone/Cargo.toml
+++ b/testnet/tui-zone/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 [dependencies]
 clap                             = { features = ["derive", "env", "std"], version = "4" }
 hex                              = "0.4"
+lb-common-http-client            = { workspace = true }
 lb-core                          = { workspace = true }
 lb-key-management-system-service = { workspace = true }
 lb-zone-sdk                      = { workspace = true }

--- a/testnet/tui-zone/src/lib.rs
+++ b/testnet/tui-zone/src/lib.rs
@@ -1,10 +1,22 @@
-use std::{fs, io::Write as _, path::Path};
+use std::{
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use clap::Parser;
 use lb_core::mantle::ops::channel::ChannelId;
 use lb_key_management_system_service::keys::{ED25519_SECRET_KEY_SIZE, Ed25519Key};
-use lb_zone_sdk::sequencer::{SequencerCheckpoint, ZoneSequencer};
+use lb_zone_sdk::sequencer::{InscriptionId, SequencerCheckpoint, ZoneSequencer};
 use reqwest::Url;
+use tracing_subscriber::{
+    Layer as _, filter::LevelFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _,
+};
+
+const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const STATUS_CHECK_TIMEOUT: Duration = Duration::from_secs(1200); // 20 minutes
 
 #[derive(Parser, Debug)]
 #[command(about = "Terminal UI zone sequencer - publish text inscriptions")]
@@ -55,12 +67,83 @@ fn load_or_create_signing_key(path: &Path) -> Ed25519Key {
     }
 }
 
+async fn wait_for_on_chain_status(
+    sequencer: Arc<ZoneSequencer>,
+    inscription_id: InscriptionId,
+) -> Result<bool, lb_zone_sdk::sequencer::Error> {
+    let deadline = tokio::time::Instant::now() + STATUS_CHECK_TIMEOUT;
+
+    loop {
+        if sequencer.status(inscription_id).await?.is_on_chain() {
+            return Ok(true);
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+
+        tokio::time::sleep(STATUS_POLL_INTERVAL).await;
+    }
+}
+
+async fn persist_checkpoint_when_on_chain(
+    msg: &str,
+    sequencer: Arc<ZoneSequencer>,
+    checkpoint_path: PathBuf,
+    inscription_id: InscriptionId,
+) {
+    let start = tokio::time::Instant::now();
+    let tx_hash = hex::encode(<[u8; 32]>::from(inscription_id));
+    let msg = capped_msg(msg, 20);
+    match wait_for_on_chain_status(Arc::<ZoneSequencer>::clone(&sequencer), inscription_id).await {
+        Ok(true) => {
+            println!(
+                "\n    mined tx: {tx_hash}/'{msg}' after {:.2?}\n> ",
+                start.elapsed()
+            );
+            match sequencer.checkpoint().await {
+                Ok(checkpoint) => {
+                    save_checkpoint(&checkpoint_path, &checkpoint);
+                }
+                Err(e) => {
+                    println!(
+                        "\n    error tx: {tx_hash}/'{msg}' failed to fetch & save checkpoint: {e}"
+                    );
+                }
+            }
+        }
+        Ok(false) => {
+            println!(
+                "\n    warning tx: {tx_hash}/'{msg}' not on-chain after {:?}\n> ",
+                start.elapsed()
+            );
+        }
+        Err(e) => {
+            println!(
+                "\n    error tx: {tx_hash}/'{msg}' status check failed after {:?}: {e}\n> ",
+                start.elapsed()
+            );
+        }
+    }
+}
+
 pub async fn run(args: InscribeArgs) {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-        )
+    let file_appender = tracing_appender::rolling::daily("logs", "tui-zone.log");
+    let (log_writer, _log_guard) = tracing_appender::non_blocking(file_appender);
+
+    let console_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stdout)
+        .with_ansi(true)
+        .with_filter(LevelFilter::WARN);
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(log_writer)
+        .with_ansi(false)
+        .with_filter(LevelFilter::DEBUG);
+
+    tracing_subscriber::registry()
+        .with(console_layer)
+        .with(file_layer)
         .init();
 
     let node_url: Url = args.node_url.parse().expect("invalid node URL");
@@ -79,7 +162,13 @@ pub async fn run(args: InscribeArgs) {
         println!("  Restored checkpoint from {}", args.checkpoint_path);
     }
 
-    let sequencer = ZoneSequencer::init(channel_id, signing_key, node_url, None, checkpoint);
+    let sequencer = Arc::new(ZoneSequencer::init(
+        channel_id,
+        signing_key,
+        node_url,
+        None,
+        checkpoint,
+    ));
 
     println!();
     println!("Type a message and press Enter to publish it as a zone block.");
@@ -97,21 +186,34 @@ pub async fn run(args: InscribeArgs) {
         let bytes_read = stdin.read_line(&mut line).expect("failed to read line");
 
         if bytes_read == 0 {
-            // EOF
             println!();
             break;
         }
 
-        let msg = line.trim_end();
+        let msg = line.trim_end().to_owned();
         if msg.is_empty() {
             break;
         }
 
         match sequencer.publish(msg.as_bytes().to_vec()).await {
             Ok(result) => {
-                let tx_hash: [u8; 32] = result.inscription_id.into();
-                println!("  published: {}", hex::encode(tx_hash));
-                save_checkpoint(checkpoint_path, &result.checkpoint);
+                let tx_hash = hex::encode(<[u8; 32]>::from(result.inscription_id));
+                println!("    published: {tx_hash}/'{}'", capped_msg(&msg, 20));
+
+                let sequencer = Arc::clone(&sequencer);
+                let checkpoint_path = checkpoint_path.to_path_buf();
+                let inscription_id = result.inscription_id;
+                let msg_for_task = msg.clone();
+
+                tokio::spawn(async move {
+                    persist_checkpoint_when_on_chain(
+                        &msg_for_task,
+                        sequencer,
+                        checkpoint_path,
+                        inscription_id,
+                    )
+                    .await;
+                });
             }
             Err(e) => {
                 println!("  error: {e}");
@@ -120,4 +222,12 @@ pub async fn run(args: InscribeArgs) {
     }
 
     println!("Goodbye!");
+}
+
+fn capped_msg(msg: &str, len: usize) -> String {
+    if msg.len() > len {
+        format!("{}...", &msg.get(0..20).unwrap_or(msg))
+    } else {
+        msg.to_owned()
+    }
 }

--- a/testnet/tui-zone/src/lib.rs
+++ b/testnet/tui-zone/src/lib.rs
@@ -7,15 +7,15 @@ use std::{
 };
 
 use clap::Parser;
+use lb_common_http_client::BasicAuthCredentials;
 use lb_core::mantle::ops::channel::ChannelId;
 use lb_key_management_system_service::keys::{ED25519_SECRET_KEY_SIZE, Ed25519Key};
-use lb_zone_sdk::sequencer::{InscriptionId, SequencerCheckpoint, ZoneSequencer};
+use lb_zone_sdk::sequencer::{Error, InscriptionId, SequencerCheckpoint, ZoneSequencer};
 use reqwest::Url;
 use tracing_subscriber::{
     Layer as _, filter::LevelFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _,
 };
 
-const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const STATUS_CHECK_TIMEOUT: Duration = Duration::from_secs(1200); // 20 minutes
 
 #[derive(Parser, Debug)]
@@ -32,6 +32,12 @@ pub struct InscribeArgs {
     /// Path to the checkpoint file for crash recovery
     #[arg(long, default_value = "sequencer.checkpoint", env = "CHECKPOINT_PATH")]
     checkpoint_path: String,
+
+    #[arg(long, env = "USERNAME")]
+    username: Option<String>,
+
+    #[arg(long, env = "PASSWORD")]
+    password: Option<String>,
 }
 
 fn save_checkpoint(path: &Path, checkpoint: &SequencerCheckpoint) {
@@ -50,8 +56,9 @@ fn load_checkpoint(path: &Path) -> Option<SequencerCheckpoint> {
 fn load_or_create_signing_key(path: &Path) -> Ed25519Key {
     if path.exists() {
         let key_bytes = fs::read(path).expect("failed to read key file");
-        assert!(
-            key_bytes.len() == ED25519_SECRET_KEY_SIZE,
+        assert_eq!(
+            key_bytes.len(),
+            ED25519_SECRET_KEY_SIZE,
             "invalid key file: expected {} bytes, got {}",
             ED25519_SECRET_KEY_SIZE,
             key_bytes.len()
@@ -70,19 +77,16 @@ fn load_or_create_signing_key(path: &Path) -> Ed25519Key {
 async fn wait_for_on_chain_status(
     sequencer: Arc<ZoneSequencer>,
     inscription_id: InscriptionId,
-) -> Result<bool, lb_zone_sdk::sequencer::Error> {
-    let deadline = tokio::time::Instant::now() + STATUS_CHECK_TIMEOUT;
-
-    loop {
-        if sequencer.status(inscription_id).await?.is_on_chain() {
-            return Ok(true);
-        }
-
-        if tokio::time::Instant::now() >= deadline {
-            return Ok(false);
-        }
-
-        tokio::time::sleep(STATUS_POLL_INTERVAL).await;
+) -> Result<bool, Error> {
+    match tokio::time::timeout(
+        STATUS_CHECK_TIMEOUT,
+        sequencer.wait_for_inclusion(inscription_id),
+    )
+    .await
+    {
+        Ok(Ok(())) => Ok(true),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Ok(false),
     }
 }
 
@@ -120,7 +124,7 @@ async fn persist_checkpoint_when_on_chain(
         }
         Err(e) => {
             println!(
-                "\n    error tx: {tx_hash}/'{msg}' status check failed after {:?}: {e}\n> ",
+                "\n    error tx: {tx_hash}/'{msg}' inclusion wait failed after {:?}: {e}\n> ",
                 start.elapsed()
             );
         }
@@ -166,7 +170,8 @@ pub async fn run(args: InscribeArgs) {
         channel_id,
         signing_key,
         node_url,
-        None,
+        args.username
+            .map(|username| BasicAuthCredentials::new(username, args.password.clone())),
         checkpoint,
     ));
 

--- a/testnet/tui-zone/src/lib.rs
+++ b/testnet/tui-zone/src/lib.rs
@@ -12,9 +12,12 @@ use lb_core::mantle::ops::channel::ChannelId;
 use lb_key_management_system_service::keys::{ED25519_SECRET_KEY_SIZE, Ed25519Key};
 use lb_zone_sdk::sequencer::{Error, InscriptionId, SequencerCheckpoint, ZoneSequencer};
 use reqwest::Url;
+use tokio::sync::Mutex;
 use tracing_subscriber::{
     Layer as _, filter::LevelFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _,
 };
+
+type TermLock = Arc<Mutex<()>>;
 
 const STATUS_CHECK_TIMEOUT: Duration = Duration::from_secs(1200); // 20 minutes
 
@@ -95,40 +98,69 @@ async fn persist_checkpoint_when_on_chain(
     sequencer: Arc<ZoneSequencer>,
     checkpoint_path: PathBuf,
     inscription_id: InscriptionId,
+    term_lock: &TermLock,
 ) {
     let start = tokio::time::Instant::now();
-    let tx_hash = hex::encode(<[u8; 32]>::from(inscription_id));
+    let tx_hash = inscription_id.as_hex();
     let msg = capped_msg(msg, 20);
     match wait_for_on_chain_status(Arc::<ZoneSequencer>::clone(&sequencer), inscription_id).await {
         Ok(true) => {
-            println!(
-                "\n    mined tx: {tx_hash}/'{msg}' after {:.2?}\n> ",
-                start.elapsed()
-            );
+            print_flush_prompt(
+                term_lock,
+                &format!(
+                    "\n    mined tx: {tx_hash}/'{msg}' after {:.2?}",
+                    start.elapsed()
+                ),
+            )
+            .await;
             match sequencer.checkpoint().await {
                 Ok(checkpoint) => {
                     save_checkpoint(&checkpoint_path, &checkpoint);
                 }
                 Err(e) => {
-                    println!(
-                        "\n    error tx: {tx_hash}/'{msg}' failed to fetch & save checkpoint: {e}"
-                    );
+                    print_flush_prompt(term_lock,
+                                       &format!(
+                                           "\n    error tx: {tx_hash}/'{msg}' failed to fetch & save checkpoint: {e}"
+
+                                       )
+                    ).await;
                 }
             }
         }
         Ok(false) => {
-            println!(
-                "\n    warning tx: {tx_hash}/'{msg}' not on-chain after {:?}\n> ",
-                start.elapsed()
-            );
+            print_flush_prompt(
+                term_lock,
+                &format!(
+                    "\n    warning tx: {tx_hash}/'{msg}' not on-chain after {:?}",
+                    start.elapsed()
+                ),
+            )
+            .await;
         }
         Err(e) => {
-            println!(
-                "\n    error tx: {tx_hash}/'{msg}' inclusion wait failed after {:?}: {e}\n> ",
-                start.elapsed()
-            );
+            print_flush_prompt(
+                term_lock,
+                &format!(
+                    "\n    error tx: {tx_hash}/'{msg}' inclusion wait failed after {:?}: {e}",
+                    start.elapsed()
+                ),
+            )
+            .await;
         }
     }
+}
+
+async fn print_prompt(term_lock: &TermLock) {
+    let _guard = term_lock.lock().await;
+    print!("> ");
+    std::io::stdout().flush().expect("failed to flush stdout");
+}
+
+async fn print_flush_prompt(term_lock: &TermLock, msg: &str) {
+    let _guard = term_lock.lock().await;
+    println!("{msg}");
+    print!("> ");
+    std::io::stdout().flush().expect("failed to flush stdout");
 }
 
 pub async fn run(args: InscribeArgs) {
@@ -157,7 +189,7 @@ pub async fn run(args: InscribeArgs) {
     println!("TUI Zone Sequencer");
     println!("  Node:       {node_url}");
     println!("  Key:        {}", args.key_path);
-    println!("  Channel ID: {}", hex::encode(channel_id.as_ref()));
+    println!("  Channel ID: {}", channel_id.as_hex());
     println!();
 
     let checkpoint_path = Path::new(&args.checkpoint_path);
@@ -183,10 +215,9 @@ pub async fn run(args: InscribeArgs) {
     let stdin = std::io::stdin();
     let mut line = String::new();
 
+    let term_lock = TermLock::new(Mutex::default());
+    print_prompt(&term_lock).await;
     loop {
-        print!("> ");
-        std::io::stdout().flush().expect("failed to flush stdout");
-
         line.clear();
         let bytes_read = stdin.read_line(&mut line).expect("failed to read line");
 
@@ -202,26 +233,36 @@ pub async fn run(args: InscribeArgs) {
 
         match sequencer.publish(msg.as_bytes().to_vec()).await {
             Ok(result) => {
-                let tx_hash = hex::encode(<[u8; 32]>::from(result.inscription_id));
-                println!("    published: {tx_hash}/'{}'", capped_msg(&msg, 20));
+                let tx_hash = result.inscription_id.as_hex();
+                print_flush_prompt(
+                    &term_lock,
+                    &format!("    published: {tx_hash}/'{}'", capped_msg(&msg, 20)),
+                )
+                .await;
 
                 let sequencer = Arc::clone(&sequencer);
                 let checkpoint_path = checkpoint_path.to_path_buf();
                 let inscription_id = result.inscription_id;
                 let msg_for_task = msg.clone();
 
+                let term_lock_clone = Arc::clone(&term_lock);
                 tokio::spawn(async move {
                     persist_checkpoint_when_on_chain(
                         &msg_for_task,
                         sequencer,
                         checkpoint_path,
                         inscription_id,
+                        &term_lock_clone,
                     )
                     .await;
                 });
             }
             Err(e) => {
-                println!("  error: {e}");
+                print_flush_prompt(
+                    &term_lock,
+                    &format!("  error: {e}"),
+                )
+                    .await;
             }
         }
     }

--- a/zone-sdk/Cargo.toml
+++ b/zone-sdk/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 futures                          = { default-features = false, version = "0.3" }
+hex                              = { workspace = true }
 lb-common-http-client            = { workspace = true }
 lb-core                          = { workspace = true }
 lb-key-management-system-service = { workspace = true }

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -6,7 +6,6 @@ use std::{
 use futures::{StreamExt as _, future::BoxFuture, stream::FuturesUnordered};
 use lb_common_http_client::{BasicAuthCredentials, CommonHttpClient, ProcessedBlockEvent, Slot};
 use lb_core::{
-    codec::SerializeOp as _,
     header::HeaderId,
     mantle::{
         MantleTx, SignedMantleTx, Transaction as _,
@@ -176,6 +175,7 @@ impl ZoneSequencer {
     /// Returns the inscription ID and a checkpoint for persistence.
     pub async fn publish(&self, data: Vec<u8>) -> Result<PublishResult, Error> {
         let (reply_tx, reply_rx) = oneshot::channel();
+        let msg = String::from_utf8_lossy(&data).into_owned();
         let request = ActorRequest::Publish {
             data,
             reply: reply_tx,
@@ -193,10 +193,10 @@ impl ZoneSequencer {
         })??;
 
         info!(
-            "Created inscription - hash: {}, this msg_id: {}, parent msg_id: {}",
-            hex::encode(result.inscription_id.to_bytes().unwrap_or_default()),
-            hex::encode(result.checkpoint.last_msg_id.as_ref()),
-            hex::encode(result.parent_msg_id.as_ref()),
+            "Created inscription - msg: {msg}, hash: '{}', this msg_id: '{}', parent msg_id: '{}'",
+            result.inscription_id.as_hex(),
+            result.checkpoint.last_msg_id.as_hex(),
+            result.parent_msg_id.as_hex(),
         );
 
         // Post to network (best effort, will be resubmitted/recreated if needed)
@@ -426,16 +426,13 @@ async fn run_loop(
         match s.resolve_inscription_chain_tip() {
             ChainTipResolution::Determinate(msg_id) => {
                 last_msg_id = msg_id;
-                info!(
-                    "Startup lineage tip resolved to '{}'",
-                    hex::encode(msg_id.as_ref())
-                );
+                info!("Startup lineage tip resolved to '{}'", msg_id.as_hex());
             }
             ChainTipResolution::NoInscriptions => {
                 if restored_from_checkpoint {
                     info!(
-                        "No on-chain inscriptions found on startup; keeping checkpoint parent {:?}",
-                        hex::encode(last_msg_id.as_ref())
+                        "No on-chain inscriptions found on startup; keeping checkpoint parent '{}'",
+                        last_msg_id.as_hex()
                     );
                 }
             }
@@ -573,20 +570,27 @@ fn handle_request(
         ActorRequest::Publish { data, reply } => {
             // If we already have unpublished/pending inscriptions, keep extending that
             // local chain tip so multiple publishes before the next block remain ordered.
-            let has_local_pending_chain = tx_state.pending_count() > 0;
             let parent_to_use = match current_tip {
-                Some(_) if has_local_pending_chain => *last_msg_id,
-                Some(_) => match tx_state.resolve_inscription_chain_tip() {
-                    ChainTipResolution::Determinate(this_id) => this_id,
-                    ChainTipResolution::NoInscriptions => *last_msg_id,
-                    ChainTipResolution::Ambiguous => {
-                        drop(reply.send(Err(Error::Unavailable {
-                            reason: "inscription fork is ambiguous",
-                        })));
-                        return;
+                Some(_) => {
+                    if let Some(active_pending_tip) =
+                        active_pending_chain_tip(tx_state, pending_publications, publish_order)
+                    {
+                        active_pending_tip
+                    } else {
+                        match tx_state.resolve_inscription_chain_tip() {
+                            ChainTipResolution::Determinate(this_id) => this_id,
+                            ChainTipResolution::NoInscriptions => *last_msg_id,
+                            ChainTipResolution::Ambiguous => {
+                                drop(reply.send(Err(Error::Unavailable {
+                                    reason: "inscription fork is ambiguous",
+                                })));
+                                return;
+                            }
+                        }
                     }
-                },
-                None => *last_msg_id,
+                }
+                None => active_pending_chain_tip(tx_state, pending_publications, publish_order)
+                    .unwrap_or(*last_msg_id),
             };
 
             let (signed_tx, new_msg_id) =
@@ -745,13 +749,44 @@ async fn handle_block_event(
         channel_id,
     );
 
+    // Refresh pending publications from newly observed on-chain lineage:
+    // - if a local current tx hash is now observed on-chain, it is no longer an
+    //   active unpublished local attempt
+    // - if a local current msg id has already been used as a parent on-chain, it is
+    //   no longer eligible to drive local chaining
+    let observed_tx_hashes = our_txs
+        .iter()
+        .map(MsgIdState::tx_hash)
+        .collect::<HashSet<_>>();
+    let observed_parent_ids = our_txs
+        .iter()
+        .map(MsgIdState::parent_id)
+        .collect::<HashSet<_>>();
+
+    for publication in pending_publications.values_mut() {
+        let current_tx_observed = publication
+            .current_tx_hash
+            .is_some_and(|tx_hash| observed_tx_hashes.contains(&tx_hash));
+
+        let current_msg_id_used_as_parent = publication
+            .current_msg_id
+            .is_some_and(|msg_id| observed_parent_ids.contains(&msg_id));
+
+        if current_tx_observed || current_msg_id_used_as_parent {
+            publication.parent_msg_id = None;
+            publication.current_msg_id = None;
+        }
+    }
+
     // Process the actual event block with real lib (triggers finalization if lib
     // advanced)
     s.process_block(block_id, parent_id, lib, &our_txs);
     *current_tip = Some(tip);
 
-    // Detect foreign inscriptions that claimed a parent used by a pending local
-    // inscription.
+    sync_last_msg_id_from_chain(s, last_msg_id, pending_publications, publish_order);
+
+    // Detect foreign newly minted inscriptions that claimed a parent used by a
+    // pending local inscription.
     let conflicted = detect_conflicting_publications(s, tip, &our_txs, pending_publications);
     suspend_publications(s, &conflicted, pending_publications);
 
@@ -815,12 +850,53 @@ fn publication_status(
 ) -> TxStatus {
     if let Some(pending) = pending_publications.get(id) {
         if let Some(current_tx_hash) = pending.current_tx_hash {
-            return state.status(&current_tx_hash, tip);
+            let status = state.status(&current_tx_hash, tip);
+            if matches!(status, TxStatus::Pending)
+                && state.is_tx_observed_on_chain(&current_tx_hash)
+            {
+                return TxStatus::Safe;
+            }
+            return status;
         }
         return TxStatus::Pending;
     }
 
     state.status(id, tip)
+}
+
+fn active_pending_chain_tip(
+    state: &TxState,
+    pending_publications: &HashMap<InscriptionId, PendingPublication>,
+    publish_order: &[InscriptionId],
+) -> Option<MsgId> {
+    publish_order.iter().rev().find_map(|logical_id| {
+        let publication = pending_publications.get(logical_id)?;
+        let current_tx_hash = publication.current_tx_hash?;
+        let current_msg_id = publication.current_msg_id?;
+
+        (state.is_tx_pending(&current_tx_hash)
+            && !state.is_tx_observed_on_chain(&current_tx_hash)
+            && !state.is_msg_id_used_as_parent_on_chain(current_msg_id))
+        .then_some(current_msg_id)
+    })
+}
+
+fn sync_last_msg_id_from_chain(
+    state: &TxState,
+    last_msg_id: &mut MsgId,
+    pending_publications: &HashMap<InscriptionId, PendingPublication>,
+    publish_order: &[InscriptionId],
+) {
+    if let Some(active_pending_tip) =
+        active_pending_chain_tip(state, pending_publications, publish_order)
+    {
+        *last_msg_id = active_pending_tip;
+        return;
+    }
+
+    if let ChainTipResolution::Determinate(msg_id) = state.resolve_inscription_chain_tip() {
+        *last_msg_id = msg_id;
+    }
 }
 
 /// Backfill finalized blocks from current `lib_slot` to new `lib_slot`.
@@ -874,6 +950,13 @@ async fn backfill_to_lib(
                 let current_lib = state.lib();
                 state.process_block(block_id, parent_id, current_lib, &our_txs);
 
+                sync_last_msg_id_from_chain(
+                    state,
+                    last_msg_id,
+                    pending_publications,
+                    publish_order,
+                );
+
                 let conflicted = detect_conflicting_publications(
                     state,
                     block_id,
@@ -881,19 +964,20 @@ async fn backfill_to_lib(
                     pending_publications,
                 );
                 suspend_publications(state, &conflicted, pending_publications);
-
-                try_recreate_suspended_publications(
-                    state,
-                    channel_id,
-                    signing_key,
-                    node_url,
-                    http_client,
-                    last_msg_id,
-                    pending_publications,
-                    publish_order,
-                )
-                .await;
             }
+
+            try_recreate_suspended_publications(
+                state,
+                channel_id,
+                signing_key,
+                node_url,
+                http_client,
+                last_msg_id,
+                pending_publications,
+                publish_order,
+            )
+            .await;
+
             debug!("Backfilled {} finalized blocks", to - from);
         }
         Err(e) => {
@@ -966,22 +1050,24 @@ async fn backfill_canonical(
         // Use current state lib to avoid premature finalization
         state.process_block(block_id, parent_id, lib, &our_txs);
 
+        sync_last_msg_id_from_chain(state, last_msg_id, pending_publications, publish_order);
+
         let conflicted =
             detect_conflicting_publications(state, block_id, &our_txs, pending_publications);
         suspend_publications(state, &conflicted, pending_publications);
-
-        try_recreate_suspended_publications(
-            state,
-            channel_id,
-            signing_key,
-            node_url,
-            http_client,
-            last_msg_id,
-            pending_publications,
-            publish_order,
-        )
-        .await;
     }
+
+    try_recreate_suspended_publications(
+        state,
+        channel_id,
+        signing_key,
+        node_url,
+        http_client,
+        last_msg_id,
+        pending_publications,
+        publish_order,
+    )
+    .await;
 
     debug!("Canonical backfill complete");
 }
@@ -1027,7 +1113,7 @@ fn enqueue_resubmit(
         "Resubmitting inscriptions: {}",
         pending_msg_ids
             .iter()
-            .map(|id| hex::encode(id.as_ref()))
+            .map(MsgId::as_hex)
             .collect::<Vec<_>>()
             .join(", ")
     );
@@ -1145,20 +1231,18 @@ async fn try_recreate_suspended_publications(
         return;
     }
 
-    let has_active_pending_chain = pending_publications
-        .values()
-        .any(|publication| publication.current_tx_hash.is_some());
-
-    let mut parent_to_use = if has_active_pending_chain {
-        *last_msg_id
+    let mut parent_to_use = if let Some(active_pending_tip) =
+        active_pending_chain_tip(state, pending_publications, publish_order)
+    {
+        active_pending_tip
     } else {
         match state.resolve_inscription_chain_tip() {
             ChainTipResolution::Determinate(msg_id) => msg_id,
-            ChainTipResolution::NoInscriptions => MsgId::root(),
+            ChainTipResolution::NoInscriptions => *last_msg_id,
             ChainTipResolution::Ambiguous => {
                 warn!(
                     "Inscription lineage is ambiguous; delaying recreation of {} pending \
-                     inscription(s) until the chain tip becomes determinate",
+                         inscription(s) until the chain tip becomes determinate",
                     suspended.len()
                 );
                 return;
@@ -1166,16 +1250,23 @@ async fn try_recreate_suspended_publications(
         }
     };
 
+    debug!(
+        "Recreating {} suspended inscription(s) from parent msg id {}",
+        suspended.len(),
+        parent_to_use.as_hex(),
+    );
+
     for logical_id in suspended {
         let Some(publication) = pending_publications.get(&logical_id).cloned() else {
             continue;
         };
 
+        let parent_used = parent_to_use;
         let (signed_tx, new_msg_id) = create_inscribe_tx(
             channel_id,
             signing_key,
             publication.data.clone(),
-            parent_to_use,
+            parent_used,
         );
         let tx_hash = signed_tx.mantle_tx.hash();
 
@@ -1183,7 +1274,7 @@ async fn try_recreate_suspended_publications(
 
         if let Some(publication) = pending_publications.get_mut(&logical_id) {
             publication.current_tx_hash = Some(tx_hash);
-            publication.parent_msg_id = Some(parent_to_use);
+            publication.parent_msg_id = Some(parent_used);
             publication.current_msg_id = Some(new_msg_id);
         }
 
@@ -1191,10 +1282,13 @@ async fn try_recreate_suspended_publications(
         parent_to_use = new_msg_id;
 
         info!(
-            "Recreated conflicting inscription - logical: {}, new hash: {}, parent msg id: {}",
-            hex::encode(logical_id.to_bytes().unwrap_or_default()),
-            hex::encode(tx_hash.to_bytes().unwrap_or_default()),
-            hex::encode(parent_to_use.as_ref()),
+            "Recreated conflicting inscription - msg: '{}', logical: '{}', new hash: '{}', parent \
+            msg id: '{}', this msg id: '{}'",
+            String::from_utf8_lossy(&publication.data).into_owned(),
+            logical_id.as_hex(),
+            tx_hash.as_hex(),
+            parent_used.as_hex(),
+            new_msg_id.as_hex(),
         );
 
         if let Err(e) = http_client
@@ -1223,12 +1317,13 @@ fn collect_msg_id_state_from_block<'a>(
             extract_msg_id_state(header_id, slot, tx, channel_id)
         {
             info!(
-                "Found inscription - block: '{}', slot: {}, msg: '{}', parent_id: {}, this_id: {}",
+                "Found inscription - block: '{}', slot: {}, msg: '{}', parent_id: '{}', this_id: \
+                '{}'",
                 msg_state.header_id(),
                 msg_state.slot().into_inner(),
                 inscription_msg,
-                hex::encode(msg_state.parent_id().as_ref()),
-                hex::encode(msg_state.this_id().as_ref())
+                msg_state.parent_id().as_hex(),
+                msg_state.this_id().as_hex(),
             );
             inscriptions.push(msg_state);
         }
@@ -1631,5 +1726,468 @@ mod tests {
             .expect("publish reply dropped")
             .expect("second publish should succeed");
         assert_eq!(publish_parent_id(&tx_2), msg_1);
+    }
+
+    fn make_signed_inscribe_tx(seed: u8, parent: MsgId) -> SignedMantleTx {
+        let channel_id = ChannelId::from([seed; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[seed; 32]);
+        let (tx, _) = create_inscribe_tx(channel_id, &signing_key, vec![seed], parent);
+        tx
+    }
+
+    fn pending_publication(
+        data: &[u8],
+        current_tx_hash: Option<TxHash>,
+        parent_msg_id: Option<MsgId>,
+        current_msg_id: Option<MsgId>,
+    ) -> PendingPublication {
+        PendingPublication {
+            data: data.to_vec(),
+            current_tx_hash,
+            parent_msg_id,
+            current_msg_id,
+        }
+    }
+
+    #[test]
+    fn active_pending_chain_tip_returns_latest_active_in_publish_order() {
+        let genesis = header_id(0);
+        let mut tx_state = TxState::new(genesis);
+
+        let tx1 = make_signed_inscribe_tx(1, MsgId::root());
+        let tx2 = make_signed_inscribe_tx(2, publish_this_id(&tx1));
+        let tx3 = make_signed_inscribe_tx(3, publish_this_id(&tx2));
+
+        let hash1 = tx1.mantle_tx.hash();
+        let hash2 = tx2.mantle_tx.hash();
+        let hash3 = tx3.mantle_tx.hash();
+
+        let msg1 = publish_this_id(&tx1);
+        let msg2 = publish_this_id(&tx2);
+        let msg3 = publish_this_id(&tx3);
+
+        tx_state.submit(hash1, tx1);
+        tx_state.submit(hash2, tx2);
+        tx_state.submit(hash3, tx3);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            hash1,
+            pending_publication(b"a1", Some(hash1), Some(MsgId::root()), Some(msg1)),
+        );
+        pending_publications.insert(
+            hash2,
+            pending_publication(b"a2", Some(hash2), Some(msg1), Some(msg2)),
+        );
+        pending_publications.insert(
+            hash3,
+            pending_publication(b"a3", Some(hash3), Some(msg2), Some(msg3)),
+        );
+
+        let publish_order = vec![hash1, hash2, hash3];
+
+        assert_eq!(
+            active_pending_chain_tip(&tx_state, &pending_publications, &publish_order),
+            Some(msg3)
+        );
+    }
+
+    #[test]
+    fn sync_last_msg_id_from_chain_prefers_active_pending_tip() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let mut tx_state = TxState::new(genesis);
+
+        let on_chain_tip = MsgId::from([31u8; 32]);
+        tx_state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b1,
+                Slot::new(100),
+                test_tx_hash(31),
+                MsgId::root(),
+                on_chain_tip,
+            )],
+        );
+
+        let pending_tx = make_signed_inscribe_tx(32, on_chain_tip);
+        let pending_hash = pending_tx.mantle_tx.hash();
+        let pending_tip = publish_this_id(&pending_tx);
+        tx_state.submit(pending_hash, pending_tx);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            pending_hash,
+            pending_publication(
+                b"pending",
+                Some(pending_hash),
+                Some(on_chain_tip),
+                Some(pending_tip),
+            ),
+        );
+
+        let publish_order = vec![pending_hash];
+        let mut last_msg_id = MsgId::root();
+
+        sync_last_msg_id_from_chain(
+            &tx_state,
+            &mut last_msg_id,
+            &pending_publications,
+            &publish_order,
+        );
+
+        assert_eq!(last_msg_id, pending_tip);
+    }
+
+    #[test]
+    fn detect_conflicting_publications_marks_direct_and_transitive_dependents() {
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let mut tx_state = TxState::new(genesis);
+
+        let tx1 = make_signed_inscribe_tx(61, MsgId::root());
+        let msg1 = publish_this_id(&tx1);
+        let hash1 = tx1.mantle_tx.hash();
+
+        let tx2 = make_signed_inscribe_tx(62, msg1);
+        let msg2 = publish_this_id(&tx2);
+        let hash2 = tx2.mantle_tx.hash();
+
+        let tx3 = make_signed_inscribe_tx(63, msg2);
+        let msg3 = publish_this_id(&tx3);
+        let hash3 = tx3.mantle_tx.hash();
+
+        tx_state.submit(hash1, tx1);
+        tx_state.submit(hash2, tx2);
+        tx_state.submit(hash3, tx3);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            hash1,
+            pending_publication(b"b1", Some(hash1), Some(MsgId::root()), Some(msg1)),
+        );
+        pending_publications.insert(
+            hash2,
+            pending_publication(b"b2", Some(hash2), Some(msg1), Some(msg2)),
+        );
+        pending_publications.insert(
+            hash3,
+            pending_publication(b"b3", Some(hash3), Some(msg2), Some(msg3)),
+        );
+
+        let foreign = MsgIdState::new(
+            tip,
+            Slot::new(111),
+            test_tx_hash(64),
+            MsgId::root(),
+            MsgId::from([64u8; 32]),
+        );
+
+        let conflicted =
+            detect_conflicting_publications(&tx_state, tip, &[foreign], &pending_publications);
+
+        assert!(conflicted.contains(&hash1));
+        assert!(conflicted.contains(&hash2));
+        assert!(conflicted.contains(&hash3));
+        assert_eq!(conflicted.len(), 3);
+    }
+
+    #[test]
+    fn suspend_publications_clears_tracking_and_removes_pending_tx() {
+        let genesis = header_id(0);
+        let mut tx_state = TxState::new(genesis);
+
+        let tx = make_signed_inscribe_tx(81, MsgId::root());
+        let hash = tx.mantle_tx.hash();
+        let msg = publish_this_id(&tx);
+
+        tx_state.submit(hash, tx);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            hash,
+            pending_publication(b"b1", Some(hash), Some(MsgId::root()), Some(msg)),
+        );
+
+        let conflicted = HashSet::from([hash]);
+        suspend_publications(&mut tx_state, &conflicted, &mut pending_publications);
+
+        let publication = pending_publications
+            .get(&hash)
+            .expect("publication should still exist logically");
+        assert_eq!(publication.current_tx_hash, None);
+        assert_eq!(publication.parent_msg_id, None);
+        assert_eq!(publication.current_msg_id, None);
+        assert!(!tx_state.is_tx_pending(&hash));
+    }
+
+    #[tokio::test]
+    async fn wait_inclusion_registers_waiter_for_pending_publication() {
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([93u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[93u8; 32]);
+
+        let mut tx_state = TxState::new(genesis);
+
+        let tx = make_signed_inscribe_tx(94, MsgId::root());
+        let current_hash = tx.mantle_tx.hash();
+        let this_id = publish_this_id(&tx);
+        tx_state.submit(current_hash, tx);
+
+        let logical_id = test_tx_hash(93);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            logical_id,
+            pending_publication(b"x", Some(current_hash), Some(MsgId::root()), Some(this_id)),
+        );
+
+        let mut state = Some(tx_state);
+        let mut last_msg_id = this_id;
+        let mut publish_order = vec![logical_id];
+        let mut inclusion_waiters = HashMap::new();
+
+        let (reply_tx, _reply_rx) = oneshot::channel();
+        handle_request(
+            ActorRequest::WaitInclusion {
+                id: logical_id,
+                reply: reply_tx,
+            },
+            &mut state,
+            Some(tip),
+            Slot::genesis(),
+            channel_id,
+            &signing_key,
+            &mut last_msg_id,
+            &mut pending_publications,
+            &mut publish_order,
+            &mut inclusion_waiters,
+        );
+
+        assert_eq!(inclusion_waiters.len(), 1);
+        assert_eq!(
+            inclusion_waiters
+                .get(&logical_id)
+                .expect("waiter should be registered")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "This test covers multiple related conditions around active_pending_chain_tip() and \
+        requires a lot of setup to properly cover the scenarios"
+    )]
+    fn active_pending_chain_tip_ignores_locally_pending_txs_once_they_are_seen_on_chain() {
+        // This test covers both suppression conditions for active_pending_chain_tip():
+        //
+        // 1. a locally pending tx must stop driving the local tip once that exact tx
+        //    has already been observed on-chain
+        // 2. a locally pending tx must also stop driving the local tip once its
+        //    current_msg_id has already been used as a parent on-chain
+
+        let genesis = header_id(0);
+        let block_1 = header_id(1);
+        let block_2 = header_id(2);
+        let channel_id = ChannelId::from([42u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[9u8; 32]);
+
+        // -------------------------------------------------------------------------
+        // Case 1: current_tx_hash is already observed on-chain
+        // -------------------------------------------------------------------------
+        let mut state = TxState::new(genesis);
+
+        let (tx_1, msg_1) =
+            create_inscribe_tx(channel_id, &signing_key, b"aa1".to_vec(), MsgId::root());
+        let (tx_2, msg_2) = create_inscribe_tx(channel_id, &signing_key, b"aa2".to_vec(), msg_1);
+        let (tx_3, msg_3) = create_inscribe_tx(channel_id, &signing_key, b"aa3".to_vec(), msg_2);
+
+        let hash_1 = tx_1.mantle_tx.hash();
+        let hash_2 = tx_2.mantle_tx.hash();
+        let hash_3 = tx_3.mantle_tx.hash();
+
+        state.submit(hash_1, tx_1);
+        state.submit(hash_2, tx_2);
+        state.submit(hash_3, tx_3);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            hash_1,
+            PendingPublication {
+                data: b"aa1".to_vec(),
+                current_tx_hash: Some(hash_1),
+                parent_msg_id: Some(MsgId::root()),
+                current_msg_id: Some(msg_1),
+            },
+        );
+        pending_publications.insert(
+            hash_2,
+            PendingPublication {
+                data: b"aa2".to_vec(),
+                current_tx_hash: Some(hash_2),
+                parent_msg_id: Some(msg_1),
+                current_msg_id: Some(msg_2),
+            },
+        );
+        pending_publications.insert(
+            hash_3,
+            PendingPublication {
+                data: b"aa3".to_vec(),
+                current_tx_hash: Some(hash_3),
+                parent_msg_id: Some(msg_2),
+                current_msg_id: Some(msg_3),
+            },
+        );
+
+        let publish_order = vec![hash_1, hash_2, hash_3];
+
+        // The chain later shows aa1 -> aa2 -> aa3 on-chain in a block.
+        state.process_block(
+            block_1,
+            genesis,
+            genesis,
+            &[
+                MsgIdState::new(block_1, Slot::new(100), hash_1, MsgId::root(), msg_1),
+                MsgIdState::new(block_1, Slot::new(100), hash_2, msg_1, msg_2),
+                MsgIdState::new(block_1, Slot::new(100), hash_3, msg_2, msg_3),
+            ],
+        );
+
+        assert_eq!(
+            active_pending_chain_tip(&state, &pending_publications, &publish_order),
+            None,
+            "once the local txs have been seen on-chain, they must no longer drive the active pending chain tip"
+        );
+
+        // -------------------------------------------------------------------------
+        // Case 2: current_msg_id has already been used as a parent on-chain
+        // -------------------------------------------------------------------------
+        let mut state = TxState::new(genesis);
+
+        let (tx_c, msg_c) =
+            create_inscribe_tx(channel_id, &signing_key, b"bb3".to_vec(), MsgId::root());
+        let hash_c = tx_c.mantle_tx.hash();
+
+        state.submit(hash_c, tx_c);
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            hash_c,
+            PendingPublication {
+                data: b"bb3".to_vec(),
+                current_tx_hash: Some(hash_c),
+                parent_msg_id: Some(MsgId::root()),
+                current_msg_id: Some(msg_c),
+            },
+        );
+
+        let publish_order = vec![hash_c];
+
+        // A foreign on-chain inscription already used msg_c as its parent.
+        // That means msg_c has been consumed on-chain and cannot remain the local
+        // active unpublished chain tip, even though hash_c itself was not observed.
+        let foreign_hash = test_tx_hash(99);
+        let foreign_child = MsgId::from([99u8; 32]);
+
+        state.process_block(
+            block_2,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                block_2,
+                Slot::new(200),
+                foreign_hash,
+                msg_c,
+                foreign_child,
+            )],
+        );
+
+        assert!(
+            !state.is_tx_observed_on_chain(&hash_c),
+            "this case requires the local tx hash itself to remain unobserved on-chain"
+        );
+        assert!(
+            state.is_msg_id_used_as_parent_on_chain(msg_c),
+            "this case requires msg_c to have been used as a parent on-chain"
+        );
+
+        assert_eq!(
+            active_pending_chain_tip(&state, &pending_publications, &publish_order),
+            None,
+            "once the local msg id has already been used as a parent on-chain, it must no longer drive the active pending chain tip"
+        );
+    }
+    #[test]
+    fn publication_status_reports_safe_when_current_hash_was_seen_on_chain_during_backfill() {
+        // This mimics the real stall:
+        // - current tip block is processed before its missing parent
+        // - later, backfill processes the missing parent block containing our tx
+        // - the tx is now definitely seen on-chain
+        // - but TxState::status(hash, current_tip) can still say Pending because the
+        //   tip's cumulative safe set was built before the parent was known
+        //
+        // Desired behavior:
+        // publication_status() should still treat the current hash as on-chain.
+
+        let genesis = header_id(0);
+        let block_1 = header_id(1);
+        let block_2 = header_id(2);
+        let channel_id = ChannelId::from([33u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[7u8; 32]);
+
+        let mut state = TxState::new(genesis);
+
+        let (tx, this_id) =
+            create_inscribe_tx(channel_id, &signing_key, b"aa4".to_vec(), MsgId::root());
+        let tx_hash = tx.mantle_tx.hash();
+
+        state.submit(tx_hash, tx);
+
+        // Simulate receiving the tip block first, before its parent is known.
+        state.process_block(block_2, block_1, genesis, &[]);
+
+        // Later backfill finds the missing parent containing our inscription.
+        state.process_block(
+            block_1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                block_1,
+                Slot::new(123),
+                tx_hash,
+                MsgId::root(),
+                this_id,
+            )],
+        );
+
+        // Sanity check: the raw TxState status at the already-built tip is still
+        // Pending.
+        assert_eq!(
+            state.status(&tx_hash, block_2),
+            TxStatus::Pending,
+            "this test requires the tx to be seen on-chain but not reflected as safe at the current tip"
+        );
+
+        let mut pending_publications = HashMap::new();
+        pending_publications.insert(
+            tx_hash,
+            PendingPublication {
+                data: b"aa4".to_vec(),
+                current_tx_hash: Some(tx_hash),
+                parent_msg_id: Some(MsgId::root()),
+                current_msg_id: Some(this_id),
+            },
+        );
+
+        assert_eq!(
+            publication_status(&state, block_2, &tx_hash, &pending_publications),
+            TxStatus::Safe,
+            "if the current recreated hash has been seen on-chain, publication_status must resolve it as on-chain instead of leaving it Pending forever"
+        );
     }
 }

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use futures::{StreamExt as _, future::BoxFuture, stream::FuturesUnordered};
 use lb_common_http_client::{BasicAuthCredentials, CommonHttpClient, ProcessedBlockEvent, Slot};
 use lb_core::{
+    codec::SerializeOp as _,
     header::HeaderId,
     mantle::{
         MantleTx, SignedMantleTx, Transaction as _,
@@ -19,7 +20,7 @@ use reqwest::Url;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-use crate::state::{TxState, TxStatus};
+use crate::state::{ChainTipResolution, MsgIdState, TxState, TxStatus};
 
 const DEFAULT_RESUBMIT_INTERVAL: Duration = Duration::from_secs(30);
 const DEFAULT_RECONNECT_DELAY: Duration = Duration::from_secs(5);
@@ -51,6 +52,8 @@ pub struct PublishResult {
     pub inscription_id: InscriptionId,
     /// Current checkpoint for persistence.
     pub checkpoint: SequencerCheckpoint,
+    /// The message ID of the parent inscription (for lineage tracking).
+    pub parent_msg_id: MsgId,
 }
 
 /// Configuration for the zone sequencer.
@@ -174,7 +177,12 @@ impl ZoneSequencer {
             reason: "actor dropped reply",
         })??;
 
-        info!("Created inscription {:?}", result.inscription_id);
+        info!(
+            "Created inscription - hash: {}, this msg_id: {}, parent msg_id: {}",
+            hex::encode(result.inscription_id.to_bytes().unwrap_or_default()),
+            hex::encode(result.checkpoint.last_msg_id.as_ref()),
+            hex::encode(result.parent_msg_id.as_ref()),
+        );
 
         // Post to network (best effort, will be resubmitted if needed)
         if let Err(e) = self
@@ -231,7 +239,7 @@ async fn initialize_from_checkpoint(
     node_url: &Url,
     reconnect_delay: Duration,
     checkpoint: Option<SequencerCheckpoint>,
-) -> (TxState, HeaderId, Slot, MsgId) {
+) -> (TxState, HeaderId, Slot, MsgId, bool) {
     // Get current network state
     let info = loop {
         match http_client.consensus_info(node_url.clone()).await {
@@ -243,10 +251,7 @@ async fn initialize_from_checkpoint(
                 break info;
             }
             Err(e) => {
-                warn!(
-                    "Failed to fetch consensus info: {e}, retrying in {:?}",
-                    reconnect_delay
-                );
+                warn!("Failed to fetch consensus info: {e}, retrying in {reconnect_delay:?}",);
                 tokio::time::sleep(reconnect_delay).await;
             }
         }
@@ -254,10 +259,10 @@ async fn initialize_from_checkpoint(
 
     if let Some(cp) = checkpoint {
         info!(
-            "Restoring from checkpoint: {} pending txs, lib={:?}, lib_slot={:?}",
+            "Restoring from checkpoint: {} pending txs, lib={:?}, lib_slot={}",
             cp.pending_txs.len(),
             cp.lib,
-            cp.lib_slot
+            cp.lib_slot.into_inner(),
         );
         let mut state = TxState::new(cp.lib);
         // Restore pending transactions
@@ -265,12 +270,62 @@ async fn initialize_from_checkpoint(
             state.submit(hash, tx);
         }
         // Use checkpoint's lib_slot as starting point for backfill
-        (state, info.tip, cp.lib_slot, cp.last_msg_id)
+        (state, info.tip, cp.lib_slot, cp.last_msg_id, true)
     } else {
         // Fresh start: get lib slot from network
         let lib_slot = get_lib_slot(http_client, node_url, info.lib).await;
         info!("Starting fresh (no checkpoint)");
-        (TxState::new(info.lib), info.tip, lib_slot, MsgId::root())
+        (
+            TxState::new(info.lib),
+            info.tip,
+            lib_slot,
+            MsgId::root(),
+            false,
+        )
+    }
+}
+
+async fn bootstrap_history_on_clean_start(
+    state: &mut TxState,
+    tip: HeaderId,
+    channel_id: ChannelId,
+    http_client: &CommonHttpClient,
+    node_url: &Url,
+) {
+    let tip_slot = match http_client.get_block(node_url.clone(), tip).await {
+        Ok(Some(block)) => block.header().slot(),
+        Ok(None) => Slot::genesis(),
+        Err(e) => {
+            warn!("Failed to fetch tip block for startup backfill: {e}");
+            return;
+        }
+    };
+
+    let to: u64 = tip_slot.into();
+    if to == 0 {
+        return;
+    }
+
+    debug!("Bootstrapping inscription lineage from genesis to tip slot {to}",);
+
+    match http_client.get_blocks(node_url.clone(), 1, to).await {
+        Ok(blocks) => {
+            let current_lib = state.lib();
+            for block in blocks {
+                let block_id = block.header.id;
+                let parent_id = block.header.parent_block;
+                let our_txs = collect_msg_id_state_from_block(
+                    block.header.id,
+                    block.header.slot,
+                    block.transactions.iter(),
+                    channel_id,
+                );
+                state.process_block(block_id, parent_id, current_lib, &our_txs);
+            }
+        }
+        Err(e) => {
+            warn!("Failed to bootstrap startup lineage: {e}");
+        }
     }
 }
 
@@ -298,10 +353,7 @@ async fn connect_blocks_stream(
         match http_client.get_blocks_stream(node_url.clone()).await {
             Ok(stream) => return stream,
             Err(e) => {
-                warn!(
-                    "Failed to connect to blocks stream: {e}, retrying in {:?}",
-                    reconnect_delay
-                );
+                warn!("Failed to connect to blocks stream: {e}, retrying in {reconnect_delay:?}",);
                 tokio::time::sleep(reconnect_delay).await;
             }
         }
@@ -317,13 +369,41 @@ async fn run_loop(
     config: SequencerConfig,
     checkpoint: Option<SequencerCheckpoint>,
 ) {
-    let (state, current_tip, lib_slot, last_msg_id) =
+    let (state, current_tip, lib_slot, last_msg_id, restored_from_checkpoint) =
         initialize_from_checkpoint(&http_client, &node_url, config.reconnect_delay, checkpoint)
             .await;
     let mut state = Some(state);
     let mut current_tip = Some(current_tip);
     let mut lib_slot = lib_slot;
     let mut last_msg_id = last_msg_id;
+
+    if let (Some(s), Some(tip)) = (state.as_mut(), current_tip) {
+        bootstrap_history_on_clean_start(s, tip, channel_id, &http_client, &node_url).await;
+
+        match s.resolve_inscription_chain_tip() {
+            ChainTipResolution::Determinate(msg_id) => {
+                last_msg_id = msg_id;
+                info!(
+                    "Startup lineage tip resolved to '{}'",
+                    hex::encode(msg_id.as_ref())
+                );
+            }
+            ChainTipResolution::NoInscriptions => {
+                if restored_from_checkpoint {
+                    info!(
+                        "No on-chain inscriptions found on startup; keeping checkpoint parent {:?}",
+                        hex::encode(last_msg_id.as_ref())
+                    );
+                }
+            }
+            ChainTipResolution::Ambiguous => {
+                warn!(
+                    "Startup lineage is ambiguous; publish will pause until chain tip becomes \
+                    determinate"
+                );
+            }
+        }
+    }
 
     let mut resubmit_interval = tokio::time::interval(config.resubmit_interval);
     let mut resubmit_active = false;
@@ -391,7 +471,7 @@ fn handle_request(
     signing_key: &Ed25519Key,
     last_msg_id: &mut MsgId,
 ) {
-    let Some(s) = state else {
+    let Some(tx_state) = state else {
         match request {
             ActorRequest::Publish { reply, .. } => {
                 drop(reply.send(Err(Error::Unavailable {
@@ -414,17 +494,39 @@ fn handle_request(
 
     match request {
         ActorRequest::Publish { data, reply } => {
-            let (signed_tx, new_msg_id) =
-                create_inscribe_tx(channel_id, signing_key, data, *last_msg_id);
-            let id = signed_tx.mantle_tx.hash();
+            // If we already have unpublished/pending inscriptions, keep extending that
+            // local chain tip so multiple publishes before the next block remain ordered.
+            let has_local_pending_chain = tx_state.pending_count() > 0;
+            let parent_to_use = match current_tip {
+                // TODO: This will be fixed in PR#2375 as there is no proof another sequencer
+                // TODO: did not publish in the meantime and newly found inscriptions currently do
+                // TODO: not invalidate invalid pending inscriptions
+                Some(_) if has_local_pending_chain => *last_msg_id,
+                Some(_) => match tx_state.resolve_inscription_chain_tip() {
+                    ChainTipResolution::Determinate(this_id) => this_id,
+                    ChainTipResolution::NoInscriptions => *last_msg_id,
+                    ChainTipResolution::Ambiguous => {
+                        drop(reply.send(Err(Error::Unavailable {
+                            reason: "inscription fork is ambiguous",
+                        })));
+                        return;
+                    }
+                },
+                None => *last_msg_id,
+            };
 
-            s.submit(id, signed_tx.clone());
+            let (signed_tx, new_msg_id) =
+                create_inscribe_tx(channel_id, signing_key, data, parent_to_use);
+            let tx_hash = signed_tx.mantle_tx.hash();
+
+            tx_state.submit(tx_hash, signed_tx.clone());
             *last_msg_id = new_msg_id;
 
-            let checkpoint = build_checkpoint(s, *last_msg_id, lib_slot);
+            let checkpoint = build_checkpoint(tx_state, *last_msg_id, lib_slot);
             let result = PublishResult {
-                inscription_id: id,
+                inscription_id: tx_hash,
                 checkpoint,
+                parent_msg_id: parent_to_use,
             };
             drop(reply.send(Ok((signed_tx, result))));
         }
@@ -433,12 +535,12 @@ fn handle_request(
                 Err(Error::Unavailable {
                     reason: "not synced (no tip yet)",
                 }),
-                |tip| Ok(s.status(&id, tip)),
+                |tip| Ok(tx_state.status(&id, tip)),
             );
             drop(reply.send(result));
         }
         ActorRequest::Checkpoint { reply } => {
-            let checkpoint = build_checkpoint(s, *last_msg_id, lib_slot);
+            let checkpoint = build_checkpoint(tx_state, *last_msg_id, lib_slot);
             drop(reply.send(Ok(checkpoint)));
         }
     }
@@ -502,30 +604,30 @@ async fn handle_block_event(
         backfill_canonical(s, parent_id, channel_id, http_client, node_url).await;
     }
 
-    // Extract tx hashes for our channel
-    let our_txs: Vec<TxHash> = event
-        .block
-        .transactions
-        .iter()
-        .filter(|tx| matches_channel(tx, channel_id))
-        .map(|tx| tx.mantle_tx.hash())
-        .collect();
+    // Extract channel tx lineage keyed by block header id.
+    let our_txs = collect_msg_id_state_from_block(
+        event.block.header.id,
+        event.block.header.slot,
+        event.block.transactions.iter(),
+        channel_id,
+    );
 
     // Process the actual event block with real lib (triggers finalization if lib
     // advanced)
-    s.process_block(block_id, parent_id, lib, our_txs);
+    s.process_block(block_id, parent_id, lib, &our_txs);
     *current_tip = Some(tip);
 }
 
 fn handle_inflight(event: InFlight, resubmit_active: &mut bool) {
+    *resubmit_active = false;
+
     match event {
         InFlight::ResubmittedBatch { results } => {
             for (id, result) in results {
                 if let Err(e) = result {
-                    warn!("Failed to resubmit inscription {id:?}: {e}");
+                    warn!("Failed to resubmit inscription {:?}: {}", id, e);
                 }
             }
-            *resubmit_active = false;
         }
     }
 }
@@ -562,16 +664,16 @@ async fn backfill_to_lib(
                 let block_id = block.header.id;
                 let parent_id = block.header.parent_block;
 
-                let our_txs: Vec<TxHash> = block
-                    .transactions
-                    .iter()
-                    .filter(|tx| matches_channel(tx, channel_id))
-                    .map(|tx| tx.mantle_tx.hash())
-                    .collect();
+                let our_txs = collect_msg_id_state_from_block(
+                    block.header.id,
+                    block.header.slot,
+                    block.transactions.iter(),
+                    channel_id,
+                );
 
                 // Use current state lib to avoid premature finalization
                 let current_lib = state.lib();
-                state.process_block(block_id, parent_id, current_lib, our_txs);
+                state.process_block(block_id, parent_id, current_lib, &our_txs);
             }
             debug!("Backfilled {} finalized blocks", to - from);
         }
@@ -627,14 +729,15 @@ async fn backfill_canonical(
         let block_id = block.header().id();
         let parent_id = block.header().parent_block();
 
-        let our_txs: Vec<TxHash> = block
-            .transactions()
-            .filter(|tx| matches_channel(tx, channel_id))
-            .map(|tx| tx.mantle_tx.hash())
-            .collect();
+        let our_txs = collect_msg_id_state_from_block(
+            block.header().id(),
+            block.header().slot(),
+            block.transactions(),
+            channel_id,
+        );
 
         // Use current state lib to avoid premature finalization
-        state.process_block(block_id, parent_id, lib, our_txs);
+        state.process_block(block_id, parent_id, lib, &our_txs);
     }
 
     debug!("Canonical backfill complete");
@@ -658,6 +761,33 @@ fn enqueue_resubmit(
     }
 
     debug!("Resubmitting {} pending inscription(s)", pending.len());
+    let all_inscriptions = state
+        .parent_msg_id_map()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
+    // Extract the pending inscription(s) 'self_id' from all_inscriptions where its
+    // 'tx_hash' is equal to 'pending.0'
+    let pending_msg_ids: Vec<MsgId> = pending
+        .iter()
+        .filter_map(|(hash, _)| {
+            all_inscriptions.iter().find_map(|msg_state| {
+                msg_state
+                    .iter()
+                    .find(|v| v.tx_hash() == *hash)
+                    .map(MsgIdState::this_id)
+            })
+        })
+        .collect();
+
+    debug!(
+        "Resubmitting inscriptions: {}",
+        pending_msg_ids
+            .iter()
+            .map(|id| hex::encode(id.as_ref()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
 
     let client = http_client.clone();
     let url = node_url.clone();
@@ -676,11 +806,56 @@ fn enqueue_resubmit(
     }));
 }
 
-fn matches_channel(tx: &SignedMantleTx, channel_id: ChannelId) -> bool {
-    tx.mantle_tx
-        .ops
-        .iter()
-        .any(|op| matches!(op, Op::ChannelInscribe(inscribe) if inscribe.channel_id == channel_id))
+#[expect(
+    single_use_lifetimes,
+    reason = "stable Rust requires a named lifetime for this impl Iterator item reference"
+)]
+fn collect_msg_id_state_from_block<'a>(
+    header_id: HeaderId,
+    slot: Slot,
+    txs: impl Iterator<Item = &'a SignedMantleTx>,
+    channel_id: ChannelId,
+) -> Vec<MsgIdState> {
+    let mut inscriptions = Vec::new();
+
+    for tx in txs {
+        if let Some((msg_state, inscription_msg)) =
+            extract_msg_id_state(header_id, slot, tx, channel_id)
+        {
+            info!(
+                "Found inscription - block: '{}', slot: {}, msg: '{}', parent_id: {}, this_id: {}",
+                msg_state.header_id(),
+                msg_state.slot().into_inner(),
+                inscription_msg,
+                hex::encode(msg_state.parent_id().as_ref()),
+                hex::encode(msg_state.this_id().as_ref())
+            );
+            inscriptions.push(msg_state);
+        }
+    }
+
+    inscriptions
+}
+
+fn extract_msg_id_state(
+    header_id: HeaderId,
+    slot: Slot,
+    tx: &SignedMantleTx,
+    channel_id: ChannelId,
+) -> Option<(MsgIdState, String)> {
+    tx.mantle_tx.ops.iter().find_map(|op| {
+        if let Op::ChannelInscribe(inscribe) = op
+            && inscribe.channel_id == channel_id
+        {
+            let tx_hash = tx.mantle_tx.hash();
+            let parent_id = inscribe.parent;
+            let this_id = inscribe.id();
+            let msg_state = MsgIdState::new(header_id, slot, tx_hash, parent_id, this_id);
+            let inscription_msg = String::from_utf8_lossy(&inscribe.inscription).into_owned();
+            return Some((msg_state, inscription_msg));
+        }
+        None
+    })
 }
 
 fn create_inscribe_tx(
@@ -719,4 +894,319 @@ fn create_inscribe_tx(
     };
 
     (signed_tx, msg_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header_id(n: u8) -> HeaderId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = n;
+        HeaderId::from(bytes)
+    }
+
+    fn publish_parent_id(tx: &SignedMantleTx) -> MsgId {
+        match tx.mantle_tx.ops.first() {
+            Some(Op::ChannelInscribe(inscribe)) => inscribe.parent,
+            _ => panic!("expected a ChannelInscribe op"),
+        }
+    }
+
+    fn publish_this_id(tx: &SignedMantleTx) -> MsgId {
+        match tx.mantle_tx.ops.first() {
+            Some(Op::ChannelInscribe(inscribe)) => inscribe.id(),
+            _ => panic!("expected a ChannelInscribe op"),
+        }
+    }
+
+    fn test_tx_hash(seed: u8) -> TxHash {
+        let channel_id = ChannelId::from([seed; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[seed; 32]);
+        let (tx, _) = create_inscribe_tx(channel_id, &signing_key, vec![seed], MsgId::root());
+        tx.mantle_tx.hash()
+    }
+
+    #[test]
+    fn test_create_inscribe_tx_chains_parent() {
+        // Verify that inscribe transactions properly chain parent IDs
+        let channel_id = ChannelId::from([1u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[0u8; 32]);
+
+        let root_msg_id = MsgId::root();
+
+        // Create first inscription with root as parent
+        let (tx1, msg_id_1) =
+            create_inscribe_tx(channel_id, &signing_key, vec![1, 2, 3, 4], root_msg_id);
+
+        // Verify transaction is well-formed
+        assert_eq!(tx1.mantle_tx.ops.len(), 1);
+        assert!(matches!(tx1.mantle_tx.ops[0], Op::ChannelInscribe(_)));
+
+        // Create second inscription with first message ID as parent
+        let (tx2, msg_id_2) =
+            create_inscribe_tx(channel_id, &signing_key, vec![1, 2, 3, 4], msg_id_1);
+
+        // Verify the parent chain is different
+        assert_ne!(msg_id_1, msg_id_2);
+        assert_ne!(msg_id_1, root_msg_id);
+
+        // Verify both transactions are different
+        assert_ne!(tx1.mantle_tx.hash(), tx2.mantle_tx.hash());
+
+        // Verify the second transaction references the first as parent
+        if let Op::ChannelInscribe(inscribe) = &tx2.mantle_tx.ops[0] {
+            assert_eq!(inscribe.parent, msg_id_1);
+        } else {
+            panic!("Expected ChannelInscribe operation");
+        }
+    }
+
+    #[test]
+    fn test_collect_msg_id_state_from_block() {
+        // Verify that collect_msg_id_state_from_block correctly extracts channel
+        // inscriptions
+        use lb_core::mantle::{MantleTx, Transaction as _, ledger::Tx as LedgerTx};
+
+        let channel_id = ChannelId::from([1u8; 32]);
+        let other_channel_id = ChannelId::from([2u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[0u8; 32]);
+        let signer = signing_key.public_key();
+
+        // Create inscription for our channel
+        let inscribe_op_1 = InscriptionOp {
+            channel_id,
+            inscription: vec![1, 2, 3],
+            parent: MsgId::root(),
+            signer,
+        };
+
+        // Create inscription for different channel (should be filtered)
+        let inscribe_op_2 = InscriptionOp {
+            channel_id: other_channel_id,
+            inscription: vec![4, 5, 6],
+            parent: MsgId::root(),
+            signer,
+        };
+
+        let ledger_tx = LedgerTx::new(vec![], vec![]);
+
+        let tx1 = MantleTx {
+            ops: vec![Op::ChannelInscribe(inscribe_op_1)],
+            ledger_tx: ledger_tx.clone(),
+            storage_gas_price: 0,
+            execution_gas_price: 0,
+        };
+
+        let tx2 = MantleTx {
+            ops: vec![Op::ChannelInscribe(inscribe_op_2)],
+            ledger_tx,
+            storage_gas_price: 0,
+            execution_gas_price: 0,
+        };
+
+        let signed_tx1 = SignedMantleTx {
+            ops_proofs: vec![],
+            ledger_tx_proof: ZkKey::multi_sign(&[], tx1.hash().as_ref()).expect("multi-sign"),
+            mantle_tx: tx1,
+        };
+
+        let signed_tx2 = SignedMantleTx {
+            ops_proofs: vec![],
+            ledger_tx_proof: ZkKey::multi_sign(&[], tx2.hash().as_ref()).expect("multi-sign"),
+            mantle_tx: tx2,
+        };
+
+        let header = header_id(1);
+        let txs = [signed_tx1, signed_tx2];
+
+        // Collect only inscriptions for our channel
+        let result =
+            collect_msg_id_state_from_block(header, Slot::new(123), txs.iter(), channel_id);
+
+        // Should have only 1 entry (from our channel)
+        assert_eq!(result.len(), 1);
+
+        let msg_state = &result[0];
+        assert_eq!(msg_state.parent_id(), MsgId::root());
+        assert_eq!(msg_state.header_id(), header);
+    }
+
+    #[tokio::test]
+    async fn publish_uses_chain_tip_over_stale_last_msg_id() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let channel_id = ChannelId::from([9u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[3u8; 32]);
+
+        let mut tx_state = TxState::new(genesis);
+        let this_id = MsgId::from([42u8; 32]);
+        let known_hash = test_tx_hash(7);
+        tx_state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b1,
+                Slot::new(123),
+                known_hash,
+                MsgId::root(),
+                this_id,
+            )],
+        );
+
+        let mut state = Some(tx_state);
+        let mut stale_last_msg_id = MsgId::root();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle_request(
+            ActorRequest::Publish {
+                data: b"after-restart".to_vec(),
+                reply: reply_tx,
+            },
+            &mut state,
+            Some(b1),
+            Slot::genesis(),
+            channel_id,
+            &signing_key,
+            &mut stale_last_msg_id,
+        );
+
+        let (signed_tx, _result) = reply_rx
+            .await
+            .expect("publish reply dropped")
+            .expect("publish should succeed");
+        assert_eq!(publish_parent_id(&signed_tx), this_id);
+        assert_ne!(stale_last_msg_id, MsgId::root());
+    }
+
+    #[tokio::test]
+    async fn publish_rejects_ambiguous_chain_tip() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let b2 = header_id(2);
+        let channel_id = ChannelId::from([8u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[4u8; 32]);
+
+        let mut tx_state = TxState::new(genesis);
+        tx_state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b1,
+                Slot::new(123),
+                test_tx_hash(1),
+                MsgId::root(),
+                MsgId::from([11u8; 32]),
+            )],
+        );
+        tx_state.process_block(
+            b2,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b2,
+                Slot::new(234),
+                test_tx_hash(2),
+                MsgId::root(),
+                MsgId::from([12u8; 32]),
+            )],
+        );
+
+        let mut state = Some(tx_state);
+        let mut last_msg_id = MsgId::root();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        handle_request(
+            ActorRequest::Publish {
+                data: b"should-fail".to_vec(),
+                reply: reply_tx,
+            },
+            &mut state,
+            Some(b2),
+            Slot::genesis(),
+            channel_id,
+            &signing_key,
+            &mut last_msg_id,
+        );
+
+        let err = reply_rx
+            .await
+            .expect("publish reply dropped")
+            .expect_err("publish should fail when chain tip is ambiguous");
+        assert!(matches!(
+            err,
+            Error::Unavailable {
+                reason: "inscription fork is ambiguous"
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn publish_chains_multiple_pending_before_next_block() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let channel_id = ChannelId::from([7u8; 32]);
+        let signing_key = Ed25519Key::from_bytes(&[7u8; 32]);
+
+        // On-chain determinate tip.
+        let mut tx_state = TxState::new(genesis);
+        let chain_tip = MsgId::from([77u8; 32]);
+        tx_state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b1,
+                Slot::new(123),
+                test_tx_hash(77),
+                MsgId::root(),
+                chain_tip,
+            )],
+        );
+
+        let mut state = Some(tx_state);
+        let mut last_msg_id = chain_tip;
+
+        // First publish should build on chain tip.
+        let (reply_tx_1, reply_rx_1) = oneshot::channel();
+        handle_request(
+            ActorRequest::Publish {
+                data: b"m-1".to_vec(),
+                reply: reply_tx_1,
+            },
+            &mut state,
+            Some(b1),
+            Slot::genesis(),
+            channel_id,
+            &signing_key,
+            &mut last_msg_id,
+        );
+        let (tx_1, _) = reply_rx_1
+            .await
+            .expect("publish reply dropped")
+            .expect("first publish should succeed");
+        let msg_1 = publish_this_id(&tx_1);
+        assert_eq!(publish_parent_id(&tx_1), chain_tip);
+
+        // Second publish happens before any new block is processed.
+        // It must build on the first publish, not on the same chain tip again.
+        let (reply_tx_2, reply_rx_2) = oneshot::channel();
+        handle_request(
+            ActorRequest::Publish {
+                data: b"m-2".to_vec(),
+                reply: reply_tx_2,
+            },
+            &mut state,
+            Some(b1),
+            Slot::genesis(),
+            channel_id,
+            &signing_key,
+            &mut last_msg_id,
+        );
+        let (tx_2, _) = reply_rx_2
+            .await
+            .expect("publish reply dropped")
+            .expect("second publish should succeed");
+        assert_eq!(publish_parent_id(&tx_2), msg_1);
+    }
 }

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use futures::{StreamExt as _, future::BoxFuture, stream::FuturesUnordered};
 use lb_common_http_client::{BasicAuthCredentials, CommonHttpClient, ProcessedBlockEvent, Slot};
@@ -93,12 +96,24 @@ enum ActorRequest {
     Checkpoint {
         reply: oneshot::Sender<Result<SequencerCheckpoint, Error>>,
     },
+    WaitInclusion {
+        id: InscriptionId,
+        reply: oneshot::Sender<Result<(), Error>>,
+    },
 }
 
 enum InFlight {
     ResubmittedBatch {
         results: Vec<(InscriptionId, Result<(), String>)>,
     },
+}
+
+#[derive(Debug, Clone)]
+struct PendingPublication {
+    data: Vec<u8>,
+    current_tx_hash: Option<TxHash>,
+    parent_msg_id: Option<MsgId>,
+    current_msg_id: Option<MsgId>,
 }
 
 /// Zone sequencer client.
@@ -184,7 +199,7 @@ impl ZoneSequencer {
             hex::encode(result.parent_msg_id.as_ref()),
         );
 
-        // Post to network (best effort, will be resubmitted if needed)
+        // Post to network (best effort, will be resubmitted/recreated if needed)
         if let Err(e) = self
             .http_client
             .post_transaction(self.node_url.clone(), signed_tx)
@@ -194,6 +209,30 @@ impl ZoneSequencer {
         }
 
         Ok(result)
+    }
+
+    /// Wait until the logical inscription publish is on-chain.
+    ///
+    /// This follows automatic local recreation after collisions, so callers can
+    /// wait on the original inscription ID returned by
+    /// [`publish`](Self::publish).
+    pub async fn wait_for_inclusion(&self, id: InscriptionId) -> Result<(), Error> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = ActorRequest::WaitInclusion {
+            id,
+            reply: reply_tx,
+        };
+
+        self.request_tx
+            .send(request)
+            .await
+            .map_err(|_| Error::Unavailable {
+                reason: "actor channel closed",
+            })?;
+
+        reply_rx.await.map_err(|_| Error::Unavailable {
+            reason: "actor dropped reply",
+        })?
     }
 
     /// Get the status of an inscription.
@@ -360,6 +399,10 @@ async fn connect_blocks_stream(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "The main loop owns the core logic and state management of the sequencer, so it's natural for it to be long"
+)]
 async fn run_loop(
     mut request_rx: mpsc::Receiver<ActorRequest>,
     channel_id: ChannelId,
@@ -408,6 +451,10 @@ async fn run_loop(
     let mut resubmit_interval = tokio::time::interval(config.resubmit_interval);
     let mut resubmit_active = false;
     let mut in_flight: FuturesUnordered<BoxFuture<'static, InFlight>> = FuturesUnordered::new();
+    let mut pending_publications: HashMap<InscriptionId, PendingPublication> = HashMap::new();
+    let mut publish_order = Vec::<InscriptionId>::new();
+    let mut inclusion_waiters: HashMap<InscriptionId, Vec<oneshot::Sender<Result<(), Error>>>> =
+        HashMap::new();
 
     loop {
         let blocks_stream =
@@ -425,6 +472,9 @@ async fn run_loop(
                         channel_id,
                         &signing_key,
                         &mut last_msg_id,
+                        &mut pending_publications,
+                        &mut publish_order,
+                        &mut inclusion_waiters,
                     );
                 }
                 maybe_event = blocks_stream.next() => {
@@ -435,10 +485,21 @@ async fn run_loop(
                             &mut current_tip,
                             &mut lib_slot,
                             channel_id,
+                            &signing_key,
                             &http_client,
                             &node_url,
+                            &mut last_msg_id,
+                            &mut pending_publications,
+                            &publish_order,
                         )
                         .await;
+
+                        notify_inclusion_waiters(
+                            state.as_ref(),
+                            current_tip,
+                            &pending_publications,
+                            &mut inclusion_waiters,
+                        );
                     } else {
                         warn!("Blocks stream disconnected, reconnecting...");
                         break;
@@ -462,6 +523,14 @@ async fn run_loop(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "stateful actor request handling keeps merge impact localized"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Handling different request types in one place helps keep the logic consistent and maintainable"
+)]
 fn handle_request(
     request: ActorRequest,
     state: &mut Option<TxState>,
@@ -470,6 +539,9 @@ fn handle_request(
     channel_id: ChannelId,
     signing_key: &Ed25519Key,
     last_msg_id: &mut MsgId,
+    pending_publications: &mut HashMap<InscriptionId, PendingPublication>,
+    publish_order: &mut Vec<InscriptionId>,
+    inclusion_waiters: &mut HashMap<InscriptionId, Vec<oneshot::Sender<Result<(), Error>>>>,
 ) {
     let Some(tx_state) = state else {
         match request {
@@ -488,6 +560,11 @@ fn handle_request(
                     reason: "not initialized",
                 })));
             }
+            ActorRequest::WaitInclusion { reply, .. } => {
+                drop(reply.send(Err(Error::Unavailable {
+                    reason: "not initialized",
+                })));
+            }
         }
         return;
     };
@@ -498,9 +575,6 @@ fn handle_request(
             // local chain tip so multiple publishes before the next block remain ordered.
             let has_local_pending_chain = tx_state.pending_count() > 0;
             let parent_to_use = match current_tip {
-                // TODO: This will be fixed in PR#2375 as there is no proof another sequencer
-                // TODO: did not publish in the meantime and newly found inscriptions currently do
-                // TODO: not invalidate invalid pending inscriptions
                 Some(_) if has_local_pending_chain => *last_msg_id,
                 Some(_) => match tx_state.resolve_inscription_chain_tip() {
                     ChainTipResolution::Determinate(this_id) => this_id,
@@ -516,11 +590,22 @@ fn handle_request(
             };
 
             let (signed_tx, new_msg_id) =
-                create_inscribe_tx(channel_id, signing_key, data, parent_to_use);
+                create_inscribe_tx(channel_id, signing_key, data.clone(), parent_to_use);
             let tx_hash = signed_tx.mantle_tx.hash();
 
             tx_state.submit(tx_hash, signed_tx.clone());
             *last_msg_id = new_msg_id;
+
+            pending_publications.insert(
+                tx_hash,
+                PendingPublication {
+                    data,
+                    current_tx_hash: Some(tx_hash),
+                    parent_msg_id: Some(parent_to_use),
+                    current_msg_id: Some(new_msg_id),
+                },
+            );
+            publish_order.push(tx_hash);
 
             let checkpoint = build_checkpoint(tx_state, *last_msg_id, lib_slot);
             let result = PublishResult {
@@ -535,13 +620,38 @@ fn handle_request(
                 Err(Error::Unavailable {
                     reason: "not synced (no tip yet)",
                 }),
-                |tip| Ok(tx_state.status(&id, tip)),
+                |tip| Ok(publication_status(tx_state, tip, &id, pending_publications)),
             );
             drop(reply.send(result));
         }
         ActorRequest::Checkpoint { reply } => {
             let checkpoint = build_checkpoint(tx_state, *last_msg_id, lib_slot);
             drop(reply.send(Ok(checkpoint)));
+        }
+        ActorRequest::WaitInclusion { id, reply } => {
+            let result = current_tip.map_or(
+                Err(Error::Unavailable {
+                    reason: "not synced (no tip yet)",
+                }),
+                |tip| Ok(publication_status(tx_state, tip, &id, pending_publications)),
+            );
+
+            match result {
+                Ok(TxStatus::Safe | TxStatus::Finalized) => {
+                    drop(reply.send(Ok(())));
+                }
+                Ok(TxStatus::Pending) => {
+                    inclusion_waiters.entry(id).or_default().push(reply);
+                }
+                Ok(TxStatus::Unknown) => {
+                    drop(reply.send(Err(Error::Unavailable {
+                        reason: "unknown inscription",
+                    })));
+                }
+                Err(err) => {
+                    drop(reply.send(Err(err)));
+                }
+            }
         }
     }
 }
@@ -558,14 +668,22 @@ fn build_checkpoint(state: &TxState, last_msg_id: MsgId, lib_slot: Slot) -> Sequ
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "block event processing owns the chain observation and local rebase logic"
+)]
 async fn handle_block_event(
     event: &ProcessedBlockEvent,
     state: &mut Option<TxState>,
     current_tip: &mut Option<HeaderId>,
     lib_slot: &mut Slot,
     channel_id: ChannelId,
+    signing_key: &Ed25519Key,
     http_client: &CommonHttpClient,
     node_url: &Url,
+    last_msg_id: &mut MsgId,
+    pending_publications: &mut HashMap<InscriptionId, PendingPublication>,
+    publish_order: &[InscriptionId],
 ) {
     let block_id = event.block.header.id;
     let parent_id = event.block.header.parent_block;
@@ -591,8 +709,12 @@ async fn handle_block_event(
                 *lib_slot,
                 new_lib_slot,
                 channel_id,
+                signing_key,
                 http_client,
                 node_url,
+                last_msg_id,
+                pending_publications,
+                publish_order,
             )
             .await;
         }
@@ -601,7 +723,18 @@ async fn handle_block_event(
 
     // 2. Backfill canonical chain if parent is missing
     if !s.has_block(&parent_id) && parent_id != s.lib() {
-        backfill_canonical(s, parent_id, channel_id, http_client, node_url).await;
+        backfill_canonical(
+            s,
+            parent_id,
+            channel_id,
+            signing_key,
+            http_client,
+            node_url,
+            last_msg_id,
+            pending_publications,
+            publish_order,
+        )
+        .await;
     }
 
     // Extract channel tx lineage keyed by block header id.
@@ -616,6 +749,23 @@ async fn handle_block_event(
     // advanced)
     s.process_block(block_id, parent_id, lib, &our_txs);
     *current_tip = Some(tip);
+
+    // Detect foreign inscriptions that claimed a parent used by a pending local
+    // inscription.
+    let conflicted = detect_conflicting_publications(s, tip, &our_txs, pending_publications);
+    suspend_publications(s, &conflicted, pending_publications);
+
+    try_recreate_suspended_publications(
+        s,
+        channel_id,
+        signing_key,
+        node_url,
+        http_client,
+        last_msg_id,
+        pending_publications,
+        publish_order,
+    )
+    .await;
 }
 
 fn handle_inflight(event: InFlight, resubmit_active: &mut bool) {
@@ -632,18 +782,67 @@ fn handle_inflight(event: InFlight, resubmit_active: &mut bool) {
     }
 }
 
+fn notify_inclusion_waiters(
+    state: Option<&TxState>,
+    current_tip: Option<HeaderId>,
+    pending_publications: &HashMap<InscriptionId, PendingPublication>,
+    inclusion_waiters: &mut HashMap<InscriptionId, Vec<oneshot::Sender<Result<(), Error>>>>,
+) {
+    let (Some(s), Some(tip)) = (state, current_tip) else {
+        return;
+    };
+
+    let resolved = inclusion_waiters
+        .keys()
+        .filter(|id| publication_status(s, tip, id, pending_publications).is_on_chain())
+        .copied()
+        .collect::<Vec<_>>();
+
+    for logical_id in resolved {
+        if let Some(waiters) = inclusion_waiters.remove(&logical_id) {
+            for waiter in waiters {
+                drop(waiter.send(Ok(())));
+            }
+        }
+    }
+}
+
+fn publication_status(
+    state: &TxState,
+    tip: HeaderId,
+    id: &InscriptionId,
+    pending_publications: &HashMap<InscriptionId, PendingPublication>,
+) -> TxStatus {
+    if let Some(pending) = pending_publications.get(id) {
+        if let Some(current_tx_hash) = pending.current_tx_hash {
+            return state.status(&current_tx_hash, tip);
+        }
+        return TxStatus::Pending;
+    }
+
+    state.status(id, tip)
+}
+
 /// Backfill finalized blocks from current `lib_slot` to new `lib_slot`.
 ///
 /// Uses `state.lib()` during replay to avoid premature finalization.
 /// The caller is responsible for triggering finalization after backfill
 /// completes.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "backfill needs access to both chain state and publication rebase state"
+)]
 async fn backfill_to_lib(
     state: &mut TxState,
     from_slot: Slot,
     to_slot: Slot,
     channel_id: ChannelId,
+    signing_key: &Ed25519Key,
     http_client: &CommonHttpClient,
     node_url: &Url,
+    last_msg_id: &mut MsgId,
+    pending_publications: &mut HashMap<InscriptionId, PendingPublication>,
+    publish_order: &[InscriptionId],
 ) {
     let from: u64 = from_slot.into();
     let to: u64 = to_slot.into();
@@ -674,6 +873,26 @@ async fn backfill_to_lib(
                 // Use current state lib to avoid premature finalization
                 let current_lib = state.lib();
                 state.process_block(block_id, parent_id, current_lib, &our_txs);
+
+                let conflicted = detect_conflicting_publications(
+                    state,
+                    block_id,
+                    &our_txs,
+                    pending_publications,
+                );
+                suspend_publications(state, &conflicted, pending_publications);
+
+                try_recreate_suspended_publications(
+                    state,
+                    channel_id,
+                    signing_key,
+                    node_url,
+                    http_client,
+                    last_msg_id,
+                    pending_publications,
+                    publish_order,
+                )
+                .await;
             }
             debug!("Backfilled {} finalized blocks", to - from);
         }
@@ -688,12 +907,20 @@ async fn backfill_to_lib(
 /// Uses `state.lib()` during replay to avoid premature finalization.
 /// The caller is responsible for triggering finalization after backfill
 /// completes.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "backfill needs access to both chain state and publication rebase state"
+)]
 async fn backfill_canonical(
     state: &mut TxState,
     missing_parent: HeaderId,
     channel_id: ChannelId,
+    signing_key: &Ed25519Key,
     http_client: &CommonHttpClient,
     node_url: &Url,
+    last_msg_id: &mut MsgId,
+    pending_publications: &mut HashMap<InscriptionId, PendingPublication>,
+    publish_order: &[InscriptionId],
 ) {
     debug!("Backfilling canonical chain from {:?}", missing_parent);
 
@@ -738,6 +965,22 @@ async fn backfill_canonical(
 
         // Use current state lib to avoid premature finalization
         state.process_block(block_id, parent_id, lib, &our_txs);
+
+        let conflicted =
+            detect_conflicting_publications(state, block_id, &our_txs, pending_publications);
+        suspend_publications(state, &conflicted, pending_publications);
+
+        try_recreate_suspended_publications(
+            state,
+            channel_id,
+            signing_key,
+            node_url,
+            http_client,
+            last_msg_id,
+            pending_publications,
+            publish_order,
+        )
+        .await;
     }
 
     debug!("Canonical backfill complete");
@@ -804,6 +1047,163 @@ fn enqueue_resubmit(
         }
         InFlight::ResubmittedBatch { results }
     }));
+}
+
+fn detect_conflicting_publications(
+    state: &TxState,
+    tip: HeaderId,
+    inscriptions: &[MsgIdState],
+    pending_publications: &HashMap<InscriptionId, PendingPublication>,
+) -> HashSet<InscriptionId> {
+    let active_current_hashes = pending_publications
+        .values()
+        .filter_map(|publication| publication.current_tx_hash)
+        .collect::<HashSet<_>>();
+
+    let mut conflicted = HashSet::new();
+
+    for inscription in inscriptions {
+        // Only foreign newly minted inscriptions can invalidate pending local attempts.
+        if active_current_hashes.contains(&inscription.tx_hash()) {
+            continue;
+        }
+
+        let mut claimed_parents = vec![inscription.parent_id()];
+        let mut seen_msg_ids = HashSet::new();
+
+        while let Some(parent_id) = claimed_parents.pop() {
+            for (logical_id, publication) in pending_publications {
+                let Some(current_parent) = publication.parent_msg_id else {
+                    continue;
+                };
+                let Some(current_msg_id) = publication.current_msg_id else {
+                    continue;
+                };
+                let Some(current_tx_hash) = publication.current_tx_hash else {
+                    continue;
+                };
+
+                if current_parent != parent_id {
+                    continue;
+                }
+
+                if !matches!(state.status(&current_tx_hash, tip), TxStatus::Pending) {
+                    continue;
+                }
+
+                if conflicted.insert(*logical_id) && seen_msg_ids.insert(current_msg_id) {
+                    claimed_parents.push(current_msg_id);
+                }
+            }
+        }
+    }
+
+    conflicted
+}
+
+fn suspend_publications(
+    state: &mut TxState,
+    conflicted: &HashSet<InscriptionId>,
+    pending_publications: &mut HashMap<InscriptionId, PendingPublication>,
+) {
+    for logical_id in conflicted {
+        if let Some(publication) = pending_publications.get_mut(logical_id) {
+            if let Some(current_tx_hash) = publication.current_tx_hash.take() {
+                let _unused = state.remove_pending(&current_tx_hash);
+            }
+            publication.parent_msg_id = None;
+            publication.current_msg_id = None;
+        }
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Publication recreation needs access to both chain state and publication rebase state"
+)]
+async fn try_recreate_suspended_publications(
+    state: &mut TxState,
+    channel_id: ChannelId,
+    signing_key: &Ed25519Key,
+    node_url: &Url,
+    http_client: &CommonHttpClient,
+    last_msg_id: &mut MsgId,
+    pending_publications: &mut HashMap<InscriptionId, PendingPublication>,
+    publish_order: &[InscriptionId],
+) {
+    let suspended = publish_order
+        .iter()
+        .copied()
+        .filter(|logical_id| {
+            pending_publications
+                .get(logical_id)
+                .is_some_and(|publication| publication.current_tx_hash.is_none())
+        })
+        .collect::<Vec<_>>();
+
+    if suspended.is_empty() {
+        return;
+    }
+
+    let has_active_pending_chain = pending_publications
+        .values()
+        .any(|publication| publication.current_tx_hash.is_some());
+
+    let mut parent_to_use = if has_active_pending_chain {
+        *last_msg_id
+    } else {
+        match state.resolve_inscription_chain_tip() {
+            ChainTipResolution::Determinate(msg_id) => msg_id,
+            ChainTipResolution::NoInscriptions => MsgId::root(),
+            ChainTipResolution::Ambiguous => {
+                warn!(
+                    "Inscription lineage is ambiguous; delaying recreation of {} pending \
+                     inscription(s) until the chain tip becomes determinate",
+                    suspended.len()
+                );
+                return;
+            }
+        }
+    };
+
+    for logical_id in suspended {
+        let Some(publication) = pending_publications.get(&logical_id).cloned() else {
+            continue;
+        };
+
+        let (signed_tx, new_msg_id) = create_inscribe_tx(
+            channel_id,
+            signing_key,
+            publication.data.clone(),
+            parent_to_use,
+        );
+        let tx_hash = signed_tx.mantle_tx.hash();
+
+        state.submit(tx_hash, signed_tx.clone());
+
+        if let Some(publication) = pending_publications.get_mut(&logical_id) {
+            publication.current_tx_hash = Some(tx_hash);
+            publication.parent_msg_id = Some(parent_to_use);
+            publication.current_msg_id = Some(new_msg_id);
+        }
+
+        *last_msg_id = new_msg_id;
+        parent_to_use = new_msg_id;
+
+        info!(
+            "Recreated conflicting inscription - logical: {}, new hash: {}, parent msg id: {}",
+            hex::encode(logical_id.to_bytes().unwrap_or_default()),
+            hex::encode(tx_hash.to_bytes().unwrap_or_default()),
+            hex::encode(parent_to_use.as_ref()),
+        );
+
+        if let Err(e) = http_client
+            .post_transaction(node_url.clone(), signed_tx)
+            .await
+        {
+            warn!("Failed to post recreated transaction: {e}");
+        }
+    }
 }
 
 #[expect(
@@ -1057,6 +1457,10 @@ mod tests {
 
         let mut state = Some(tx_state);
         let mut stale_last_msg_id = MsgId::root();
+        let mut pending_publications = HashMap::new();
+        let mut publish_order = Vec::new();
+        let mut inclusion_waiters = HashMap::new();
+
         let (reply_tx, reply_rx) = oneshot::channel();
         handle_request(
             ActorRequest::Publish {
@@ -1069,6 +1473,9 @@ mod tests {
             channel_id,
             &signing_key,
             &mut stale_last_msg_id,
+            &mut pending_publications,
+            &mut publish_order,
+            &mut inclusion_waiters,
         );
 
         let (signed_tx, _result) = reply_rx
@@ -1115,6 +1522,10 @@ mod tests {
 
         let mut state = Some(tx_state);
         let mut last_msg_id = MsgId::root();
+        let mut pending_publications = HashMap::new();
+        let mut publish_order = Vec::new();
+        let mut inclusion_waiters = HashMap::new();
+
         let (reply_tx, reply_rx) = oneshot::channel();
         handle_request(
             ActorRequest::Publish {
@@ -1127,6 +1538,9 @@ mod tests {
             channel_id,
             &signing_key,
             &mut last_msg_id,
+            &mut pending_publications,
+            &mut publish_order,
+            &mut inclusion_waiters,
         );
 
         let err = reply_rx
@@ -1166,6 +1580,9 @@ mod tests {
 
         let mut state = Some(tx_state);
         let mut last_msg_id = chain_tip;
+        let mut pending_publications = HashMap::new();
+        let mut publish_order = Vec::new();
+        let mut inclusion_waiters = HashMap::new();
 
         // First publish should build on chain tip.
         let (reply_tx_1, reply_rx_1) = oneshot::channel();
@@ -1180,6 +1597,9 @@ mod tests {
             channel_id,
             &signing_key,
             &mut last_msg_id,
+            &mut pending_publications,
+            &mut publish_order,
+            &mut inclusion_waiters,
         );
         let (tx_1, _) = reply_rx_1
             .await
@@ -1202,6 +1622,9 @@ mod tests {
             channel_id,
             &signing_key,
             &mut last_msg_id,
+            &mut pending_publications,
+            &mut publish_order,
+            &mut inclusion_waiters,
         );
         let (tx_2, _) = reply_rx_2
             .await

--- a/zone-sdk/src/state.rs
+++ b/zone-sdk/src/state.rs
@@ -398,9 +398,26 @@ impl TxState {
         self.current_lib
     }
 
+    /// Remove a pending transaction, returning it if it existed.
+    ///
+    /// Also scrubs the tx hash from every block safe set so that
+    /// [`status`](Self::status) immediately reflects the removal.
+    pub fn remove_pending(&mut self, tx_hash: &TxHash) -> Option<SignedMantleTx> {
+        let tx = self.pending.remove(tx_hash)?;
+        for safe_set in self.block_states.values_mut() {
+            *safe_set = safe_set.remove(tx_hash);
+        }
+        Some(tx)
+    }
+
     /// All pending transactions (for checkpoint serialization).
     pub fn all_pending_txs(&self) -> impl Iterator<Item = (&TxHash, &SignedMantleTx)> {
         self.pending.iter()
+    }
+
+    #[must_use]
+    pub fn is_tx_pending(&self, tx_hash: &TxHash) -> bool {
+        self.pending.contains_key(tx_hash)
     }
 
     fn all_known_inscriptions(&self) -> Vec<MsgIdState> {
@@ -822,7 +839,7 @@ mod tests {
             genesis,
             genesis,
             &[MsgIdState::new(
-                header_id(1),
+                header_id(2),
                 Slot::new(123),
                 tx_b.mantle_tx.hash(),
                 MsgId::root(),
@@ -843,7 +860,7 @@ mod tests {
             block_2,
             genesis,
             &[MsgIdState::new(
-                header_id(2),
+                header_id(3),
                 Slot::new(234),
                 tx_b_child.mantle_tx.hash(),
                 this_pid_b,

--- a/zone-sdk/src/state.rs
+++ b/zone-sdk/src/state.rs
@@ -1,8 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use lb_common_http_client::Slot;
 use lb_core::{
     header::HeaderId,
-    mantle::{SignedMantleTx, tx::TxHash},
+    mantle::{SignedMantleTx, ops::channel::MsgId, tx::TxHash},
 };
 use rpds::HashTrieSetSync;
 
@@ -19,6 +20,24 @@ pub enum TxStatus {
     Unknown,
 }
 
+impl TxStatus {
+    #[must_use]
+    pub const fn is_on_chain(&self) -> bool {
+        matches!(self, Self::Safe | Self::Finalized)
+    }
+}
+
+/// Result of resolving the latest inscription chain tip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainTipResolution {
+    /// A deterministic chain tip was found.
+    Determinate(MsgId),
+    /// No inscriptions are known yet.
+    NoInscriptions,
+    /// Competing branches are present with no deterministic winner yet.
+    Ambiguous,
+}
+
 /// Transaction state tracker.
 pub struct TxState {
     /// All transactions being tracked, kept until finalized.
@@ -31,6 +50,71 @@ pub struct TxState {
     finalized: HashSet<TxHash>,
     /// Current LIB for pruning.
     current_lib: HeaderId,
+    /// Inscriptions tracked per block header (allows multiple inscriptions per
+    /// block)
+    parent_msg_id_map: HashMap<HeaderId, Vec<MsgIdState>>,
+    /// Last finalized inscription state retained when older blocks are pruned.
+    /// This preserves enough lineage to continue building the correct chain.
+    last_finalized_msg_state: Option<MsgIdState>,
+}
+
+/// Relationship between `HeaderId`, `TxHash` and `MsgId`
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct MsgIdState {
+    /// The header ID of the block containing this inscription
+    header_id: HeaderId,
+    /// The slot of the block containing this inscription
+    slot: Slot,
+    /// The `TxHash` of the transaction that was included in the block
+    tx_hash: TxHash,
+    /// The `MsgId` of the parent message
+    parent_id: MsgId,
+    /// The `MsgId` of this message
+    this_id: MsgId,
+}
+
+impl MsgIdState {
+    #[must_use]
+    pub const fn new(
+        header_id: HeaderId,
+        slot: Slot,
+        tx_hash: TxHash,
+        parent_id: MsgId,
+        this_id: MsgId,
+    ) -> Self {
+        Self {
+            header_id,
+            slot,
+            tx_hash,
+            parent_id,
+            this_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn header_id(&self) -> HeaderId {
+        self.header_id
+    }
+
+    #[must_use]
+    pub const fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    #[must_use]
+    pub const fn tx_hash(&self) -> TxHash {
+        self.tx_hash
+    }
+
+    #[must_use]
+    pub const fn parent_id(&self) -> MsgId {
+        self.parent_id
+    }
+
+    #[must_use]
+    pub const fn this_id(&self) -> MsgId {
+        self.this_id
+    }
 }
 
 impl TxState {
@@ -44,6 +128,8 @@ impl TxState {
             parent_map: HashMap::new(),
             finalized: HashSet::new(),
             current_lib: lib,
+            parent_msg_id_map: HashMap::new(),
+            last_finalized_msg_state: None,
         }
     }
 
@@ -52,13 +138,75 @@ impl TxState {
         self.pending.insert(tx_hash, signed_tx);
     }
 
+    // Order MsgIdState values into parent-linked chain(s).
+    // A chain starts at a root inscription (parent_id == MsgId::root())
+    // or at an orphan relative to this batch (its parent_id does not appear
+    // as any this_id in the provided states).
+    fn order_msg_id_states(states: &[MsgIdState]) -> Vec<Vec<MsgIdState>> {
+        const fn all_assigned(all: usize, assigned: &[MsgIdState]) -> bool {
+            assigned.len() >= all
+        }
+
+        let mut ordered = Vec::new();
+        let mut roots = Vec::new();
+        let mut assigned = Vec::new();
+
+        // First find the root inscription(s), those that have parent_id ==
+        // MsgId::root() or whose parent_id is not referenced as a this_id in
+        // any other inscription (orphans).
+        for state in states {
+            if state.parent_id() == MsgId::root()
+                || !states.iter().any(|s| s.this_id() == state.parent_id())
+            {
+                roots.push(*state);
+            }
+        }
+
+        for root in roots {
+            ordered.push(vec![root]);
+            assigned.push(root);
+        }
+
+        let mut cyclic = 0;
+        while !all_assigned(states.len(), &assigned) && cyclic < states.len() {
+            let mut progress = false;
+
+            for chain in &mut ordered {
+                let Some(mut last) = chain.last().copied() else {
+                    continue;
+                };
+
+                for state in states {
+                    if assigned.contains(state) {
+                        continue; // Already ordered
+                    }
+
+                    if state.parent_id() == last.this_id() {
+                        chain.push(*state);
+                        assigned.push(*state);
+                        last = *state;
+                        progress = true;
+                    }
+                }
+            }
+
+            if progress {
+                cyclic = 0;
+            } else {
+                cyclic += 1;
+            }
+        }
+
+        ordered
+    }
+
     /// Process a new block.
     pub fn process_block(
         &mut self,
         block_id: HeaderId,
         parent_id: HeaderId,
         lib: HeaderId,
-        our_txs: impl IntoIterator<Item = TxHash>,
+        our_txs: &[MsgIdState],
     ) {
         // Store parent relationship for pruning
         self.parent_map.insert(block_id, parent_id);
@@ -74,11 +222,26 @@ impl TxState {
             .cloned()
             .unwrap_or_default();
 
-        for tx in our_txs {
-            if self.pending.contains_key(&tx) {
-                safe_set = safe_set.insert(tx);
+        for msg_state in our_txs {
+            if self.pending.contains_key(&msg_state.tx_hash) {
+                safe_set = safe_set.insert(msg_state.tx_hash);
             }
         }
+
+        // Store inscriptions for this block
+        if !our_txs.is_empty() {
+            let ordered = Self::order_msg_id_states(our_txs);
+            debug_assert!(
+                ordered.len() <= 1,
+                "expected at most one inscription chain per block, got {}",
+                ordered.len()
+            );
+
+            if let Some(chain) = ordered.into_iter().next() {
+                self.parent_msg_id_map.insert(block_id, chain);
+            }
+        }
+
         self.block_states.insert(block_id, safe_set);
 
         // When lib advances: finalize txs and prune
@@ -103,19 +266,56 @@ impl TxState {
                 block_opt = self.parent_map.get(&block).copied();
             }
 
-            // Prune ancestors of new lib (but not lib itself)
+            // Prune finalized ancestors of new lib (but not lib itself)
+            // Keep parent/inscription lineage so we can reconstruct chain ancestry
+            // after clean restarts and around shallow reorg windows.
             let mut prune_cursor = self.parent_map.get(&lib).copied();
+            let mut pruned_headers = Vec::new();
+
             while let Some(b) = prune_cursor {
+                pruned_headers.push(b);
                 self.block_states.remove(&b);
-                prune_cursor = self.parent_map.remove(&b);
+                prune_cursor = self.parent_map.get(&b).copied();
             }
+
+            let pruned_msg_id_set = pruned_headers
+                .iter()
+                .filter_map(|header_id| self.parent_msg_id_map.get(header_id))
+                .flatten()
+                .copied()
+                .collect::<Vec<_>>();
+
+            let ordered_msg_id_states = Self::order_msg_id_states(&pruned_msg_id_set);
+
+            // Determine which header(s) to keep below LIB: the last block in each chain.
+            let kept_headers = ordered_msg_id_states
+                .iter()
+                .filter_map(|chain| chain.last().map(MsgIdState::header_id))
+                .collect::<HashSet<_>>();
+
+            // Remove all other pruned below-LIB headers from parent_msg_id_map.
+            for header_id in &pruned_headers {
+                if !kept_headers.contains(header_id) {
+                    self.parent_msg_id_map.remove(header_id);
+                }
+            }
+
+            // Refresh the finalized fallback from the retained below-LIB blocks.
+            self.last_finalized_msg_state = kept_headers
+                .iter()
+                .filter_map(|header_id| self.parent_msg_id_map.get(header_id))
+                .flatten()
+                .copied()
+                .last();
 
             self.prune_orphans(lib);
             self.current_lib = lib;
         }
     }
 
-    /// Remove orphaned blocks whose parent was pruned.
+    /// Remove orphaned block-state snapshots whose parent snapshot was pruned.
+    /// Keep block/inscription lineage maps for deterministic parent
+    /// reconstruction.
     fn prune_orphans(&mut self, lib: HeaderId) {
         loop {
             let orphans: Vec<_> = self
@@ -126,8 +326,8 @@ impl TxState {
                         return None; // lib is root
                     }
                     let parent_is_lib = *parent == lib;
-                    let parent_exists = self.parent_map.contains_key(parent);
-                    (!parent_is_lib && !parent_exists).then_some(*id)
+                    let parent_snapshot_exists = self.block_states.contains_key(parent);
+                    (!parent_is_lib && !parent_snapshot_exists).then_some(*id)
                 })
                 .collect();
 
@@ -137,6 +337,7 @@ impl TxState {
 
             for orphan in orphans {
                 self.block_states.remove(&orphan);
+                // Keep parent_msg_id_map lineage, but remove orphan edges so pruning converges.
                 self.parent_map.remove(&orphan);
             }
         }
@@ -201,6 +402,84 @@ impl TxState {
     pub fn all_pending_txs(&self) -> impl Iterator<Item = (&TxHash, &SignedMantleTx)> {
         self.pending.iter()
     }
+
+    fn all_known_inscriptions(&self) -> Vec<MsgIdState> {
+        let mut all = Vec::new();
+        for states in self.parent_msg_id_map.values() {
+            all.extend(states.iter().copied());
+        }
+        if let Some(finalized) = self.last_finalized_msg_state
+            && !all.contains(&finalized)
+        {
+            all.push(finalized);
+        }
+        all
+    }
+
+    /// Resolve the latest known inscription chain tip.
+    ///
+    /// If two competing branches have equal best length, the tip is ambiguous
+    /// until a subsequent inscription extends one branch.
+    #[must_use]
+    pub fn resolve_inscription_chain_tip(&self) -> ChainTipResolution {
+        let all = self.all_known_inscriptions();
+
+        if all.is_empty() {
+            return ChainTipResolution::NoInscriptions;
+        }
+
+        let chains = Self::order_msg_id_states(&all);
+
+        if chains.is_empty() {
+            return ChainTipResolution::NoInscriptions;
+        }
+
+        let max_len = chains.iter().map(Vec::len).max().unwrap_or(0);
+
+        let best: Vec<&Vec<MsgIdState>> = chains.iter().filter(|c| c.len() == max_len).collect();
+
+        if best.len() > 1 {
+            return ChainTipResolution::Ambiguous;
+        }
+
+        best[0]
+            .last()
+            .map_or(ChainTipResolution::NoInscriptions, |state| {
+                ChainTipResolution::Determinate(state.this_id())
+            })
+    }
+
+    /// Get the latest confirmed parent message ID from blocks that have been
+    /// processed. Returns `None` if there are no inscriptions or the latest
+    /// tip is ambiguous.
+    #[must_use]
+    pub fn latest_confirmed_parent_id(&self) -> Option<MsgId> {
+        match self.resolve_inscription_chain_tip() {
+            ChainTipResolution::Determinate(this_id) => self
+                .all_known_inscriptions()
+                .into_iter()
+                .find(|s| s.this_id() == this_id)
+                .map(|s| s.parent_id()),
+            ChainTipResolution::NoInscriptions | ChainTipResolution::Ambiguous => None,
+        }
+    }
+
+    /// Get the latest chain tip message ID from processed blocks.
+    /// Returns `None` when no inscriptions are known or the tip is ambiguous.
+    #[must_use]
+    pub fn latest_inscriptions_tip_id(&self) -> Option<MsgId> {
+        match self.resolve_inscription_chain_tip() {
+            ChainTipResolution::Determinate(this_id) => Some(this_id),
+            ChainTipResolution::NoInscriptions | ChainTipResolution::Ambiguous => None,
+        }
+    }
+
+    /// Get the mapping of block headers to their included inscriptions
+    /// (`MsgIdState`).
+    #[must_use]
+    pub fn parent_msg_id_map(&self) -> HashMap<HeaderId, Vec<MsgIdState>> {
+        self.parent_msg_id_map.clone()
+    }
 }
 
 #[cfg(test)]
@@ -234,6 +513,24 @@ mod tests {
         }
     }
 
+    fn empty_our_txs() -> Vec<MsgIdState> {
+        Vec::new()
+    }
+
+    fn our_txs_with_hash(header_id: HeaderId, slot: Slot, hash: TxHash) -> Vec<MsgIdState> {
+        // Derive a distinct this_id from the tx_hash bytes so parent_id != this_id,
+        // preventing a self-loop in the inscription children map.
+        let bytes: [u8; 32] = hash.into();
+        let this_id = MsgId::from(bytes);
+        vec![MsgIdState::new(
+            header_id,
+            slot,
+            hash,
+            MsgId::root(),
+            this_id,
+        )]
+    }
+
     #[test]
     fn submit_and_query_pending() {
         let genesis = header_id(0);
@@ -257,7 +554,12 @@ mod tests {
         state.submit(hash, tx);
 
         // Process block containing our tx, lib stays at genesis
-        state.process_block(b1, genesis, genesis, vec![hash]);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &our_txs_with_hash(header_id(1), Slot::new(123), hash),
+        );
 
         assert_eq!(state.status(&hash, b1), TxStatus::Safe);
         assert_eq!(state.status(&hash, genesis), TxStatus::Pending);
@@ -275,11 +577,16 @@ mod tests {
         state.submit(hash, tx);
 
         // b1 with our tx
-        state.process_block(b1, genesis, genesis, vec![hash]);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &our_txs_with_hash(header_id(1), Slot::new(123), hash),
+        );
         assert_eq!(state.status(&hash, b1), TxStatus::Safe);
 
         // b2, lib advances to b1
-        state.process_block(b2, b1, b1, vec![]);
+        state.process_block(b2, b1, b1, &empty_our_txs());
         assert_eq!(state.status(&hash, b2), TxStatus::Finalized);
         assert_eq!(state.finalized_count(), 1);
     }
@@ -299,7 +606,12 @@ mod tests {
         state.submit(hash2, tx2);
 
         // b1 contains only tx1
-        state.process_block(b1, genesis, genesis, vec![hash1]);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &our_txs_with_hash(header_id(1), Slot::new(123), hash1),
+        );
 
         // pending_txs at b1 should only return tx2
         let pending: Vec<_> = state.pending_txs(b1).map(|(h, _)| *h).collect();
@@ -321,11 +633,16 @@ mod tests {
         state.submit(hash, tx);
 
         // b1 has our tx
-        state.process_block(b1, genesis, genesis, vec![hash]);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &our_txs_with_hash(header_id(1), Slot::new(123), hash),
+        );
         assert_eq!(state.status(&hash, b1), TxStatus::Safe);
 
         // b2 forks from genesis, no tx
-        state.process_block(b2, genesis, genesis, vec![]);
+        state.process_block(b2, genesis, genesis, &empty_our_txs());
 
         // At b2 tip, tx is not safe (different branch)
         assert_eq!(state.status(&hash, b2), TxStatus::Pending);
@@ -351,19 +668,19 @@ mod tests {
         let mut state = TxState::new(genesis);
 
         // Build main chain up to a1
-        state.process_block(a1, genesis, genesis, vec![]);
+        state.process_block(a1, genesis, genesis, &empty_our_txs());
 
         // Build fork from a1 (before lib advances past a1)
-        state.process_block(b1, a1, genesis, vec![]);
-        state.process_block(b2, b1, genesis, vec![]);
+        state.process_block(b1, a1, genesis, &empty_our_txs());
+        state.process_block(b2, b1, genesis, &empty_our_txs());
 
         // Verify fork blocks exist before lib advances
         assert!(state.block_states.contains_key(&b1));
         assert!(state.block_states.contains_key(&b2));
 
         // Continue main chain, lib advances to a3
-        state.process_block(a2, a1, genesis, vec![]);
-        state.process_block(a3, a2, a3, vec![]); // lib advances to a3
+        state.process_block(a2, a1, genesis, &empty_our_txs());
+        state.process_block(a3, a2, a3, &empty_our_txs()); // lib advances to a3
 
         // After lib advances to a3:
         // - genesis, a1, a2 should be pruned (ancestors up to and including old lib)
@@ -388,9 +705,9 @@ mod tests {
         assert!(state.block_states.contains_key(&a3), "lib should exist");
 
         // Continue and verify pruning continues working
-        state.process_block(a4, a3, a3, vec![]);
-        state.process_block(a5, a4, a5, vec![]); // lib advances to a5
-        state.process_block(a6, a5, a5, vec![]);
+        state.process_block(a4, a3, a3, &empty_our_txs());
+        state.process_block(a5, a4, a5, &empty_our_txs()); // lib advances to a5
+        state.process_block(a6, a5, a5, &empty_our_txs());
 
         assert!(
             !state.block_states.contains_key(&a3),
@@ -422,15 +739,121 @@ mod tests {
         state.submit(hash2, tx2);
 
         // b1 has tx1
-        state.process_block(b1, genesis, genesis, vec![hash1]);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &our_txs_with_hash(header_id(1), Slot::new(123), hash1),
+        );
         // b2 has tx2
-        state.process_block(b2, b1, genesis, vec![hash2]);
+        state.process_block(
+            b2,
+            b1,
+            genesis,
+            &our_txs_with_hash(header_id(2), Slot::new(234), hash2),
+        );
         // b3, lib jumps from genesis to b2 (skipping b1)
-        state.process_block(b3, b2, b2, vec![]);
+        state.process_block(b3, b2, b2, &empty_our_txs());
 
         // Both tx1 (in b1) and tx2 (in b2) should be finalized
         assert_eq!(state.status(&hash1, b3), TxStatus::Finalized);
         assert_eq!(state.status(&hash2, b3), TxStatus::Finalized);
         assert_eq!(state.finalized_count(), 2);
+    }
+
+    #[test]
+    fn keeps_finalized_history_when_pruned_below_lib() {
+        // Ensure we keep enough inscription history below LIB to keep building
+        // correct parent relationships even when no inscriptions are above LIB.
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let b2 = header_id(2);
+        let mut state = TxState::new(genesis);
+
+        let tx1 = make_dummy_tx(1);
+        let hash1 = tx1.mantle_tx.hash();
+        state.submit(hash1, tx1);
+
+        let parent_1 = MsgId::root();
+        let this_1 = MsgId::from([9u8; 32]);
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(b1, Slot::new(123), hash1, parent_1, this_1)],
+        );
+
+        // Advance LIB to b2 with no inscriptions. This prunes b1 from maps.
+        state.process_block(b2, b1, b2, &empty_our_txs());
+
+        // We still retain finalized inscription lineage for future parent selection.
+        assert_eq!(state.latest_inscriptions_tip_id(), Some(this_1));
+        assert_eq!(state.latest_confirmed_parent_id(), Some(parent_1));
+    }
+
+    #[test]
+    fn competing_children_are_ambiguous_until_one_branch_extends() {
+        let genesis = header_id(0);
+        let block_1 = header_id(1);
+        let block_2 = header_id(2);
+        let block_3 = header_id(3);
+        let mut state = TxState::new(genesis);
+
+        let this_pid_a = MsgId::from([21u8; 32]);
+        let this_pid_b = MsgId::from([22u8; 32]);
+
+        let tx_a = make_dummy_tx(21);
+        let tx_b = make_dummy_tx(22);
+
+        state.process_block(
+            block_1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                header_id(1),
+                Slot::new(123),
+                tx_a.mantle_tx.hash(),
+                MsgId::root(),
+                this_pid_a,
+            )],
+        );
+        state.process_block(
+            block_2,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                header_id(1),
+                Slot::new(123),
+                tx_b.mantle_tx.hash(),
+                MsgId::root(),
+                this_pid_b,
+            )],
+        );
+
+        assert_eq!(
+            state.resolve_inscription_chain_tip(),
+            ChainTipResolution::Ambiguous,
+            "two children of the same parent are ambiguous without a tie-break"
+        );
+
+        let this_pid_b_child = MsgId::from([23u8; 32]);
+        let tx_b_child = make_dummy_tx(23);
+        state.process_block(
+            block_3,
+            block_2,
+            genesis,
+            &[MsgIdState::new(
+                header_id(2),
+                Slot::new(234),
+                tx_b_child.mantle_tx.hash(),
+                this_pid_b,
+                this_pid_b_child,
+            )],
+        );
+
+        assert_eq!(
+            state.resolve_inscription_chain_tip(),
+            ChainTipResolution::Determinate(this_pid_b_child)
+        );
     }
 }

--- a/zone-sdk/src/state.rs
+++ b/zone-sdk/src/state.rs
@@ -420,6 +420,40 @@ impl TxState {
         self.pending.contains_key(tx_hash)
     }
 
+    /// Returns true if the transaction hash has been observed in any on-chain
+    /// inscription that this state has processed, even if the current tip's
+    /// cumulative safe set has not yet been rebuilt to include it.
+    #[must_use]
+    pub fn is_tx_observed_on_chain(&self, tx_hash: &TxHash) -> bool {
+        if self.finalized.contains(tx_hash) {
+            return true;
+        }
+
+        if self
+            .block_states
+            .values()
+            .any(|safe_set| safe_set.contains(tx_hash))
+        {
+            return true;
+        }
+
+        self.parent_msg_id_map
+            .values()
+            .flatten()
+            .any(|msg_state| msg_state.tx_hash() == *tx_hash)
+    }
+
+    #[must_use]
+    pub fn is_msg_id_used_as_parent_on_chain(&self, msg_id: MsgId) -> bool {
+        self.parent_msg_id_map
+            .values()
+            .flatten()
+            .any(|msg_state| msg_state.parent_id() == msg_id)
+            || self
+                .last_finalized_msg_state
+                .is_some_and(|s| s.parent_id() == msg_id)
+    }
+
     fn all_known_inscriptions(&self) -> Vec<MsgIdState> {
         let mut all = Vec::new();
         for states in self.parent_msg_id_map.values() {
@@ -871,6 +905,234 @@ mod tests {
         assert_eq!(
             state.resolve_inscription_chain_tip(),
             ChainTipResolution::Determinate(this_pid_b_child)
+        );
+    }
+
+    #[test]
+    fn remove_pending_scrubs_safe_sets_and_status_becomes_unknown() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let mut state = TxState::new(genesis);
+
+        let tx = make_dummy_tx(1);
+        let hash = tx.mantle_tx.hash();
+        state.submit(hash, tx);
+
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &our_txs_with_hash(b1, Slot::new(123), hash),
+        );
+        assert_eq!(state.status(&hash, b1), TxStatus::Safe);
+
+        let removed = state.remove_pending(&hash);
+        assert!(removed.is_some());
+        assert_eq!(state.status(&hash, b1), TxStatus::Unknown);
+        assert!(!state.is_tx_pending(&hash));
+    }
+
+    #[test]
+    fn process_block_keeps_multiple_inscriptions_from_same_block_in_order() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let mut state = TxState::new(genesis);
+
+        let tx1 = make_dummy_tx(41);
+        let tx2 = make_dummy_tx(42);
+        let tx3 = make_dummy_tx(43);
+
+        let this_1 = MsgId::from([41u8; 32]);
+        let this_2 = MsgId::from([42u8; 32]);
+        let this_3 = MsgId::from([43u8; 32]);
+
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[
+                MsgIdState::new(
+                    b1,
+                    Slot::new(100),
+                    tx1.mantle_tx.hash(),
+                    MsgId::root(),
+                    this_1,
+                ),
+                MsgIdState::new(b1, Slot::new(100), tx2.mantle_tx.hash(), this_1, this_2),
+                MsgIdState::new(b1, Slot::new(100), tx3.mantle_tx.hash(), this_2, this_3),
+            ],
+        );
+
+        let map = state.parent_msg_id_map();
+        let chain = map.get(&b1).expect("block chain should be stored");
+        assert_eq!(chain.len(), 3);
+        assert_eq!(chain[0].this_id(), this_1);
+        assert_eq!(chain[1].this_id(), this_2);
+        assert_eq!(chain[2].this_id(), this_3);
+        assert_eq!(state.latest_inscriptions_tip_id(), Some(this_3));
+    }
+
+    #[test]
+    fn latest_tip_and_parent_are_none_when_no_inscriptions_exist() {
+        let genesis = header_id(0);
+        let state = TxState::new(genesis);
+
+        assert_eq!(state.latest_inscriptions_tip_id(), None);
+        assert_eq!(state.latest_confirmed_parent_id(), None);
+        assert_eq!(
+            state.resolve_inscription_chain_tip(),
+            ChainTipResolution::NoInscriptions
+        );
+    }
+
+    #[test]
+    fn latest_tip_and_parent_follow_linear_chain() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let b2 = header_id(2);
+        let mut state = TxState::new(genesis);
+
+        let this_1 = MsgId::from([31u8; 32]);
+        let this_2 = MsgId::from([32u8; 32]);
+
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b1,
+                Slot::new(101),
+                make_dummy_tx(31).mantle_tx.hash(),
+                MsgId::root(),
+                this_1,
+            )],
+        );
+        state.process_block(
+            b2,
+            b1,
+            genesis,
+            &[MsgIdState::new(
+                b2,
+                Slot::new(102),
+                make_dummy_tx(32).mantle_tx.hash(),
+                this_1,
+                this_2,
+            )],
+        );
+
+        assert_eq!(
+            state.resolve_inscription_chain_tip(),
+            ChainTipResolution::Determinate(this_2)
+        );
+        assert_eq!(state.latest_inscriptions_tip_id(), Some(this_2));
+        assert_eq!(state.latest_confirmed_parent_id(), Some(this_1));
+    }
+
+    #[test]
+    fn process_block_keeps_only_tail_below_lib_for_each_chain() {
+        let genesis = header_id(0);
+        let a1 = header_id(1);
+        let a2 = header_id(2);
+        let a3 = header_id(3);
+        let mut state = TxState::new(genesis);
+
+        let tx1 = make_dummy_tx(51);
+        let tx2 = make_dummy_tx(52);
+
+        let this_1 = MsgId::from([51u8; 32]);
+        let this_2 = MsgId::from([52u8; 32]);
+
+        state.process_block(
+            a1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                a1,
+                Slot::new(100),
+                tx1.mantle_tx.hash(),
+                MsgId::root(),
+                this_1,
+            )],
+        );
+        state.process_block(
+            a2,
+            a1,
+            genesis,
+            &[MsgIdState::new(
+                a2,
+                Slot::new(101),
+                tx2.mantle_tx.hash(),
+                this_1,
+                this_2,
+            )],
+        );
+
+        state.process_block(a3, a2, a3, &empty_our_txs());
+
+        let map = state.parent_msg_id_map();
+        assert!(
+            !map.contains_key(&a1),
+            "older below-lib lineage should be dropped when superseded"
+        );
+        assert!(
+            map.contains_key(&a2),
+            "tail below-lib lineage should be retained"
+        );
+        assert_eq!(state.latest_inscriptions_tip_id(), Some(this_2));
+    }
+
+    #[test]
+    fn resolve_chain_tip_prefers_longest_chain() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let b2 = header_id(2);
+        let b3 = header_id(3);
+        let mut state = TxState::new(genesis);
+
+        let a1 = MsgId::from([61u8; 32]);
+        let a2 = MsgId::from([62u8; 32]);
+        let b1_msg = MsgId::from([63u8; 32]);
+
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b1,
+                Slot::new(100),
+                make_dummy_tx(61).mantle_tx.hash(),
+                MsgId::root(),
+                a1,
+            )],
+        );
+        state.process_block(
+            b2,
+            b1,
+            genesis,
+            &[MsgIdState::new(
+                b2,
+                Slot::new(101),
+                make_dummy_tx(62).mantle_tx.hash(),
+                a1,
+                a2,
+            )],
+        );
+        state.process_block(
+            b3,
+            genesis,
+            genesis,
+            &[MsgIdState::new(
+                b3,
+                Slot::new(102),
+                make_dummy_tx(63).mantle_tx.hash(),
+                MsgId::root(),
+                b1_msg,
+            )],
+        );
+
+        assert_eq!(
+            state.resolve_inscription_chain_tip(),
+            ChainTipResolution::Determinate(a2)
         );
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Added sequencer inscription lineage tracking and delayed checkpoint persistence.

This is a WIP from the Lisbon All-Hands together with @ntn-x2. This PR manually merges additions from #2375, 
builds on top of that work and supplements it. However, the previously proposed blocking publishing model was 
replaced with asynchronous publishing.

This change upgrades the zone sequencer from tx-only tracking to inscription-aware chain tracking.

On the SDK side, `TxState` now tracks inscription lineage per block using `MsgIdState`. It resolves the latest deterministic inscription tip, detects ambiguous competing branches, and retains sufficient finalized lineage below LIB to continue publishing against the correct parent after pruning, restart, or backfill. Block processing, backfill, and restart bootstrap were updated to rebuild and maintain this lineage information. Publish parent selection now prefers the resolved on-chain inscription tip and rejects ambiguous forks.

On the TUI side, checkpoint handling was changed from immediate persistence on publish to persistence after the inscription is observed on-chain. The sequencer now notifies the application of inscription status in the background and saves checkpoints only once the chain state reflects the persisted inscription. Logging and terminal output were also improved for published, mined, delayed, and failed inscriptions.

When inscription collisions are detected with a peer sequencer, the affected inscriptions are recreated and resubmitted until they are successfully mined. This design depends on refreshing `pending_publications` promptly when new on-chain `MsgIdState` is observed. That refresh timing is critical to avoiding stale parent selection.

Overall, this makes the sequencer more robust across restarts, reorg windows, delayed inclusion, and concurrent local publishing while preserving correct inscription parent chaining.

System-level tests were performed where three sequencers were started concurrently and used to post inscriptions in random order. All inscriptions eventually resolved automatically. This also included clean starts without any saved state information.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 and @hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
