### PR TITLE
chore: respect cucumber node log level in local tests

### DIFF
--- a/tests/src/cucumber/defaults.rs
+++ b/tests/src/cucumber/defaults.rs
@@ -1,5 +1,6 @@
 use std::{fs, path::PathBuf};
 
+use lb_testing_framework::LOGOS_BLOCKCHAIN_LOG_LEVEL;
 use tracing::warn;
 use tracing_subscriber::{EnvFilter, fmt};
 
@@ -16,7 +17,6 @@ const TARGET: &str = "cucumber_defaults";
 const LOGOS_BLOCKCHAIN_TESTS_TRACING: &str = "LOGOS_BLOCKCHAIN_TESTS_TRACING";
 const TF_KEEP_LOGS: &str = "TF_KEEP_LOGS";
 const CUCUMBER_LOG_LEVEL: &str = "CUCUMBER_LOG_LEVEL";
-const LOGOS_BLOCKCHAIN_LOG_LEVEL: &str = "LOGOS_BLOCKCHAIN_LOG_LEVEL";
 const RUST_LOG: &str = "RUST_LOG";
 const LOGOS_BLOCKCHAIN_LOG_DIR: &str = "LOGOS_BLOCKCHAIN_LOG_DIR";
 const CUCUMBER_RETRIES: &str = "CUCUMBER_RETRIES";

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -12,7 +12,10 @@ use lb_key_management_system_service::keys::{Key, secured_key::SecuredKey as _};
 use lb_libp2p::Multiaddr;
 use lb_node::{
     UserConfig, config,
-    config::{RunConfig, tracing::serde::logger},
+    config::{
+        RunConfig,
+        tracing::serde::{Level, logger},
+    },
 };
 use rand::Rng as _;
 use testing_framework_core::scenario::{Application, DynError, PeerSelection, StartNodeOptions};
@@ -25,6 +28,7 @@ use testing_framework_runner_local::{
 use tracing::debug;
 
 use crate::{
+    LOGOS_BLOCKCHAIN_LOG_LEVEL,
     framework::LbcEnv,
     node::{
         DeploymentPlan, NodeHttpClient, NodePlan,
@@ -127,6 +131,7 @@ impl LocalDeployerEnv for LbcEnv {
     ) -> Result<LaunchSpec, DynError> {
         let mut config = config.clone();
         ensure_recovery_paths(dir).map_err(|source| -> DynError { source.into() })?;
+        config.user.tracing.level = configured_node_log_level();
 
         if !tf_env::debug_tracing() {
             let log_prefix = format!("{LOGS_PREFIX}-{label}");
@@ -298,6 +303,13 @@ fn configure_logging(base_dir: &Path, prefix: &str) -> logger::Layers {
         stdout: false,
         stderr: false,
     }
+}
+
+fn configured_node_log_level() -> Level {
+    env::var(LOGOS_BLOCKCHAIN_LOG_LEVEL)
+        .ok()
+        .and_then(|raw| raw.parse::<Level>().ok())
+        .unwrap_or(Level::INFO)
 }
 
 fn build_node_config_for(

--- a/tests/testing_framework/src/lib.rs
+++ b/tests/testing_framework/src/lib.rs
@@ -21,6 +21,7 @@ pub(crate) mod common {
 }
 
 pub static IS_DEBUG_TRACING: LazyLock<bool> = LazyLock::new(testing_framework_env::debug_tracing);
+pub const LOGOS_BLOCKCHAIN_LOG_LEVEL: &str = "LOGOS_BLOCKCHAIN_LOG_LEVEL";
 
 fn node_address_from_port(port: u16) -> Multiaddr {
     multiaddr(Ipv4Addr::LOCALHOST, port)


### PR DESCRIPTION
## 1. What does this PR implement?

This fixes local cucumber node logging to actually respect `LOGOS_BLOCKCHAIN_LOG_LEVEL` instead of falling back to the node default `DEBUG`. This should also reduce space used by tests.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
