### PR TITLE
perf(blend): improve release round generation scheduling

### DIFF
--- a/blend/scheduling/src/cover_traffic.rs
+++ b/blend/scheduling/src/cover_traffic.rs
@@ -78,36 +78,36 @@ where
     ///   already-queued data message.
     fn consume_round(&mut self) -> bool {
         // We need to check this since we use it as a fraction denominator later on.
-        let Ok(non_zero_unprocessed_remaining_rounds) =
+        let Ok(non_zero_unconsumed_remaining_rounds) =
             NonZeroU128::try_from(self.remaining_rounds.inner())
         else {
-            tracing::trace!(target: LOG_TARGET, "No remaining rounds.");
-            debug_assert!(
+            assert!(
                 self.remaining_messages == 0,
                 "If there are no remaining rounds, there should be no remaining messages."
             );
+            tracing::trace!(target: LOG_TARGET, "No remaining rounds.");
             return false;
         };
         // Update remaining rounds regardless of what we do next, since we are consuming
         // this round.
-        self.remaining_rounds = (non_zero_unprocessed_remaining_rounds.get() - 1).into();
+        self.remaining_rounds = (non_zero_unconsumed_remaining_rounds.get() - 1).into();
 
         // Decide whether this round is a release round based on the ratio of
         // messages still to emit over the rounds still available.
         let is_release_round = self.rng.gen_bool(
-            self.remaining_messages as f64 / non_zero_unprocessed_remaining_rounds.get() as f64,
+            self.remaining_messages as f64 / non_zero_unconsumed_remaining_rounds.get() as f64,
         );
 
         if !is_release_round {
             return false;
         }
 
-        let non_zero_unprocessed_remaining_messages = NonZeroU64::try_from(self.remaining_messages)
+        let non_zero_unconsumed_remaining_messages = NonZeroU64::try_from(self.remaining_messages)
             .expect("There should be at least one remaining message if this is a release round.");
 
         // This is a release round, so no matter if we end up releasing a new cover
         // message or not, we consume one quota.
-        self.remaining_messages = non_zero_unprocessed_remaining_messages.get() - 1;
+        self.remaining_messages = non_zero_unconsumed_remaining_messages.get() - 1;
 
         if self.unprocessed_data_messages == 0 {
             return true;
@@ -120,7 +120,7 @@ where
         // consumed).
         let should_skip = {
             let threshold = self.unprocessed_data_messages as f64
-                / non_zero_unprocessed_remaining_messages.get() as f64;
+                / non_zero_unconsumed_remaining_messages.get() as f64;
             self.rng.gen_range(0f64..=1f64) <= threshold
         };
         if should_skip {

--- a/blend/scheduling/src/message_scheduler/tests.rs
+++ b/blend/scheduling/src/message_scheduler/tests.rs
@@ -208,6 +208,7 @@ async fn round_change() {
             release_type: Some(RoundReleaseType::OnlyCoverMessage)
         }))
     );
+    assert!(scheduler.data_messages.is_empty());
 
     scheduler.queue_data_message(3);
 


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes https://github.com/logos-blockchain/logos-blockchain/issues/2320.

Before this PR, we were pre-generating a hashset of all release rounds for a new session. That was ugly because the closer the number of the messages to the number of total rounds, the more iterations we needed to run in the loop to populate the hashset.

This is very easily replaceable by a coin-flip model where at each release round, we see how many messages we still need to release and how many rounds are left. This allows us to remove all the ugly initialization code and run smooth.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee @madxor 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.