### PR TITLE
fix(docker): Manual docker build

### DIFF
--- a/.github/workflows/publish-node-image.yml
+++ b/.github/workflows/publish-node-image.yml
@@ -3,6 +3,12 @@ name: Publish Logos Blockchain Node Docker Image
 on:
   release:
     types: [published, created]
+  workflow_dispatch:
+    inputs:
+      node_version:
+        description: 'Node version (e.g. 0.2.1)'
+        required: true
+        default: '0.2.1'
 
 env:
   REGISTRY: ghcr.io
@@ -53,9 +59,14 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            # If manual, use the version input. If release, use the tag name.
+            LB_NODE_VERSION=${{ inputs.node_version || github.ref_name }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            # Primary tag (e.g., 0.2.1).
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.node_version || github.ref_name }}
+            # Only update 'latest' if this is a standard Release trigger.
+            ${{ github.event_name == 'release' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation


### PR DESCRIPTION
## 1. What does this PR implement?

We were building docker images with wrong node version on release, the main idea is to have `LB_NODE_VERSION` set to `github.ref_name` when release is triggered. To fix current docker image, a manual workflow trigger was added, we should remove this functionality once an updated docker image is released.

## 2. Does the code have enough context to be clearly understood?


Yes

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
