### PR TITLE
doc: configure `CARGO_PROFILE_RELEASE_STRIP=none` for heap profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,17 @@ Or paste the `.dot` file into [Graphviz Online][graphviz-online].
 
 To enable debug symbols with dhat profiling in release mode, enable the 'dhat-heap' feature and use
 CARGO_PROFILE_* Environment Variables:
+
+On Linux / macOS:
 ```bash
-   CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --features=dhat-heap               ...(Linux)
+   CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=none \
+       cargo build --release --features=dhat-heap
 ```
+On PowerShell:
 ```pwsh
-   $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; cargo build --release --features=dhat-heap     ...(PowerShell)
+   $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; CARGO_PROFILE_RELEASE_STRIP = "none"; cargo build --release --features=dhat-heap
 ```
-Run, then stop the node normally to capture the output, then read the generated 'dhat-heap.json' file with 
+Run, then stop the node normally to capture the output, then read the generated `dhat-heap.json` file with 
 https://nnethercote.github.io/dh_view/dh_view.html or other.
 
 ---


### PR DESCRIPTION
## 1. What does this PR implement?

To build a binary for DHAT profiling, we should configure `CARGO_PROFILE_RELEASE_STRIP=none` as well as `CARGO_PROFILE_RELEASE_DEBUG=true`, because our `Cargo.toml` has `strip = true`, which removes debug symbols after building the binary even if `CARGO_PROFILE_RELEASE_DEBUG=true` is configured: https://github.com/logos-blockchain/logos-blockchain/blob/149e18451b41cf845ee480a504dc606a7c7db8c0/Cargo.toml#L14

Without this, all stack frames in DHAT reports show as `__mh_execute_header (???:0:0)`.
With this, stack frames show useful information as below:
<img width="1244" height="120" alt="image" src="https://github.com/user-attachments/assets/8dd52ae7-8843-4d30-b6e7-654efa5d751c" />


## 2. Does the code have enough context to be clearly understood?

Y

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
