### PR TITLE
test: compare poseidon only with nested poseidon-blake mantle transaction hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hasher"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbba678b6567f27ce22870d951f4208e1dc2fef64993bd4521b1d497ef8a3aa"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,7 +4242,9 @@ dependencies = [
  "bytes",
  "const-hex",
  "futures",
+ "hasher",
  "hex",
+ "logos-blockchain-blend-crypto",
  "logos-blockchain-blend-proofs",
  "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-groth16",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ bytes                         = { workspace = true }
 const-hex                     = { default-features = false, features = ["alloc"], version = "1" }
 futures                       = { default-features = false, features = ["alloc"], version = "0.3" }
 hex                           = { default-features = false, features = ["alloc"], version = "0.4" }
+lb-blend-crypto               = { workspace = true }
 lb-blend-proofs               = { workspace = true }
 lb-cryptarchia-engine         = { features = ["serde"], workspace = true }
 lb-groth16                    = { features = ["deser"], workspace = true }
@@ -39,6 +40,7 @@ thiserror                     = "1.0"
 tracing                       = { workspace = true }
 
 [dev-dependencies]
+hasher     = "0.1.4"
 rand       = { workspace = true }
 serde_json = { default-features = false, features = ["alloc"], version = "1.0" }
 tokio      = "1.49.0"

--- a/core/src/mantle/encoding.rs
+++ b/core/src/mantle/encoding.rs
@@ -690,11 +690,17 @@ pub(crate) fn predict_signed_mantle_tx_size(tx: &MantleTx) -> usize {
 #[cfg(test)]
 mod tests {
     use ark_ff::Field as _;
+    use lb_blend_crypto::blake2b512;
+    use lb_groth16::{GROTH16_SAFE_BYTES_SIZE, fr_from_bytes_unchecked};
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
+    use lb_poseidon2::Digest;
     use num_bigint::BigUint;
+    use tokio::time::Instant as TokioInstant;
 
     use super::*;
     use crate::{
+        codec::SerializeOp as _,
+        crypto::ZkHasher,
         mantle::{Transaction as _, TxHash},
         sdp::blend::ActivityProof,
     };
@@ -921,29 +927,82 @@ mod tests {
         assert_eq!(decoded_tx, signed_tx);
     }
 
+    struct BlakePoseidonHasher(Vec<u8>);
+    impl BlakePoseidonHasher {
+        fn hash(&self) -> TxHash {
+            let blake2 = blake2b512(&[&self.0]);
+            let frs: Vec<Fr> = blake2
+                .chunks(GROTH16_SAFE_BYTES_SIZE)
+                .map(fr_from_bytes_unchecked)
+                .collect();
+            <ZkHasher as Digest>::digest(&frs).into()
+        }
+    }
+
+    #[derive(Debug)]
+    struct BenchRow {
+        payload_size: usize,
+        pre: std::time::Duration,
+        p2: std::time::Duration,
+        pbl: std::time::Duration,
+        sign: std::time::Duration,
+        enc: std::time::Duration,
+        pred: std::time::Duration,
+        dec: std::time::Duration,
+        tot: std::time::Duration,
+        p2_over_pbl: f64,
+        p2_over_tot: f64,
+        sign_over_tot: f64,
+        dec_over_tot: f64,
+    }
+
+    // This test encodes and decodes transactions with large inscriptions to
+    // benchmark the performance of the encoding and decoding logic, as well as
+    // to verify that it works correctly for large payloads. It tests payload
+    // sizes from 128kB up to 2MiB in 128kB increments, measuring the time taken
+    // for each step of the process and printing a table of results. It also
+    // compares Blake2b + Poseidon2 hashing against the standard
+    // Poseidon2 hashing to see how much overhead the Poseidon2 only hashing step
+    // adds for large payloads.
     #[tokio::test]
     async fn test_large_payload_encoding_decoding() {
-        // Test payload sizes from 512kB up to 2MiB in 512kB increments
-        const CHUNK_SIZE: usize = 512 * 1024;
-        const MAX_SIZE: usize = 2 * 1024 * 1024;
+        // Cunks size in 128 byte increments
+        const CHUNK_SIZE: [usize; 8] = [1, 4, 8, 4 * 8, 32 * 8, 256 * 8, 1024 * 8, 4096 * 8];
+
+        let mut payload_sizes_kb = Vec::new();
+
+        for (i, pair) in CHUNK_SIZE.windows(2).enumerate() {
+            let step = pair[0];
+            let end = pair[1];
+
+            // first segment starts at 4, next segments start at 2*step to avoid duplicates
+            let start = if i == 0 { step } else { step * 2 };
+
+            for kb in (start..=end).step_by(step) {
+                payload_sizes_kb.push(kb);
+            }
+        }
 
         let signing_key = Ed25519Key::from_bytes(&[1; 32]);
 
         let mut tasks = Vec::new();
 
-        for payload_size in (CHUNK_SIZE..=MAX_SIZE).step_by(CHUNK_SIZE) {
+        for payload_kb in payload_sizes_kb {
+            let payload_size = payload_kb * 128;
+
             let signing_key = signing_key.clone();
 
             let task = tokio::task::spawn(async move {
                 let large_inscription = vec![0xAB; payload_size];
 
+                // Preamble
+                let start_time = TokioInstant::now();
                 let inscribe_op = InscriptionOp {
                     channel_id: ChannelId::from([0xAA; 32]),
                     inscription: large_inscription,
                     parent: MsgId::from([0xBB; 32]),
                     signer: signing_key.public_key(),
                 };
-
                 let mantle_tx = MantleTx {
                     ops: vec![Op::ChannelInscribe(inscribe_op)],
                     ledger_tx: LedgerTx::new(vec![], vec![]),
@@ -951,7 +1010,24 @@ mod tests {
                     storage_gas_price: 50,
                 };
 
+                let time_0 = start_time.elapsed();
+
+                // Poseidon2 hash (--1)
+                let start_time = TokioInstant::now();
+
                 let txhash = mantle_tx.hash();
+
+                let time_1 = start_time.elapsed();
+
+                // Poseidon2-Blake2b hash (--2)
+                let start_time = TokioInstant::now();
+
+                let _txhash = BlakePoseidonHasher(mantle_tx.to_bytes().unwrap().to_vec()).hash();
+
+                let time_2 = start_time.elapsed();
+
+                // Sign (--3)
+                let start_time = TokioInstant::now();
                 let op_sig = signing_key.sign_payload(&txhash.as_signing_bytes());
                 let signed_tx = SignedMantleTx::new(
                     mantle_tx,
@@ -960,8 +1036,16 @@ mod tests {
                 )
                 .unwrap();
 
+                let time_3 = start_time.elapsed();
+
+                // Encode (--4)
+                let start_time = TokioInstant::now();
                 let encoded = encode_signed_mantle_tx(&signed_tx);
 
+                let time_4 = start_time.elapsed();
+                let start_time = TokioInstant::now();
+
+                // Predicted size (--5)
                 let predicted_size = predict_signed_mantle_tx_size(&signed_tx.mantle_tx);
                 assert_eq!(
                     predicted_size,
@@ -969,8 +1053,15 @@ mod tests {
                     "Size mismatch at payload size {payload_size}",
                 );
 
+                let time_5 = start_time.elapsed();
+
+                // Decode (--5)
+                let start_time = TokioInstant::now();
+
                 let (remaining, decoded_tx) = decode_signed_mantle_tx(&encoded)
                     .unwrap_or_else(|_| panic!("Failed to decode at payload size {payload_size}"));
+
+                let time_6 = start_time.elapsed();
 
                 assert!(
                     remaining.is_empty(),
@@ -980,15 +1071,112 @@ mod tests {
                     decoded_tx, signed_tx,
                     "Roundtrip mismatch at payload size {payload_size}",
                 );
+
+                let total = time_0 + time_1 + time_2 + time_3 + time_4 + time_5 + time_6;
+
+                let p2_over_pbl = time_1.as_secs_f64() / time_2.as_secs_f64();
+                let p2_over_tot = time_1.as_secs_f64() / total.as_secs_f64();
+                let sign_over_tot = time_3.as_secs_f64() / total.as_secs_f64();
+                let dec_over_tot = time_6.as_secs_f64() / total.as_secs_f64();
+
+                BenchRow {
+                    payload_size,
+                    pre: time_0,
+                    p2: time_1,
+                    pbl: time_2,
+                    sign: time_3,
+                    enc: time_4,
+                    pred: time_5,
+                    dec: time_6,
+                    tot: total,
+                    p2_over_pbl,
+                    p2_over_tot,
+                    sign_over_tot,
+                    dec_over_tot,
+                }
             });
 
             tasks.push(task);
         }
 
         // Wait for all tasks to complete
+        let mut rows = Vec::new();
         for task in tasks {
-            task.await.unwrap();
+            rows.push(task.await.unwrap());
         }
+
+        let print = false;
+        if print {
+            print_results(rows);
+        }
+    }
+
+    fn print_results(mut bench_rows: Vec<BenchRow>) {
+        const SEP_TIMINGS: &str = "+------------+------------+------------+------------+------------+------------+------------+------------+------------+";
+        const SEP_RATIOS: &str =
+            "+------------+---------------+----------+----------+------------+";
+
+        bench_rows.sort_by_key(|r| r.payload_size);
+
+        let fmt_commas = |n: usize| -> String {
+            let s = n.to_string();
+            let mut out = String::new();
+            for (i, c) in s.chars().rev().enumerate() {
+                if i > 0 && i % 3 == 0 {
+                    out.push(',');
+                }
+                out.push(c);
+            }
+            out.chars().rev().collect()
+        };
+
+        println!("{SEP_TIMINGS}");
+        println!(
+            "| {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} |",
+            "payload",
+            "preamble",
+            "pos2",
+            "pos2(bl)",
+            "sign",
+            "encode",
+            "predict",
+            "decode",
+            "total"
+        );
+        println!("{SEP_TIMINGS}");
+        for r in &bench_rows {
+            println!(
+                "| {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} | {:>10} |",
+                fmt_commas(r.payload_size),
+                format!("{:.2?}", r.pre),
+                format!("{:.2?}", r.p2),
+                format!("{:.2?}", r.pbl),
+                format!("{:.2?}", r.sign),
+                format!("{:.2?}", r.enc),
+                format!("{:.2?}", r.pred),
+                format!("{:.2?}", r.dec),
+                format!("{:.2?}", r.tot),
+            );
+        }
+        println!("{SEP_TIMINGS}");
+
+        println!("{SEP_RATIOS}");
+        println!(
+            "| {:>10} | {:>12} | {:>8} | {:>8} | {:>10} |",
+            "payload", "pos2:pos2(bl)", "pos2:tot", "sign:tot", "decode:tot"
+        );
+        println!("{SEP_RATIOS}");
+        for r in &bench_rows {
+            println!(
+                "| {:>10} | {:>13} | {:>8} | {:>8} | {:>10} |",
+                fmt_commas(r.payload_size),
+                format!("{:.2}x", r.p2_over_pbl),
+                format!("{:.2}%", r.p2_over_tot * 100.0),
+                format!("{:.2}%", r.sign_over_tot * 100.0),
+                format!("{:.2}%", r.dec_over_tot * 100.0),
+            );
+        }
+        println!("{SEP_RATIOS}");
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds profiling to unit test `async fn test_large_payload_encoding_decoding()` test to compare _Poseidon only_ with _nested Poseidon-Blake_ mantle transaction hashing, and to perform general profiling for the `hash->sign->encode->predict_size->decode` cycle. The Poseidon-Blake mantle transaction hashing is only available in the test environment for hash profiling purposes and cannot be used to produce a valid signature due to downline verifiers not recognizing the nested hash.

**Poseidon-Blake hash implementation:**
```rust
    struct BlakePoseidonHasher(Vec<u8>);
    impl BlakePoseidonHasher {
        fn hash(&self) -> TxHash {
            let blake2 = blake2b512(&[&self.0]);
            let frs: Vec<Fr> = blake2
                .chunks(GROTH16_SAFE_BYTES_SIZE)
                .map(fr_from_bytes_unchecked)
                .collect();
            <ZkHasher as Digest>::digest(&frs).into()
        }
    }
```
**The mantle transaction that needs to be hashed and signed is produced as:**
```rust
                let inscribe_op = InscriptionOp {
                    channel_id: ChannelId::from([0xAA; 32]),
                    inscription: large_inscription,
                    parent: MsgId::from([0xBB; 32]),
                    signer: signing_key.public_key(),
                };
                let mantle_tx = MantleTx {
                    ops: vec![Op::ChannelInscribe(inscribe_op)],
                    ledger_tx: LedgerTx::new(vec![], vec![]),
                    execution_gas_price: 100,
                    storage_gas_price: 50,
                };
```
**The two hashing calculations that that are profiled for comparison are:**
```rust
                let txhash = mantle_tx.hash();

                let _txhash = BlakePoseidonHasher(mantle_tx.to_bytes().unwrap().to_vec()).hash();
```
**To print the profiling results, make this `true`:**
```rust
        let print = false;
        if print {
            print_results(rows);
        }
```
See results below (AMD Ryzen 9 9950X 16-Core Processor CPU, Ubuntu 20.04 WSL). For smaller payloads, `Poseidon2(Blake2B) ` is roughly 1 order of magnitude faster than `Poseidon2` and for larger payloads 2 orders of magnitude.

```rust
+------------+------------+------------+------------+------------+------------+------------+------------+------------+
|    payload |   preamble |       pos2 |   pos2(bl) |       sign |     encode |    predict |     decode |      total |
+------------+------------+------------+------------+------------+------------+------------+------------+------------+
|        128 |   116.00ns |    94.17µs |    22.12µs |    85.84ms |     2.96µs |     1.35µs |   128.01µs |    86.09ms |
|        256 |   158.00ns |   119.98µs |    38.94µs |    85.23ms |     1.86µs |   918.00ns |    83.24µs |    85.48ms |
|        384 |   116.00ns |    77.23µs |    22.01µs |    85.03ms |     1.92µs |     1.18µs |    97.77µs |    85.23ms |
|        512 |   106.00ns |    93.77µs |    21.59µs |    85.50ms |     1.33µs |     1.90µs |   111.14µs |    85.73ms |
|      1,024 |   106.00ns |   157.07µs |    22.23µs |    84.72ms |     1.90µs |   886.00ns |   172.57µs |    85.07ms |
|      2,048 |   295.00ns |   288.09µs |    21.40µs |    84.07ms |     1.95µs |     1.49µs |   305.25µs |    84.69ms |
|      3,072 |   106.00ns |   417.90µs |    22.11µs |    84.96ms |     1.85µs |   960.00ns |   454.31µs |    85.85ms |
|      4,096 |   380.00ns |   541.55µs |    22.99µs |    87.27ms |     2.26µs |     1.08µs |   564.29µs |    88.40ms |
|      8,192 |   116.00ns |     1.20ms |    27.50µs |    88.12ms |     3.62µs |     1.76µs |     1.11ms |    90.46ms |
|     12,288 |   106.00ns |     1.61ms |    29.16µs |    86.35ms |     3.90µs |     1.92µs |     1.73ms |    89.72ms |
|     16,384 |   106.00ns |     2.20ms |    33.41µs |    87.26ms |     4.21µs |     2.32µs |     2.19ms |    91.70ms |
|     20,480 |   116.00ns |     2.70ms |    35.94µs |    90.62ms |     5.10µs |     2.04µs |     2.68ms |    96.04ms |
|     24,576 |   106.00ns |     4.21ms |    53.40µs |    91.51ms |     4.50µs |     2.58µs |     3.27ms |    99.05ms |
|     28,672 |   105.00ns |     3.74ms |    41.45µs |    90.88ms |     7.40µs |     2.60µs |     3.82ms |    98.49ms |
|     32,768 |   105.00ns |     4.36ms |    44.99µs |    91.85ms |     5.87µs |     3.08µs |     4.39ms |   100.66ms |
|     65,536 |   105.00ns |     8.74ms |    67.38µs |    92.29ms |     8.51µs |    16.78µs |     9.16ms |   110.28ms |
|     98,304 |   116.00ns |    12.74ms |    97.81µs |    98.82ms |    18.99µs |    33.95µs |    13.64ms |   125.36ms |
|    131,072 |   126.00ns |    17.61ms |   146.42µs |   103.68ms |    31.06µs |    50.06µs |    19.00ms |   140.52ms |
|    163,840 |   158.00ns |    23.04ms |   309.60µs |   107.15ms |    39.05µs |    50.53µs |    21.34ms |   151.92ms |
|    196,608 |   127.00ns |    25.53ms |   296.52µs |   111.94ms |   162.84µs |    91.16µs |    28.43ms |   166.45ms |
|    229,376 |   116.00ns |    30.61ms |   336.58µs |   115.39ms |   145.09µs |    50.54µs |    29.84ms |   176.37ms |
|    262,144 |   158.00ns |    33.88ms |   231.92µs |   121.79ms |   158.43µs |    66.91µs |    34.39ms |   190.52ms |
|    524,288 |   137.00ns |    69.52ms |   481.01µs |   155.00ms |   400.77µs |   138.02µs |    69.98ms |   295.51ms |
|    786,432 |   528.00ns |   107.27ms |   856.70µs |   202.98ms |   637.53µs |   218.23µs |   104.46ms |   416.42ms |
|  1,048,576 |   212.00ns |   138.44ms |   976.64µs |   221.15ms |   782.05µs |   289.93µs |   143.04ms |   504.68ms |
|  2,097,152 |   190.00ns |   276.31ms |     2.22ms |   371.63ms |     2.03ms |   613.02µs |   279.39ms |   932.20ms |
|  3,145,728 |   264.00ns |   429.86ms |     3.18ms |   517.52ms |     2.67ms |   992.65µs |   429.39ms |      1.38s |
|  4,194,304 |   317.00ns |   544.74ms |     4.33ms |   637.11ms |     3.64ms |     1.23ms |   543.70ms |      1.73s |
+------------+------------+------------+------------+------------+------------+------------+------------+------------+
+------------+---------------+----------+----------+------------+
|    payload | pos2:pos2(bl) | pos2:tot | sign:tot | decode:tot |
+------------+---------------+----------+----------+------------+
|        128 |         4.26x |    0.11% |   99.71% |      0.15% |
|        256 |         3.08x |    0.14% |   99.71% |      0.10% |
|        384 |         3.51x |    0.09% |   99.77% |      0.11% |
|        512 |         4.34x |    0.11% |   99.73% |      0.13% |
|      1,024 |         7.07x |    0.18% |   99.58% |      0.20% |
|      2,048 |        13.46x |    0.34% |   99.27% |      0.36% |
|      3,072 |        18.90x |    0.49% |   98.95% |      0.53% |
|      4,096 |        23.56x |    0.61% |   98.72% |      0.64% |
|      8,192 |        43.75x |    1.33% |   97.41% |      1.23% |
|     12,288 |        55.06x |    1.79% |   96.24% |      1.93% |
|     16,384 |        65.97x |    2.40% |   95.16% |      2.39% |
|     20,480 |        75.02x |    2.81% |   94.36% |      2.79% |
|     24,576 |        78.87x |    4.25% |   92.38% |      3.30% |
|     28,672 |        90.27x |    3.80% |   92.27% |      3.88% |
|     32,768 |        96.98x |    4.33% |   91.25% |      4.37% |
|     65,536 |       129.66x |    7.92% |   83.69% |      8.31% |
|     98,304 |       130.29x |   10.17% |   78.83% |     10.88% |
|    131,072 |       120.25x |   12.53% |   73.78% |     13.52% |
|    163,840 |        74.41x |   15.16% |   70.53% |     14.04% |
|    196,608 |        86.10x |   15.34% |   67.25% |     17.08% |
|    229,376 |        90.95x |   17.36% |   65.42% |     16.92% |
|    262,144 |       146.10x |   17.78% |   63.93% |     18.05% |
|    524,288 |       144.52x |   23.52% |   52.45% |     23.68% |
|    786,432 |       125.21x |   25.76% |   48.74% |     25.08% |
|  1,048,576 |       141.75x |   27.43% |   43.82% |     28.34% |
|  2,097,152 |       124.44x |   29.64% |   39.87% |     29.97% |
|  3,145,728 |       135.30x |   31.07% |   37.40% |     31.03% |
|  4,194,304 |       125.84x |   31.40% |   36.73% |     31.34% |
+------------+---------------+----------+----------+------------+
```

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal and @thomaslavaur 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
