### PR TITLE
chore: add cargo profile for profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ strip         = true  # Remove symbols to reduce binary size
 codegen-units = 1
 opt-level     = 3
 
+[profile.release-profiling]
+debug    = true      # Include debug symbols for profiling
+inherits = "release"
+strip    = "none"    # Don't strip symbols to allow for better profiling results
+
 [workspace]
 # Make sure any excluded crates are still clipped in our CI. Also, make sure they use the same Clippy and rustc lints we specify in this file down below.
 members = [

--- a/README.md
+++ b/README.md
@@ -209,18 +209,12 @@ Or paste the `.dot` file into [Graphviz Online][graphviz-online].
 
 ### Heap profiling
 
-To enable debug symbols with dhat profiling in release mode, enable the 'dhat-heap' feature and use
-CARGO_PROFILE_* Environment Variables:
+Heap profiling can be run on release builds by using the `release-profiling` Cargo profile:
 
-On Linux / macOS:
 ```bash
-   CARGO_PROFILE_RELEASE_DEBUG=true CARGO_PROFILE_RELEASE_STRIP=none \
-       cargo build --release --features=dhat-heap
+    cargo build --profile release-profiling --features=dhat-heap
 ```
-On PowerShell:
-```pwsh
-   $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; CARGO_PROFILE_RELEASE_STRIP = "none"; cargo build --release --features=dhat-heap
-```
+
 Run, then stop the node normally to capture the output, then read the generated `dhat-heap.json` file with 
 https://nnethercote.github.io/dh_view/dh_view.html or other.
 

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -87,11 +87,8 @@ rand = { workspace = true }
 [features]
 config-gen      = ["lb-key-management-system-service/unsafe"]
 default         = ["config-gen", "tracing"]
+dhat-heap       = ["dep:dhat"]
 instrumentation = []
 profiling       = ["lb-http-api-common/profiling", "lb-tracing-service/profiling"]
 testing         = ["lb-key-management-system-service/unsafe"]
 tracing         = []
-# If you are doing heap profiling, use 'dhat-heap' and enable debug symbols:
-#   CARGO_PROFILE_RELEASE_DEBUG=true cargo build --release --bin minotari_merge_mining_proxy --features=dhat-heap            ...(Linux)
-#   $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; cargo build --release --bin minotari_merge_mining_proxy --features=dhat-heap  ...(PowerShell)
-dhat-heap = ["dep:dhat"]


### PR DESCRIPTION
## 1. What does this PR implement?

Instead of relying on env variables which are easy to forget, let's have Cargo profile that everyone can use instead. This allows building a release profile with the necessary debug symbols to enable dhat profiling with `--profile release-profiling`.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.