### PR TITLE
fix(chain-network): defer opening gossipsub subscriptions until after IBD

### DIFF
--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -250,16 +250,6 @@ where
             .notifier()
             .get_updated_settings();
 
-        let network_adapter = NetAdapter::new(network_config, relays.network_relay().clone()).await;
-
-        let mut incoming_proposals = network_adapter.proposals_stream().await?;
-        let mut chainsync_events = network_adapter.chainsync_events_stream().await?;
-
-        let mut orphan_downloader = Box::pin(OrphanBlocksDownloader::new(
-            network_adapter.clone(),
-            sync_config.orphan.max_orphan_cache_size,
-        ));
-
         wait_until_services_are_ready!(
             &self.service_resources_handle.overwatch_handle,
             Some(Duration::from_secs(60)),
@@ -270,12 +260,14 @@ where
         )
         .await?;
 
+        let network_adapter = NetAdapter::new(network_config, relays.network_relay().clone()).await;
+
         let initial_block_download = InitialBlockDownload::new(
             ChainNetworkIbdBlockProcessor::<_, Mempool, _> {
                 cryptarchia: relays.cryptarchia().clone(),
                 mempool_adapter: relays.mempool_adapter().clone(),
             },
-            network_adapter,
+            network_adapter.clone(),
         );
 
         match initial_block_download.run(bootstrap_config.ibd).await {
@@ -305,6 +297,14 @@ where
                 )));
             }
         }
+
+        let mut incoming_proposals = network_adapter.proposals_stream().await?;
+        let mut chainsync_events = network_adapter.chainsync_events_stream().await?;
+
+        let mut orphan_downloader = Box::pin(OrphanBlocksDownloader::new(
+            network_adapter,
+            sync_config.orphan.max_orphan_cache_size,
+        ));
 
         self.notify_service_ready();
 


### PR DESCRIPTION
## 1. What does this PR implement?

- Defer opening gossipsub subscription streams (`proposals_stream`, `chainsync_events_stream`) until after IBD completes

The chain-network service subscribed to `BroadcastChannel` streams from the network service before starting IBD. During IBD, these streams are not drained. While `BroadcastChannel` has a fixed capacity (64) and won't grow unbounded, subscribing early is wasteful. Of course, the chain-network service will try to read the streams after IBD, but most old messages may be already evicted (causing one `Lagged(n)` error). Deferring the subscription until after IBD avoids this unnecessary overhead.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
