### PR TITLE
fix(mmr): fix `frontier_root` building one level too high

### DIFF
--- a/mmr/src/lib.rs
+++ b/mmr/src/lib.rs
@@ -7,6 +7,7 @@ use lb_poseidon2::{Digest, Fr};
 use rpds::StackSync;
 
 const EMPTY_VALUE: Fr = Fr::ZERO;
+const ACCEPTABLE_MAX_HEIGHT: u8 = 32;
 
 /// An append-only persistent Merkle Mountain Range (MMR), which can accept up
 /// to 2^(`MAX_HEIGHT`-1) elements (leaves).
@@ -23,7 +24,7 @@ const EMPTY_VALUE: Fr = Fr::ZERO;
 /// need to preserve structural sharing, you should use a custom serialization.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
-pub struct MerkleMountainRange<T, Hash, const MAX_HEIGHT: u8 = 32> {
+pub struct MerkleMountainRange<T, Hash, const MAX_HEIGHT: u8 = ACCEPTABLE_MAX_HEIGHT> {
     roots: StackSync<Root>,
     #[cfg_attr(feature = "serde", serde(skip))]
     _hash: std::marker::PhantomData<(T, Hash)>,
@@ -63,8 +64,8 @@ where
     #[must_use]
     pub fn new() -> Self {
         assert!(
-            MAX_HEIGHT <= 32,
-            "MAX_HEIGHT must be less than or equal to 32"
+            MAX_HEIGHT <= ACCEPTABLE_MAX_HEIGHT,
+            "MAX_HEIGHT must be <= {ACCEPTABLE_MAX_HEIGHT}"
         );
         Self {
             roots: StackSync::new_sync(),
@@ -105,26 +106,32 @@ where
         })
     }
 
-    // TODO: fix: this builds a root one level too high
     #[must_use]
     pub fn frontier_root(&self) -> Fr {
-        let mut root = empty_subtree_root::<Hash>(0);
-        let mut height = 0;
-        for last in &self.roots {
-            while height < last.height - 1 {
-                root = Hash::compress(&[root, empty_subtree_root::<Hash>(height as usize)]);
+        let mut iter = self.roots.iter();
+
+        let (mut root, mut height) = match iter.next() {
+            Some(last) => (last.root, last.height),
+            None => {
+                // MMR is empty. Return the root of an entirely empty tree.
+                return empty_subtree_root::<Hash>(MAX_HEIGHT);
+            }
+        };
+
+        for last in iter {
+            while height < last.height {
+                root = Hash::compress(&[root, empty_subtree_root::<Hash>(height)]);
                 height += 1;
             }
             root = Hash::compress(&[last.root, root]);
             height += 1;
         }
+
         assert!(height <= MAX_HEIGHT);
-        // ensure a fixed depth
         while height < MAX_HEIGHT {
-            root = Hash::compress(&[root, empty_subtree_root::<Hash>(height as usize)]);
+            root = Hash::compress(&[root, empty_subtree_root::<Hash>(height)]);
             height += 1;
         }
-
         assert_eq!(height, MAX_HEIGHT);
 
         root
@@ -150,16 +157,20 @@ where
     }
 }
 
-fn empty_subtree_root<Hash: Digest>(height: usize) -> Fr {
-    static PRECOMPUTED_EMPTY_ROOTS: OnceLock<[Fr; 32]> = OnceLock::new();
-    assert!(height < 32, "Height must be less than 32: {height}");
+fn empty_subtree_root<Hash: Digest>(height: u8) -> Fr {
+    static PRECOMPUTED_EMPTY_ROOTS: OnceLock<[Fr; ACCEPTABLE_MAX_HEIGHT as usize]> =
+        OnceLock::new();
+    assert!(
+        (1..=ACCEPTABLE_MAX_HEIGHT).contains(&height),
+        "Height:{height} must be in 1..={ACCEPTABLE_MAX_HEIGHT}"
+    );
     PRECOMPUTED_EMPTY_ROOTS.get_or_init(|| {
-        let mut hashes = [EMPTY_VALUE; 32];
-        for i in 1..32 {
+        let mut hashes = [EMPTY_VALUE; ACCEPTABLE_MAX_HEIGHT as usize];
+        for i in 1..ACCEPTABLE_MAX_HEIGHT as usize {
             hashes[i] = Hash::compress(&[hashes[i - 1], hashes[i - 1]]);
         }
         hashes
-    })[height]
+    })[(height - 1) as usize]
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -204,7 +215,7 @@ mod test {
     #[expect(clippy::clone_on_copy, reason = "for the sake of the test")]
     fn test_empty_roots() {
         let mut root = Fr::ZERO;
-        for i in 0..32 {
+        for i in 1..=32 {
             assert_eq!(root, empty_subtree_root::<ZkHasher>(i));
             root = <ZkHasher as Digest>::compress(&[root.clone(), root]);
         }
@@ -215,7 +226,7 @@ mod test {
             .into_iter()
             .map(|e| leaf(e.as_ref()))
             .collect::<Vec<_>>();
-        let pad = (1 << height as usize) - leaves.len();
+        let pad = (1 << (height - 1) as usize) - leaves.len();
         leaves.extend(std::iter::repeat_n(EMPTY_VALUE, pad));
         leaves
     }
@@ -254,23 +265,29 @@ mod test {
 
     #[test]
     fn test_empty_tree() {
-        let mmr = <MerkleMountainRange<TestFr, ZkHasher>>::new();
+        let mmr = <MerkleMountainRange<TestFr, ZkHasher, 3>>::new();
         assert_eq!(mmr.len(), 0);
         assert!(mmr.is_empty());
+        assert_eq!(mmr.frontier_root(), empty_subtree_root::<ZkHasher>(3));
     }
 
     #[test]
+    #[expect(clippy::cognitive_complexity, reason = "test continuity")]
     fn test_mmr_push() {
         const HEIGHT: u8 = 3; // max 2^(3-1) = 4 leaves
         let mut mmr = <MerkleMountainRange<TestFr, ZkHasher, HEIGHT>>::new();
         assert_eq!(mmr.capacity(), 4);
         assert_eq!(mmr.len(), 0);
+        let frontier_root0 = mmr.frontier_root();
+        assert_eq!(frontier_root0, empty_subtree_root::<ZkHasher>(HEIGHT));
 
         mmr = mmr.push(b"hello".as_ref().into()).unwrap();
         assert_eq!(mmr.len(), 1);
         assert_eq!(mmr.roots.size(), 1);
         assert_eq!(mmr.roots.peek().unwrap().height, 1);
         assert_eq!(mmr.roots.peek().unwrap().root, leaf(b"hello"));
+        let frontier_root1 = mmr.frontier_root();
+        assert_ne!(frontier_root1, frontier_root0);
 
         mmr = mmr.push(b"world".as_ref().into()).unwrap();
         assert_eq!(mmr.len(), 2);
@@ -280,6 +297,8 @@ mod test {
             mmr.roots.peek().unwrap().root,
             <ZkHasher as Digest>::compress(&[leaf(b"hello"), leaf(b"world")])
         );
+        let frontier_root2 = mmr.frontier_root();
+        assert_ne!(frontier_root2, frontier_root1);
 
         mmr = mmr.push(b"!".as_ref().into()).unwrap();
         assert_eq!(mmr.len(), 3);
@@ -292,6 +311,8 @@ mod test {
         );
         assert_eq!(mmr.roots.peek().unwrap().height, 1);
         assert_eq!(mmr.roots.peek().unwrap().root, leaf(b"!"));
+        let frontier_root3 = mmr.frontier_root();
+        assert_ne!(frontier_root3, frontier_root2);
 
         mmr = mmr.push(b"!".as_ref().into()).unwrap();
         assert_eq!(mmr.len(), 4);
@@ -304,6 +325,8 @@ mod test {
                 <ZkHasher as Digest>::compress(&[leaf(b"!"), leaf(b"!")])
             ])
         );
+        let frontier_root4 = mmr.frontier_root();
+        assert_ne!(frontier_root4, frontier_root3);
 
         assert!(matches!(
             mmr.push(b"already full".as_ref().into()),


### PR DESCRIPTION
## 1. What does this PR implement?

(We are not using MMR anywhere, but I am preparing to use it to improve memory usage for voucher management. This PR is a preparation for it.)

The `frontier_root` function had a bug. It's easier to explain it with this picture.
<img width="3539" height="2905" alt="IMG_2767" src="https://github.com/user-attachments/assets/8d410656-a051-4bf3-8492-ec6893af8a3d" />

Actually, we should be fine(?) even if we do not fix this bug, as long as all MMR implementations (ours and others) are consistent. But, anyway this is incorrect.

This PR fixes it even by simplifying the code. Also, I eliminated magic numbers by defining a constant.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
