### PR TITLE
refactor(chain): do not clone `Cryptarchia` when processing blocks

### DIFF
--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -304,6 +304,7 @@ impl Cryptarchia {
                 err => Error::Ledger(err),
             })?;
 
+        // TODO: On failure, rollback `self.ledger`
         let UpdatedCryptarchia {
             cryptarchia: consensus,
             pruned_blocks,
@@ -610,7 +611,7 @@ where
                             ConsensusMsg::ApplyBlock { block, tx } => {
                                 // TODO: move this into the process_message() function after making the process_message async.
                                 match Self::process_block_and_update_state(
-                                        cryptarchia.clone(),
+                                        &mut cryptarchia,
                                         *block,
                                         current_slot,
                                         &storage_blocks_to_remove,
@@ -619,8 +620,7 @@ where
                                         &self.lib_subscription_sender,
                                         &self.service_resources_handle.state_updater,
                                     ).await {
-                                    Ok((new_cryptarchia, new_storage_blocks_to_remove, reorged_txs)) => {
-                                        cryptarchia = new_cryptarchia;
+                                    Ok((new_storage_blocks_to_remove, reorged_txs)) => {
                                         storage_blocks_to_remove = new_storage_blocks_to_remove;
                                         tx.send(Ok((cryptarchia.tip(), reorged_txs))).unwrap_or_else(|_| {
                                             error!("Could not send process block result through channel");
@@ -835,9 +835,12 @@ where
         }
     }
 
+    /// Process a block and update the state accordingly.
+    ///
+    /// On error, the `cryptarchia` is not mutated.
     #[expect(clippy::too_many_arguments, reason = "Need all args")]
     async fn process_block_and_update_state(
-        cryptarchia: Cryptarchia,
+        cryptarchia: &mut Cryptarchia,
         block: Block<Tx>,
         current_slot: Slot,
         storage_blocks_to_remove: &HashSet<HeaderId>,
@@ -845,8 +848,8 @@ where
         new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
         lib_subscription_sender: &broadcast::Sender<LibUpdate>,
         state_updater: &StateUpdater<Option<CryptarchiaConsensusState>>,
-    ) -> Result<(Cryptarchia, HashSet<HeaderId>, Vec<Tx>), Error> {
-        let (cryptarchia, pruned_blocks, reorged_txs) = Self::process_block(
+    ) -> Result<(HashSet<HeaderId>, Vec<Tx>), Error> {
+        let (pruned_blocks, reorged_txs) = Self::process_block(
             cryptarchia,
             block,
             current_slot,
@@ -863,13 +866,9 @@ where
         )
         .await;
 
-        Self::update_state(
-            &cryptarchia,
-            storage_blocks_to_remove.clone(),
-            state_updater,
-        );
+        Self::update_state(cryptarchia, storage_blocks_to_remove.clone(), state_updater);
 
-        Ok((cryptarchia, storage_blocks_to_remove, reorged_txs))
+        Ok((storage_blocks_to_remove, reorged_txs))
     }
 
     fn update_state(
@@ -891,17 +890,19 @@ where
     }
 
     /// Try to add a [`Block`] to [`Cryptarchia`].
-    /// A [`Block`] is only added if it's valid
+    ///
+    /// A [`Block`] is only added if it's valid.
+    /// Otherwise, the [`Cryptarchia`] is unchanged and an error is returned.
     #[expect(clippy::allow_attributes_without_reason)]
     #[instrument(level = "debug", skip(cryptarchia, relays))]
     async fn process_block(
-        mut cryptarchia: Cryptarchia,
+        cryptarchia: &mut Cryptarchia,
         block: Block<Tx>,
         current_slot: Slot,
         relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
         new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
         lib_broadcaster: &broadcast::Sender<LibUpdate>,
-    ) -> Result<(Cryptarchia, PrunedBlocks<HeaderId>, Vec<Tx>), Error> {
+    ) -> Result<(PrunedBlocks<HeaderId>, Vec<Tx>), Error> {
         debug!("Received proposal with ID: {:?}", block.header().id());
         let header = block.header();
         let prev_lib = cryptarchia.lib();
@@ -972,7 +973,7 @@ where
             }
 
             Self::broadcast_session_updates_for_block(
-                &cryptarchia,
+                cryptarchia,
                 &new_lib,
                 relays,
                 Some(&previous_session_numbers),
@@ -991,7 +992,7 @@ where
         .flat_map(Block::into_transactions)
         .collect();
 
-        Ok((cryptarchia, pruned_blocks, reorged_txs))
+        Ok((pruned_blocks, reorged_txs))
     }
 
     /// Store immutable block IDs to storage, including the new LIB if needed.
@@ -1124,7 +1125,7 @@ where
         let mut pruned_blocks = PrunedBlocks::new();
         for block in blocks {
             match Self::process_block(
-                cryptarchia.clone(),
+                &mut cryptarchia,
                 block,
                 current_slot,
                 relays,
@@ -1133,8 +1134,7 @@ where
             )
             .await
             {
-                Ok((new_cryptarchia, new_pruned_blocks, _)) => {
-                    cryptarchia = new_cryptarchia;
+                Ok((new_pruned_blocks, _)) => {
                     pruned_blocks.extend(&new_pruned_blocks);
                 }
                 Err(e) => {


### PR DESCRIPTION
## 1. What does this PR implement?

We were cloning `Cryptarchia` struct whenever a new block is received. This is the top-most struct which holds `lb_ledger::Ledger` and `lb_cryptarchia_engine::Cryptarchia`, and this is held by the chain service.

The old `Cryptarchia` is dropped immediately. Nevertheless, we don't actually have to clone this struct, because:
- In [#2367](https://github.com/logos-blockchain/logos-blockchain/pull/2367), I already made `lb_ledger::Ledger` mutable. We don't need to clone this.
- `lb_cryptarchia_engine::Cryptarchia` is still immutable, but I will make it mutable in a next PR.

This PR doesn't fix the continuous memory growth issue completely, but may be helpful. During Bootstrapping, the `lb_ledger::Ledger` holds a `HashMap` which has 60K+ `LedgerState`s. Although `LedgerState` uses `rpds`s inside, cloning the `lb_ledger::Ledger` many times can cause heap fragmentation. Also, even after Bootstrapping, the `HashMap`'s capacity is not reduced dramatically even if we call `shrink`. It means that cloning the `HashMap` causes a big allocation.

Long story short, it is better to NOT clone structs if possible.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
