### PR TITLE
fix(chain): make ledger+chain updates atomic

### DIFF
--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -614,13 +614,14 @@ pub mod tests {
             .unwrap();
         let id = make_id(parent, slot, utxo);
         let proof = generate_proof(&ledger_state, &utxo, slot);
-        ledger.try_update::<_, MainnetGasConstants>(
+        let (_, state) = ledger.prepare_update::<_, MainnetGasConstants>(
             id,
             parent,
             slot,
             &proof,
             std::iter::empty::<&SignedMantleTx>(),
         )?;
+        ledger.commit_update(id, state);
         Ok(id)
     }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -105,16 +105,19 @@ where
         }
     }
 
-    /// Try to update the ledger state by applying the given proof and
+    /// Prepare adding a new [`LedgerState`] by applying the given proof and
     /// transactions on top of the parent state.
-    pub fn try_update<LeaderProof, Constants>(
-        &mut self,
+    ///
+    /// On success, a new [`LedgerState`] is returned, which can then be
+    /// committed by calling [`Self::commit_update`].
+    pub fn prepare_update<LeaderProof, Constants>(
+        &self,
         id: Id,
         parent_id: Id,
         slot: Slot,
         proof: &LeaderProof,
         txs: impl Iterator<Item = impl AuthenticatedMantleTx>,
-    ) -> Result<(), LedgerError<Id>>
+    ) -> Result<(Id, LedgerState), LedgerError<Id>>
     where
         LeaderProof: leader_proof::LeaderProof,
         Constants: GasConstants,
@@ -129,8 +132,12 @@ where
                 .clone()
                 .try_update::<_, _, Constants>(slot, proof, txs, &self.config)?;
 
-        self.states.insert(id, new_state);
-        Ok(())
+        Ok((id, new_state))
+    }
+
+    /// Commits a new [`LedgerState`] created by [`Self::prepare_update`].
+    pub fn commit_update(&mut self, id: Id, state: LedgerState) {
+        self.states.insert(id, state);
     }
 
     pub fn state(&self, id: &Id) -> Option<&LedgerState> {
@@ -463,8 +470,8 @@ mod tests {
         );
 
         let new_id = [1; 32];
-        ledger
-            .try_update::<_, MainnetGasConstants>(
+        let (_, state) = ledger
+            .prepare_update::<_, MainnetGasConstants>(
                 new_id,
                 genesis_id,
                 Slot::from(1u64),
@@ -472,6 +479,7 @@ mod tests {
                 std::iter::once(&tx),
             )
             .unwrap();
+        ledger.commit_update(new_id, state);
 
         // Verify the transaction was applied
         let new_state = ledger.state(&new_id).unwrap();

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -288,8 +288,9 @@ impl Cryptarchia {
         }
 
         // A block number of this block if it's applied to the chain.
-        self.ledger
-            .try_update::<_, MainnetGasConstants>(
+        let (_, state) = self
+            .ledger
+            .prepare_update::<_, MainnetGasConstants>(
                 id,
                 parent,
                 slot,
@@ -304,7 +305,6 @@ impl Cryptarchia {
                 err => Error::Ledger(err),
             })?;
 
-        // TODO: On failure, rollback `self.ledger`
         let UpdatedCryptarchia {
             cryptarchia: consensus,
             pruned_blocks,
@@ -319,7 +319,9 @@ impl Cryptarchia {
                 },
                 err => Error::Consensus(err),
             })?;
+
         self.consensus = consensus;
+        self.ledger.commit_update(id, state);
 
         // Prune the ledger states of all the pruned blocks.
         self.prune_ledger_states(pruned_blocks.all());


### PR DESCRIPTION
## 1. What does this PR implement?

Now that we made `Cryptarchia` mutable in [#2416](https://github.com/logos-blockchain/logos-blockchain/pull/2416), we need to make sure that both ledger and engine inside `Cryptarchia` are updated atomically. This PR resolves it by introducing the prepare-commit pattern.

Actually, this should have been resolved before because the update function was accepting `&mut self`. This issue was not revealed because the `self` was being cloned outside (before [#2416](https://github.com/logos-blockchain/logos-blockchain/pull/2416)). Anyway, this PR fixes it. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
