### PR TITLE
refactor(chain): do not clone branches when switching to online

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -567,16 +567,11 @@ where
             .expect("Local chain tip height must be >= LIB height.")
     }
 
-    pub fn online(self) -> (Self, PrunedBlocks<Id>) {
-        let mut new = Self {
-            local_chain: self.local_chain,
-            branches: self.branches.clone(),
-            config: self.config,
-            state: State::Online,
-        };
+    pub fn online(mut self) -> (Self, PrunedBlocks<Id>) {
+        self.state = State::Online;
         // Update the LIB to the current local chain's tip
-        let pruned_blocks = new.update_lib();
-        (new, pruned_blocks)
+        let pruned_blocks = self.update_lib();
+        (self, pruned_blocks)
     }
 
     pub const fn config(&self) -> &Config {

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -564,7 +564,7 @@ where
             .await;
         // These are blocks that have been pruned by the cryptarchia engine but have not
         // yet been deleted from the storage layer.
-        let mut storage_blocks_to_remove = Self::delete_pruned_blocks_from_storage(
+        let mut storage_blocks_to_remove = Self::delete_stale_blocks_from_storage(
             pruned_blocks.stale_blocks().copied(),
             &self.state.storage_blocks_to_remove,
             relays.storage_adapter(),
@@ -871,7 +871,7 @@ where
         )
         .await?;
 
-        let storage_blocks_to_remove = Self::delete_pruned_blocks_from_storage(
+        let storage_blocks_to_remove = Self::delete_stale_blocks_from_storage(
             pruned_blocks.stale_blocks().copied(),
             storage_blocks_to_remove,
             relays.storage_adapter(),
@@ -1158,7 +1158,7 @@ where
         (cryptarchia, pruned_blocks)
     }
 
-    /// Remove the pruned blocks from the storage layer.
+    /// Remove the stale blocks from the storage layer.
     ///
     /// Also, this removes the `additional_blocks` from the storage
     /// layer. These blocks might belong to previous pruning operations and
@@ -1166,13 +1166,13 @@ where
     ///
     /// This function returns any block that fails to be deleted from the
     /// storage layer.
-    async fn delete_pruned_blocks_from_storage(
-        pruned_blocks: impl Iterator<Item = HeaderId> + Send,
+    async fn delete_stale_blocks_from_storage(
+        stale_blocks: impl Iterator<Item = HeaderId> + Send,
         additional_blocks: &HashSet<HeaderId>,
         storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
     ) -> HashSet<HeaderId> {
         match Self::delete_blocks_from_storage(
-            pruned_blocks.chain(additional_blocks.iter().copied()),
+            stale_blocks.chain(additional_blocks.iter().copied()),
             storage_adapter,
         )
         .await
@@ -1329,7 +1329,7 @@ where
             error!("Could not store immutable block IDs: {e}");
         }
 
-        let storage_blocks_to_remove = Self::delete_pruned_blocks_from_storage(
+        let storage_blocks_to_remove = Self::delete_stale_blocks_from_storage(
             pruned_blocks.stale_blocks().copied(),
             storage_blocks_to_remove,
             storage_adapter,


### PR DESCRIPTION
## 1. What does this PR implement?

This is a very small fix. When switching to Online, we were cloning the entire `Branches`, but we don't actually need to. This PR doesn't fix the memory growth issue completely, but I'm opening this before forgetting.

Also, I renamed a function in the chain service to make it clearer.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
