### PR TITLE
feat(autonat): remove explicit setting of server mode

### DIFF
--- a/libp2p/src/behaviour/nat/inner.rs
+++ b/libp2p/src/behaviour/nat/inner.rs
@@ -18,7 +18,7 @@ use libp2p::{
 };
 use rand::RngCore;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::{
     behaviour::nat::{
@@ -63,11 +63,6 @@ where
     autonat_client_tick_interval: Duration,
     /// Current local address that is being managed
     local_address: Option<Multiaddr>,
-    /// Optional external address candidate provided by the operator to be
-    /// verified via `AutoNAT`. Useful for nodes with manual port forwarding
-    /// where the correct public address may not be discovered automatically.
-    /// Emitted once as a `NewExternalAddrCandidate` on first poll.
-    external_address_candidate: Option<Multiaddr>,
 }
 
 pub type NatBehaviour<Rng> = InnerNatBehaviour<Rng, ProtocolManager, SystemGatewayDetector>;
@@ -113,7 +108,6 @@ where
             next_autonat_client_tick: OptionFuture::default().fuse(),
             autonat_client_tick_interval,
             local_address: None,
-            external_address_candidate: settings.external_address.clone(),
         }
     }
 }
@@ -210,11 +204,6 @@ where
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
-        if let Some(addr) = self.external_address_candidate.take() {
-            debug!("Emitting external address candidate for AutoNAT verification: {addr}");
-            return Poll::Ready(ToSwarm::NewExternalAddrCandidate(addr));
-        }
-
         if let Poll::Ready(to_swarm) = self.autonat_client_behaviour.poll(cx) {
             // Forward all autonat results to the state machine unconditionally.
             // The state machine's own guard clauses filter by the address it is

--- a/libp2p/src/config/nat/mod.rs
+++ b/libp2p/src/config/nat/mod.rs
@@ -9,11 +9,6 @@ pub struct TraversalSettings {
     pub autonat: autonat_client::Settings,
     pub mapping: mapping::Settings,
     pub gateway_monitor: gateway::Settings,
-    /// Optional external address candidate to verify via `AutoNAT`.
-    /// Useful for nodes with manual port forwarding where the correct
-    /// public address may not be discovered automatically.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub external_address: Option<libp2p::Multiaddr>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/nodes/node/binary/src/config/network/serde/nat.rs
+++ b/nodes/node/binary/src/config/network/serde/nat.rs
@@ -41,7 +41,6 @@ impl From<Config> for lb_libp2p::NatSettings {
                 gateway_monitor: lb_libp2p::GatewaySettings {
                     check_interval: traversal_config.gateway_monitor.check_interval,
                 },
-                external_address: traversal_config.external_address,
             }),
             Config::Static { external_address } => Self::Static { external_address },
         }
@@ -60,11 +59,6 @@ pub struct TraversalConfig {
     pub autonat: AutonatClientConfig,
     pub mapping: MappingConfig,
     pub gateway_monitor: GatewayConfig,
-    /// Optional external address candidate to verify via `AutoNAT`.
-    /// Useful for nodes with manual port forwarding where the correct
-    /// public address may not be discovered automatically.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub external_address: Option<Multiaddr>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]


### PR DESCRIPTION
## 1. What does this PR implement?

Removed forced Kademlia Server mode and rely on libp2p’s automatic mode switching based on confirmed external addresses (**static** mode still sets it manually, so behavior remains unchanged in that case), and added logging for the mode state changed event.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No, it just adds a possibility for a user to add another candidate for probe in `traversal` mode.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
