### PR TITLE
fix(cryptarchia-engine): shrink branches after switching to online

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -331,6 +331,12 @@ where
         }
         *current
     }
+
+    /// Shrink internal data structures to release unused capacity.
+    fn shrink(&mut self) {
+        self.branches.shrink_to_fit();
+        self.tips.shrink_to_fit();
+    }
 }
 
 #[derive(Debug, Clone, Error)]
@@ -541,6 +547,16 @@ where
         })
     }
 
+    /// Shrink internal data structures to release unused capacity.
+    ///
+    /// This should be called after a significant number of blocks have been
+    /// pruned by [`Self::prune_fork`] and [`Self::prune_immutable_blocks`] to
+    /// free up memory. This should not be called frequently since it is an
+    /// expensive operation.
+    fn shrink(&mut self) {
+        self.branches.shrink();
+    }
+
     pub const fn branches(&self) -> &Branches<Id> {
         &self.branches
     }
@@ -571,6 +587,7 @@ where
         self.state = State::Online;
         // Update the LIB to the current local chain's tip
         let pruned_blocks = self.update_lib();
+        self.shrink();
         (self, pruned_blocks)
     }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Like `Ledger`, this PR shrinks `Branches` in the cryptarchia-engine after switching to Online. I overlooked it because `Branches` is much smaller than `LedgerState`s. But it's better to have a consistent behavior (shrinking) for all data structures. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
