### PR TITLE
fix: slot ticks debugging

### DIFF
--- a/blend/message/src/crypto/proofs.rs
+++ b/blend/message/src/crypto/proofs.rs
@@ -1,4 +1,5 @@
 use core::mem::swap;
+use std::time::Instant;
 
 use lb_blend_proofs::{
     quota::{
@@ -107,7 +108,8 @@ impl ProofsVerifier for RealProofsVerifier {
         tracing::debug!(
             "Verifying proof of quota {proof:?} with session {session:?}, public core inputs: {core:?}, leader inputs: {leader:?} and signing key: {signing_key:?}."
         );
-        proof
+        let start = Instant::now();
+        let proof_verification_result = proof
             .verify(&PublicInputs {
                 core,
                 leader,
@@ -132,7 +134,14 @@ impl ProofsVerifier for RealProofsVerifier {
                     .map_err(Error::ProofOfQuota).inspect_err(|_| {
                         tracing::debug!("Input proof invalid with both current and previous epoch public inputs.");
                     })
-            })
+            });
+
+        tracing::trace!(
+            "Proof verification time: {} ms",
+            start.elapsed().as_millis()
+        );
+
+        proof_verification_result
     }
 
     fn verify_proof_of_selection(

--- a/blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -21,7 +21,7 @@ use libp2p::{
     identity::{PublicKey, ed25519},
 };
 use libp2p_swarm_test::SwarmExt as _;
-use tokio::time::interval;
+use tokio::time::{MissedTickBehavior, interval};
 use tokio_stream::wrappers::IntervalStream;
 
 use crate::core::{
@@ -38,7 +38,13 @@ impl IntervalStreamProvider for IntervalProvider {
 
     fn interval_stream(&self) -> Self::IntervalStream {
         let range = self.1.clone();
-        Box::new(IntervalStream::new(interval(self.0)).map(move |_| range.clone()))
+        let interval = {
+            let mut interval = interval(self.0);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            interval
+        };
+        Box::new(IntervalStream::new(interval).map(move |_| range.clone()))
     }
 }
 

--- a/blend/scheduling/src/message_scheduler/mod.rs
+++ b/blend/scheduling/src/message_scheduler/mod.rs
@@ -10,7 +10,7 @@ use core::{
 use fork_stream::StreamExt as _;
 use futures::{Stream, StreamExt as _};
 use rand::RngCore;
-use tokio::time::interval;
+use tokio::time::{MissedTickBehavior, interval};
 use tokio_stream::wrappers::IntervalStream;
 use tracing::{info, trace};
 
@@ -60,8 +60,14 @@ where
     DataMessage: Debug + Unpin,
 {
     pub fn new(session_info: SessionInfo, rng: Rng, settings: Settings) -> Self {
+        let interval = {
+            let mut interval = interval(settings.round_duration);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            interval
+        };
         let round_clock = Box::new(
-            IntervalStream::new(interval(settings.round_duration))
+            IntervalStream::new(interval)
                 .enumerate()
                 .map(|(round, _)| (round as u128).into()),
         )

--- a/blend/scheduling/src/message_scheduler/round_info.rs
+++ b/blend/scheduling/src/message_scheduler/round_info.rs
@@ -5,7 +5,7 @@ use core::{
 
 use futures::Stream;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Round(u128);
 
 impl Round {

--- a/blend/scheduling/src/release_delayer.rs
+++ b/blend/scheduling/src/release_delayer.rs
@@ -141,7 +141,7 @@ where
         };
 
         // If it's time to release messages...
-        if new_round == self.next_release_round {
+        if new_round >= self.next_release_round {
             // Reset the next release round.
             self.next_release_round = calculate_next_release_round(
                 new_round,

--- a/services/blend/src/core/backends/libp2p/tokio_provider.rs
+++ b/services/blend/src/core/backends/libp2p/tokio_provider.rs
@@ -6,6 +6,7 @@ use lb_blend::{
     network::core::with_core::behaviour::IntervalStreamProvider, scheduling::membership::Membership,
 };
 use lb_utils::math::NonNegativeF64;
+use tokio::time::MissedTickBehavior;
 use tokio_stream::wrappers::IntervalStream;
 
 use crate::core::{
@@ -48,12 +49,15 @@ impl IntervalStreamProvider for ObservationWindowTokioIntervalProvider {
 
     fn interval_stream(&self) -> Self::IntervalStream {
         let expected_message_range = self.calculate_expected_message_range();
-        Box::new(
-            IntervalStream::new(tokio::time::interval(Duration::from_secs(
+        let interval = {
+            let mut interval = tokio::time::interval(Duration::from_secs(
                 (self.rounds_per_observation_window.get()) * self.round_duration_seconds.get(),
-            )))
-            .map(move |_| expected_message_range.clone()),
-        )
+            ));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            interval
+        };
+        Box::new(IntervalStream::new(interval).map(move |_| expected_message_range.clone()))
     }
 }
 

--- a/services/chain/chain-leader/src/leadership.rs
+++ b/services/chain/chain-leader/src/leadership.rs
@@ -13,7 +13,10 @@ use lb_ledger::{EpochState, UtxoTree};
 use lb_wallet_service::{UtxoWithKeyId, api::WalletApi};
 use overwatch::services::AsServiceId;
 use rand::rngs::OsRng;
-use tokio::sync::{oneshot, watch::Sender};
+use tokio::{
+    sync::{oneshot, watch::Sender},
+    time::Instant,
+};
 
 use crate::{WinningPolInfo, kms::KmsAdapter};
 
@@ -243,6 +246,7 @@ impl<'service> PotentialWinningPoLSlotNotifier<'service> {
             .into();
 
         let mut first_winning_slot: Option<Slot> = None;
+        let start = Instant::now();
         for UtxoWithKeyId { utxo, key_id } in utxos {
             for offset in 0..slots_per_epoch {
                 let slot = epoch_starting_slot
@@ -255,7 +259,6 @@ impl<'service> PotentialWinningPoLSlotNotifier<'service> {
                 if !winning {
                     continue;
                 }
-                tracing::debug!("Found winning utxo with ID {:?} for slot {slot}", utxo.id());
 
                 // Note: We discard the signing key here since this is just for pre-computing
                 // winning slots. The actual signing key will be generated when building the
@@ -296,6 +299,12 @@ impl<'service> PotentialWinningPoLSlotNotifier<'service> {
                 }
             }
         }
+        tracing::debug!(
+            "Found all winning utxos for epoch {:?} in {:?} ms",
+            epoch_state.epoch,
+            start.elapsed().as_millis()
+        );
+
         self.last_processed_epoch_and_found_first_winning_slot =
             Some((epoch_state.epoch, first_winning_slot));
     }

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -20,8 +20,8 @@ use overwatch::{
         state::{NoOperator, NoState},
     },
 };
-use tokio::sync::{broadcast, oneshot};
-use tokio_stream::wrappers::BroadcastStream;
+use tokio::sync::{oneshot, watch};
+use tokio_stream::wrappers::WatchStream;
 
 use crate::backends::TimeBackend;
 
@@ -108,9 +108,6 @@ where
     }
 
     async fn run(self) -> Result<(), DynError> {
-        // 3 slots buffer should be enough
-        const SLOTS_BUFFER: usize = 3;
-
         let Self {
             service_resources_handle,
             backend,
@@ -118,7 +115,7 @@ where
         let mut inbound_relay = service_resources_handle.inbound_relay;
         let (mut current_slot_tick, mut tick_stream) = backend.tick_stream();
 
-        let (broadcast_sender, broadcast_receiver) = broadcast::channel(SLOTS_BUFFER);
+        let (watch_sender, watch_receiver) = watch::channel(current_slot_tick);
 
         service_resources_handle.status_updater.notify_ready();
         tracing::info!(
@@ -129,14 +126,14 @@ where
         loop {
             tokio::select! {
                 Some(service_message) = inbound_relay.recv() => {
-                    handle_service_message(service_message, &broadcast_receiver, &current_slot_tick);
+                    handle_service_message(service_message, &watch_receiver, &current_slot_tick);
                 }
                 Some(slot_tick) = tick_stream.next() => {
                     current_slot_tick = slot_tick;
                     metrics::time_current_slot(u64::from(slot_tick.slot));
                     metrics::time_current_epoch(u32::from(slot_tick.epoch));
 
-                    if let Err(e) = broadcast_sender.send(slot_tick) {
+                    if let Err(e) = watch_sender.send(slot_tick) {
                         error!("Error updating slot tick: {e}");
                         metrics::time_broadcast_errors();
                     }
@@ -148,26 +145,12 @@ where
 
 fn handle_service_message(
     message: TimeServiceMessage,
-    broadcast_receiver: &broadcast::Receiver<SlotTick>,
+    watch_receiver: &watch::Receiver<SlotTick>,
     current_slot_tick: &SlotTick,
 ) {
     match message {
         TimeServiceMessage::Subscribe { sender } => {
-            let channel_stream =
-                BroadcastStream::new(broadcast_receiver.resubscribe()).filter_map(|result| {
-                    Box::pin(async {
-                        match result {
-                            Ok(tick) => Some(tick),
-                            Err(e) => {
-                                // log lagging errors, services should always aim to be ready for
-                                // next slot
-                                error!("Lagging behind slot ticks: {e:?}");
-                                None
-                            }
-                        }
-                    })
-                });
-            let stream = Pin::new(Box::new(channel_stream));
+            let stream = Pin::new(Box::new(WatchStream::from_changes(watch_receiver.clone())));
             if sender.send(stream).is_err() {
                 error!("Couldn't send back a Subscribe response");
             }


### PR DESCRIPTION
Make all components resilient to missed slot and round ticks. In most of the cases, this should not happen, but if it does, it's fair to expect all nodes to remain in sync and skip missed slots and rounds instead of get a burst of the missed ones, which can cause more problems than it tries to fix.

So main change is to the time service channel, which is not a broadcast (with a buffer size of `3`) anymore, but a watch channel, and the Blend stack is configured to skip missed round ticks, which is not bad since we would, in the worst case, simply generate less cover traffic, which was the behaviour also in case we were lagging behind, with the difference that in that case we were also leaking the fact that we were lagging behind.