### PR TITLE
feat: add --version support for node binary

### DIFF
--- a/nodes/node/binary/build.rs
+++ b/nodes/node/binary/build.rs
@@ -1,0 +1,53 @@
+use std::{env, ffi::OsStr, process::Command};
+
+fn run_command<Cmd, ArgIter, Arg>(command: Cmd, args: ArgIter) -> Option<String>
+where
+    Cmd: AsRef<OsStr>,
+    ArgIter: IntoIterator<Item = Arg>,
+    Arg: AsRef<OsStr>,
+{
+    Command::new(command)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn get_head_commit_hash() -> Option<String> {
+    run_command("git", ["rev-parse", "--short", "HEAD"])
+}
+
+fn get_head_tag_name() -> Option<String> {
+    run_command("git", ["describe", "--tags", "--exact-match", "HEAD"])
+}
+
+fn get_rustc_version() -> String {
+    let rustc_binary = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    run_command(rustc_binary, ["--version"])
+        .expect("Rustc binary should always be available when compiling a Rust project.")
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+
+    let head_commit_hash = get_head_commit_hash().unwrap_or_default();
+    println!("cargo:rustc-env=HEAD_COMMIT_HASH={head_commit_hash}");
+
+    let head_tag_name = get_head_tag_name().unwrap_or_default();
+    println!("cargo:rustc-env=HEAD_TAG_NAME={head_tag_name}");
+
+    let rustc_version = get_rustc_version();
+    println!("cargo:rustc-env=RUSTC_VERSION={rustc_version}");
+
+    // These env variables are injected by Cargo.
+    let pkg_version = env::var("CARGO_PKG_VERSION").unwrap();
+    println!("cargo:rustc-env=PKG_VERSION={pkg_version}");
+
+    let profile = env::var("PROFILE").unwrap();
+    println!("cargo:rustc-env=PROFILE={profile}");
+
+    let target = env::var("TARGET").unwrap();
+    println!("cargo:rustc-env=TARGET={target}");
+}

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -44,8 +44,36 @@ pub mod wallet;
 #[cfg(test)]
 mod tests;
 
+fn long_version() -> String {
+    let head_commit_hash = env!("HEAD_COMMIT_HASH");
+    let head_tag_name = env!("HEAD_TAG_NAME");
+    let pkg_version = env!("PKG_VERSION");
+    let target = env!("TARGET");
+    let profile = env!("PROFILE");
+    let rustc_version = env!("RUSTC_VERSION");
+
+    let commit_line = match (head_commit_hash, head_tag_name) {
+        (commit_hash, tag_name) if !commit_hash.is_empty() && !tag_name.is_empty() => {
+            format!("commit:  {commit_hash} (tag {tag_name})")
+        }
+        (commit_hash, _) if !commit_hash.is_empty() => {
+            format!("commit:  {commit_hash}")
+        }
+        _ => "commit:  unknown".to_owned(),
+    };
+
+    format!(
+        "\
+{pkg_version}
+{commit_line}
+target:  {target}
+profile: {profile}
+rustc:   {rustc_version}"
+    )
+}
+
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None,
+#[command(author, version, long_version = long_version(), about, long_about = None,
           args_conflicts_with_subcommands = true,
           subcommand_negates_reqs = true)]
 pub struct CliArgs {


### PR DESCRIPTION
## 1. What does this PR implement?

Now when running `logos-blockchain-node --version` we get the following output:

```
logos-blockchain-node 0.2.1
commit:  bb4655c9b (tag X.Y.Z, if present)
target:  aarch64-apple-darwin
profile: debug
rustc:   rustc 1.94.0 (4a4ef493e 2026-03-02)
```

while `logos-blockchain-node -V` will continue printing only `logos-blockchain-node 0.2.1`.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.
