### PR TITLE
feat: clamp ntp jitter

### DIFF
--- a/services/time/src/backends/ntp/mod.rs
+++ b/services/time/src/backends/ntp/mod.rs
@@ -143,21 +143,21 @@ impl NtpStream {
         let roundtrip = Duration::from_micros(timestamp.roundtrip());
         let ts_nanos_u128 = (seconds + nanos_fraction + roundtrip / 2).as_nanos();
 
-        let ts_nanos = match u64::try_from(ts_nanos_u128) {
+        let ts_nanos_i128 = match i128::try_from(ts_nanos_u128) {
             Ok(ts_nanos) => ts_nanos,
             Err(e) => {
                 tracing::warn!(
                     "Skipping invalid NTP timestamp {ts_nanos_u128} vs. {}: {e}",
-                    u64::MAX
+                    i128::MAX
                 );
                 return;
             }
         };
 
-        let date = match OffsetDateTime::from_unix_timestamp_nanos(i128::from(ts_nanos)) {
+        let date = match OffsetDateTime::from_unix_timestamp_nanos(ts_nanos_i128) {
             Ok(date) => date,
             Err(e) => {
-                tracing::warn!("Skipping invalid NTP timestamp: {e:?} (ts_nanos={ts_nanos})");
+                tracing::warn!("Skipping invalid NTP timestamp: {e:?} (ts_nanos={ts_nanos_i128})");
                 return;
             }
         };


### PR DESCRIPTION
## 1. What does this PR implement?

In recent e-2-e system-level tests it was observed that the current slot moved backwards. This can result in unwanted system-level behaviour.

- Clamped NTP jitter by ensuring that current slot, epoch and the slot timer cannot move backwards, ensuring monotonicity.
- Added unit test to confirm `NtpStream` works as expected when injecting it with jitter time stamps.
- Added unit tests to confirm that the `NtpTimeBackend` + `NtpStream` combination works as expected when polling a real world NTP server so fast that we are guaranteed to pick up time-stamp jitter, in the `ms` range.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
