### PR TITLE
fix(blend): use core proofs for data encapsulation

### DIFF
--- a/blend/scheduling/src/message_blend/crypto/core_and_leader/send.rs
+++ b/blend/scheduling/src/message_blend/crypto/core_and_leader/send.rs
@@ -141,6 +141,11 @@ where
         // We validate the payload early on so we don't generate proofs unnecessarily.
         let validated_payload = PaddedPayloadBody::try_from(payload)?;
         let mut proofs = Vec::with_capacity(self.num_blend_layers.get() as usize);
+        let membership_size = self.membership.size();
+        let local_index = self
+            .membership
+            .local_index()
+            .expect("Local node index should exist.");
 
         match payload_type {
             PayloadType::Cover => {
@@ -152,16 +157,25 @@ where
                 }
             }
             PayloadType::Data => {
-                for _ in 0..self.num_blend_layers.into() {
-                    let Some(proof) = self.proofs_generator.get_next_leader_proof().await else {
-                        return Err(Error::NoLeadershipInfoProvided);
-                    };
-                    proofs.push(proof);
+                for _ in 0..self.num_blend_layers.get() {
+                    loop {
+                        let Some(proof) = self.proofs_generator.get_next_core_proof().await else {
+                            return Err(Error::NoMoreProofOfQuotas);
+                        };
+                        let expected_index = proof
+                            .proof_of_selection
+                            .expected_index(membership_size)
+                            .expect("Node index should exist.");
+                        if expected_index == local_index {
+                            continue;
+                        }
+                        proofs.push(proof);
+                        break;
+                    }
                 }
             }
         }
 
-        let membership_size = self.membership.size();
         let proofs_and_signing_keys = proofs
             .into_iter()
             // Collect remote (or local) index info for each PoSel.


### PR DESCRIPTION
## 1. What does this PR implement?

I’m not very confident in the protocol semantics here, so this may be the wrong fix direction, but it is the smallest change I found that consistently fixes the observed runtime failure.

This changes Blend data-message encapsulation to use core proofs for per-hop layers instead of leader proofs.

What I observed:
- proposals were entering Blend
- but some of them were not completing the decapsulation chain cleanly enough to come back out as shared chain traffic
- that showed up most clearly in the fork-detector test, where nodes quickly diverged onto different tips

What I changed:
- in `blend/scheduling/src/message_blend/crypto/core_and_leader/send.rs`
- `PayloadType::Data` now uses `get_next_core_proof()` for encapsulation layers
- and skips self-targeted outer layers

Why I tried this:
- cover messages already used core proofs for encapsulation layers
- data messages used leader proofs
- since the failure looked like data-message delivery through Blend, this was the smallest targeted thing to try

Result:
- the 10-node fork-detector passes for 600s

I’m still not certain this matches the intended Blend protocol semantics.

## 2. Does the code have enough context to be clearly understood?

> [!IMPORTANT]  
> Add a link to the specification document, pointing at the specific section.  
> Any implementation detail that could be considered idiosyncratic and not direct from the specification, should be  
> explained.  
> Always consider what someone new would need to know for the code to make sense, and add this context to it.

## 3. Who are the specification authors and who is accountable for this PR?

> [!IMPORTANT]  
> Ping the original specification author(s) and add them as reviewers, alongside any other from the engineering team.  
> You are accountable for the PR and its rapid resolution, so make sure anyone involved is aware and actively
> advancing  
> the review.

## 4. Is the specification accurate and complete?

> [!IMPORTANT]
> * If not, engage in a conversation directly with the authors, prompting any updates in the document.
> * You are accountable of this process, and the specification author needs to give priority to unblocking you.

## 5. Does the implementation introduce changes in the specification?

> [!IMPORTANT]
> * Contact the specification author(s) and engage in the necessary conversation to agree on the proposed  
    modification/solutions.
> * Ensure the new changes are on par with the implementation at the end of the process.
> * The PR should not be merged until parity between implementation and specifications has been reached.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
