### PR TITLE
chore: panic on unexpected circuit version

### DIFF
--- a/zk/circuits/utils/src/lib.rs
+++ b/zk/circuits/utils/src/lib.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
+use std::{fs::read_to_string, path::PathBuf};
 
 const LOGOS_BLOCKCHAIN_CIRCUITS_ENV_VAR: &str = "LOGOS_BLOCKCHAIN_CIRCUITS";
 const LOGOS_BLOCKCHAIN_CIRCUITS_DEFAULT_DIR: &str = ".logos-blockchain-circuits";
+const EXPECTED_CIRCUITS_VERSION: &str = "v0.4.2";
 
 #[cfg(target_os = "windows")]
 const BINARY_NAME: &str = "witness_generator.exe";
@@ -15,7 +16,8 @@ const BINARY_NAME: &str = "witness_generator";
 ///
 /// # Panics
 ///
-/// Panics if a logos-blockchain-circuits directory is not found
+/// Panics if a logos-blockchain-circuits directory is not found or if the
+/// circuits version does not match the expected one.
 #[must_use]
 pub fn circuits_dir() -> PathBuf {
     // Check LOGOS_BLOCKCHAIN_CIRCUITS env var first
@@ -35,6 +37,16 @@ pub fn circuits_dir() -> PathBuf {
         .join(LOGOS_BLOCKCHAIN_CIRCUITS_DEFAULT_DIR);
 
     if path.is_dir() {
+        let circuits_version = read_to_string(path.join("VERSION"))
+            .unwrap()
+            .trim()
+            .to_owned();
+        assert_eq!(
+            circuits_version,
+            EXPECTED_CIRCUITS_VERSION,
+            "The logos-blockchain-circuits directory at '{}' is version '{circuits_version}', but version '{EXPECTED_CIRCUITS_VERSION}' is expected. Please update your circuits directory or set the {LOGOS_BLOCKCHAIN_CIRCUITS_ENV_VAR} environment variable to point to a compatible circuits directory.",
+            path.display()
+        );
         path
     } else {
         panic!(


### PR DESCRIPTION
## 1. What does this PR implement?

Until we migrate circuits to be a library, we need to enforce that the circuits match the version the node expects. @andrussal and I spent the whole day trying to debug an issue which was caused by an outdated version of the circuits, with the latest version only updating leadership proofs.

My suggestion is to enforce the expected version in the zk utility library, which is called both at build time in the various `build.rs` modules as well as runtime. So now it's not possible to build a node binary referencing an unexpected circuits version, and if using a pre-compiled binary, the right circuits must be set up before the node can correctly produce a block.

This should avoid issues related to running outdated circuit binaries going forward, until we swap the binaries with bundled static libraries.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.