### PR TITLE
refactor(cryptarchia): add `lib_slot` to `CryptarchiaInfo` and simplify zone-sdk

### DIFF
--- a/nodes/node/binary/src/api/serializers/blocks.rs
+++ b/nodes/node/binary/src/api/serializers/blocks.rs
@@ -57,8 +57,10 @@ pub struct ApiProcessedBlockEvent {
     pub block: Block<SignedMantleTx>,
     /// The current canonical tip after processing this block.
     pub tip: HeaderId,
+    pub tip_slot: Slot,
     /// The current Last Irreversible Block after processing this block.
     pub lib: HeaderId,
+    pub lib_slot: Slot,
 }
 
 impl From<BlockWithChainState<SignedMantleTx>> for ApiProcessedBlockEvent {
@@ -66,7 +68,9 @@ impl From<BlockWithChainState<SignedMantleTx>> for ApiProcessedBlockEvent {
         Self {
             block: value.block,
             tip: value.tip,
+            tip_slot: value.tip_slot,
             lib: value.lib,
+            lib_slot: value.lib_slot,
         }
     }
 }

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use futures::{Stream, StreamExt as _};
 pub use lb_chain_broadcast_service::BlockInfo;
-use lb_chain_service::CryptarchiaInfo;
-pub use lb_chain_service::Slot;
+pub use lb_chain_service::{CryptarchiaInfo, Slot, State};
 use lb_core::{
     block::Block,
     header::{ContentId, HeaderId},
@@ -52,7 +51,9 @@ pub struct ApiBlock {
 pub struct ProcessedBlockEvent {
     pub block: ApiBlock,
     pub tip: HeaderId,
+    pub tip_slot: Slot,
     pub lib: HeaderId,
+    pub lib_slot: Slot,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/services/api/src/http/mantle.rs
+++ b/services/api/src/http/mantle.rs
@@ -42,8 +42,10 @@ pub struct BlockWithChainState<Tx> {
     pub block: Block<Tx>,
     /// The current canonical tip after processing this block.
     pub tip: HeaderId,
+    pub tip_slot: Slot,
     /// The current Last Irreversible Block after processing this block.
     pub lib: HeaderId,
+    pub lib_slot: Slot,
 }
 
 pub type MempoolService<StorageAdapter, RuntimeServiceId> = TxMempoolService<
@@ -246,7 +248,9 @@ where
             Some(BlockWithChainState {
                 block,
                 tip: event.tip,
+                tip_slot: event.tip_slot,
                 lib: event.lib,
+                lib_slot: event.lib_slot,
             })
         }
     });

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -23,7 +23,7 @@ pub enum ApiError {
     #[error("Missing parent while applying block {parent}, {info:?}")]
     ParentMissing {
         parent: HeaderId,
-        info: CryptarchiaInfo,
+        info: Box<CryptarchiaInfo>,
     },
     #[error("Failed to establish connection to chain-service: {0}")]
     CommsFailure(String),

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -30,8 +30,8 @@ use lb_core::{
     },
     sdp::{Declaration, DeclarationId, ProviderId, ProviderInfo, ServiceType},
 };
-pub use lb_cryptarchia_engine::{Epoch, Slot};
-use lb_cryptarchia_engine::{PrunedBlocks, ReorgedBlocks};
+use lb_cryptarchia_engine::{Branch, PrunedBlocks, ReorgedBlocks};
+pub use lb_cryptarchia_engine::{Epoch, Slot, State};
 use lb_cryptarchia_sync::{GetTipResponse, ProviderResponse};
 pub use lb_ledger::EpochState;
 use lb_ledger::LedgerState;
@@ -79,7 +79,7 @@ pub enum Error {
     #[error("Missing parent while applying block {parent}, {info:?}")]
     ParentMissing {
         parent: HeaderId,
-        info: CryptarchiaInfo,
+        info: Box<CryptarchiaInfo>,
     },
     #[error("Block from future slot({block_slot:?}): current_slot:{current_slot:?}")]
     FutureBlock {
@@ -159,10 +159,11 @@ pub enum ConsensusMsg<Tx> {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CryptarchiaInfo {
     pub lib: HeaderId,
+    pub lib_slot: Slot,
     pub tip: HeaderId,
     pub slot: Slot,
     pub height: u64,
-    pub mode: lb_cryptarchia_engine::State,
+    pub mode: State,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -192,8 +193,10 @@ pub struct ProcessedBlockEvent {
     pub block_id: HeaderId,
     /// The current canonical tip after processing this block.
     pub tip: HeaderId,
+    pub tip_slot: Slot,
     /// The current Last Irreversible Block after processing this block.
     pub lib: HeaderId,
+    pub lib_slot: Slot,
 }
 
 impl PrunedBlocksInfo {
@@ -221,7 +224,7 @@ impl Cryptarchia {
         lib_ledger_state: LedgerState,
         genesis_id: HeaderId,
         ledger_config: lb_ledger::Config,
-        state: lb_cryptarchia_engine::State,
+        state: State,
         lib_slot: Slot,
         lib_length: u64,
     ) -> Self {
@@ -240,15 +243,13 @@ impl Cryptarchia {
 
     #[must_use]
     pub fn info(&self) -> CryptarchiaInfo {
-        let tip_branch = self
-            .consensus
-            .branches()
-            .get(&self.tip())
-            .expect("tip branch not available");
+        let tip_branch = self.tip_branch();
+        let lib_branch = self.lib_branch();
 
         CryptarchiaInfo {
-            lib: self.lib(),
-            tip: self.tip(),
+            lib: lib_branch.id(),
+            lib_slot: lib_branch.slot(),
+            tip: tip_branch.id(),
             slot: tip_branch.slot(),
             height: tip_branch.length(),
             mode: *self.consensus.state(),
@@ -261,8 +262,18 @@ impl Cryptarchia {
     }
 
     #[must_use]
+    pub const fn tip_branch(&self) -> &Branch<HeaderId> {
+        self.consensus.tip_branch()
+    }
+
+    #[must_use]
     pub const fn lib(&self) -> HeaderId {
         self.consensus.lib()
+    }
+
+    #[must_use]
+    pub fn lib_branch(&self) -> &Branch<HeaderId> {
+        self.consensus.lib_branch()
     }
 
     /// Try to apply a block to the chain.
@@ -300,7 +311,7 @@ impl Cryptarchia {
             .map_err(|err| match err {
                 lb_ledger::LedgerError::ParentNotFound(parent) => Error::ParentMissing {
                     parent,
-                    info: self.info(),
+                    info: Box::new(self.info()),
                 },
                 err => Error::Ledger(err),
             })?;
@@ -311,7 +322,7 @@ impl Cryptarchia {
             .map_err(|err| match err {
                 lb_cryptarchia_engine::Error::ParentMissing(parent) => Error::ParentMissing {
                     parent,
-                    info: self.info(),
+                    info: Box::new(self.info()),
                 },
                 err => Error::Consensus(err),
             })?;
@@ -383,7 +394,7 @@ impl Cryptarchia {
         self.consensus.state().is_bootstrapping()
     }
 
-    const fn state(&self) -> &lb_cryptarchia_engine::State {
+    const fn state(&self) -> &State {
         self.consensus.state()
     }
 
@@ -952,10 +963,16 @@ where
         )
         .await?;
 
-        let processed_block_event = ProcessedBlockEvent {
-            block_id: header.id(),
-            tip: cryptarchia.tip(),
-            lib: cryptarchia.lib(),
+        let processed_block_event = {
+            let tip = cryptarchia.tip_branch();
+            let lib = cryptarchia.lib_branch();
+            ProcessedBlockEvent {
+                block_id: header.id(),
+                tip: tip.id(),
+                tip_slot: tip.slot(),
+                lib: lib.id(),
+                lib_slot: lib.slot(),
+            }
         };
         if let Err(e) = new_block_subscription_sender.send(processed_block_event) {
             error!("Could not notify new block to services {e}");
@@ -1127,16 +1144,21 @@ where
         let blocks = blocks.into_iter().skip(1);
 
         // Stream the already applied state.
-        let init_tip = cryptarchia.tip();
-        let init_event = ProcessedBlockEvent {
-            block_id: init_tip,
-            tip: init_tip,
-            lib: cryptarchia.lib(),
+        let init_tip = cryptarchia.tip_branch();
+        let init_event = {
+            let lib = cryptarchia.lib_branch();
+            ProcessedBlockEvent {
+                block_id: init_tip.id(),
+                tip: init_tip.id(),
+                tip_slot: init_tip.slot(),
+                lib: lib.id(),
+                lib_slot: lib.slot(),
+            }
         };
         if let Err(e) = self.new_block_subscription_sender.send(init_event) {
             error!("Could not notify new block to services {e}");
         }
-        Self::broadcast_session_updates_for_block(&cryptarchia, &init_tip, relays, None).await;
+        Self::broadcast_session_updates_for_block(&cryptarchia, &init_tip.id(), relays, None).await;
 
         let mut pruned_blocks = PrunedBlocks::new();
         for block in blocks {

--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{Stream, stream};
-use lb_common_http_client::{BlockInfo, CommonHttpClient, Error, Slot};
+use lb_common_http_client::{BlockInfo, CommonHttpClient, CryptarchiaInfo, Error, Slot};
 use lb_core::{
     block::Block,
     header::HeaderId,
@@ -12,7 +12,7 @@ use crate::{Deposit, ZoneBlock, ZoneMessage};
 
 #[async_trait]
 pub trait Node {
-    async fn lib_slot(&self) -> Result<Slot, Error>;
+    async fn consensus_info(&self) -> Result<CryptarchiaInfo, Error>;
 
     async fn lib_stream(&self) -> Result<impl Stream<Item = BlockInfo>, Error>;
 
@@ -45,19 +45,8 @@ impl NodeHttpClient {
 
 #[async_trait]
 impl Node for NodeHttpClient {
-    // TODO(node-api): expose `lib_slot` in /cryptarchia/info so indexer
-    // doesn't need two calls (`consensus_info` + `get_block(lib)`).
-    async fn lib_slot(&self) -> Result<Slot, Error> {
-        let info = self.client.consensus_info(self.base_url.clone()).await?;
-        Ok(self
-            .client
-            .get_block(self.base_url.clone(), info.lib)
-            .await?
-            .map_or(
-                // Genesis block isn't stored as a regular block
-                Slot::genesis(),
-                |block| block.header().slot(),
-            ))
+    async fn consensus_info(&self) -> Result<CryptarchiaInfo, Error> {
+        self.client.consensus_info(self.base_url.clone()).await
     }
 
     async fn lib_stream(&self) -> Result<impl Stream<Item = BlockInfo>, Error> {

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -64,7 +64,7 @@ where
         &self,
         last_zone_block: Option<(MsgId, Slot)>,
     ) -> Result<impl Stream<Item = (ZoneMessage, Slot)> + '_, Error> {
-        let lib_slot = self.node.lib_slot().await?;
+        let lib_slot = self.node.consensus_info().await?.lib_slot;
         let current_slot = last_zone_block
             .as_ref()
             .map_or_else(Slot::genesis, |(_, slot)| *slot);
@@ -144,7 +144,7 @@ fn should_skip(message: &ZoneMessage, slot: Slot, skip_until: &mut Option<(MsgId
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use lb_common_http_client::BlockInfo;
+    use lb_common_http_client::{BlockInfo, CryptarchiaInfo};
     use lb_core::header::HeaderId;
 
     use super::*;
@@ -336,8 +336,15 @@ mod tests {
 
     #[async_trait]
     impl adapter::Node for MockNode {
-        async fn lib_slot(&self) -> Result<Slot, lb_common_http_client::Error> {
-            Ok(self.lib_slot)
+        async fn consensus_info(&self) -> Result<CryptarchiaInfo, lb_common_http_client::Error> {
+            Ok(CryptarchiaInfo {
+                lib: HeaderId::from([0; 32]),
+                lib_slot: self.lib_slot,
+                tip: HeaderId::from([0; 32]),
+                slot: self.lib_slot,
+                height: 0,
+                mode: lb_common_http_client::State::Online,
+            })
         }
 
         async fn lib_stream(

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -488,19 +488,10 @@ impl ZoneSequencer {
                     );
                     self.state = Some(TxState::new(info.lib));
                     self.current_tip = Some(info.tip);
-                    match get_lib_slot(&self.http_client, &self.node_url, info.lib).await {
-                        Ok(_) => {
-                            // Do NOT update lib_slot here for fresh starts.
-                            // Keep it at genesis so the backfill check in
-                            // handle_block_event detects the gap and catches
-                            // up on existing channel inscriptions.
-                        }
-                        Err(e) => {
-                            warn!("Failed to get LIB slot: {e}");
-                            tokio::time::sleep(self.config.reconnect_delay).await;
-                            return false;
-                        }
-                    }
+                    // Do NOT update lib_slot here for fresh starts.
+                    // Keep it at genesis so the backfill check in
+                    // handle_block_event detects the gap and catches
+                    // up on existing channel inscriptions.
                 }
                 Err(e) => {
                     warn!("Failed to fetch consensus info: {e}");
@@ -622,13 +613,7 @@ async fn handle_block_event(
     // 1. Backfill finalized blocks up to LIB (only when state's LIB is behind)
     let mut channel_tip = None;
     if lib != s.lib() {
-        let Ok(new_lib_slot) = get_lib_slot(http_client, node_url, lib).await else {
-            warn!("Failed to get LIB slot during backfill, skipping");
-            return BlockEventResult {
-                newly_finalized: Vec::new(),
-                channel_tip: None,
-            };
-        };
+        let new_lib_slot = event.lib_slot;
         if *lib_slot < new_lib_slot
             && let Some(tip) = backfill_to_lib(
                 s,
@@ -683,17 +668,6 @@ fn handle_inflight(event: InFlight, resubmit_active: &mut bool) {
             *resubmit_active = false;
         }
     }
-}
-
-async fn get_lib_slot(
-    http_client: &CommonHttpClient,
-    node_url: &Url,
-    lib: HeaderId,
-) -> Result<Slot, lb_common_http_client::Error> {
-    Ok(http_client
-        .get_block(node_url.clone(), lib)
-        .await?
-        .map_or(Slot::genesis(), |block| block.header().slot()))
 }
 
 /// Backfill finalized blocks from current `lib_slot` to new `lib_slot`.


### PR DESCRIPTION
## 1. What does this PR implement?

Added the `lib_slot` field to the `CryptarchiaInfo`, so that `zone-sdk` doesn't need to fetch the LIB slot separately.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
