### PR TITLE
feat(mmr): change ACCEPTABLE_MAX_HEIGHT: 32 -> 33, as required by circuits

### DIFF
--- a/mmr/src/lib.rs
+++ b/mmr/src/lib.rs
@@ -12,7 +12,7 @@ pub use path::MerklePath;
 use path::{update_paths_above_merge, update_paths_at_merge};
 
 const EMPTY_VALUE: Fr = Fr::ZERO;
-const ACCEPTABLE_MAX_HEIGHT: u8 = 32;
+const ACCEPTABLE_MAX_HEIGHT: u8 = 33;
 
 /// An append-only persistent Merkle Mountain Range (MMR), which can accept up
 /// to 2^(`MAX_HEIGHT`-1) elements (leaves).
@@ -283,7 +283,7 @@ mod test {
     #[expect(clippy::clone_on_copy, reason = "for the sake of the test")]
     fn test_empty_roots() {
         let mut root = Fr::ZERO;
-        for i in 1..=32 {
+        for i in 1..=ACCEPTABLE_MAX_HEIGHT {
             assert_eq!(root, empty_subtree_root::<ZkHasher>(i));
             root = <ZkHasher as Digest>::compress(&[root.clone(), root]);
         }


### PR DESCRIPTION
## 1. What does this PR implement?

Increased `ACCEPTABLE_MAX_HEIGHT` from 32 to 33 in the MMR crate to match the PoC circuit's [`proof_of_membership(32)`](https://github.com/logos-blockchain/logos-blockchain-circuits/blob/1ce5a77e4420fa761486f42d4a3d28ebbedff329/mantle/poc.circom#L51) template, which requires 32 siblings, except root (i.e., height 33 tree).

This behavior is identical to the [`DynamicMerkleTree`](https://github.com/logos-blockchain/logos-blockchain/blob/725806bd05b93ee49db14aecfb8b376222379411/utxotree/src/merkle.rs#L14) that we are currently using and that will be replaced with MMR soon in next PRs.

## 2. Does the code have enough context to be clearly understood?

I believe so.

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

We don't have spec for MMR. Instead, I followed the circuit [implementation](https://github.com/logos-blockchain/logos-blockchain-circuits/blob/1ce5a77e4420fa761486f42d4a3d28ebbedff329/mantle/poc.circom#L51).

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
