### PR TITLE
fix(mmr): use raw element as leaf instead of hashing it

### DIFF
--- a/mmr/src/lib.rs
+++ b/mmr/src/lib.rs
@@ -83,7 +83,7 @@ where
             return Err(MmrFull);
         }
 
-        let root = Hash::digest(&[*elem.as_ref()]);
+        let root = *elem.as_ref();
         let mut last_root = Root { root, height: 1 };
         let mut roots = self.roots.clone();
 
@@ -132,7 +132,7 @@ where
                 .collect(),
         };
 
-        let root = Hash::digest(&[*elem.as_ref()]);
+        let root = *elem.as_ref();
         let mut last_root = Root { root, height: 1 };
         let mut roots = self.roots.clone();
 
@@ -276,7 +276,7 @@ mod test {
     }
 
     pub fn leaf(data: &[u8]) -> Fr {
-        ZkHasher::digest(&[b2p(data)])
+        b2p(data)
     }
 
     #[test]

--- a/mmr/src/path.rs
+++ b/mmr/src/path.rs
@@ -22,8 +22,8 @@ pub struct MerklePath {
 impl MerklePath {
     /// Compute the merkle root from a leaf hash and this proof.
     #[must_use]
-    pub fn root<Hash: Digest>(&self, leaf_hash: Fr) -> Fr {
-        let mut current = leaf_hash;
+    pub fn root<Hash: Digest>(&self, leaf: Fr) -> Fr {
+        let mut current = leaf;
         for (h, &sibling) in self.siblings.iter().enumerate() {
             let height = h + 1;
             if is_left_child(self.leaf_index, height) {
@@ -35,10 +35,10 @@ impl MerklePath {
         current
     }
 
-    /// Verify that `leaf_hash` is included under `expected_root`.
+    /// Verify that `leaf` is included under `expected_root`.
     #[must_use]
-    pub fn verify<Hash: Digest>(&self, leaf_hash: Fr, expected_root: Fr) -> bool {
-        self.root::<Hash>(leaf_hash) == expected_root
+    pub fn verify<Hash: Digest>(&self, leaf: Fr, expected_root: Fr) -> bool {
+        self.root::<Hash>(leaf) == expected_root
     }
 
     /// The 0-indexed leaf position this path corresponds to.


### PR DESCRIPTION
## 1. What does this PR implement?
The MMR was applying `Hash::digest()` to leaves on insertion, but the PoC circuit expects raw voucher commitments as leaves (matching the [`DynamicMerkleTree`](https://github.com/logos-blockchain/logos-blockchain/blob/a62c09a7f8ad04b574931eca5c1d3b26f61c9306/utxotree/src/merkle.rs#L53) behavior that will be replaced by MMR in nexst PRs).

So I removed the double-hashing in MMR, so the merkle root and paths match what the circuit computes. It's possible because the type of both internal nodes and leaves is `Fr`.

## 2. Does the code have enough context to be clearly understood?

I believe so. 



## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

AFAIK, the [PoC](https://www.notion.so/nomos-tech/v1-3-Mantle-Specification-330261aa09df80a899a6efd74f12a7c4?source=copy_link#330261aa09df81d48e26e141e8eed17b) spec or any other specs don't cover this topic clearly. But I checked that this fix works with the [PoC](https://github.com/logos-blockchain/logos-blockchain-circuits/blob/1ce5a77e4420fa761486f42d4a3d28ebbedff329/hash_bn/merkle.circom#L34) circuit.

## 5. Does the implementation introduce changes in the specification?

It'd be great if this topic is clearly covered by specs, but I think it's not urgent. Maybe I failed to find specs that are already covering the topic.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
