### PR TITLE
feat(tx-builder): account for ops balance when funding tx

### DIFF
--- a/core/src/mantle/genesis_tx.rs
+++ b/core/src/mantle/genesis_tx.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{OpProof, SignedMantleTx, ops::sdp::SDPDeclareOp};
 #[cfg(feature = "mock")]
-use crate::mantle::tx::MantleTxGasContext;
+use crate::mantle::tx::MantleTxContext;
 use crate::{
     crypto::ZkHasher,
     mantle::{
@@ -96,7 +96,7 @@ impl GenesisTx {
 
     #[cfg(feature = "mock")]
     #[must_use]
-    pub fn new_mocked(context: MantleTxGasContext) -> Self {
+    pub fn new_mocked(context: MantleTxContext) -> Self {
         use crate::mantle::tx_builder::MantleTxBuilder;
 
         Self(SignedMantleTx::new_unverified(

--- a/core/src/mantle/tx.rs
+++ b/core/src/mantle/tx.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::{
     crypto::{Digest as _, HALF_BLAKE_DIGEST_BYTES_SIZE, Hasher, ZkHasher},
     mantle::{
-        AuthenticatedMantleTx, StorageSize, Transaction, TransactionHasher,
+        AuthenticatedMantleTx, StorageSize, Transaction, TransactionHasher, Value,
         encoding::{decode_mantle_tx, encode_mantle_tx, encode_signed_mantle_tx},
         gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow, GasPrice},
         ops::{
@@ -91,7 +91,13 @@ struct MantleTxDeSerImpl {
     pub storage_gas_price: GasPrice,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
+pub struct MantleTxContext {
+    pub gas_context: MantleTxGasContext,
+    pub leader_reward_amount: Value,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct MantleTxGasContext {
     withdraw_thresholds: HashMap<ChannelId, ChannelKeyIndex>,
 }

--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -223,6 +223,7 @@ mod tests {
     use lb_key_management_system_keys::keys::Ed25519Key;
     use num_bigint::BigUint;
 
+    use super::*;
     use crate::mantle::{
         gas::MainnetGasConstants,
         ops::{
@@ -231,8 +232,6 @@ mod tests {
         },
         tx::MantleTxGasContext,
     };
-
-    use super::*;
 
     #[test]
     fn inscription_op() {

--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -216,3 +216,246 @@ impl MantleTxBuilder {
         self.mantle_tx
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use lb_groth16::{Field as _, Fr};
+    use lb_key_management_system_keys::keys::Ed25519Key;
+    use num_bigint::BigUint;
+
+    use crate::mantle::{
+        gas::MainnetGasConstants,
+        ops::{
+            channel::{ChannelId, deposit::DepositOp, inscribe::InscriptionOp},
+            leader_claim::LeaderClaimOp,
+        },
+        tx::MantleTxGasContext,
+    };
+
+    use super::*;
+
+    #[test]
+    fn inscription_op() {
+        // Build an operation
+        let op = InscriptionOp {
+            channel_id: [0; 32].into(),
+            inscription: b"hello".into(),
+            parent: [1; 32].into(),
+            signer: Ed25519Key::from_bytes(&[0; 32]).public_key(),
+        };
+
+        // Init a tx builder
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::default(),
+            leader_reward_amount: 30,
+        };
+        let builder = MantleTxBuilder::new(context).push_op(Op::ChannelInscribe(op));
+
+        // Check that the tx is already balanced becuase of zero gas price
+        assert_eq!(builder.net_balance(), 0);
+        assert_eq!(builder.funding_delta::<MainnetGasConstants>().unwrap(), 0);
+    }
+
+    #[test]
+    fn deposit_op() {
+        // Build an operation
+        let op = DepositOp {
+            channel_id: [0; 32].into(),
+            amount: 1,
+            metadata: b"Mint 1 to Alice in Zone".to_vec(),
+        };
+
+        // Init a tx builder
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::default(),
+            leader_reward_amount: 30,
+        };
+        let builder = MantleTxBuilder::new(context).push_op(Op::ChannelDeposit(op.clone()));
+
+        // Check that the balance reflects the deposit op
+        assert_eq!(builder.net_balance(), -i128::from(op.amount)); // not yet funded
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            -i128::from(op.amount) // zero gas price for now
+        );
+
+        // Fund tx and add change note
+        let builder = builder
+            .add_ledger_input(Utxo::new(
+                BigUint::ZERO.into(),
+                0,
+                Note::new(3, ZkPublicKey::zero()),
+            ))
+            .add_ledger_output(Note::new(2, ZkPublicKey::zero()));
+
+        // Check the tx is balanced
+        assert_eq!(builder.net_balance(), 0);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            0 // zero gas price for now
+        );
+    }
+
+    #[test]
+    fn withdraw_op() {
+        // Build an operation
+        let op = ChannelWithdrawOp {
+            channel_id: [0; 32].into(),
+            amount: 1,
+        };
+
+        // Init a tx builder
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::new([(op.channel_id, 1)].into()),
+            leader_reward_amount: 30,
+        };
+        let builder = MantleTxBuilder::new(context).push_op(Op::ChannelWithdraw(op.clone()));
+
+        // Check that the balance reflects the withdraw op
+        assert_eq!(builder.net_balance(), i128::from(op.amount)); // not yet funded
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            i128::from(op.amount) // zero gas price for now
+        );
+
+        // Add change note
+        let builder = builder
+            .return_change::<MainnetGasConstants>(ZkPublicKey::zero())
+            .unwrap()
+            .unwrap();
+
+        // Check the tx is balanced
+        assert_eq!(builder.net_balance(), 0);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            0 // zero gas price for now
+        );
+    }
+
+    #[test]
+    fn leader_claim_op() {
+        // Build an operation
+        let op = LeaderClaimOp {
+            rewards_root: Fr::ZERO.into(),
+            voucher_nullifier: Fr::ZERO.into(),
+        };
+
+        // Init a tx builder
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::default(),
+            leader_reward_amount: 30,
+        };
+        let builder = MantleTxBuilder::new(context.clone()).push_op(Op::LeaderClaim(op));
+
+        // Check that the balance reflects the LeaderClaim op
+        assert_eq!(
+            builder.net_balance(),
+            i128::from(context.leader_reward_amount) // not yet funded
+        );
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            i128::from(context.leader_reward_amount) // zero gas price for now
+        );
+
+        // Add change note
+        let builder = builder
+            .return_change::<MainnetGasConstants>(ZkPublicKey::zero())
+            .unwrap()
+            .unwrap();
+
+        // Check the tx is balanced
+        assert_eq!(builder.net_balance(), 0);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            0 // zero gas price for now
+        );
+    }
+
+    #[test]
+    fn transfer_op() {
+        // Init a tx builder for sending 30 to the recipient
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::default(),
+            leader_reward_amount: 30,
+        };
+        let builder = MantleTxBuilder::new(context)
+            .add_ledger_output(Note::new(40, ZkPublicKey::zero()))
+            .add_ledger_input(Utxo::new(
+                BigUint::ZERO.into(),
+                0,
+                Note::new(50, ZkPublicKey::zero()),
+            ));
+
+        // Check that the balance is 10 (= 50 - 40)
+        assert_eq!(builder.net_balance(), 10);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            10 // zero gas price for now
+        );
+
+        // Add change note
+        let builder = builder
+            .return_change::<MainnetGasConstants>(ZkPublicKey::zero())
+            .unwrap()
+            .unwrap();
+
+        // Check the tx is balanced
+        assert_eq!(builder.net_balance(), 0);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            0 // zero gas price for now
+        );
+    }
+
+    #[test]
+    fn all_ops() {
+        // Init a tx builder for sending 30 to the recipient
+        let channel_id = ChannelId::from([0; 32]);
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::new([(channel_id, 1)].into()),
+            leader_reward_amount: 30,
+        };
+        let builder = MantleTxBuilder::new(context)
+            .push_op(Op::ChannelInscribe(InscriptionOp {
+                channel_id,
+                inscription: b"hello".into(),
+                parent: [1; 32].into(),
+                signer: Ed25519Key::from_bytes(&[0; 32]).public_key(),
+            }))
+            .push_op(Op::ChannelDeposit(DepositOp {
+                channel_id,
+                amount: 10,
+                metadata: b"Mint 10 to Alice in Zone".to_vec(),
+            }))
+            .push_op(Op::ChannelWithdraw(ChannelWithdrawOp {
+                channel_id,
+                amount: 1,
+            }))
+            .push_op(Op::LeaderClaim(LeaderClaimOp {
+                rewards_root: Fr::ZERO.into(),
+                voucher_nullifier: Fr::ZERO.into(),
+            }))
+            .add_ledger_output(Note::new(40, ZkPublicKey::zero()));
+
+        // Check the balance before funding tx: -10 + 1 + 30 - 40 = -19
+        assert_eq!(builder.net_balance(), -19);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            -19 // zero gas price for now
+        );
+
+        // Fund tx
+        let builder = builder.add_ledger_input(Utxo::new(
+            BigUint::ZERO.into(),
+            0,
+            Note::new(19, ZkPublicKey::zero()),
+        ));
+
+        // Check the tx is balanced
+        assert_eq!(builder.net_balance(), 0);
+        assert_eq!(
+            builder.funding_delta::<MainnetGasConstants>().unwrap(),
+            0 // zero gas price for now
+        );
+    }
+}

--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -8,7 +8,7 @@ use crate::{
         NoteId,
         gas::{GasCost, GasOverflow, GasPrice},
         ops::{channel::withdraw::ChannelWithdrawOp, transfer::TransferOp},
-        tx::MantleTxGasContext,
+        tx::MantleTxContext,
     },
     proofs::channel_withdraw_proof::ChannelWithdrawProof,
 };
@@ -20,13 +20,13 @@ pub struct MantleTxBuilder {
     pending_transfer: TransferOp,
     // Maps a Proof to its Op by the Op Index
     channel_withdraw_proofs: HashMap<usize, ChannelWithdrawProof>,
-    context: MantleTxGasContext,
+    context: MantleTxContext,
 }
 
 // TODO: refactor to support more than 32 inputs (more than a single transfer)
 impl MantleTxBuilder {
     #[must_use]
-    pub fn new(context: MantleTxGasContext) -> Self {
+    pub fn new(context: MantleTxContext) -> Self {
         Self {
             mantle_tx: MantleTx {
                 ops: vec![],
@@ -156,12 +156,29 @@ impl MantleTxBuilder {
             .map(|n| i128::from(n.value))
             .sum();
 
-        in_sum - out_sum
+        // TODO: reuse this for `LedgerState::try_apply_tx` with some refactoring
+        // https://github.com/logos-blockchain/logos-blockchain/issues/2498
+        let ops_balance: i128 = self
+            .mantle_tx
+            .ops
+            .iter()
+            .map(|op| match op {
+                Op::ChannelDeposit(deposit) => -i128::from(deposit.amount),
+                Op::ChannelWithdraw(withdraw) => i128::from(withdraw.amount),
+                Op::LeaderClaim(_) => i128::from(self.context.leader_reward_amount),
+                // `Op::Transfer` is not handled here since `self.ledger_inputs` and
+                // `self.pending_transfer.outputs` already account for the balance changes from
+                // `Op::Transfer`s.
+                _ => 0,
+            })
+            .sum();
+
+        in_sum - out_sum + ops_balance
     }
 
     pub fn gas_cost<G: GasConstants>(&self) -> Result<GasCost, GasOverflow> {
         let build = self.clone().build();
-        build.total_gas_cost::<G>(&self.context)
+        build.total_gas_cost::<G>(&self.context.gas_context)
     }
 
     pub fn funding_delta<G: GasConstants>(&self) -> Result<i128, GasOverflow> {

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -16,6 +16,7 @@ use lb_core::{
     mantle::{
         AuthenticatedMantleTx, GenesisTx, NoteId, Op, OpProof, Utxo, Value, VerificationError,
         gas::{Gas, GasConstants, GasCost, GasOverflow},
+        tx::MantleTxContext,
     },
     proofs::leader_proof,
     sdp::{Declaration, DeclarationId, ProviderId, ProviderInfo, ServiceType, SessionNumber},
@@ -342,6 +343,13 @@ impl LedgerState {
 
             // Check the transaction is balanced
             let total_gas_cost = AuthenticatedMantleTx::total_gas_cost::<Constants>(&tx)?;
+            tracing::debug!(
+                balance,
+                total_gas_cost = total_gas_cost.into_inner(),
+                storage_gas_price = ?tx.mantle_tx().storage_gas_price,
+                execution_gas_price = ?tx.mantle_tx().execution_gas_price,
+                "tx balance check"
+            );
             match balance.cmp(&Balance::from(total_gas_cost.into_inner())) {
                 Ordering::Less => return Err(LedgerError::InsufficientBalance),
                 Ordering::Greater => return Err(LedgerError::UnbalancedTransaction),
@@ -477,6 +485,14 @@ impl LedgerState {
     #[must_use]
     pub fn active_sessions(&self) -> HashMap<ServiceType, SessionNumber> {
         self.mantle_ledger.active_sessions()
+    }
+
+    #[must_use]
+    pub fn tx_context(&self) -> MantleTxContext {
+        MantleTxContext {
+            gas_context: self.mantle_ledger().channels().into(),
+            leader_reward_amount: self.mantle_ledger().leader_reward_amount(),
+        }
     }
 
     /// Applies a transaction to the ledger state, returning the updated state

--- a/ledger/src/mantle/leader.rs
+++ b/ledger/src/mantle/leader.rs
@@ -150,6 +150,19 @@ impl LeaderState {
         self.claimable_vouchers.path(*index)
     }
 
+    /// Compute the per-voucher reward given current state.
+    #[must_use]
+    pub fn reward_amount(&self) -> Value {
+        let n_unclaimed_vouchers = self
+            .n_claimable_vouchers
+            .saturating_sub(self.nfs.size() as u64);
+        if n_unclaimed_vouchers > 0 {
+            self.claimable_rewards / n_unclaimed_vouchers
+        } else {
+            0
+        }
+    }
+
     /// Claim the reward associated with a voucher.
     /// Any cryptographic proof of correct derivation of the voucher nullifier
     /// and membership proof in the merkle tree is expected to happen
@@ -163,29 +176,14 @@ impl LeaderState {
             return Err(Error::VoucherNotFound);
         }
 
+        let reward_amount = self.reward_amount();
         let nfs = self.nfs.insert(op.voucher_nullifier);
-        let n_unclaimed_vouchers = self
-            .n_claimable_vouchers
-            .checked_sub(self.nfs.size() as u64)
-            .expect("more nullifiers than vouchers");
-        let reward_amount = if n_unclaimed_vouchers > 0 {
-            self.claimable_rewards / n_unclaimed_vouchers
-        } else {
-            0
-        };
-
         let claimable_rewards = self.claimable_rewards - reward_amount;
         Ok((
             Self {
-                epoch: self.epoch,
-                claimable_vouchers_root: self.claimable_vouchers_root,
-                n_claimable_vouchers: self.n_claimable_vouchers,
                 nfs,
-                pending_rewards: self.pending_rewards,
                 claimable_rewards,
-                claimable_vouchers: self.claimable_vouchers.clone(),
-                claimable_voucher_indices: self.claimable_voucher_indices.clone(),
-                pending_vouchers: self.pending_vouchers.clone(),
+                ..self.clone()
             },
             reward_amount,
         ))

--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -136,6 +136,11 @@ impl LedgerState {
         self.leaders.voucher_merkle_path(voucher_cm)
     }
 
+    #[must_use]
+    pub fn leader_reward_amount(&self) -> Value {
+        self.leaders.reward_amount()
+    }
+
     pub fn try_apply_header(
         mut self,
         epoch_state: &EpochState,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -438,8 +438,8 @@ where
             handle.relay::<WalletService>().await?,
         );
 
-        let gas_context = wallet.get_gas_context(None).await?;
-        let tx_builder = MantleTxBuilder::new(gas_context)
+        let tx_context = wallet.get_tx_context(None).await?;
+        let tx_builder = MantleTxBuilder::new(tx_context)
             .push_op(Op::ChannelDeposit(req.deposit))
             .push_op(Op::Transfer(req.burn));
         let lb_wallet_service::TipResponse {

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -799,11 +799,13 @@ where
             .ok_or(Error::NoClaimableVoucher)?
             .nullifier;
 
+        let reward_amount = ledger_state.mantle_ledger().leader_reward_amount();
         let signed_tx = fund_and_sign_leader_claim_tx(
             LeaderClaimOp {
                 rewards_root: ledger_state.mantle_ledger().claimable_vouchers_root(),
                 voucher_nullifier,
             },
+            reward_amount,
             tip,
             wallet,
             config,

--- a/services/chain/chain-leader/src/wallet.rs
+++ b/services/chain/chain-leader/src/wallet.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display};
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Op, SignedMantleTx,
+        Note, Op, SignedMantleTx, Value,
         gas::{GasCost, GasOverflow, MainnetGasConstants},
         ops::leader_claim::LeaderClaimOp,
         tx_builder::MantleTxBuilder,
@@ -26,6 +26,7 @@ pub struct LeaderWalletConfig {
 
 pub async fn fund_and_sign_leader_claim_tx<Wallet, RuntimeServiceId>(
     op: LeaderClaimOp,
+    reward_amount: Value,
     tip: HeaderId,
     wallet: &WalletApi<Wallet, RuntimeServiceId>,
     config: &LeaderWalletConfig,
@@ -34,11 +35,13 @@ where
     Wallet: WalletServiceData,
     RuntimeServiceId: Debug + Send + Sync + Display + 'static + AsServiceId<Wallet>,
 {
-    let gas_context = wallet
-        .get_gas_context(Some(tip))
+    let tx_context = wallet
+        .get_tx_context(Some(tip))
         .await
         .map_err(|error| LeaderWalletError::WalletApi(Box::new(error)))?;
-    let tx_builder = MantleTxBuilder::new(gas_context).push_op(Op::LeaderClaim(op));
+    let tx_builder = MantleTxBuilder::new(tx_context)
+        .push_op(Op::LeaderClaim(op))
+        .add_ledger_output(Note::new(reward_amount, config.funding_pk));
     let funded_tx_builder = wallet
         .fund_tx(
             Some(tip),
@@ -51,6 +54,13 @@ where
         .response;
 
     let tx_fee = funded_tx_builder.gas_cost::<MainnetGasConstants>()?;
+    tracing::debug!(
+        net_balance = funded_tx_builder.net_balance(),
+        gas_cost = ?tx_fee,
+        reward_amount,
+        n_inputs = funded_tx_builder.ledger_inputs().len(),
+        "leader claim tx builder state after funding"
+    );
     if tx_fee > config.max_tx_fee {
         return Err(LeaderWalletError::TxFeeExceedsMaxFee {
             tx_fee,

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -15,7 +15,7 @@ use lb_chain_service::api::{CryptarchiaServiceApi, CryptarchiaServiceData};
 use lb_core::{
     block::BlockNumber,
     header::HeaderId,
-    mantle::{NoteId, SignedMantleTx, tx::MantleTxGasContext, tx_builder::MantleTxBuilder},
+    mantle::{NoteId, SignedMantleTx, tx::MantleTxContext, tx_builder::MantleTxBuilder},
     sdp::{
         ActiveMessage, ActivityMetadata, DeclarationId, DeclarationMessage, Locator, ProviderId,
         ServiceType, WithdrawMessage,
@@ -327,11 +327,11 @@ where
         reply_channel: oneshot::Sender<Result<DeclarationId, DynError>>,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
     ) {
-        let Ok(gas_context) = self.get_gas_context(None, chain_api).await else {
+        let Ok(tx_context) = self.get_tx_context(None, chain_api).await else {
             tracing::error!("Failed to get gas context for declaration");
             return;
         };
-        let tx_builder = MantleTxBuilder::new(gas_context);
+        let tx_builder = MantleTxBuilder::new(tx_context);
         let declaration_id = declaration.id();
 
         let signed_tx = match wallet_adapter
@@ -382,11 +382,11 @@ where
             metadata,
         };
 
-        let Ok(gas_context) = self.get_gas_context(None, chain_api).await else {
+        let Ok(tx_context) = self.get_tx_context(None, chain_api).await else {
             tracing::error!("Failed to get gas context for activity");
             return;
         };
-        let tx_builder = MantleTxBuilder::new(gas_context);
+        let tx_builder = MantleTxBuilder::new(tx_context);
 
         let signed_tx = match wallet_adapter
             .active_tx(tx_builder, active_message, &self.wallet_config)
@@ -432,11 +432,11 @@ where
             nonce: self.bump_nonce(),
         };
 
-        let Ok(gas_context) = self.get_gas_context(None, chain_api).await else {
+        let Ok(tx_context) = self.get_tx_context(None, chain_api).await else {
             tracing::error!("Failed to get gas context for withdrawal");
             return;
         };
-        let tx_builder = MantleTxBuilder::new(gas_context);
+        let tx_builder = MantleTxBuilder::new(tx_context);
 
         let signed_tx = match wallet_adapter
             .withdraw_tx(tx_builder, withdraw_message, &self.wallet_config)
@@ -491,16 +491,16 @@ where
         }
     }
 
-    async fn get_gas_context(
+    async fn get_tx_context(
         &self,
         block_id: Option<HeaderId>,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
-    ) -> Result<MantleTxGasContext, DynError> {
+    ) -> Result<MantleTxContext, DynError> {
         let block_id = self.block_id_or_tip(block_id, chain_api).await?;
         let Some(ledger_state) = chain_api.get_ledger_state(block_id).await? else {
             return Err(format!("Ledger state not found for block {block_id:?}").into());
         };
-        Ok(ledger_state.mantle_ledger().channels().into())
+        Ok(ledger_state.tx_context())
     }
 
     /// Increments the nonce of the current declaration, and returns the

--- a/services/wallet/src/api.rs
+++ b/services/wallet/src/api.rs
@@ -1,7 +1,7 @@
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Note, SignedMantleTx, Value, ops::leader_claim::VoucherCm, tx::MantleTxGasContext,
+        Note, SignedMantleTx, Value, ops::leader_claim::VoucherCm, tx::MantleTxContext,
         tx_builder::MantleTxBuilder,
     },
 };
@@ -130,13 +130,13 @@ where
         Ok(rx.await??)
     }
 
-    pub async fn get_gas_context(
+    pub async fn get_tx_context(
         &self,
         block_id: Option<HeaderId>,
-    ) -> Result<MantleTxGasContext, WalletApiError> {
+    ) -> Result<MantleTxContext, WalletApiError> {
         let (resp_tx, rx) = oneshot::channel();
         self.relay
-            .send(WalletMsg::GetGasContext { block_id, resp_tx })
+            .send(WalletMsg::GetTxContext { block_id, resp_tx })
             .await?;
         Ok(rx.await??)
     }
@@ -149,7 +149,7 @@ where
         recipient_pk: ZkPublicKey,
         amount: Value,
     ) -> Result<TipResponse<SignedMantleTx>, WalletApiError> {
-        let context = self.get_gas_context(tip).await?;
+        let context = self.get_tx_context(tip).await?;
         let mantle_tx_builder =
             MantleTxBuilder::new(context).add_ledger_output(Note::new(amount, recipient_pk));
         let funded_tx_builder = self
@@ -213,7 +213,10 @@ where
 mod tests {
     use std::fmt::{self, Display, Formatter};
 
-    use lb_core::mantle::ops::channel::{ChannelId, ChannelKeyIndex};
+    use lb_core::mantle::{
+        ops::channel::{ChannelId, ChannelKeyIndex},
+        tx::MantleTxGasContext,
+    };
     use overwatch::services::state::{NoOperator, NoState};
     use tokio::sync::mpsc;
 
@@ -249,7 +252,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_gas_context_round_trips_through_wallet_api() {
+    async fn get_tx_context_round_trips_through_wallet_api() {
         let expected_block_id = HeaderId::from([7u8; 32]);
         let expected_channel_id = ChannelId::from([9u8; 32]);
         let expected_threshold: ChannelKeyIndex = 2;
@@ -257,11 +260,14 @@ mod tests {
         let (msg_sender, mut msg_receiver) = mpsc::channel(1);
         tokio::spawn(async move {
             while let Some(msg) = msg_receiver.recv().await {
-                if let WalletMsg::GetGasContext { block_id, resp_tx } = msg {
+                if let WalletMsg::GetTxContext { block_id, resp_tx } = msg {
                     assert_eq!(block_id, Some(expected_block_id));
-                    let context = MantleTxGasContext::new(
-                        std::iter::once((expected_channel_id, expected_threshold)).collect(),
-                    );
+                    let context = MantleTxContext {
+                        gas_context: MantleTxGasContext::new(
+                            std::iter::once((expected_channel_id, expected_threshold)).collect(),
+                        ),
+                        leader_reward_amount: 0,
+                    };
                     drop(resp_tx.send(Ok(context)));
                     break;
                 }
@@ -271,17 +277,20 @@ mod tests {
         let api =
             WalletApi::<DummyWallet, TestRuntimeServiceId>::new(OutboundRelay::new(msg_sender));
         let context = api
-            .get_gas_context(Some(expected_block_id))
+            .get_tx_context(Some(expected_block_id))
             .await
             .expect("gas context should round-trip through the wallet API");
 
         assert_eq!(
-            context.withdraw_threshold(&expected_channel_id),
+            context.gas_context.withdraw_threshold(&expected_channel_id),
             Some(expected_threshold)
         );
         assert_eq!(
-            context.withdraw_threshold(&ChannelId::from([1u8; 32])),
+            context
+                .gas_context
+                .withdraw_threshold(&ChannelId::from([1u8; 32])),
             None
         );
+        assert_eq!(context.leader_reward_amount, 0);
     }
 }

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -24,7 +24,7 @@ use lb_core::{
             },
             sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
         },
-        tx::MantleTxGasContext,
+        tx::MantleTxContext,
         tx_builder::MantleTxBuilder,
     },
     proofs::leader_claim_proof::{Groth16LeaderClaimProof, LeaderClaimPrivate, LeaderClaimPublic},
@@ -145,9 +145,9 @@ pub enum WalletMsg {
     GetKnownAddresses {
         resp_tx: Sender<Result<Vec<ZkPublicKey>, WalletServiceError>>,
     },
-    GetGasContext {
+    GetTxContext {
         block_id: Option<HeaderId>,
-        resp_tx: Sender<Result<MantleTxGasContext, WalletServiceError>>,
+        resp_tx: Sender<Result<MantleTxContext, WalletServiceError>>,
     },
 }
 
@@ -180,7 +180,7 @@ impl WalletMsg {
             | Self::SignTx { tip, .. }
             | Self::GetLeaderAgedNotes { tip, .. }
             | Self::GetClaimableVoucher { tip, .. }
-            | Self::GetGasContext { block_id: tip, .. } => *tip,
+            | Self::GetTxContext { block_id: tip, .. } => *tip,
             Self::GenerateNewVoucherSecret { .. } | Self::GetKnownAddresses { .. } => None,
         }
     }
@@ -498,8 +498,8 @@ where
             WalletMsg::GetKnownAddresses { resp_tx } => {
                 Self::get_known_addresses(state.wallet(), resp_tx);
             }
-            WalletMsg::GetGasContext { block_id, resp_tx } => {
-                Self::get_gas_context(block_id, resp_tx, cryptarchia).await;
+            WalletMsg::GetTxContext { block_id, resp_tx } => {
+                Self::get_tx_context(block_id, resp_tx, cryptarchia).await;
             }
         }
     }
@@ -1129,9 +1129,9 @@ where
         }
     }
 
-    async fn get_gas_context(
+    async fn get_tx_context(
         block_id: Option<HeaderId>,
-        resp_tx: Sender<Result<MantleTxGasContext, WalletServiceError>>,
+        resp_tx: Sender<Result<MantleTxContext, WalletServiceError>>,
         cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
     ) {
         let block_id = match Self::msg_tip_or_latest(block_id, cryptarchia).await {
@@ -1154,8 +1154,7 @@ where
             }
         };
 
-        let gas_context = ledger_state.mantle_ledger().channels().into();
-        if let Err(e) = resp_tx.send(Ok(gas_context)) {
+        if let Err(e) = resp_tx.send(Ok(ledger_state.tx_context())) {
             error!(err = ?e, "Failed to send gas context response");
         }
     }

--- a/tests/src/cucumber/steps/manual_transactions/utils.rs
+++ b/tests/src/cucumber/steps/manual_transactions/utils.rs
@@ -5,7 +5,7 @@ use lb_core::{
     codec::SerializeOp as _,
     mantle::{
         Note, NoteId, SignedMantleTx, Transaction as _, Utxo, gas::MainnetGasConstants,
-        tx_builder::MantleTxBuilder,
+        tx::MantleTxContext, tx_builder::MantleTxBuilder,
     },
 };
 use lb_key_management_system_service::keys::{ZkKey, ZkPublicKey};
@@ -43,7 +43,7 @@ impl Display for WalletStateType {
 
 use std::str::FromStr;
 
-use lb_core::mantle::{OpProof, tx::MantleTxGasContext};
+use lb_core::mantle::OpProof;
 use lb_http_api_common::bodies::wallet::transfer_funds::WalletTransferFundsRequestBody;
 use lb_testing_framework::is_truthy_env;
 
@@ -84,7 +84,7 @@ pub async fn create_and_submit_transaction(
             ref wallet_account, ..
         } => {
             let wallet_state = wallet_state_from_utxos(available_utxos);
-            let empty_context = MantleTxGasContext::new(HashMap::new());
+            let empty_context = MantleTxContext::default();
             let mut tx_builder = MantleTxBuilder::new(empty_context);
             for (receiver_pk, value) in receivers {
                 tx_builder = tx_builder.add_ledger_output(Note::new(*value, *receiver_pk));

--- a/tests/testing_framework/src/workloads/transaction/workload.rs
+++ b/tests/testing_framework/src/workloads/transaction/workload.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use lb_core::mantle::{
-    GenesisTx as _, Note, OpProof, SignedMantleTx, Transaction as _, Utxo, tx::MantleTxGasContext,
+    GenesisTx as _, Note, OpProof, SignedMantleTx, Transaction as _, Utxo, tx::MantleTxContext,
     tx_builder::MantleTxBuilder,
 };
 use lb_key_management_system_service::keys::{ZkKey, ZkPublicKey};
@@ -184,9 +184,9 @@ impl<'a, E: LbcScenarioEnv> Submission<'a, E> {
     }
 
     async fn execute(mut self) -> Result<(), DynError> {
-        let gas_context = MantleTxGasContext::new(HashMap::new());
+        let tx_context = MantleTxContext::default();
         while let Some(input) = self.plan.pop_front() {
-            submit_wallet_transaction(self.ctx, &input, gas_context.clone()).await?;
+            submit_wallet_transaction(self.ctx, &input, tx_context.clone()).await?;
             if !self.interval.is_zero() {
                 sleep(self.interval).await;
             }
@@ -198,9 +198,9 @@ impl<'a, E: LbcScenarioEnv> Submission<'a, E> {
 async fn submit_wallet_transaction(
     ctx: &RunContext<impl LbcScenarioEnv>,
     input: &WalletInput,
-    gas_context: MantleTxGasContext,
+    tx_context: MantleTxContext,
 ) -> Result<(), DynError> {
-    let signed_tx = Arc::new(build_wallet_transaction(input, gas_context)?);
+    let signed_tx = Arc::new(build_wallet_transaction(input, tx_context)?);
     submit_transaction_via_cluster(ctx, signed_tx).await
 }
 
@@ -267,9 +267,9 @@ fn cluster_client_exhausted_error() -> DynError {
 
 fn build_wallet_transaction(
     input: &WalletInput,
-    gas_context: MantleTxGasContext,
+    tx_context: MantleTxContext,
 ) -> Result<SignedMantleTx, DynError> {
-    let tx = MantleTxBuilder::new(gas_context)
+    let tx = MantleTxBuilder::new(tx_context)
         .add_ledger_input(input.utxo)
         .add_ledger_output(Note::new(input.utxo.note.value, input.account.public_key()))
         .build();

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -354,7 +354,7 @@ mod tests {
             Note, Op, TxHash,
             gas::MainnetGasConstants as Gas,
             ops::channel::{ChannelId, MsgId, inscribe::InscriptionOp},
-            tx::MantleTxGasContext,
+            tx::MantleTxContext,
         },
         sdp::{MinStake, ServiceParameters, ServiceType},
     };
@@ -521,8 +521,7 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
 
-        let context: MantleTxGasContext = ledger_state.mantle_ledger().channels().into();
-        let tx_builder = MantleTxBuilder::new(context)
+        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context())
             .set_execution_gas_price(1.into())
             .set_storage_gas_price(1.into());
 
@@ -571,8 +570,7 @@ mod tests {
 
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
-        let context: MantleTxGasContext = ledger_state.mantle_ledger().channels().into();
-        let mut tx_builder = MantleTxBuilder::new(context)
+        let mut tx_builder = MantleTxBuilder::new(ledger_state.tx_context())
             .set_execution_gas_price(1.into())
             .set_storage_gas_price(1.into());
 
@@ -604,8 +602,7 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
 
-        let context: MantleTxGasContext = ledger_state.mantle_ledger().channels().into();
-        let tx_builder = MantleTxBuilder::new(context)
+        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context())
             .set_execution_gas_price(1.into())
             .set_storage_gas_price(1.into());
 
@@ -629,8 +626,7 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1), (bob, 2)]), &ledger_state);
 
-        let context: MantleTxGasContext = ledger_state.mantle_ledger().channels().into();
-        let tx_builder = MantleTxBuilder::new(context)
+        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context())
             .set_execution_gas_price(1.into())
             .set_storage_gas_price(1.into());
 
@@ -652,8 +648,7 @@ mod tests {
     fn test_fund_tx_unfundable_region() {
         let alice = pk(1);
 
-        let context = MantleTxGasContext::new(HashMap::new());
-        let tx_builder = MantleTxBuilder::new(context)
+        let tx_builder = MantleTxBuilder::new(MantleTxContext::default())
             .set_execution_gas_price(1.into())
             .set_storage_gas_price(1.into());
 


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #2494 

### Issue

Tx builder calculates `net_balance` when funding a tx. But, it was not accounting for balance changes from some operations (deposit, withdraw, leader_claim). It causes `UnbalancedTransaction` or `UnsufficientBalance` error when the tx is validated by Ledger.

Let me give you some examples. It's easier.

Let's assume that execution/storage gas price is 0 (i.e., no fee required).

```
Tx {
  Deposit { amount: 10 }
}
```
A user wants to fund this tx using the tx builder, because the current tx balance is `-10` which will be rejected by Ledger.

The funded tx should look like below. Then, the tx balance will be `-10 + 100 - 90 = 0` which will be accepted by Ledger.
```
Tx {
  Deposit { amount: 10 }
  Transfer { inputs: [100], outputs: [(90, change_pk)] }
}
```
The purpose of the tx builder is adding those inputs and outputs automatically, because it's not simple for users to track all the notes they own. But, the issue is that the current tx builder is ignoring the `Deposit.amount = 10` when calculating the tx net balance. It thinks that the tx balance is 0 and doesn't add any inputs. Then, the ledger will reject the tx with `InsufficientBalance`.

I have another example. A user wants to fund the following tx using the tx builder:
```
Tx {
  LeaderClaim { ... }
}
```
The funded tx should look like:
```
Tx {
  LeaderClaim { ... }
  Transfer { inputs: [], outputs: [(38, change_pk)] }
}
```
However, the current tx builder ignores the balance contribution from the `LeaderClaim` operation and doesn't add any outputs. Then, the ledger will reject the tx with `UnbalancedTransaction`.

 
### Solution
As the same as what Ledger does when applying txs, Tx builder also has to account for operations when calculating `net_balance`. In other words, the tx builder should have the same logic as what the Ledger has. This PR implemented it.

But, in a next PR, I will refactor the logic as a common function that can be reused for both Tx builder and Ledger. Also, there are some points in the tx builder to be simplified. I have an idea and opened an issue https://github.com/logos-blockchain/logos-blockchain/issues/2498. For now, I don't want to make big changes and just want to focus on the fix.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
