### PR TITLE
fix(api): remove Transfer op from `POST /channel/deposit` and add e2e test

### DIFF
--- a/nodes/api-common/src/bodies/channel.rs
+++ b/nodes/api-common/src/bodies/channel.rs
@@ -1,10 +1,6 @@
 use lb_core::{
     header::HeaderId,
-    mantle::{
-        TxHash,
-        gas::GasCost,
-        ops::{channel::deposit::DepositOp, transfer::TransferOp},
-    },
+    mantle::{TxHash, gas::GasCost, ops::channel::deposit::DepositOp},
 };
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use serde::{Deserialize, Serialize};
@@ -13,7 +9,6 @@ use serde::{Deserialize, Serialize};
 pub struct ChannelDepositRequestBody {
     pub tip: Option<HeaderId>,
     pub deposit: DepositOp,
-    pub burn: TransferOp,
     pub change_public_key: ZkPublicKey,
     pub funding_public_keys: Vec<ZkPublicKey>,
     pub max_tx_fee: GasCost,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -439,9 +439,7 @@ where
         );
 
         let tx_context = wallet.get_tx_context(None).await?;
-        let tx_builder = MantleTxBuilder::new(tx_context)
-            .push_op(Op::ChannelDeposit(req.deposit))
-            .push_op(Op::Transfer(req.burn));
+        let tx_builder = MantleTxBuilder::new(tx_context).push_op(Op::ChannelDeposit(req.deposit));
         let lb_wallet_service::TipResponse {
             tip,
             response: funded_tx_builder,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -91,6 +91,10 @@ name = "test_mempool_api"
 path = "src/tests/mempool/api.rs"
 
 [[test]]
+name = "test_mantle_channel"
+path = "src/tests/mantle/channel.rs"
+
+[[test]]
 name = "test_mantle_sdp_ops"
 path = "src/tests/mantle/sdp_ops.rs"
 

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -1,0 +1,197 @@
+use std::{num::NonZero, time::Duration};
+
+use futures::future::join_all;
+use lb_core::mantle::{
+    GenesisTx as _,
+    gas::GasCost,
+    ops::channel::{ChannelId, deposit::DepositOp},
+};
+use lb_http_api_common::bodies::channel::ChannelDepositRequestBody;
+use lb_utils::math::NonNegativeRatio;
+use logos_blockchain_tests::{
+    common::{sync::wait_for_validators_mode_and_height, time::max_block_propagation_time},
+    nodes::{create_validator_config, validator::Validator},
+    topology::configs::{
+        create_general_configs, deployment::e2e_deployment_settings_with_genesis_tx,
+    },
+};
+use serial_test::serial;
+use tokio::time::sleep;
+
+/// End-to-end test for the channel deposit flow:
+///
+/// 1. Spawn one validators that produce blocks.
+/// 2. Call the POST `/channel/deposit` HTTP endpoint on the validator.
+/// 4. Verify the API call succeeds (the endpoint returns 200).
+/// 5. Wait for the transaction to be included in a block.
+/// 6. Verify the funding key's wallet balanceting has decreased due to the
+///    deposit.
+#[tokio::test]
+#[serial]
+async fn channel_deposit() {
+    // Spwan a validator
+    let (configs, genesis_tx) = create_general_configs(1, None);
+    let deployment_settings = e2e_deployment_settings_with_genesis_tx(genesis_tx.clone());
+    let configs: Vec<_> = configs
+        .into_iter()
+        .map(|c| {
+            let mut config = create_validator_config(c, deployment_settings.clone());
+            config.deployment.time.slot_duration = Duration::from_secs(1);
+            config.deployment.cryptarchia.security_param = NonZero::new(3).unwrap();
+            config.deployment.cryptarchia.slot_activation_coeff =
+                NonNegativeRatio::new(1, 2.try_into().unwrap());
+            config
+        })
+        .collect();
+
+    let validators: Vec<Validator> = join_all(configs.into_iter().map(Validator::spawn))
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("Failed to spawn validators");
+    let validator = &validators[0];
+
+    let target_height = 3;
+    wait_for_validators_mode_and_height(
+        &validators,
+        lb_cryptarchia_engine::State::Online,
+        target_height,
+        max_block_propagation_time(
+            target_height as u32,
+            validators.len() as u64,
+            &validator.config().deployment,
+            3.0,
+        ),
+    )
+    .await;
+
+    // Record the funding key's balance before deposit
+    let funding_pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
+    let balance_before = get_wallet_balance(validator, funding_pk).await;
+    println!("Wallet balance before deposit: {balance_before}");
+
+    // Also, record the channel balance before deposit
+    // We use the channel created by the genesis inscription for simplicity.
+    let channel_id = genesis_tx.genesis_inscription().channel_id;
+    let channel_balance_before = get_channel_balance(validator, channel_id).await;
+    println!("Channel balance before deposit: {channel_balance_before}");
+
+    // Trigger deposit via the HTTP API.
+    let deposit_amount = 1;
+    let body = ChannelDepositRequestBody {
+        tip: None,
+        deposit: DepositOp {
+            channel_id,
+            amount: deposit_amount,
+            metadata: b"Mint 1 to Alice in Zone".to_vec(),
+        },
+        change_public_key: funding_pk,
+        funding_public_keys: vec![funding_pk],
+        max_tx_fee: GasCost::new(10),
+    };
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{}/channel/deposit",
+            validators[0].config().user.api.backend.listen_address
+        ))
+        .json(&body)
+        .send()
+        .await
+        .expect("request should not fail");
+
+    assert!(
+        resp.status().is_success(),
+        "request should succeed, got status: {} body: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default(),
+    );
+
+    // Wait for the deposit tx to be included (a few more blocks)
+    let new_target_height = target_height + 5;
+    wait_for_validators_mode_and_height(
+        &validators,
+        lb_cryptarchia_engine::State::Online,
+        new_target_height,
+        max_block_propagation_time(
+            (new_target_height - target_height) as u32,
+            validators.len() as u64,
+            &validator.config().deployment,
+            3.0,
+        ),
+    )
+    .await;
+
+    // Check the funding key's balance has decreased
+    let balance_after = get_wallet_balance(validator, funding_pk).await;
+    println!("Wallet balance after deposit: {balance_after}");
+    assert_eq!(
+        balance_after,
+        balance_before - deposit_amount,
+        "wallet balance should decrease after deposit: before={balance_before}, after={balance_after}, deposit_amount={deposit_amount}",
+    );
+
+    // Check the channel balance has increased
+    let channel_balance_after = get_channel_balance(validator, channel_id).await;
+    println!("Channel balance after deposit: {channel_balance_after}");
+    assert_eq!(
+        channel_balance_after,
+        channel_balance_before + deposit_amount,
+        "channel balance should decrease after deposit: before={balance_before}, after={balance_after}, deposit_amount={deposit_amount}",
+    );
+}
+
+async fn get_wallet_balance(
+    validator: &Validator,
+    pk: lb_key_management_system_service::keys::ZkPublicKey,
+) -> u64 {
+    let pk_hex = hex::encode(lb_groth16::fr_to_bytes(&pk.into()));
+    let url = format!(
+        "http://{}/wallet/{}/balance",
+        validator.config().user.api.backend.listen_address,
+        pk_hex,
+    );
+
+    // Retry a few times - the wallet might not have processed the latest block yet
+    for _ in 0..5 {
+        let resp = reqwest::Client::new()
+            .get(&url)
+            .send()
+            .await
+            .expect("balance request should not fail");
+
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp.json().await.unwrap();
+            return body["balance"].as_u64().unwrap_or(0);
+        }
+
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    panic!("Failed to get wallet balance after retries");
+}
+
+async fn get_channel_balance(validator: &Validator, channel_id: ChannelId) -> u64 {
+    let url = format!(
+        "http://{}/channel/{}",
+        validator.config().user.api.backend.listen_address,
+        channel_id,
+    );
+
+    // Retry a few times until the channel is created
+    for _ in 0..5 {
+        let resp = reqwest::Client::new()
+            .get(&url)
+            .send()
+            .await
+            .expect("channel request should not fail");
+
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp.json().await.unwrap();
+            return body["balance"].as_u64().unwrap_or(0);
+        }
+
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    panic!("Failed to get channel state after retries");
+}

--- a/tests/src/tests/mantle/mod.rs
+++ b/tests/src/tests/mantle/mod.rs
@@ -1,1 +1,2 @@
+pub mod channel;
 pub mod sdp_ops;


### PR DESCRIPTION
## 1. What does this PR implement?

My previous PR #2443 added an API `POST /channel/deposit`, which includes both `DepositOp` and `TransferOp` in the request. But, after fixing the `MantleTxBuilder` in PR #2499, we don't need the `TransferOp` because the `MantleTxBuilder` funds the tx automatically (i.e. it adds a `Transfer` op automatically).

I also added an e2e test.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
