### PR TITLE
chore(build): exclude `jemalloc` from `default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ cargo test -p logos-blockchain-circuits-prover -p logos-blockchain-circuits-veri
 ```bash
 cargo build -p logos-blockchain-node --release
 ```
-The `jemalloc` feature is automatically enabled by default to mitigate heap fragmentation.
+
+If you want to use [Jemalloc](https://crates.io/crates/tikv-jemallocator) as the global allocator, enable the `jemalloc` feature:
+```bash
+cargo build -p logos-blockchain-node --release --features jemalloc
+```
 
 ### 3. Run a standalone node
 

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -90,7 +90,7 @@ rand = { workspace = true }
 
 [features]
 config-gen      = ["lb-key-management-system-service/unsafe"]
-default         = ["config-gen", "jemalloc", "tracing"]
+default         = ["config-gen", "tracing"]
 dhat-heap       = ["dep:dhat"]
 instrumentation = []
 jemalloc        = ["dep:tikv-jemallocator"]


### PR DESCRIPTION
## 1. What does this PR implement?

Since Jemalloc doesn't work on aarch64 unless we change the page size to 4KB, I'm excluding the `jemalloc` feature from `default`. 

Then, the release binary will be built **without** jemalloc. If we wanna run a node with jemalloc in some x86 machines, we have to build the binary with `--features jemalloc` instead of downloading the pre-built binary from Github release page.

I am not reverting the Dockerfile change https://github.com/logos-blockchain/logos-blockchain/commit/9c86efb525829504c0f9ed3ae4142b07c3d4cddc that @bacv made, because the `build-essential` is actually a super set, and we may want to enable jemalloc in Dockerfile in the future. Please let me know if you guys think its' better to revert the change as well to speed up buliding docker images.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a
## 5. Does the implementation introduce changes in the specification?

n/a
## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
