### PR TITLE
fix(blend): address self audit findings

### DIFF
--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -124,17 +124,32 @@ pub struct EncapsulatedPart {
 }
 
 impl EncapsulatedPart {
-    /// Initializes the encapsulated part as preparation for actual
-    /// encapsulations.
-    pub(super) fn initialize(
+    #[cfg(test)]
+    #[must_use]
+    pub fn new_unchecked(
         inputs: &[EncapsulationInput],
         payload_type: PayloadType,
         payload_body: PaddedPayloadBody,
     ) -> Self {
         Self {
-            private_header: EncapsulatedPrivateHeader::initialize(inputs),
+            private_header: EncapsulatedPrivateHeader::new_unchecked(inputs),
             payload: EncapsulatedPayload::initialize(&Payload::new(payload_type, payload_body)),
         }
+    }
+
+    /// Initializes the encapsulated part as preparation for actual
+    /// encapsulations.
+    ///
+    /// It returns an error if the slice of inputs is empty.
+    pub(super) fn try_initialize(
+        inputs: &[EncapsulationInput],
+        payload_type: PayloadType,
+        payload_body: PaddedPayloadBody,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            private_header: EncapsulatedPrivateHeader::try_initialize(inputs)?,
+            payload: EncapsulatedPayload::initialize(&Payload::new(payload_type, payload_body)),
+        })
     }
 
     /// Add a layer of encapsulation.
@@ -289,19 +304,34 @@ fn signing_body(
 pub(super) struct EncapsulatedPrivateHeader(Vec<EncapsulatedBlendingHeader>);
 
 impl EncapsulatedPrivateHeader {
+    #[cfg(test)]
+    pub fn new_unchecked(inputs: &[EncapsulationInput]) -> Self {
+        Self::from_inputs(inputs)
+    }
+
     /// Initializes the private header as preparation for actual encapsulations.
-    fn initialize(inputs: &[EncapsulationInput]) -> Self {
-        // Randomize the private header in the reconstructable way,
-        // so that the corresponding signatures can be verified later.
-        // Plus, encapsulate the last `inputs.len()` blending headers.
-        //
-        // Example: for 2 inputs,
-        // BlendingHeaders[0]: Enc(inputs[1], Enc(inputs[0], RND(inputs[1])))
-        // BlendingHeaders[1]:               Enc(inputs[0], RND(inputs[0]))
-        //
-        // Notation:
-        // - RND(seed): Pseudo-random bytes generated from `seed` with the `HEADER` DST
-        // - Enc(key, data): Encrypt `data` by XOR-ing with RND(key)
+    ///
+    /// It returns an error if the slice of inputs is empty.
+    fn try_initialize(inputs: &[EncapsulationInput]) -> Result<Self, Error> {
+        if inputs.is_empty() {
+            return Err(Error::EmptyEncapsulationInputs);
+        }
+
+        Ok(Self::from_inputs(inputs))
+    }
+
+    // Randomize the private header in the reconstructable way,
+    // so that the corresponding signatures can be verified later.
+    // Plus, encapsulate the last `inputs.len()` blending headers.
+    //
+    // Example: for 2 inputs,
+    // BlendingHeaders[0]: Enc(inputs[1], Enc(inputs[0], RND(inputs[1])))
+    // BlendingHeaders[1]:               Enc(inputs[0], RND(inputs[0]))
+    //
+    // Notation:
+    // - RND(seed): Pseudo-random bytes generated from `seed` with the `HEADER` DST
+    // - Enc(key, data): Encrypt `data` by XOR-ing with RND(key)
+    fn from_inputs(inputs: &[EncapsulationInput]) -> Self {
         Self(
             inputs
                 .iter()
@@ -370,6 +400,12 @@ impl EncapsulatedPrivateHeader {
     where
         Verifier: ProofsVerifier,
     {
+        // We call a bunch of `.expect()`s in the following code, so we need to check we
+        // are dealing with a message with at least one layer.
+        if self.0.is_empty() {
+            return Err(Error::EmptyEncapsulationInputs);
+        }
+
         // Decrypt all blending headers
         self.0.iter_mut().for_each(|header| {
             let mut header_cipher = key.cipher(domains::HEADER);

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -15,13 +15,13 @@ use crate::{
     encap::{
         ProofsVerifier,
         decapsulated::DecapsulationOutput,
-        encapsulated::EncapsulatedMessage,
+        encapsulated::{EncapsulatedMessage, EncapsulatedPart},
         validated::{
             EncapsulatedMessageWithVerifiedPublicHeader, RequiredProofOfSelectionVerificationInputs,
         },
     },
     input::EncapsulationInput,
-    message::payload::MAX_PAYLOAD_BODY_SIZE,
+    message::{payload::MAX_PAYLOAD_BODY_SIZE, public_header::VerifiedPublicHeader},
 };
 
 struct NeverFailingProofsVerifier;
@@ -124,11 +124,14 @@ fn encapsulate_and_decapsulate() {
     let verifier = NeverFailingProofsVerifier;
 
     let (inputs, blend_node_enc_keys) = generate_inputs(2);
-    let msg = EncapsulatedMessage::from(EncapsulatedMessageWithVerifiedPublicHeader::new(
-        &inputs,
-        PayloadType::Data,
-        PAYLOAD_BODY.try_into().unwrap(),
-    ));
+    let msg = EncapsulatedMessage::from(
+        EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+            &inputs,
+            PayloadType::Data,
+            PAYLOAD_BODY.try_into().unwrap(),
+        )
+        .unwrap(),
+    );
 
     // NOTE: We expect that the decapsulations can be done
     // in the "reverse" order of blend_node_enc_keys.
@@ -191,7 +194,7 @@ fn encapsulate_and_decapsulate() {
 #[should_panic(expected = "Payload too large")]
 fn payload_too_long() {
     let (inputs, _) = generate_inputs(1);
-    drop(EncapsulatedMessageWithVerifiedPublicHeader::new(
+    drop(EncapsulatedMessageWithVerifiedPublicHeader::try_new(
         &inputs,
         PayloadType::Data,
         vec![0u8; MAX_PAYLOAD_BODY_SIZE + 1]
@@ -207,11 +210,14 @@ fn invalid_public_header_signature() {
 
     let msg_with_invalid_signature = {
         let (inputs, _) = generate_inputs(2);
-        let mut msg = EncapsulatedMessage::from(EncapsulatedMessageWithVerifiedPublicHeader::new(
-            &inputs,
-            PayloadType::Data,
-            PAYLOAD_BODY.try_into().unwrap(),
-        ));
+        let mut msg = EncapsulatedMessage::from(
+            EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+                &inputs,
+                PayloadType::Data,
+                PAYLOAD_BODY.try_into().unwrap(),
+            )
+            .unwrap(),
+        );
         *msg.public_header_mut().signature_mut() = Ed25519Signature::from([100u8; _]);
         msg
     };
@@ -232,11 +238,14 @@ fn invalid_public_header_proof_of_quota() {
     let verifier = AlwaysFailingProofOfQuotaVerifier;
 
     let (inputs, _) = generate_inputs(2);
-    let msg = EncapsulatedMessage::from(EncapsulatedMessageWithVerifiedPublicHeader::new(
-        &inputs,
-        PayloadType::Data,
-        PAYLOAD_BODY.try_into().unwrap(),
-    ));
+    let msg = EncapsulatedMessage::from(
+        EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+            &inputs,
+            PayloadType::Data,
+            PAYLOAD_BODY.try_into().unwrap(),
+        )
+        .unwrap(),
+    );
 
     let public_header_verification_result = msg.verify_public_header(&verifier);
     assert!(matches!(
@@ -255,11 +264,14 @@ fn invalid_blend_header_proof_of_selection() {
     let verifier = AlwaysFailingProofOfSelectionVerifier;
 
     let (inputs, blend_node_enc_keys) = generate_inputs(2);
-    let msg = EncapsulatedMessage::from(EncapsulatedMessageWithVerifiedPublicHeader::new(
-        &inputs,
-        PayloadType::Data,
-        PAYLOAD_BODY.try_into().unwrap(),
-    ));
+    let msg = EncapsulatedMessage::from(
+        EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+            &inputs,
+            PayloadType::Data,
+            PAYLOAD_BODY.try_into().unwrap(),
+        )
+        .unwrap(),
+    );
     let validated_message = msg.verify_public_header(&verifier).unwrap();
 
     let validated_message_decapsulation_result = validated_message.decapsulate(
@@ -278,11 +290,12 @@ fn invalid_blend_header_proof_of_selection() {
 #[test]
 fn serde_encapsulated_and_verified() {
     let (inputs, _) = generate_inputs(3);
-    let msg = EncapsulatedMessageWithVerifiedPublicHeader::new(
+    let msg = EncapsulatedMessageWithVerifiedPublicHeader::try_new(
         &inputs,
         PayloadType::Data,
         b"".as_slice().try_into().unwrap(),
-    );
+    )
+    .unwrap();
     let serialized_encapsulated_message = msg.to_bytes().unwrap();
 
     let deserialized_as_unverified =
@@ -299,11 +312,14 @@ fn encapsulate_and_decapsulate_via_two_step_verification() {
     let verifier = NeverFailingProofsVerifier;
 
     let (inputs, blend_node_enc_keys) = generate_inputs(2);
-    let msg = EncapsulatedMessage::from(EncapsulatedMessageWithVerifiedPublicHeader::new(
-        &inputs,
-        PayloadType::Data,
-        PAYLOAD_BODY.try_into().unwrap(),
-    ));
+    let msg = EncapsulatedMessage::from(
+        EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+            &inputs,
+            PayloadType::Data,
+            PAYLOAD_BODY.try_into().unwrap(),
+        )
+        .unwrap(),
+    );
 
     // Step 1: verify signature (forwarding would happen here)
     let sig_verified = msg.verify_header_signature().unwrap();
@@ -344,6 +360,43 @@ fn encapsulate_and_decapsulate_via_two_step_verification() {
 
     assert_eq!(fully_decapsulated_message.payload_type(), PayloadType::Data);
     assert_eq!(fully_decapsulated_message.payload_body(), PAYLOAD_BODY);
+}
+
+#[test]
+fn empty_inputs_returns_error() {
+    assert!(matches!(
+        EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+            &[],
+            PayloadType::Data,
+            b"hello".as_slice().try_into().unwrap(),
+        ),
+        Err(Error::EmptyEncapsulationInputs)
+    ));
+}
+
+#[test]
+fn decapsulate_empty_private_headers_returns_error() {
+    let msg = {
+        let part = EncapsulatedPart::new_unchecked(
+            // Empty inputs
+            &[],
+            PayloadType::Data,
+            b"hello".as_slice().try_into().unwrap(),
+        );
+        let verified_public_header = VerifiedPublicHeader::new(
+            VerifiedProofOfQuota::from_bytes_unchecked([0; _]),
+            UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+            [0u8; _].into(),
+        );
+        EncapsulatedMessageWithVerifiedPublicHeader::from_components(verified_public_header, part)
+    };
+    let result = msg.decapsulate(
+        // Dummy private key
+        &[0; _].into(),
+        &RequiredProofOfSelectionVerificationInputs::default(),
+        &NeverFailingProofsVerifier,
+    );
+    assert!(matches!(result, Err(Error::EmptyEncapsulationInputs)));
 }
 
 fn generate_inputs(cnt: usize) -> (Vec<EncapsulationInput>, Vec<X25519PrivateKey>) {

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -30,13 +30,17 @@ pub struct EncapsulatedMessageWithVerifiedSignature {
 }
 
 impl EncapsulatedMessageWithVerifiedSignature {
-    #[must_use]
-    pub fn new(
+    pub fn try_new(
         inputs: &[EncapsulationInput],
         payload_type: PayloadType,
         payload_body: PaddedPayloadBody,
-    ) -> Self {
-        EncapsulatedMessageWithVerifiedPublicHeader::new(inputs, payload_type, payload_body).into()
+    ) -> Result<Self, Error> {
+        Ok(EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+            inputs,
+            payload_type,
+            payload_body,
+        )?
+        .into())
     }
 
     #[must_use]
@@ -120,18 +124,17 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
         )
     }
 
-    #[must_use]
-    pub fn new(
+    pub fn try_new(
         inputs: &[EncapsulationInput],
         payload_type: PayloadType,
         payload_body: PaddedPayloadBody,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         // Create the encapsulated part.
         let (part, signing_key, proof_of_quota) = inputs.iter().enumerate().fold(
             (
                 // Start with an initialized encapsulated part,
                 // a random signing key, and proof of quota.
-                EncapsulatedPart::initialize(inputs, payload_type, payload_body),
+                EncapsulatedPart::try_initialize(inputs, payload_type, payload_body)?,
                 UnsecuredEd25519Key::generate_with_blake_rng(),
                 VerifiedProofOfQuota::from_bytes_unchecked(random_sized_bytes()),
             ),
@@ -157,10 +160,10 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
             part.sign(&signing_key),
         );
 
-        Self {
+        Ok(Self {
             validated_public_header,
             encapsulated_part: part,
-        }
+        })
     }
 
     #[must_use]

--- a/blend/message/src/message/public_header.rs
+++ b/blend/message/src/message/public_header.rs
@@ -1,6 +1,6 @@
 use lb_blend_proofs::quota::{self, ProofOfQuota, VerifiedProofOfQuota};
 use lb_key_management_system_keys::keys::{Ed25519PublicKey, Ed25519Signature};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::{Error, MessageIdentifier, encap::ProofsVerifier};
 
@@ -9,10 +9,25 @@ const LATEST_BLEND_MESSAGE_VERSION: u8 = 1;
 // A public header that is revealed to all nodes.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PublicHeader {
+    #[serde(deserialize_with = "deserialize_version_number")]
     version: u8,
     signing_pubkey: Ed25519PublicKey,
     proof_of_quota: ProofOfQuota,
     signature: Ed25519Signature,
+}
+
+fn deserialize_version_number<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let version = u8::deserialize(deserializer)?;
+    if version == LATEST_BLEND_MESSAGE_VERSION {
+        Ok(version)
+    } else {
+        Err(de::Error::custom(format!(
+            "Unsupported message version: {version}",
+        )))
+    }
 }
 
 impl PublicHeader {
@@ -278,5 +293,18 @@ mod tests {
 
         let deserialized_as_unverified = PublicHeader::from_bytes(&serialized_header).unwrap();
         assert_eq!(deserialized_as_unverified, verified_header.into());
+    }
+
+    #[test]
+    fn serde_invalid_version_number() {
+        let header_with_invalid_version = PublicHeader {
+            version: 2,
+            signing_pubkey: Ed25519PublicKey::from_bytes(&[0; ED25519_PUBLIC_KEY_SIZE]).unwrap(),
+            proof_of_quota: [1; _].try_into().unwrap(),
+            signature: [2; _].into(),
+        };
+
+        let serialized_header = header_with_invalid_version.to_bytes().unwrap();
+        PublicHeader::from_bytes(&serialized_header).unwrap_err();
     }
 }

--- a/blend/network/src/core/tests/utils.rs
+++ b/blend/network/src/core/tests/utils.rs
@@ -97,11 +97,14 @@ pub struct TestEncapsulatedMessage(EncapsulatedMessageWithVerifiedPublicHeader);
 
 impl TestEncapsulatedMessage {
     pub fn new(payload: &[u8]) -> Self {
-        Self(EncapsulatedMessageWithVerifiedPublicHeader::new(
-            &generate_valid_inputs(0),
-            PayloadType::Data,
-            payload.try_into().unwrap(),
-        ))
+        Self(
+            EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+                &generate_valid_inputs(0),
+                PayloadType::Data,
+                payload.try_into().unwrap(),
+            )
+            .unwrap(),
+        )
     }
 
     pub fn new_with_invalid_signature(payload: &[u8]) -> Self {
@@ -129,11 +132,14 @@ pub struct TestEncapsulatedMessageWithSession(EncapsulatedMessageWithVerifiedPub
 
 impl TestEncapsulatedMessageWithSession {
     pub fn new(session: SessionNumber, payload: &[u8]) -> Self {
-        Self(EncapsulatedMessageWithVerifiedPublicHeader::new(
-            &generate_valid_inputs(session),
-            PayloadType::Data,
-            payload.try_into().unwrap(),
-        ))
+        Self(
+            EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+                &generate_valid_inputs(session),
+                PayloadType::Data,
+                payload.try_into().unwrap(),
+            )
+            .unwrap(),
+        )
     }
 }
 

--- a/blend/network/src/core/with_core/behaviour/handler/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/handler/mod.rs
@@ -202,7 +202,13 @@ where
                     self.pending_events_to_behaviour
                         .push_back(ToBehaviour::HealthyPeer);
                 }
-                None => panic!("Connection monitor stream was closed."),
+                None => {
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        "Connection monitor stream closed unexpectedly. Closing substreams proactively."
+                    );
+                    self.close_substreams();
+                }
             }
         }
 

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -654,7 +654,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
                 "Provided connection ID {connection_id:?} does not match the stored connection ID {:?} for peer {peer_id:?}. Ignoring state update.",
                 peer_details.connection_id
             );
-            return Some(state);
+            return None;
         }
         Some(mem::replace(&mut peer_details.negotiated_state, state))
     }

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -297,35 +297,73 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
     /// Force send a message to a peer, as long as the peer is connected, no
     /// matter the state the connection is in.
     #[cfg(any(test, feature = "unsafe-test-functions"))]
-    pub fn force_send_message_to_peer(
+    pub fn force_send_message_to_current_session_peer(
         &mut self,
         message: &EncapsulatedMessageWithVerifiedPublicHeader,
         peer_id: PeerId,
+    ) -> Result<(), SendError> {
+        self.force_send_message_to_peer_at_session(message, peer_id, self.current_session_info.1)
+    }
+
+    /// Force send a message to a peer, as long as the peer is connected, no
+    /// matter the state the connection is in.
+    #[cfg(any(test, feature = "unsafe-test-functions"))]
+    pub fn force_send_message_to_peer_at_session(
+        &mut self,
+        message: &EncapsulatedMessageWithVerifiedPublicHeader,
+        peer_id: PeerId,
+        session: u64,
     ) -> Result<(), SendError> {
         let serialized_message =
             lb_blend_scheduling::serialize_encapsulated_message_with_verified_public_header(
                 message,
             );
-        self.force_send_serialized_message_to_peer(serialized_message, peer_id)
+        self.force_send_serialized_message_to_peer_at_session(serialized_message, peer_id, session)
     }
 
     /// Force send a serialized message to a peer (without trying to deserialize
     /// nor validating it first), as long as the peer is connected, no
     /// matter the state the connection is in.
     #[cfg(any(test, feature = "unsafe-test-functions"))]
-    pub fn force_send_serialized_message_to_peer(
+    pub fn force_send_serialized_message_to_current_session_peer(
         &mut self,
         serialized_message: Vec<u8>,
         peer_id: PeerId,
     ) -> Result<(), SendError> {
+        self.force_send_serialized_message_to_peer_at_session(
+            serialized_message,
+            peer_id,
+            self.current_session_info.1,
+        )
+    }
+
+    #[cfg(any(test, feature = "unsafe-test-functions"))]
+    pub fn force_send_serialized_message_to_peer_at_session(
+        &mut self,
+        serialized_message: Vec<u8>,
+        peer_id: PeerId,
+        session: u64,
+    ) -> Result<(), SendError> {
+        if session != self.current_session_info.1 {
+            let Some(old_session) = &mut self.old_session else {
+                return Err(SendError::InvalidSession);
+            };
+            return old_session.force_send_serialized_message_to_peer_at_session(
+                serialized_message,
+                peer_id,
+                session,
+            );
+        }
+
         let Some(RemotePeerConnectionDetails { connection_id, .. }) =
             self.negotiated_peers.get(&peer_id)
         else {
             return Err(SendError::NoPeers);
         };
+
         tracing::trace!(
             target: LOG_TARGET,
-            "Notifying handler with peer {peer_id:?} on connection {connection_id:?} to deliver already-serialized message."
+            "Notifying handler with peer {peer_id:?} on current session connection {connection_id:?} to deliver already-serialized message."
         );
         self.events.push_back(ToSwarm::NotifyHandler {
             peer_id,
@@ -853,8 +891,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
                         return;
                     }
                 }
-                Err(e) => {
-                    tracing::debug!(target: LOG_TARGET, "Failed to handle message from the old session: {e:?}");
+                Err(_) => {
                     return;
                 }
             }

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -308,7 +308,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
     /// Force send a message to a peer, as long as the peer is connected, no
     /// matter the state the connection is in.
     #[cfg(any(test, feature = "unsafe-test-functions"))]
-    pub fn force_send_message_to_peer_at_session(
+    fn force_send_message_to_peer_at_session(
         &mut self,
         message: &EncapsulatedMessageWithVerifiedPublicHeader,
         peer_id: PeerId,
@@ -324,8 +324,8 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
     /// Force send a serialized message to a peer (without trying to deserialize
     /// nor validating it first), as long as the peer is connected, no
     /// matter the state the connection is in.
-    #[cfg(any(test, feature = "unsafe-test-functions"))]
-    pub fn force_send_serialized_message_to_current_session_peer(
+    #[cfg(test)]
+    fn force_send_serialized_message_to_current_session_peer(
         &mut self,
         serialized_message: Vec<u8>,
         peer_id: PeerId,

--- a/blend/network/src/core/with_core/behaviour/old_session.rs
+++ b/blend/network/src/core/with_core/behaviour/old_session.rs
@@ -26,6 +26,8 @@ use crate::core::with_core::{
     error::{ReceiveError, SendError},
 };
 
+const LOG_TARGET: &str = "blend::network::core::core::behaviour::old";
+
 /// Defines behaviours for processing messages from the old session
 /// until the session transition period has passed.
 pub struct OldSession {
@@ -100,6 +102,33 @@ impl OldSession {
         )
     }
 
+    #[cfg(any(test, feature = "unsafe-test-functions"))]
+    pub(super) fn force_send_serialized_message_to_peer_at_session(
+        &mut self,
+        serialized_message: Vec<u8>,
+        peer_id: PeerId,
+        session: u64,
+    ) -> Result<(), SendError> {
+        if session != self.session_number {
+            return Err(SendError::InvalidSession);
+        }
+
+        let Some(connection_id) = self.negotiated_peers.get(&peer_id) else {
+            return Err(SendError::NoPeers);
+        };
+        tracing::trace!(
+            target: LOG_TARGET,
+            "Notifying handler with peer {peer_id:?} on old session connection {connection_id:?} to deliver already-serialized message."
+        );
+        self.events.push_back(ToSwarm::NotifyHandler {
+            peer_id,
+            handler: NotifyHandler::One(*connection_id),
+            event: Either::Left(FromBehaviour::Message(serialized_message)),
+        });
+        self.try_wake();
+        Ok(())
+    }
+
     /// Handles a message received from a peer.
     ///
     /// # Returns
@@ -123,7 +152,15 @@ impl OldSession {
             &mut self.events,
             self.waker.take(),
             self.session_number,
-        )?;
+        ).inspect_err(|receive_error| {
+            tracing::debug!(target: LOG_TARGET, "Failed to handle message from the old session: {receive_error:?}. Closing connection with spammy peer.");
+            self.events.push_back(ToSwarm::NotifyHandler {
+                peer_id: from_peer_id,
+                handler: NotifyHandler::One(from_connection_id),
+                event: Either::Left(FromBehaviour::CloseSubstreams),
+            });
+            self.try_wake();
+        })?;
 
         Ok(true)
     }
@@ -168,6 +205,12 @@ impl OldSession {
             return true;
         }
         false
+    }
+
+    fn try_wake(&mut self) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
     }
 
     pub fn poll(

--- a/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
@@ -166,7 +166,7 @@ async fn restore_healthy_peer() {
     // Send a message to the listening swarm to revert from unhealthy to healthy.
     dialing_swarm
         .behaviour_mut()
-        .force_send_message_to_peer(
+        .force_send_message_to_current_session_peer(
             &TestEncapsulatedMessage::new(b"msg").into_inner(),
             *listening_swarm.local_peer_id(),
         )

--- a/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -8,7 +8,7 @@ use test_log::test;
 use tokio::{select, time::sleep};
 
 use crate::core::{
-    tests::utils::{TestEncapsulatedMessage, TestSwarm},
+    tests::utils::{TestEncapsulatedMessage, TestEncapsulatedMessageWithSession, TestSwarm},
     with_core::{
         behaviour::{
             Event, NegotiatedPeerState, SpamReason,
@@ -113,7 +113,10 @@ async fn undeserializable_message_received() {
 
     dialing_swarm
         .behaviour_mut()
-        .force_send_serialized_message_to_peer(b"msg".to_vec(), *listening_swarm.local_peer_id())
+        .force_send_serialized_message_to_current_session_peer(
+            b"msg".to_vec(),
+            *listening_swarm.local_peer_id(),
+        )
         .unwrap();
 
     let mut events_to_match = 2u8;
@@ -187,7 +190,10 @@ async fn duplicate_message_received_from_same_peer() {
     // This is a duplicate message, so the listener will mark the dialer as spammy.
     dialing_swarm
         .behaviour_mut()
-        .force_send_message_to_peer(&test_message.into_inner(), *listening_swarm.local_peer_id())
+        .force_send_message_to_current_session_peer(
+            &test_message.into_inner(),
+            *listening_swarm.local_peer_id(),
+        )
         .unwrap();
 
     let mut events_to_match = 2u8;
@@ -291,7 +297,7 @@ async fn invalid_signature_message_received() {
     let invalid_public_header_message = TestEncapsulatedMessage::new_with_invalid_signature(b"");
     dialing_swarm
         .behaviour_mut()
-        .force_send_message_to_peer(
+        .force_send_message_to_current_session_peer(
             &invalid_public_header_message.as_ref().clone(),
             *listening_swarm.local_peer_id(),
         )
@@ -365,7 +371,10 @@ async fn message_already_forwarded_silently_ignored_when_received_from_peer() {
     // silently dropped - no event, no spam marking.
     node_b
         .behaviour_mut()
-        .force_send_message_to_peer(&test_message.into_inner(), *node_a.local_peer_id())
+        .force_send_message_to_current_session_peer(
+            &test_message.into_inner(),
+            *node_a.local_peer_id(),
+        )
         .unwrap();
 
     let mut node_a_got_message = false;
@@ -399,7 +408,7 @@ async fn message_already_forwarded_silently_ignored_when_received_from_peer() {
 }
 
 #[test(tokio::test)]
-async fn duplicate_message_in_old_session_does_not_disconnect_peer() {
+async fn duplicate_message_in_old_session_disconnects_peer_without_swarm_notification() {
     let (mut identities, nodes) = new_nodes_with_empty_address(2);
     let mut sender = TestSwarm::new(&identities.next().unwrap(), |id| {
         BehaviourBuilder::new(id).with_membership(&nodes).build()
@@ -446,31 +455,181 @@ async fn duplicate_message_in_old_session_does_not_disconnect_peer() {
 
     // Sender sends X again, bypassing its own `Forwarded` guard. From
     // receiver's point of view this arrives over the old-session connection.
-    // The old-session handler detects a duplicate from the same peer and
-    // returns `Err(DuplicateMessageFromPeer)`, but it currently must NOT close the
-    // connection as spammy.
+    // The old-session handler detects a duplicate from the same peer,
+    // closes the connection, but must NOT emit a `PeerDisconnected` event.
     sender
         .behaviour_mut()
-        .force_send_message_to_peer(&test_message.into_inner(), *receiver.local_peer_id())
+        .force_send_message_to_current_session_peer(
+            &test_message.into_inner(),
+            *receiver.local_peer_id(),
+        )
         .unwrap();
 
-    let mut peer_disconnected = false;
+    let mut peer_disconnected_event = false;
+    let mut connection_closed = false;
     loop {
         select! {
-            () = sleep(Duration::from_secs(3)) => { break; }
+            () = sleep(Duration::from_secs(15)) => { break; }
             _ = sender.select_next_some() => {}
             event = receiver.select_next_some() => {
-                if let SwarmEvent::Behaviour(Event::PeerDisconnected(..)) = event {
-                    peer_disconnected = true;
+                println!("Received event: {event:?}");
+                match event {
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(..)) => {
+                        peer_disconnected_event = true;
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, .. } if peer_id == *sender.local_peer_id() => {
+                        connection_closed = true;
+                    }
+                    _ => {}
                 }
             }
         }
     }
 
     assert!(
-        !peer_disconnected,
-        "Receiver must not disconnect sender for a duplicate message received over the old-session connection"
+        connection_closed,
+        "Connection with spammy old-session peer must be closed"
     );
+    assert!(
+        !peer_disconnected_event,
+        "No PeerDisconnected event must be emitted for a spammy old-session peer"
+    );
+}
+
+#[test(tokio::test)]
+async fn undeserializable_message_in_old_session_closes_connection_without_swarm_notification() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let mut sender = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let mut receiver = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+
+    receiver.listen().with_memory_addr_external().await;
+    sender.connect_and_wait_for_upgrade(&mut receiver).await;
+
+    // Receiver starts a new session. Sender's connection moves to the old
+    // session.
+    let memberships = build_memberships(&[&sender, &receiver]);
+    receiver
+        .behaviour_mut()
+        .start_new_session((memberships[1].clone(), 1));
+
+    // Sender sends garbage data over the old-session connection.
+    sender
+        .behaviour_mut()
+        .force_send_serialized_message_to_current_session_peer(
+            b"garbage".to_vec(),
+            *receiver.local_peer_id(),
+        )
+        .unwrap();
+
+    let mut peer_disconnected_event = false;
+    let mut connection_closed = false;
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(15)) => { break; }
+            _ = sender.select_next_some() => {}
+            event = receiver.select_next_some() => {
+                match event {
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(..)) => {
+                        peer_disconnected_event = true;
+                    }
+                    SwarmEvent::ConnectionClosed { .. } => {
+                        connection_closed = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    assert!(
+        connection_closed,
+        "Connection with spammy old-session peer must be closed"
+    );
+    assert!(
+        !peer_disconnected_event,
+        "No PeerDisconnected event must be emitted for a spammy old-session peer"
+    );
+}
+
+#[test(tokio::test)]
+async fn spammy_old_session_peer_does_not_affect_current_session() {
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let mut sender = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let mut receiver = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+
+    receiver.listen().with_memory_addr_external().await;
+    sender.connect_and_wait_for_upgrade(&mut receiver).await;
+
+    // Receiver starts a new session. Sender's connection moves to the old
+    // session.
+    let memberships = build_memberships(&[&sender, &receiver]);
+    receiver
+        .behaviour_mut()
+        .start_new_session((memberships[1].clone(), 1));
+
+    // Re-connect for the new session.
+    sender
+        .behaviour_mut()
+        .start_new_session((memberships[0].clone(), 1));
+    sender.connect_and_wait_for_upgrade(&mut receiver).await;
+
+    // Sender sends garbage over the old-session connection. This should
+    // close the old-session connection but NOT mark the peer as spammy in
+    // the current session.
+    sender
+        .behaviour_mut()
+        .force_send_serialized_message_to_peer_at_session(
+            b"garbage".to_vec(),
+            *receiver.local_peer_id(),
+            0,
+        )
+        .unwrap();
+
+    // Wait for the old-session connection to close.
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(15)) => {
+                panic!("Timed out waiting for old-session connection to close");
+            }
+            _ = sender.select_next_some() => {}
+            event = receiver.select_next_some() => {
+                if let SwarmEvent::ConnectionClosed { .. } = event {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Now verify the current session connection is healthy by sending a
+    // valid message through it.
+    let test_message = TestEncapsulatedMessageWithSession::new(1, b"after-spam");
+    sender
+        .behaviour_mut()
+        .publish_message_with_validated_header(test_message.clone(), 1)
+        .unwrap();
+
+    loop {
+        select! {
+            () = sleep(Duration::from_secs(15)) => {
+                panic!("Timed out waiting for message on current session - current session connection was incorrectly affected by old session spam");
+            }
+            _ = sender.select_next_some() => {}
+            event = receiver.select_next_some() => {
+                if let SwarmEvent::Behaviour(Event::Message { message, .. }) = event {
+                    assert_eq!(message.id(), test_message.id());
+                    break;
+                }
+            }
+        }
+    }
 }
 
 #[test(tokio::test)]

--- a/blend/scheduling/src/message_blend/crypto/core_and_leader/send.rs
+++ b/blend/scheduling/src/message_blend/crypto/core_and_leader/send.rs
@@ -207,11 +207,12 @@ where
             })
             .collect::<Vec<_>>();
 
-        Ok(EncapsulatedMessageWithVerifiedPublicHeader::new(
+        Ok(EncapsulatedMessageWithVerifiedPublicHeader::try_new(
             &inputs,
             payload_type,
             validated_payload,
-        ))
+        )
+        .expect("Number of encapsulation layers is greater than 0."))
     }
 }
 

--- a/blend/scheduling/src/message_blend/crypto/leader/send.rs
+++ b/blend/scheduling/src/message_blend/crypto/leader/send.rs
@@ -127,11 +127,12 @@ where
             })
             .collect::<Vec<_>>();
 
-        Ok(EncapsulatedMessageWithVerifiedPublicHeader::new(
+        Ok(EncapsulatedMessageWithVerifiedPublicHeader::try_new(
             &inputs,
             PayloadType::Data,
             validated_payload,
-        ))
+        )
+        .expect("Number of encapsulation layers is greater than 0."))
     }
 
     pub async fn encapsulate_and_serialize_data_payload(

--- a/services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
+++ b/services/blend/src/core/backends/libp2p/tests/network_maintenance.rs
@@ -168,13 +168,13 @@ async fn on_malicious_peer() {
         .behaviour_mut()
         .blend
         .with_core_mut()
-        .force_send_message_to_peer(&message_1, listening_swarm_peer_id)
+        .force_send_message_to_current_session_peer(&message_1, listening_swarm_peer_id)
         .unwrap();
     malicious_swarm
         .behaviour_mut()
         .blend
         .with_core_mut()
-        .force_send_message_to_peer(&message_2, listening_swarm_peer_id)
+        .force_send_message_to_current_session_peer(&message_2, listening_swarm_peer_id)
         .unwrap();
 
     loop {

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -1574,7 +1574,7 @@ fn handle_incoming_blend_message_from_old_session<
             }
         }
         Err(e) => {
-            if matches!(e, MessageError::MessageDeserializationFailed) {
+            if matches!(e, MessageError::PrivateHeaderDeserializationFailed) {
                 tracing::trace!(target: LOG_TARGET, "Failed to decapsulate received message from old session due to deserialization error. This can happen when the message was intended for another node or when the message is malformed. Ignoring...");
             } else {
                 tracing::debug!(target: LOG_TARGET, "Failed to decapsulate received message from old session: {e:?}");

--- a/services/blend/src/core/processor.rs
+++ b/services/blend/src/core/processor.rs
@@ -506,11 +506,12 @@ mod tests {
         })
         .take(3)
         .collect::<Vec<_>>();
-        EncapsulatedMessageWithVerifiedPublicHeader::new(
+        EncapsulatedMessageWithVerifiedPublicHeader::try_new(
             &inputs,
             PayloadType::Cover,
             b"".as_slice().try_into().unwrap(),
         )
+        .unwrap()
     }
 
     fn settings(local_id: NodeId) -> SessionCryptographicProcessorSettings {

--- a/services/blend/src/test_utils/libp2p.rs
+++ b/services/blend/src/test_utils/libp2p.rs
@@ -26,11 +26,14 @@ pub struct TestEncapsulatedMessage(EncapsulatedMessageWithVerifiedPublicHeader);
 
 impl TestEncapsulatedMessage {
     pub fn new(payload: &[u8]) -> Self {
-        Self(EncapsulatedMessageWithVerifiedPublicHeader::new(
-            &generate_valid_inputs(),
-            PayloadType::Data,
-            payload.try_into().unwrap(),
-        ))
+        Self(
+            EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+                &generate_valid_inputs(),
+                PayloadType::Data,
+                payload.try_into().unwrap(),
+            )
+            .unwrap(),
+        )
     }
 
     pub fn into_inner(self) -> EncapsulatedMessageWithVerifiedPublicHeader {


### PR DESCRIPTION
## 1. What does this PR implement?

PR on top of https://github.com/logos-blockchain/logos-blockchain/pull/2514.

It introduces the following fixes, ordered by importance:

* Verify that the received message has at least one encapsulation layer, without panicking otherwise (with test). This is a fix that does not change the current code structure. Ideally we enforce this at the type level after verifying the minimum number of headers is matched. But for now, this will do it.
* Close connections with spammy peers belonging to the old session (with tests). The swarm is not notified about it, so it won't try to dial new peers, nor the peer will be banned. Since old session won't be accepting/establishing new connections, the node is safe going forward until the STP elapses.
* Verify that the version of a received public header matches the expected one (with test)
* Do not panic in core-core connection handler in case of unexpected shutdowns, but attempt to simply close the substreams
* Fix the return value when updating the state of a negotiated connection in case it belongs to the old session (now returning `None` instead of `Some`). Minor issue, but could create confusion in the future.
* Change the error kind captured when self-decapsulating

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.