### PR TITLE
feat(api): add raw signing REST API and e2e test for atomic deposit

### DIFF
--- a/nodes/api-common/src/bodies/wallet.rs
+++ b/nodes/api-common/src/bodies/wallet.rs
@@ -85,3 +85,33 @@ pub mod transfer_funds {
         }
     }
 }
+
+pub mod sign {
+    use lb_core::mantle::TxHash;
+    use lb_key_management_system_keys::keys::{
+        Ed25519Key, ZkPublicKey, ZkSignature, secured_key::SecuredKey,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    pub struct WalletSignTxEd25519RequestBody {
+        pub tx_hash: TxHash,
+        pub pk: <Ed25519Key as SecuredKey>::PublicKey,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct WalletSignTxEd25519ResponseBody {
+        pub sig: <Ed25519Key as SecuredKey>::Signature,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct WalletSignTxZkRequestBody {
+        pub tx_hash: TxHash,
+        pub pks: Vec<ZkPublicKey>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct WalletSignTxZkResponseBody {
+        pub sig: ZkSignature,
+    }
+}

--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -20,6 +20,8 @@ pub const BLOCKS_STREAM: &str = "/cryptarchia/events/blocks/stream";
 pub mod wallet {
     pub const BALANCE: &str = "/wallet/:public_key/balance";
     pub const TRANSACTIONS_TRANSFER_FUNDS: &str = "/wallet/transactions/transfer-funds";
+    pub const SIGN_TX_ED25519: &str = "/wallet/sign/ed25519";
+    pub const SIGN_TX_ZK: &str = "/wallet/sign/zk";
 }
 
 // testing paths

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -275,6 +275,14 @@ where
                         _,
                     >,
                 ),
+            )
+            .route(
+                paths::wallet::SIGN_TX_ED25519,
+                routing::post(wallet::sign_tx_ed25519::<WalletService, MempoolStorageAdapter, _>),
+            )
+            .route(
+                paths::wallet::SIGN_TX_ZK,
+                routing::post(wallet::sign_tx_zk::<WalletService, MempoolStorageAdapter, _>),
             );
 
         let app = app.route(

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -683,6 +683,10 @@ where
 }
 
 pub mod wallet {
+    use lb_http_api_common::bodies::wallet::sign::{
+        WalletSignTxEd25519RequestBody, WalletSignTxEd25519ResponseBody, WalletSignTxZkRequestBody,
+        WalletSignTxZkResponseBody,
+    };
     use lb_key_management_system_service::keys::ZkPublicKey;
 
     use super::*;
@@ -831,5 +835,121 @@ pub mod wallet {
             }
             Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
         }
+    }
+
+    #[utoipa::path(
+        post,
+        path = paths::wallet::SIGN_TX_ED25519,
+        responses(
+            (status = 200, description = "Signed transaction"),
+            (status = 500, description = "Internal server error", body = String),
+        )
+    )]
+    pub async fn sign_tx_ed25519<WalletService, StorageAdapter, RuntimeServiceId>(
+        State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+        Json(req): Json<WalletSignTxEd25519RequestBody>,
+    ) -> Response
+    where
+        WalletService: WalletServiceData,
+        StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
+                RuntimeServiceId,
+                Item = SignedMantleTx,
+                Key = <SignedMantleTx as Transaction>::Hash,
+            > + Send
+            + Sync
+            + Clone
+            + 'static,
+        StorageAdapter::Error: Debug,
+        RuntimeServiceId: Debug
+            + Display
+            + Send
+            + Sync
+            + 'static
+            + AsServiceId<WalletService>
+            + AsServiceId<
+                TxMempoolService<
+                    MempoolNetworkAdapter<
+                        SignedMantleTx,
+                        <SignedMantleTx as Transaction>::Hash,
+                        RuntimeServiceId,
+                    >,
+                    Mempool<
+                        HeaderId,
+                        SignedMantleTx,
+                        <SignedMantleTx as Transaction>::Hash,
+                        StorageAdapter,
+                        RuntimeServiceId,
+                    >,
+                    StorageAdapter,
+                    RuntimeServiceId,
+                >,
+            >,
+    {
+        make_request_and_return_response!(async {
+            let wallet = WalletApi::<WalletService, RuntimeServiceId>::new(
+                handle.relay::<WalletService>().await?,
+            );
+
+            let sig = wallet.sign_tx_with_ed25519(req.tx_hash, req.pk).await?;
+            Ok::<_, DynError>(WalletSignTxEd25519ResponseBody { sig })
+        })
+    }
+
+    #[utoipa::path(
+        post,
+        path = paths::wallet::SIGN_TX_ZK,
+        responses(
+            (status = 200, description = "Signed transaction"),
+            (status = 500, description = "Internal server error", body = String),
+        )
+    )]
+    pub async fn sign_tx_zk<WalletService, StorageAdapter, RuntimeServiceId>(
+        State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+        Json(req): Json<WalletSignTxZkRequestBody>,
+    ) -> Response
+    where
+        WalletService: WalletServiceData,
+        StorageAdapter: lb_tx_service::storage::MempoolStorageAdapter<
+                RuntimeServiceId,
+                Item = SignedMantleTx,
+                Key = <SignedMantleTx as Transaction>::Hash,
+            > + Send
+            + Sync
+            + Clone
+            + 'static,
+        StorageAdapter::Error: Debug,
+        RuntimeServiceId: Debug
+            + Display
+            + Send
+            + Sync
+            + 'static
+            + AsServiceId<WalletService>
+            + AsServiceId<
+                TxMempoolService<
+                    MempoolNetworkAdapter<
+                        SignedMantleTx,
+                        <SignedMantleTx as Transaction>::Hash,
+                        RuntimeServiceId,
+                    >,
+                    Mempool<
+                        HeaderId,
+                        SignedMantleTx,
+                        <SignedMantleTx as Transaction>::Hash,
+                        StorageAdapter,
+                        RuntimeServiceId,
+                    >,
+                    StorageAdapter,
+                    RuntimeServiceId,
+                >,
+            >,
+    {
+        make_request_and_return_response!(async {
+            let wallet = WalletApi::<WalletService, RuntimeServiceId>::new(
+                handle.relay::<WalletService>().await?,
+            );
+
+            let sig = wallet.sign_tx_with_zk(req.tx_hash, req.pks).await?;
+            Ok::<_, DynError>(WalletSignTxZkResponseBody { sig })
+        })
     }
 }

--- a/services/wallet/src/api.rs
+++ b/services/wallet/src/api.rs
@@ -1,11 +1,13 @@
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Note, SignedMantleTx, Value, ops::leader_claim::VoucherCm, tx::MantleTxContext,
+        Note, SignedMantleTx, TxHash, Value, ops::leader_claim::VoucherCm, tx::MantleTxContext,
         tx_builder::MantleTxBuilder,
     },
 };
-use lb_key_management_system_service::keys::ZkPublicKey;
+use lb_key_management_system_service::keys::{
+    Ed25519Key, ZkPublicKey, ZkSignature, secured_key::SecuredKey,
+};
 use lb_wallet::WalletBalance;
 use overwatch::{
     overwatch::OverwatchHandle,
@@ -169,6 +171,42 @@ where
             .send(WalletMsg::SignTx {
                 tip,
                 tx_builder,
+                resp_tx,
+            })
+            .await?;
+
+        Ok(rx.await??)
+    }
+
+    pub async fn sign_tx_with_ed25519(
+        &self,
+        tx_hash: TxHash,
+        pk: <Ed25519Key as SecuredKey>::PublicKey,
+    ) -> Result<<Ed25519Key as SecuredKey>::Signature, WalletApiError> {
+        let (resp_tx, rx) = oneshot::channel();
+
+        self.relay
+            .send(WalletMsg::SignTxWithEd25519 {
+                tx_hash,
+                pk,
+                resp_tx,
+            })
+            .await?;
+
+        Ok(rx.await??)
+    }
+
+    pub async fn sign_tx_with_zk(
+        &self,
+        tx_hash: TxHash,
+        pks: Vec<ZkPublicKey>,
+    ) -> Result<ZkSignature, WalletApiError> {
+        let (resp_tx, rx) = oneshot::channel();
+
+        self.relay
+            .send(WalletMsg::SignTxWithZk {
+                tx_hash,
+                pks,
                 resp_tx,
             })
             .await?;

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -130,6 +130,16 @@ pub enum WalletMsg {
         tx_builder: MantleTxBuilder,
         resp_tx: Sender<Result<TipResponse<SignedMantleTx>, WalletServiceError>>,
     },
+    SignTxWithEd25519 {
+        tx_hash: TxHash,
+        pk: <Ed25519Key as SecuredKey>::PublicKey,
+        resp_tx: Sender<Result<<Ed25519Key as SecuredKey>::Signature, WalletServiceError>>,
+    },
+    SignTxWithZk {
+        tx_hash: TxHash,
+        pks: Vec<ZkPublicKey>,
+        resp_tx: Sender<Result<ZkSignature, WalletServiceError>>,
+    },
     GetLeaderAgedNotes {
         tip: Option<HeaderId>,
         resp_tx: Sender<Result<TipResponse<Vec<UtxoWithKeyId>>, WalletServiceError>>,
@@ -181,7 +191,10 @@ impl WalletMsg {
             | Self::GetLeaderAgedNotes { tip, .. }
             | Self::GetClaimableVoucher { tip, .. }
             | Self::GetTxContext { block_id: tip, .. } => *tip,
-            Self::GenerateNewVoucherSecret { .. } | Self::GetKnownAddresses { .. } => None,
+            Self::SignTxWithEd25519 { .. }
+            | Self::SignTxWithZk { .. }
+            | Self::GenerateNewVoucherSecret { .. }
+            | Self::GetKnownAddresses { .. } => None,
         }
     }
 }
@@ -478,6 +491,26 @@ where
 
                 if resp_tx.send(resp).is_err() {
                     error!("Failed to respond to SignTx");
+                }
+            }
+            WalletMsg::SignTxWithEd25519 {
+                tx_hash,
+                pk,
+                resp_tx,
+            } => {
+                let result = Self::sign_ed25519(tx_hash, pk, kms).await;
+                if resp_tx.send(result).is_err() {
+                    error!("Failed to respond to SignTxWithEd25519");
+                }
+            }
+            WalletMsg::SignTxWithZk {
+                tx_hash,
+                pks,
+                resp_tx,
+            } => {
+                let result = Self::sign_zksig(tx_hash, pks.into_iter(), kms).await;
+                if resp_tx.send(result).is_err() {
+                    error!("Failed to respond to SignTxWithZk");
                 }
             }
             WalletMsg::GetLeaderAgedNotes { tip, resp_tx } => {

--- a/tests/src/common/sync.rs
+++ b/tests/src/common/sync.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use futures_util::{StreamExt as _, stream};
 use lb_chain_service::CryptarchiaInfo;
+use lb_zone_sdk::Slot;
 use tokio::time::timeout;
 
 use crate::nodes::validator::Validator;
@@ -12,36 +13,55 @@ pub async fn wait_for_validators_mode_and_height(
     min_height: u64,
     timeout_duration: Duration,
 ) {
-    timeout(timeout_duration, async {
-        loop {
-            let infos: Vec<_> = stream::iter(validators)
-                .then(async |n| { n.consensus_info(false).await })
-                .collect()
-                .await;
-            print_validators_info(&infos);
+    wait_for_validators(
+        validators,
+        timeout_duration,
+        |info| info.mode == mode && info.height >= min_height,
+        format!("All validators reached are in mode {mode:?} and height {min_height}").as_str(),
+        format!("Failed to wait for validators to reach mode {mode:?} and height {min_height}")
+            .as_str(),
+    )
+    .await;
+}
 
-            if infos.iter().all(|info| info.mode == mode)
-                && infos.iter().all(|info| info.height >= min_height)
-            {
-                println!("   All validators reached are in mode {mode:?} and height {min_height}");
-                return;
-            }
-
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    })
-    .await
-    .unwrap_or_else(|_| {
-        panic!(
-            "Timeout ({timeout_duration:?}) waiting for validators to reach mode {mode:?} and height {min_height}",
-        )
-    });
+pub async fn wait_for_validators_mode_and_slot(
+    validators: &[Validator],
+    mode: lb_cryptarchia_engine::State,
+    min_slot: Slot,
+    timeout_duration: Duration,
+) {
+    wait_for_validators(
+        validators,
+        timeout_duration,
+        |info| info.mode == mode && info.slot >= min_slot,
+        format!("All validators reached are in mode {mode:?} and slot {min_slot:?}").as_str(),
+        format!("Failed to wait for validators to reach mode {mode:?} and slot {min_slot:?}")
+            .as_str(),
+    )
+    .await;
 }
 
 pub async fn wait_for_validators_mode(
-    validators: &[&Validator],
+    validators: &[Validator],
     mode: lb_cryptarchia_engine::State,
     timeout_duration: Duration,
+) {
+    wait_for_validators(
+        validators,
+        timeout_duration,
+        |info| info.mode == mode,
+        format!("All validators reached are in mode {mode:?}").as_str(),
+        format!("Failed to wait for validators to reach mode {mode:?}").as_str(),
+    )
+    .await;
+}
+
+async fn wait_for_validators(
+    validators: &[Validator],
+    timeout_duration: Duration,
+    criteria: impl Fn(&CryptarchiaInfo) -> bool + Send + Sync,
+    success_msg: &str,
+    failure_msg: &str,
 ) {
     timeout(timeout_duration, async {
         loop {
@@ -51,8 +71,8 @@ pub async fn wait_for_validators_mode(
                 .await;
             print_validators_info(&infos);
 
-            if infos.iter().all(|info| info.mode == mode) {
-                println!("   All validators reached are in mode {mode:?}");
+            if infos.iter().all(&criteria) {
+                println!("{success_msg}");
                 return;
             }
 
@@ -60,9 +80,7 @@ pub async fn wait_for_validators_mode(
         }
     })
     .await
-    .unwrap_or_else(|_| {
-        panic!("Timeout ({timeout_duration:?}) waiting for validators to reach mode {mode:?}",)
-    });
+    .unwrap_or_else(|_| panic!("Timeout ({timeout_duration:?}): {failure_msg}"));
 }
 
 fn print_validators_info(infos: &[CryptarchiaInfo]) {

--- a/tests/src/tests/cryptarchia/bootstrap.rs
+++ b/tests/src/tests/cryptarchia/bootstrap.rs
@@ -100,13 +100,14 @@ async fn test_ibd_behind_nodes() {
         .bootstrap
         .prolonged_bootstrap_period = Duration::ZERO;
 
-    let behind_node = Validator::spawn(config.clone())
+    let behind_nodes = [Validator::spawn(config.clone())
         .await
-        .expect("Behind node should start successfully");
+        .expect("Behind node should start successfully")];
+    let behind_node = &behind_nodes[0];
 
     println!("Behind node started, waiting for it to finish IBD and switch to online mode...");
     wait_for_validators_mode(
-        &[&behind_node],
+        &behind_nodes,
         lb_cryptarchia_engine::State::Online,
         Duration::from_secs(10),
     )

--- a/tests/src/tests/mantle/leader.rs
+++ b/tests/src/tests/mantle/leader.rs
@@ -4,7 +4,10 @@ use futures::future::join_all;
 use lb_node::config::cryptarchia::deployment::EpochConfig;
 use lb_utils::math::NonNegativeRatio;
 use logos_blockchain_tests::{
-    common::{sync::wait_for_validators_mode_and_height, time::max_block_propagation_time},
+    common::{
+        sync::{wait_for_validators_mode_and_height, wait_for_validators_mode_and_slot},
+        time::max_block_propagation_time,
+    },
     nodes::{create_validator_config, validator::Validator},
     topology::configs::{
         create_general_configs, deployment::e2e_deployment_settings_with_genesis_tx,
@@ -52,25 +55,19 @@ async fn leader_claim() {
         .collect::<Result<Vec<_>, _>>()
         .expect("Failed to spawn validators");
 
-    // Wait for 3 epochs to be safe.
-    // We need at least 2 epoch transitions:
+    // Wait for 2 epoch transitions:
     // epoch 0→1 (vouchers become pending), epoch 1→2 (vouchers flushed into MMR).
     let validator = &validators[0];
-    let target_height = 3 * validator.config().deployment.cryptarchia.blocks_per_epoch();
+    let target_slot = 2 * validator.config().deployment.cryptarchia.slots_per_epoch();
     println!(
-        "target_height:{target_height}, deployment.cryptarchia:{:?}",
+        "target_slot:{target_slot}, deployment.cryptarchia:{:?}",
         validator.config().deployment.cryptarchia
     );
-    wait_for_validators_mode_and_height(
+    wait_for_validators_mode_and_slot(
         &validators,
         lb_cryptarchia_engine::State::Online,
-        target_height,
-        max_block_propagation_time(
-            target_height as u32,
-            validators.len() as u64,
-            &validator.config().deployment,
-            3.0,
-        ),
+        target_slot.into(),
+        Duration::from_secs(300),
     )
     .await;
 
@@ -97,13 +94,14 @@ async fn leader_claim() {
     );
 
     // Wait for the claim tx to be included (a few more blocks)
-    let post_claim_height = target_height + 5;
+    let tip_height = validator.consensus_info(false).await.height;
+    let target_height = tip_height + 5;
     wait_for_validators_mode_and_height(
         &validators,
         lb_cryptarchia_engine::State::Online,
-        post_claim_height,
+        target_height,
         max_block_propagation_time(
-            (post_claim_height - target_height) as u32,
+            5,
             validators.len() as u64,
             &validator.config().deployment,
             3.0,

--- a/tests/src/tests/zone_sdk/e2e.rs
+++ b/tests/src/tests/zone_sdk/e2e.rs
@@ -2,10 +2,22 @@ use std::{collections::HashSet, num::NonZero, time::Duration};
 
 use futures::{StreamExt as _, future::join_all};
 use lb_common_http_client::CommonHttpClient;
-use lb_core::mantle::ops::channel::{ChannelId, deposit::DepositOp};
-use lb_http_api_common::bodies::channel::ChannelDepositRequestBody;
-use lb_key_management_system_service::keys::Ed25519Key;
-use lb_node::config::RunConfig;
+use lb_core::mantle::{
+    MantleTx, Note, NoteId, Op, OpProof, Value,
+    ops::{
+        channel::{ChannelId, deposit::DepositOp},
+        transfer::TransferOp,
+    },
+};
+use lb_http_api_common::bodies::{
+    channel::ChannelDepositRequestBody,
+    wallet::{
+        balance::WalletBalanceResponseBody,
+        sign::{WalletSignTxZkRequestBody, WalletSignTxZkResponseBody},
+    },
+};
+use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey, ZkSignature};
+use lb_node::{SignedMantleTx, Transaction as _, config::RunConfig};
 use lb_utils::math::NonNegativeRatio;
 use lb_zone_sdk::{
     ZoneMessage,
@@ -635,6 +647,114 @@ async fn test_subscribe_to_finalized_deposit() {
     sequencer_task.abort();
 }
 
+#[tokio::test]
+#[serial]
+async fn test_atomic_deposit_inscription() {
+    // Setup network with faster block production
+    let validators = spawn_validators(
+        Some("test_atomic_deposit_inscription"),
+        1,
+        |mut config| {
+            config.deployment.time.slot_duration = Duration::from_secs(1);
+            config
+                .user
+                .cryptarchia
+                .service
+                .bootstrap
+                .prolonged_bootstrap_period = Duration::ZERO;
+            config.deployment.cryptarchia.security_param = NonZero::new(3).unwrap();
+            config.deployment.cryptarchia.slot_activation_coeff =
+                NonNegativeRatio::new(1, 2.try_into().unwrap());
+            config
+        },
+        1,
+    )
+    .await;
+    let validator = &validators[0];
+    let node_url = validator.url();
+
+    // Initialize a sequencer
+    // Random signing key per test run to avoid channel collisions
+    let mut key_bytes = [0u8; 32];
+    thread_rng().fill(&mut key_bytes);
+    let signing_key = Ed25519Key::from_bytes(&key_bytes);
+    let channel_id = channel_id_from_key(&signing_key);
+
+    let (sequencer, mut handle) = ZoneSequencer::init_with_config(
+        channel_id,
+        signing_key,
+        NodeHttpClient::new(CommonHttpClient::new(None), node_url.clone()),
+        SequencerConfig::default(),
+        None, // Fresh start, no checkpoint
+    );
+    let sequencer_task = sequencer.spawn();
+    handle.wait_ready().await;
+
+    // Create a channel, so that a user can deposit into it.
+    let msg1 = b"initial inscription".to_vec();
+    handle.publish_message(msg1.clone()).await.unwrap();
+
+    // Wait for the inscription to be accepted.
+    // We wait for finalization even though it's not necessary,
+    // because that's the only way we have currently.
+    let indexer = ZoneIndexer::new(
+        channel_id,
+        NodeHttpClient::new(CommonHttpClient::new(None), node_url),
+    );
+    wait_for_zone_block(&indexer, msg1, Duration::from_secs(60)).await;
+
+    // Now, prepare a tx for deposit (from user) + inscription (from sequencer)
+    let deposit = DepositOp {
+        channel_id,
+        amount: 1,
+        metadata: b"Mint 1 to Alice in Zone".to_vec(),
+    };
+    let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
+    let (note_id, note_value) = get_note(validator, pk, deposit.amount)
+        .await
+        .expect("should find a note with sufficient balance for deposit");
+    let change = note_value.checked_sub(deposit.amount).unwrap();
+    let transfer = TransferOp {
+        inputs: vec![note_id],
+        outputs: if change > 0 {
+            vec![Note::new(change, pk)]
+        } else {
+            vec![]
+        },
+    };
+    let inscription_data = b"Mint 1 to Alice".to_vec();
+    let (tx, msg_id, sequencer_sig) = handle
+        .prepare_tx(
+            vec![Op::ChannelDeposit(deposit.clone()), Op::Transfer(transfer)],
+            inscription_data.clone(),
+        )
+        .await
+        .unwrap();
+
+    // Ask the user to sign tx only for his own operations (deposit + transfer)
+    let user_transfer_sig = sign_tx_zk(validator, &tx, vec![pk]).await;
+
+    // Build a signed tx using signatures from user and sequencer
+    let signed_tx = SignedMantleTx::new(
+        tx,
+        vec![
+            OpProof::NoProof,
+            OpProof::ZkSig(user_transfer_sig),
+            OpProof::Ed25519Sig(sequencer_sig),
+        ],
+    )
+    .unwrap();
+
+    // Submit the signed tx via zone-sdk
+    handle.submit_signed_tx(signed_tx, msg_id).await.unwrap();
+
+    // Wait for deposit/inscription to be finalized and detected by the ZoneIndexer
+    wait_for_deposit(&indexer, &deposit, Duration::from_secs(120)).await;
+    wait_for_zone_block(&indexer, inscription_data, Duration::from_secs(120)).await;
+
+    sequencer_task.abort();
+}
+
 async fn spawn_validators(
     test_context: Option<&str>,
     count: usize,
@@ -733,4 +853,66 @@ async fn wait_for_deposit(
     })
     .await
     .expect("timed out");
+}
+
+async fn get_note(
+    validator: &Validator,
+    pk: ZkPublicKey,
+    min_value: Value,
+) -> Option<(NoteId, Value)> {
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "http://{}/wallet/{}/balance",
+            validator.config().user.api.backend.listen_address,
+            hex::encode(lb_groth16::fr_to_bytes(&pk.into()))
+        ))
+        .send()
+        .await
+        .expect("balance request should not fail");
+
+    assert!(
+        resp.status().is_success(),
+        "balance request should succeed: status={}",
+        resp.status()
+    );
+
+    let body: WalletBalanceResponseBody = resp
+        .json()
+        .await
+        .expect("balance response should be valid JSON");
+    for (note_id, value) in body.notes {
+        if value >= min_value {
+            return Some((note_id, value));
+        }
+    }
+
+    None
+}
+
+async fn sign_tx_zk(validator: &Validator, tx: &MantleTx, pks: Vec<ZkPublicKey>) -> ZkSignature {
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{}/wallet/sign/zk",
+            validator.config().user.api.backend.listen_address,
+        ))
+        .json(&WalletSignTxZkRequestBody {
+            tx_hash: tx.hash(),
+            pks,
+        })
+        .send()
+        .await
+        .expect("sign API should not fail");
+
+    assert!(
+        resp.status().is_success(),
+        "sign API should succeed: status={}",
+        resp.status()
+    );
+
+    let body: WalletSignTxZkResponseBody = resp
+        .json()
+        .await
+        .expect("sign response should be valid JSON");
+
+    body.sig
 }


### PR DESCRIPTION
## 1. What does this PR implement?

- Added `POST /sign/tx/ed25519` and `POST /sign/tx/zk`.
  - For signing `MantleTx` using keys in KMS. These don't involve any funding mechanism, only sign the tx hash.
- Added an e2e test in zone-sdk for atomic deposit+inscription.

## 2. Does the code have enough context to be clearly understood?
yes

[Atomic deposit suggestion in the spec](https://www.notion.so/nomos-tech/RFC-Make-Ledger-Transaction-an-Operation-31e261aa09df80bc9e02ea4e9affc082?source=copy_link#333261aa09df80b1baaddc41a08107ec)

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?
yes

## 5. Does the implementation introduce changes in the specification?
no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
