### PR TITLE
feat(zone-sdk): support withdraw op

### DIFF
--- a/tests/src/tests/zone_sdk/e2e.rs
+++ b/tests/src/tests/zone_sdk/e2e.rs
@@ -2,12 +2,15 @@ use std::{collections::HashSet, num::NonZero, time::Duration};
 
 use futures::{StreamExt as _, future::join_all};
 use lb_common_http_client::CommonHttpClient;
-use lb_core::mantle::{
-    MantleTx, Note, NoteId, Op, OpProof, Value,
-    ops::{
-        channel::{ChannelId, deposit::DepositOp},
-        transfer::TransferOp,
+use lb_core::{
+    mantle::{
+        MantleTx, Note, NoteId, Op, OpProof, Value,
+        ops::{
+            channel::{ChannelId, deposit::DepositOp, withdraw::ChannelWithdrawOp},
+            transfer::TransferOp,
+        },
     },
+    proofs::channel_withdraw_proof::{ChannelWithdrawProof, WithdrawSignature},
 };
 use lb_http_api_common::bodies::{
     channel::ChannelDepositRequestBody,
@@ -618,28 +621,7 @@ async fn test_subscribe_to_finalized_deposit() {
         metadata: b"Mint 1 to Alice in Zone".to_vec(),
     };
     let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
-    let body = ChannelDepositRequestBody {
-        tip: None,
-        deposit: deposit.clone(),
-        change_public_key: pk,
-        funding_public_keys: vec![pk],
-        max_tx_fee: 10.into(),
-    };
-    let resp = reqwest::Client::new()
-        .post(format!(
-            "http://{}/channel/deposit",
-            validator.config().user.api.backend.listen_address
-        ))
-        .json(&body)
-        .send()
-        .await
-        .expect("request should not fail");
-    assert!(
-        resp.status().is_success(),
-        "request should succeed, got status: {} body: {}",
-        resp.status(),
-        resp.text().await.unwrap_or_default(),
-    );
+    submit_deposit(validator, deposit.clone(), pk).await;
 
     // Wait for the deposit to be finalized and detected by the ZoneIndexer
     wait_for_deposit(&indexer, &deposit, Duration::from_secs(120)).await;
@@ -755,6 +737,136 @@ async fn test_atomic_deposit_inscription() {
     sequencer_task.abort();
 }
 
+#[tokio::test]
+#[serial]
+async fn test_subscribe_to_finalized_withdraw() {
+    // Setup network with faster block production
+    let validators = spawn_validators(
+        Some("test_subscribe_to_finalized_withdraw"),
+        1,
+        |mut config| {
+            config.deployment.time.slot_duration = Duration::from_secs(1);
+            config
+                .user
+                .cryptarchia
+                .service
+                .bootstrap
+                .prolonged_bootstrap_period = Duration::ZERO;
+            config.deployment.cryptarchia.security_param = NonZero::new(3).unwrap();
+            config.deployment.cryptarchia.slot_activation_coeff =
+                NonNegativeRatio::new(1, 2.try_into().unwrap());
+            config
+        },
+        1,
+    )
+    .await;
+    let validator = &validators[0];
+    let node_url = validator.url();
+
+    // Initialize a sequencer
+    // Random signing key per test run to avoid channel collisions
+    let mut key_bytes = [0u8; 32];
+    thread_rng().fill(&mut key_bytes);
+    let signing_key = Ed25519Key::from_bytes(&key_bytes);
+    let channel_id = channel_id_from_key(&signing_key);
+
+    let (sequencer, mut handle) = ZoneSequencer::init_with_config(
+        channel_id,
+        signing_key,
+        NodeHttpClient::new(CommonHttpClient::new(None), node_url.clone()),
+        SequencerConfig::default(),
+        None, // Fresh start, no checkpoint
+    );
+    let sequencer_task = sequencer.spawn();
+    handle.wait_ready().await;
+
+    // Create a channel first
+    let msg1 = b"initial inscription".to_vec();
+    handle.publish_message(msg1.clone()).await.unwrap();
+
+    // Wait for the inscription to be accepted.
+    // We wait for finalization even though it's not necessary,
+    // because that's the only way we have currently.
+    let indexer = ZoneIndexer::new(
+        channel_id,
+        NodeHttpClient::new(CommonHttpClient::new(None), node_url),
+    );
+    wait_for_zone_block(&indexer, msg1, Duration::from_secs(60)).await;
+
+    // Deposit 3 into the channel
+    let deposit = DepositOp {
+        channel_id,
+        amount: 3,
+        metadata: b"Mint 3 to Alice in Zone".to_vec(),
+    };
+    let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
+    submit_deposit(validator, deposit.clone(), pk).await;
+
+    // Wait for the deposit to be finalized and detected by the ZoneIndexer
+    wait_for_deposit(&indexer, &deposit, Duration::from_secs(120)).await;
+
+    // Withdraw 1 from the channel
+    let withdraw = ChannelWithdrawOp {
+        channel_id,
+        amount: 2,
+    };
+    // Prepare a transfer op to send the withdrawn fund to a certain note.
+    // `inputs` is not required actually, but signing tx with 0 key is not support.
+    // So, we're setting a input note. It'll be necessary anyway once we set
+    // non-zero gas price.
+    let (note_id, note_value) = get_note(validator, pk, 1)
+        .await
+        .expect("should find a note with sufficient balance for deposit");
+    let transfer = TransferOp {
+        inputs: vec![note_id],
+        outputs: vec![Note::new(note_value, pk), Note::new(withdraw.amount, pk)],
+    };
+    let inscription_data = b"Burn 2".to_vec();
+    let (tx, msg_id, inscription_proof) = handle
+        .prepare_tx(
+            vec![
+                Op::ChannelWithdraw(withdraw.clone()),
+                Op::Transfer(transfer),
+            ],
+            inscription_data.clone(),
+        )
+        .await
+        .unwrap();
+
+    // For this channel, a single sequencer signature is sufficient for withdraw,
+    // because withdraw_threhold is 1.
+    // We can actually reuse `inscription_proof`, but here we use
+    // `SequencerHandle::sign_tx` to show how to sign tx built by other sequencers.
+    let withdraw_proof = ChannelWithdrawProof::new(vec![WithdrawSignature::new(
+        0,
+        handle.sign_tx(&tx).await.unwrap(),
+    )])
+    .unwrap();
+
+    // Sign tx for transfer op
+    let transfer_proof = sign_tx_zk(validator, &tx, vec![pk]).await;
+
+    // Build a signed tx using signatures from user and sequencer
+    let signed_tx = SignedMantleTx::new(
+        tx,
+        vec![
+            OpProof::ChannelWithdrawProof(withdraw_proof),
+            OpProof::ZkSig(transfer_proof),
+            OpProof::Ed25519Sig(inscription_proof),
+        ],
+    )
+    .unwrap();
+
+    // Submit the signed tx via zone-sdk
+    handle.submit_signed_tx(signed_tx, msg_id).await.unwrap();
+
+    // Wait for withdraw/inscription to be finalized and detected by the ZoneIndexer
+    wait_for_withdraw(&indexer, &withdraw, Duration::from_secs(120)).await;
+    wait_for_zone_block(&indexer, inscription_data, Duration::from_secs(120)).await;
+
+    sequencer_task.abort();
+}
+
 async fn spawn_validators(
     test_context: Option<&str>,
     count: usize,
@@ -845,6 +957,43 @@ async fn wait_for_deposit(
                             return;
                         }
                     }
+                    ZoneMessage::Withdraw(_) => {}
+                }
+            }
+
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .expect("timed out");
+}
+
+async fn wait_for_withdraw(
+    indexer: &ZoneIndexer<NodeHttpClient>,
+    expected: &ChannelWithdrawOp,
+    timeout: Duration,
+) {
+    tokio::time::timeout(timeout, async {
+        let mut last_zone_block = None;
+        loop {
+            let stream = indexer.next_messages(last_zone_block).await.unwrap();
+            futures::pin_mut!(stream);
+
+            while let Some((msg, slot)) = stream.next().await {
+                match msg {
+                    ZoneMessage::Block(block) => {
+                        last_zone_block = Some((block.id, slot));
+                    }
+                    ZoneMessage::Withdraw(withdraw) => {
+                        if withdraw.amount == expected.amount {
+                            println!(
+                                "Found expected withdraw in indexer: amount={}",
+                                withdraw.amount,
+                            );
+                            return;
+                        }
+                    }
+                    ZoneMessage::Deposit(_) => {}
                 }
             }
 
@@ -905,8 +1054,9 @@ async fn sign_tx_zk(validator: &Validator, tx: &MantleTx, pks: Vec<ZkPublicKey>)
 
     assert!(
         resp.status().is_success(),
-        "sign API should succeed: status={}",
-        resp.status()
+        "sign API should succeed: status={}, resp={}",
+        resp.status(),
+        resp.text().await.unwrap_or_default(),
     );
 
     let body: WalletSignTxZkResponseBody = resp
@@ -915,4 +1065,29 @@ async fn sign_tx_zk(validator: &Validator, tx: &MantleTx, pks: Vec<ZkPublicKey>)
         .expect("sign response should be valid JSON");
 
     body.sig
+}
+
+async fn submit_deposit(validator: &Validator, deposit: DepositOp, pk: ZkPublicKey) {
+    let body = ChannelDepositRequestBody {
+        tip: None,
+        deposit,
+        change_public_key: pk,
+        funding_public_keys: vec![pk],
+        max_tx_fee: 10.into(),
+    };
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "http://{}/channel/deposit",
+            validator.config().user.api.backend.listen_address
+        ))
+        .json(&body)
+        .send()
+        .await
+        .expect("request should not fail");
+    assert!(
+        resp.status().is_success(),
+        "request should succeed, got status: {} body: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default(),
+    );
 }

--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -10,7 +10,7 @@ use lb_core::{
 };
 use reqwest::Url;
 
-use crate::{Deposit, ZoneBlock, ZoneMessage};
+use crate::{Deposit, Withdraw, ZoneBlock, ZoneMessage};
 
 #[async_trait]
 pub trait Node {
@@ -152,6 +152,11 @@ fn op_to_zone_message(op: &Op, channel_id: ChannelId) -> Option<ZoneMessage> {
             Some(ZoneMessage::Deposit(Deposit {
                 amount: deposit.amount,
                 metadata: deposit.metadata.clone(),
+            }))
+        }
+        Op::ChannelWithdraw(withdraw) if withdraw.channel_id == channel_id => {
+            Some(ZoneMessage::Withdraw(Withdraw {
+                amount: withdraw.amount,
             }))
         }
         _ => None,

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -135,8 +135,8 @@ fn should_skip(message: &ZoneMessage, slot: Slot, skip_until: &mut Option<(MsgId
                 *skip_until = None;
             }
         }
-        // Deposits have no ID, so keep skipping.
-        ZoneMessage::Deposit(_) => {}
+        // Deposits/withdraws have no ID, so keep skipping.
+        ZoneMessage::Deposit(_) | ZoneMessage::Withdraw(_) => {}
     }
     true
 }

--- a/zone-sdk/src/lib.rs
+++ b/zone-sdk/src/lib.rs
@@ -14,6 +14,8 @@ pub enum ZoneMessage {
     Block(ZoneBlock),
     /// A deposit operation submitted to a channel
     Deposit(Deposit),
+    /// An withdraw operation submitted to a channel
+    Withdraw(Withdraw),
 }
 
 /// A zone block from a zone channel, included/finalized in Bedrock
@@ -32,4 +34,11 @@ pub struct Deposit {
     pub amount: Value,
     /// Opaque metadata associated with this deposit
     pub metadata: Vec<u8>,
+}
+
+/// An withdrawal from a zone channel, included/finalized in Bedrock
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Withdraw {
+    /// Amount of the withdrawal
+    pub amount: Value,
 }

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -101,6 +101,13 @@ enum ActorRequest {
         msg: Vec<u8>,
         reply: tokio::sync::oneshot::Sender<Result<(MantleTx, MsgId, Ed25519Signature), Error>>,
     },
+    /// Sign a tx using the sequencer's key
+    ///
+    /// Useful when signing tx built by other sequencers (e.g. withdraw).
+    SignTx {
+        tx_hash: TxHash,
+        reply: tokio::sync::oneshot::Sender<Result<Ed25519Signature, Error>>,
+    },
     /// Submit a signed tx associated with a msg ID
     SubmitSignedTx {
         tx: SignedMantleTx,
@@ -202,6 +209,30 @@ where
         reply_rx.await.map_err(|_| Error::Unavailable {
             reason: "actor dropped reply",
         })?
+    }
+
+    /// Sign a [`MantleTx`] using the sequencer's key.
+    ///
+    /// Useful when signing tx built by other sequencers (e.g. withdraw).
+    pub async fn sign_tx(&self, tx: &MantleTx) -> Result<Ed25519Signature, Error> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        let request = ActorRequest::SignTx {
+            tx_hash: tx.hash(),
+            reply: reply_tx,
+        };
+
+        self.request_tx
+            .send(request)
+            .await
+            .map_err(|_| Error::Unavailable {
+                reason: "actor channel closed",
+            })?;
+
+        let result = reply_rx.await.map_err(|_| Error::Unavailable {
+            reason: "actor dropped reply",
+        })??;
+
+        Ok(result)
     }
 
     /// Submit a [`SignedMantleTx`] that is associated with a [`MsgId`]
@@ -604,6 +635,11 @@ where
                         reason: "sequencer not yet ready",
                     })));
                 }
+                ActorRequest::SignTx { reply, .. } => {
+                    drop(reply.send(Err(Error::Unavailable {
+                        reason: "sequencer not yet ready",
+                    })));
+                }
                 ActorRequest::SubmitSignedTx { reply, .. } => {
                     drop(reply.send(Err(Error::Unavailable {
                         reason: "sequencer not yet ready",
@@ -639,6 +675,10 @@ where
                 );
                 // do not update last_msg_id since tx is not submitted yet
                 drop(reply.send(Ok(result)));
+            }
+            ActorRequest::SignTx { tx_hash, reply } => {
+                let signature = sign_tx(tx_hash, &self.signing_key);
+                drop(reply.send(Ok(signature)));
             }
             ActorRequest::SubmitSignedTx { tx, msg_id, reply } => {
                 let result = submit_signed_tx(s, tx, msg_id, &mut self.last_msg_id, self.lib_slot);
@@ -988,7 +1028,7 @@ fn create_inscribe_tx(
     };
 
     let tx_hash = inscribe_tx.hash();
-    let signature = signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
+    let signature = sign_tx(tx_hash, signing_key);
 
     let signed_tx = SignedMantleTx {
         ops_proofs: vec![OpProof::Ed25519Sig(signature)],
@@ -1016,7 +1056,7 @@ fn create_set_keys_tx(
     };
 
     let tx_hash = set_keys_tx.hash();
-    let signature = signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
+    let signature = sign_tx(tx_hash, signing_key);
 
     SignedMantleTx {
         ops_proofs: vec![OpProof::Ed25519Sig(signature)],
@@ -1047,9 +1087,13 @@ fn prepare_tx(
         execution_gas_price: 0.into(),
     };
 
-    let inscription_sig = signing_key.sign_payload(tx.hash().as_signing_bytes().as_ref());
+    let inscription_sig = sign_tx(tx.hash(), signing_key);
 
     (tx, msg_id, inscription_sig)
+}
+
+fn sign_tx(tx_hash: TxHash, signing_key: &Ed25519Key) -> Ed25519Signature {
+    signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 1. What does this PR implement?

Now sequencers can submit Withdraw operations using zone-sdk.
- Added `SequencerHandle::sign_tx` to sign txs built by other sequencers.
  - Actually this is the same logic used in the `SequencerHandle::publish_message`, but this is usually for signing txs built by other sequencers. Please note that a Withdraw op must be signed by multiple sequencers, as per [spec](https://www.notion.so/nomos-tech/v1-3-Mantle-Specification-330261aa09df80a899a6efd74f12a7c4?source=copy_link#330261aa09df8158936bdb3fbb6ed489). Communicating between sequencers is out of scope of zone-sdk. Instead, zone-sdk provides APIs flexible enough to support most of use cases. It may be easier to read the e2e test first to understand the flow.
- Added an e2e test for withdraw op. 

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
