### PR TITLE
fix(blend): enable DNS in libp2p swarm

### DIFF
--- a/blend/network/Cargo.toml
+++ b/blend/network/Cargo.toml
@@ -23,7 +23,7 @@ lb-blend-scheduling           = { workspace = true }
 lb-core                       = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-libp2p                     = { workspace = true }
-libp2p                        = { workspace = true, features = ["dns", "quic"] }
+libp2p                        = { workspace = true }
 tracing                       = { workspace = true }
 
 [dev-dependencies]

--- a/blend/network/Cargo.toml
+++ b/blend/network/Cargo.toml
@@ -23,7 +23,7 @@ lb-blend-scheduling           = { workspace = true }
 lb-core                       = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-libp2p                     = { workspace = true }
-libp2p                        = { workspace = true }
+libp2p                        = { workspace = true, features = ["dns", "quic"] }
 tracing                       = { workspace = true }
 
 [dev-dependencies]

--- a/services/blend/Cargo.toml
+++ b/services/blend/Cargo.toml
@@ -33,7 +33,7 @@ lb-services-utils                = { workspace = true }
 lb-time-service                  = { workspace = true }
 lb-tracing                       = { workspace = true }
 lb-utils                         = { features = ["serde"], workspace = true }
-libp2p                           = { optional = true, workspace = true }
+libp2p                           = { optional = true, workspace = true, features = ["dns"] }
 libp2p-stream                    = { optional = true, workspace = true }
 overwatch                        = { workspace = true }
 rand                             = { workspace = true }

--- a/services/blend/Cargo.toml
+++ b/services/blend/Cargo.toml
@@ -33,7 +33,7 @@ lb-services-utils                = { workspace = true }
 lb-time-service                  = { workspace = true }
 lb-tracing                       = { workspace = true }
 lb-utils                         = { features = ["serde"], workspace = true }
-libp2p                           = { optional = true, workspace = true, features = ["dns"] }
+libp2p                           = { features = ["dns"], optional = true, workspace = true }
 libp2p-stream                    = { optional = true, workspace = true }
 overwatch                        = { workspace = true }
 rand                             = { workspace = true }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -126,6 +126,8 @@ where
         let mut swarm = SwarmBuilder::with_existing_identity(config.keypair())
             .with_tokio()
             .with_quic()
+            .with_dns()
+            .expect("DNS transport should be supported")
             .with_behaviour(|_| {
                 BlendBehaviour::new(
                     config,

--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -87,6 +87,8 @@ where
         let swarm = SwarmBuilder::with_existing_identity(identity)
             .with_tokio()
             .with_quic()
+            .with_dns()
+            .expect("DNS transport should be supported")
             .with_behaviour(|_| libp2p_stream::Behaviour::new())
             .expect("Behaviour should be built")
             .with_swarm_config(|cfg| {


### PR DESCRIPTION
## 1. What does this PR implement?

Enable DNS in Blend swarms to be able to connect to DNS core nodes. At the moment, SDP supports any `Multiaddr`, so it's hard to keep the Blend swarm in sync with the set of supported protocols in SDP. I will unify the two so that SDP can contain only protocols that Blend explicitly supports, to catch those issue at compile time instead.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.