### PR TITLE
 perf(mmr): optimize merkle path updates

### DIFF
--- a/mmr/src/lib.rs
+++ b/mmr/src/lib.rs
@@ -83,8 +83,10 @@ where
             return Err(MmrFull);
         }
 
-        let root = *elem.as_ref();
-        let mut last_root = Root { root, height: 1 };
+        let mut last_root = Root {
+            root: *elem.as_ref(),
+            height: 1,
+        };
         let mut roots = self.roots.clone();
 
         while let Some(root) = roots.peek().copied() {
@@ -132,8 +134,10 @@ where
                 .collect(),
         };
 
-        let root = *elem.as_ref();
-        let mut last_root = Root { root, height: 1 };
+        let mut last_root = Root {
+            root: *elem.as_ref(),
+            height: 1,
+        };
         let mut roots = self.roots.clone();
 
         // Phase 1: merge same-height peaks, updating sibling hashes at each merge

--- a/mmr/src/path.rs
+++ b/mmr/src/path.rs
@@ -54,12 +54,19 @@ impl MerklePath {
 /// leaf), and `left` is the existing peak being popped from the stack. At this
 /// height, `right.root` is the sibling for any tracked leaf on the left side,
 /// and `left.root` is the sibling for the new leaf's path.
+///
+/// Time complexity: O(p), where p = number of tracked paths
 pub fn update_paths_at_merge(
     right: Root,
     left: Root,
     paths: &mut [MerklePath],
     new_path: &mut MerklePath,
 ) {
+    assert_eq!(
+        left.height, right.height,
+        "merge requires same-height peaks: left={}, right={}",
+        left.height, right.height
+    );
     let height = right.height as usize;
 
     for path in paths.iter_mut() {
@@ -78,30 +85,39 @@ pub fn update_paths_at_merge(
 /// at greater heights. This function walks upward, computing the growing
 /// subtree root by combining with remaining peaks (left siblings) or empty
 /// subtree roots (right siblings).
+///
+/// Time complexity: O(`MAX_HEIGHT` + p), where p = number of tracked paths.
 pub fn update_paths_above_merge<Hash: Digest, const MAX_HEIGHT: u8>(
     merged_root: Root,
-    remaining_peaks: impl Iterator<Item = Root>,
+    mut remaining_peaks: impl Iterator<Item = Root>,
     paths: &mut [MerklePath],
     new_path: &mut MerklePath,
 ) {
+    let merged_height = merged_root.height as usize;
     let mut subtree_hash = merged_root.root;
-    let mut peaks = remaining_peaks;
 
-    for height in merged_root.height as usize..MAX_HEIGHT as usize {
-        for path in paths.iter_mut() {
-            if are_siblings_at(new_path.leaf_index, path.leaf_index, height) {
-                path.siblings[height - 1] = subtree_hash;
-            }
-        }
+    // Phase 1: precompute subtree hashes at each height and update new_path.
+    let height_range = merged_height..MAX_HEIGHT as usize;
+    let mut hashes = Vec::with_capacity(height_range.len());
+    for height in height_range.clone() {
+        hashes.push(subtree_hash);
 
         if is_left_child(new_path.leaf_index, height) {
             let empty = empty_subtree_root::<Hash>(height as u8);
             new_path.siblings[height - 1] = empty;
             subtree_hash = Hash::compress(&[subtree_hash, empty]);
         } else {
-            let left = peaks.next().expect("stack underflow");
+            let left = remaining_peaks.next().expect("stack underflow");
             new_path.siblings[height - 1] = left.root;
             subtree_hash = Hash::compress(&[left.root, subtree_hash]);
+        }
+    }
+
+    // Phase 2: update each path at its unique sibling height.
+    for path in paths.iter_mut() {
+        let h = sibling_height(new_path.leaf_index, path.leaf_index);
+        if height_range.contains(&h) {
+            path.siblings[h - 1] = hashes[h - merged_height];
         }
     }
 }
@@ -116,4 +132,70 @@ const fn is_left_child(leaf: usize, height: usize) -> bool {
 /// different subtrees at `height`).
 const fn are_siblings_at(a: usize, b: usize, height: usize) -> bool {
     (a >> (height - 1)) == (b >> (height - 1)) ^ 1
+}
+
+/// The unique height at which leaves `a` and `b` are siblings.
+const fn sibling_height(a: usize, b: usize) -> usize {
+    (usize::BITS - (a ^ b).leading_zeros()) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    //       h=3
+    //      /    \
+    //    h=2    h=2
+    //   /  \   /  \
+    //  h=1 h=1 h=1 h=1
+    //  0 1 2 3 4 5 6 7
+
+    #[test]
+    fn test_is_left_child() {
+        assert!(is_left_child(0, 1));
+        assert!(!is_left_child(1, 1));
+        assert!(is_left_child(2, 1));
+        assert!(!is_left_child(3, 1));
+
+        assert!(is_left_child(0, 2));
+        assert!(is_left_child(1, 2));
+        assert!(!is_left_child(2, 2));
+        assert!(!is_left_child(3, 2));
+
+        assert!(is_left_child(0, 3));
+        assert!(is_left_child(3, 3));
+        assert!(!is_left_child(4, 3));
+        assert!(!is_left_child(7, 3));
+    }
+
+    #[test]
+    fn test_are_siblings_at() {
+        // Leaves 0,1 are siblings at h=1
+        assert!(are_siblings_at(0, 1, 1));
+        assert!(are_siblings_at(1, 0, 1));
+        // Leaves 2,3 are siblings at h=1
+        assert!(are_siblings_at(2, 3, 1));
+        // Leaves 0,1 are NOT siblings at h=2
+        assert!(!are_siblings_at(0, 1, 2));
+        // Leaves 0,2 are siblings at h=2 (subtrees [0,1] and [2,3])
+        assert!(are_siblings_at(0, 2, 2));
+        assert!(are_siblings_at(1, 3, 2));
+        // Leaves 0,4 are siblings at h=3 (subtrees [0..3] and [4..7])
+        assert!(are_siblings_at(0, 4, 3));
+        assert!(are_siblings_at(3, 7, 3));
+        assert!(!are_siblings_at(0, 4, 2));
+    }
+
+    #[test]
+    fn test_sibling_height() {
+        // Adjacent pairs → h=1
+        assert_eq!(sibling_height(0, 1), 1);
+        assert_eq!(sibling_height(6, 7), 1);
+        // Across h=2 subtrees
+        assert_eq!(sibling_height(0, 2), 2);
+        assert_eq!(sibling_height(1, 3), 2);
+        // Across h=3 subtrees
+        assert_eq!(sibling_height(0, 4), 3);
+        assert_eq!(sibling_height(3, 7), 3);
+    }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

### Background
Whenever a new element is inserted into MMR, we update all tracked paths in two phases, as implemented in #2469:
- Phase 1: `update_paths_at_merge`
- Phase 2: `update_paths_above_merge`

`update_paths_at_merge` is already `O(p)` where `p` is the number of tracked paths. But, `update_paths_above_merge` is `O(MAX_HEIGHT * p)` where `MAX_HEIGHT = 33`.

The 3s difference between `mmr_1st_epoch` and `mmr_11th_epoch` in the benchmark #2528 is because of the slow `update_paths_above_merge`.

### Optimization

I realized that the `update_paths_above_merge` doesn't need to have a nested loop, which iterates all `p` tracked paths at every height in `[merged_height, MAX_HEIGHT)`, checking `are_siblings_at` at each height.

Actually, each tracked path can only be updated at **one specific height** -- the height where the new leaf and the tracked leaf are indirect siblings (cousins?). 

Therefore, we can precompute a list of subtree hashes that are affected by the new leaf, and updates each tracked path directly at its matching height. Then, the complexity becomes  `O(MAX_HEIGHT + p)` (`+` instead of `*`).

### New Benchmark Result

#### Before Optimization
```
voucher                        fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ mmr_1st_epoch               17.46 s       │ 17.47 s       │ 17.46 s       │ 17.47 s       │ 3       │ 3
├─ mmr_11th_epoch              20.96 s       │ 20.98 s       │ 20.96 s       │ 20.97 s       │ 3       │ 3
``` 
- 3s difference

#### After Optimization
```
voucher             fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ mmr_1st_epoch    17.29 s       │ 17.3 s        │ 17.29 s       │ 17.3 s        │ 3       │ 3
├─ mmr_11th_epoch   17.84 s       │ 17.92 s       │ 17.84 s       │ 17.87 s       │ 3       │ 3
```
- Only 0.6s difference


## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?
yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
