### PR TITLE
fix(chain-network): filter by topic for block proposal stream

### DIFF
--- a/services/chain/chain-network/src/network/adapters/libp2p.rs
+++ b/services/chain/chain-network/src/network/adapters/libp2p.rs
@@ -13,7 +13,7 @@ use lb_network_service::{
     NetworkService,
     backends::libp2p::{
         ChainSyncCommand, Command, DiscoveryCommand, Libp2p, NetworkCommand, PeerId,
-        PubSubCommand::Subscribe,
+        PubSubCommand::Subscribe, TopicHash,
     },
     message::{ChainSyncEvent, NetworkMsg},
 };
@@ -147,17 +147,21 @@ where
         {
             return Err(Box::new(e));
         }
+        let topic_hash = TopicHash::from_raw(self.settings.topic.clone());
         let stream = receiver.await.map_err(Box::new)?;
-        Ok(Box::new(stream.filter_map(|message| match message {
-            Ok(message) => NetworkMessage::from_bytes(&message.data).map_or_else(
-                |_| {
-                    tracing::trace!("unrecognized gossipsub message");
-                    None
-                },
-                |msg| match msg {
-                    NetworkMessage::Proposal(proposal) => Some(proposal),
-                },
-            ),
+        Ok(Box::new(stream.filter_map(move |message| match message {
+            Ok(message) if message.topic == topic_hash => {
+                NetworkMessage::from_bytes(&message.data).map_or_else(
+                    |_| {
+                        tracing::debug!("unrecognized gossipsub message");
+                        None
+                    },
+                    |msg| match msg {
+                        NetworkMessage::Proposal(proposal) => Some(proposal),
+                    },
+                )
+            }
+            Ok(_) => None,
             Err(BroadcastStreamRecvError::Lagged(n)) => {
                 tracing::error!("lagged messages: {n}");
                 None


### PR DESCRIPTION
## 1. What does this PR implement?

With trace logs enabled, I saw a bunch of `TRACE ChainNetwork: logos_blockchain_chain_network_service::network::adapters::libp2p: unrecognized gossipsub message` log entries. That is because in the block proposal stream we get all messages, including the mempool ones, as we did not filter by topic. I added the topic filter and changed the log to `debug` since we are now not meant to get any invalid messages anymore after applying the filter.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.