### PR TITLE
fix(blend): keep memory of failed peers for new attempts in both edge and core swarms

### DIFF
--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -60,6 +60,10 @@ pub struct DialAttempt {
     address: Multiaddr,
     /// The latest (ongoing) attempt number.
     attempt_number: NonZeroU64,
+    /// Peers that have already been tried and failed for this dial cycle.
+    /// When all available peers have been tried, this set is cleared to allow
+    /// retrying from scratch.
+    failed_peers: HashSet<PeerId>,
 }
 
 /// [`DialAttempt`] with session information, i.e., whether the attempt was made
@@ -168,7 +172,7 @@ where
             minimum_network_size,
         };
 
-        self_instance.check_and_dial_new_peers_except(None);
+        self_instance.check_and_dial_new_peers_except(HashSet::new());
 
         self_instance
     }
@@ -182,9 +186,20 @@ where
 {
     /// Dial random peers from the membership list,
     /// excluding the peers with a negotiated connection in the ongoing session,
-    /// the peers that we are already trying to dial, and the blocked peers.
-    fn dial_random_peers_except(&mut self, amount: usize, except: Option<PeerId>) {
+    /// the peers that we are already trying to dial, the blocked peers, and
+    /// any extra peers specified in `except`.
+    fn dial_random_peers_except(&mut self, amount: usize, mut except: HashSet<PeerId>) {
         let negotiated_peers = self.behaviour().blend.with_core().negotiated_peers().keys();
+
+        // We need to clone else we would not be able to call `self.dial` inside which
+        // requires access to `&mut self`.
+        let current_membership = self.public_info.session.membership.clone();
+        // Membership contains local node, so we need to exclude that from the count.
+        if except.len() == current_membership.size() - 1 {
+            tracing::debug!(target: LOG_TARGET, "All eligible peers have been tried. Clearing failed peers memory and retrying from scratch.");
+            except.clear();
+        }
+
         let exclude_peers: HashSet<PeerId> = negotiated_peers
             .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
             .chain(self.ongoing_dials.keys())
@@ -194,21 +209,18 @@ where
 
         tracing::trace!(target: LOG_TARGET, amount, ?except, ?exclude_peers, "Dialing random peers");
 
-        // We need to clone else we would not be able to call `self.dial` inside which
-        // requires access to `&mut self`.
-        let current_membership = self.public_info.session.membership.clone();
         current_membership
             .filter_and_choose_remote_nodes(&mut self.rng, amount, &exclude_peers)
             .for_each(|peer| {
                 let peer_address = peer.address.clone();
                 let peer_id = peer.id;
-                self.dial(peer_id, peer_address);
+                self.dial(peer_id, peer_address, except.clone());
             });
     }
 
     /// Dial new peers, if necessary, to maintain the peering degree.
     /// We aim to have at least the peering degree number of "healthy" peers.
-    fn check_and_dial_new_peers_except(&mut self, except: Option<PeerId>) {
+    fn check_and_dial_new_peers_except(&mut self, except: HashSet<PeerId>) {
         tracing::trace!(target: LOG_TARGET, ?except, "Checking if we need to dial new peers");
 
         let membership_size = self.public_info.session.membership.size();
@@ -232,12 +244,12 @@ where
         if peer_state.is_spammy() {
             self.swarm.behaviour_mut().blocked_peers.block_peer(peer_id);
         }
-        self.check_and_dial_new_peers_except(Some(peer_id));
+        self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
     }
 
     fn handle_unhealthy_peer(&mut self, peer_id: PeerId) {
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} is unhealthy");
-        self.check_and_dial_new_peers_except(Some(peer_id));
+        self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
     }
 
     fn handle_blend_core_behaviour_event(&mut self, blend_event: CoreToCoreEvent) {
@@ -264,15 +276,20 @@ where
                 match reason {
                     ConnectionUpgradeFailureReason::ConnectionFailure => {
                         // If we ran out of dial attempts, we try to connect to another random peer that we are not yet connected to, if the dial attempt was performed in the current session.
-                        let SessionDialAttempt::OngoingSession(Some(_)) = self.schedule_retry(peer) else {
+                        let SessionDialAttempt::OngoingSession(Some(dial_attempt)) = self.schedule_retry(peer) else {
                             return;
                         };
-                        self.check_and_dial_new_peers_except(Some(peer));
+                        let failed_peers = {
+                            let mut failed_peers = dial_attempt.failed_peers;
+                            failed_peers.insert(peer);
+                            failed_peers
+                        };
+                        self.check_and_dial_new_peers_except(failed_peers);
                     }
                     upgrade_error @ (ConnectionUpgradeFailureReason::DuplicateConnection | ConnectionUpgradeFailureReason::MaximumPeeringDegreeReached | ConnectionUpgradeFailureReason::ReverseDirectionPreferred) => {
                         tracing::trace!(target: LOG_TARGET, "Outbound connection upgrade somewhat expectedly failed for {peer:?}. Reason: {upgrade_error:?}. Trying with a different peer if necessary.");
                         self.ongoing_dials.remove(&peer);
-                        self.check_and_dial_new_peers_except(Some(peer));
+                        self.check_and_dial_new_peers_except(HashSet::from([peer]));
                     }
                 }
             }
@@ -323,7 +340,7 @@ where
                 // We don't retry if `peer_id` is `None` or if we've achieved the maximum number
                 // of retries for this peer.
                 let Some(peer_id) = peer_id else {
-                    self.check_and_dial_new_peers_except(None);
+                    self.check_and_dial_new_peers_except(HashSet::new());
                     return;
                 };
 
@@ -331,8 +348,13 @@ where
                     SessionDialAttempt::PreviousSession => {
                         tracing::debug!(target: LOG_TARGET, "Received a dial error for peer {peer_id:?} that is not being tracked. This means that a new session has cleared the map of pending dials. No retry will be performed.");
                     }
-                    SessionDialAttempt::OngoingSession(Some(_)) => {
-                        self.check_and_dial_new_peers_except(Some(peer_id));
+                    SessionDialAttempt::OngoingSession(Some(dial_attempt)) => {
+                        let failed_peers = {
+                            let mut failed_peers = dial_attempt.failed_peers;
+                            failed_peers.insert(peer_id);
+                            failed_peers
+                        };
+                        self.check_and_dial_new_peers_except(failed_peers);
                     }
                     // Retry in progress.
                     SessionDialAttempt::OngoingSession(None) => {}
@@ -358,7 +380,7 @@ where
                 ));
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
-                self.check_and_dial_new_peers_except(None);
+                self.check_and_dial_new_peers_except(HashSet::new());
             }
             BlendSwarmMessage::CompleteSessionTransition => {
                 self.swarm.behaviour_mut().blend.finish_session_transition();
@@ -428,13 +450,14 @@ where
     /// This function always tries to dial and update the counter of attempted
     /// dials. Any checks about the maximum allowed dials must be performed in
     /// the context of the calling function.
-    fn dial(&mut self, peer_id: PeerId, address: Multiaddr) {
+    fn dial(&mut self, peer_id: PeerId, address: Multiaddr, failed_peers: HashSet<PeerId>) {
         tracing::trace!(target: LOG_TARGET, "Dialing peer {peer_id:?} at address {address:?}.");
         self.ongoing_dials.insert(
             peer_id,
             DialAttempt {
                 address: address.clone(),
                 attempt_number: 1.try_into().unwrap(),
+                failed_peers,
             },
         );
 
@@ -453,7 +476,7 @@ where
 
     #[cfg(test)]
     pub fn dial_peer_at_addr(&mut self, peer_id: PeerId, address: Multiaddr) {
-        self.dial(peer_id, address);
+        self.dial(peer_id, address, HashSet::new());
     }
 
     #[cfg(test)]
@@ -464,6 +487,13 @@ where
     #[cfg(test)]
     pub fn pending_retries_count(&self) -> usize {
         self.pending_retries.len()
+    }
+
+    #[cfg(test)]
+    pub fn failed_peers_for(&self, peer_id: &PeerId) -> Option<&HashSet<PeerId>> {
+        self.ongoing_dials
+            .get(peer_id)
+            .map(|attempt| &attempt.failed_peers)
     }
 
     /// Schedule a retry for a failed dial attempt with exponential backoff.
@@ -530,16 +560,11 @@ where
             "Executing backoff retry for peer {peer_id:?} (attempt {}).",
             dial_attempt.attempt_number
         );
-        self.ongoing_dials.insert(
-            peer_id,
-            DialAttempt {
-                address: dial_attempt.address.clone(),
-                ..dial_attempt
-            },
-        );
+        let address = dial_attempt.address.clone();
+        self.ongoing_dials.insert(peer_id, dial_attempt);
         if let Err(e) = self.swarm.dial(
             DialOpts::peer_id(peer_id)
-                .addresses(vec![dial_attempt.address])
+                .addresses(vec![address])
                 .condition(PeerCondition::Always)
                 .build(),
         ) {

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+use std::collections::HashSet;
 
 use lb_blend::scheduling::membership::Membership;
 use lb_core::crypto::ZkHash;
@@ -177,6 +178,115 @@ async fn core_redial_uses_exponential_backoff() {
         .await;
     let second_backoff = before_third_error.elapsed();
     assert!(second_backoff >= Duration::from_secs(4),);
+}
+
+/// Verifies that when a peer fails all dial attempts, it is added to the failed
+/// peers set, preventing it from being chosen again on the next attempt.
+#[test(tokio::test)]
+async fn core_remembers_failed_peers_across_retries() {
+    // Create 3 membership nodes: 1 local (the dialing swarm) + 2 remote
+    // unreachable.
+    let (mut identities, nodes) = new_nodes_with_empty_address(3);
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes)
+        // Use max_dial_attempts=1 to avoid backoff delays.
+        .with_max_dial_attempts(1.try_into().unwrap())
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+
+    // Manually dial one of the unreachable peers.
+    let unreachable_peer_1 = nodes[1].id;
+    let unreachable_peer_2 = nodes[2].id;
+    dialing_swarm.dial_peer_at_addr(unreachable_peer_1, Protocol::Memory(0).into());
+
+    // The first dial has no failed peers memory.
+    assert_eq!(
+        dialing_swarm.failed_peers_for(&unreachable_peer_1),
+        Some(&HashSet::new()),
+    );
+
+    // Let the first peer fail its single dial attempt.
+    dialing_swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(unreachable_peer_1)
+        })
+        .await;
+
+    // After failure, check_and_dial_new_peers should have picked the second peer,
+    // and the second peer's dial attempt should carry the first peer in its
+    // failed_peers set.
+    assert!(
+        dialing_swarm
+            .ongoing_dials()
+            .contains_key(&unreachable_peer_2),
+        "Second peer should be dialed after first peer failed"
+    );
+    assert_eq!(
+        dialing_swarm.failed_peers_for(&unreachable_peer_2),
+        Some(&HashSet::from([unreachable_peer_1])),
+    );
+}
+
+/// Verifies that when all peers have been tried and failed, the failed peers
+/// memory is cleared and peers are retried from scratch.
+#[test(tokio::test)]
+async fn core_clears_failed_peers_memory_when_all_exhausted() {
+    // Create 3 membership nodes: 1 local + 2 remote unreachable.
+    let (mut identities, nodes) = new_nodes_with_empty_address(3);
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .with_max_dial_attempts(1.try_into().unwrap())
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+
+    let unreachable_peer_1 = nodes[1].id;
+    dialing_swarm.dial_peer_at_addr(unreachable_peer_1, Protocol::Memory(0).into());
+
+    // Fail the first peer.
+    dialing_swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(unreachable_peer_1)
+        })
+        .await;
+
+    // The second peer should now be being dialed.
+    let second_peer = *dialing_swarm
+        .ongoing_dials()
+        .keys()
+        .next()
+        .expect("should have an ongoing dial");
+    assert_ne!(unreachable_peer_1, second_peer);
+
+    // Fail the second peer.
+    dialing_swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(second_peer)
+        })
+        .await;
+
+    // Both peers have been tried. The memory should be cleared and a new dial
+    // should be attempted with an empty failed_peers set.
+    assert!(
+        !dialing_swarm.ongoing_dials().is_empty(),
+        "A new dial should be attempted after clearing failed peers memory"
+    );
+    let retried_peer = *dialing_swarm.ongoing_dials().keys().next().unwrap();
+    assert_eq!(
+        dialing_swarm.failed_peers_for(&retried_peer),
+        Some(&HashSet::new()),
+        "Failed peers memory should be cleared after all peers have been tried"
+    );
 }
 
 /// When a new session rotation occurs, pending backoff retries should be

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -1,4 +1,4 @@
-use core::{ops::RangeInclusive, time::Duration};
+use core::{num::NonZeroU64, ops::RangeInclusive, time::Duration};
 use std::iter::repeat_with;
 
 use async_trait::async_trait;
@@ -93,6 +93,7 @@ pub fn build_membership(
 pub struct SwarmBuilder {
     identity: Keypair,
     public_info: PublicInfo<PeerId>,
+    max_dial_attempts: Option<NonZeroU64>,
 }
 
 impl SwarmBuilder {
@@ -101,7 +102,13 @@ impl SwarmBuilder {
         Self {
             identity,
             public_info,
+            max_dial_attempts: None,
         }
+    }
+
+    pub fn with_max_dial_attempts(mut self, max_dial_attempts: NonZeroU64) -> Self {
+        self.max_dial_attempts = Some(max_dial_attempts);
+        self
     }
 
     pub fn build<BehaviourConstructor>(
@@ -122,7 +129,8 @@ impl SwarmBuilder {
             incoming_message_sender,
             self.public_info,
             BlakeRng::from_entropy(),
-            3u64.try_into().unwrap(),
+            self.max_dial_attempts
+                .unwrap_or_else(|| 3u64.try_into().unwrap()),
             1usize.try_into().unwrap(),
         );
 

--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -3,7 +3,7 @@ use core::{
     pin::Pin,
 };
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{HashMap, HashSet, hash_map::Entry},
     io,
     time::Duration,
 };
@@ -39,6 +39,10 @@ pub struct DialAttempt {
     attempt_number: NonZeroU64,
     /// The message to send once the peer is successfully dialed.
     message: EncapsulatedMessageWithVerifiedPublicHeader,
+    /// Peers that have already been tried and failed for this message delivery.
+    /// When all available peers have been tried, this set is cleared to allow
+    /// retrying from scratch.
+    failed_peers: HashSet<PeerId>,
 }
 
 #[cfg(test)]
@@ -173,19 +177,24 @@ where
     }
 
     fn handle_send_message_command(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
-        self.dial_and_schedule_message_except(msg, None);
+        self.dial_and_schedule_message(msg, HashSet::new());
     }
 
     /// Schedule a dial with retries for a given message.
     ///
-    /// The peer to send the message to is chosen at random, except the provided
-    /// peer, if specified.
-    fn dial_and_schedule_message_except(
+    /// The peer to send the message to is chosen at random, excluding the peers
+    /// in `failed_peers`. If all available peers have already been tried, the
+    /// set is cleared and peers are chosen from scratch.
+    fn dial_and_schedule_message(
         &mut self,
         msg: &EncapsulatedMessageWithVerifiedPublicHeader,
-        except: Option<PeerId>,
+        mut failed_peers: HashSet<PeerId>,
     ) {
-        let peers = self.choose_peers_except(except);
+        if failed_peers.len() == self.membership.size() {
+            debug!(target: LOG_TARGET, "All peers have been tried for message with ID {:?}. Clearing failed peers memory and retrying from scratch.", msg.id());
+            failed_peers.clear();
+        }
+        let peers = self.choose_peers_except(&failed_peers);
         if peers.is_empty() {
             error!(target: LOG_TARGET, "No peers available to send the message to");
             return;
@@ -205,6 +214,7 @@ where
                 address,
                 attempt_number: 1.try_into().unwrap(),
                 message: msg.clone(),
+                failed_peers: failed_peers.clone(),
             });
 
             if let Err(e) = self.swarm.dial(opts) {
@@ -255,14 +265,10 @@ where
         None
     }
 
-    fn choose_peers_except(&mut self, except: Option<PeerId>) -> Vec<Node<PeerId>> {
+    fn choose_peers_except(&mut self, except: &HashSet<PeerId>) -> Vec<Node<PeerId>> {
         let peers_to_choose = self.membership.size().min(self.replication_factor.get());
         self.membership
-            .filter_and_choose_remote_nodes(
-                &mut self.rng,
-                peers_to_choose,
-                &except.into_iter().collect(),
-            )
+            .filter_and_choose_remote_nodes(&mut self.rng, peers_to_choose, except)
             .cloned()
             .collect()
     }
@@ -356,9 +362,9 @@ where
     ) {
         error!(target: LOG_TARGET, "Failed to send message: {error} to peer {peer_id:?} on connection {connection_id:?}.");
         // If the maximum attempt count was reached for this peer, try to schedule the
-        // message for a different peer.
-        if let Some(DialAttempt { message, .. }) = self.schedule_retry(peer_id, connection_id) {
-            self.dial_and_schedule_message_except(&message, Some(peer_id));
+        // message for a different peer, remembering all previously failed peers.
+        if let Some(dial_attempt) = self.schedule_retry(peer_id, connection_id) {
+            self.retry_with_different_peer(peer_id, dial_attempt);
         }
     }
 
@@ -369,9 +375,9 @@ where
     ) {
         error!(target: LOG_TARGET, "Failed to open stream to {peer_id}: {error}");
         // If the maximum attempt count was reached for this peer, try to schedule the
-        // message for a different peer.
-        if let Some(DialAttempt { message, .. }) = self.schedule_retry(peer_id, connection_id) {
-            self.dial_and_schedule_message_except(&message, Some(peer_id));
+        // message for a different peer, remembering all previously failed peers.
+        if let Some(dial_attempt) = self.schedule_retry(peer_id, connection_id) {
+            self.retry_with_different_peer(peer_id, dial_attempt);
         }
     }
 
@@ -389,15 +395,31 @@ where
         };
 
         // If the maximum attempt count was reached for this peer, try to schedule the
-        // message for a different peer.
-        if let Some(DialAttempt { message, .. }) = self.schedule_retry(peer_id, connection_id) {
-            self.dial_and_schedule_message_except(&message, Some(peer_id));
+        // message for a different peer, remembering all previously failed peers.
+        if let Some(dial_attempt) = self.schedule_retry(peer_id, connection_id) {
+            self.retry_with_different_peer(peer_id, dial_attempt);
         }
+    }
+
+    /// After exhausting retries for a peer, add it to the failed peers set
+    /// and attempt the message with a different peer.
+    fn retry_with_different_peer(&mut self, failed_peer_id: PeerId, dial_attempt: DialAttempt) {
+        let DialAttempt {
+            message,
+            mut failed_peers,
+            ..
+        } = dial_attempt;
+        let is_peer_added = failed_peers.insert(failed_peer_id);
+        debug_assert!(
+            is_peer_added,
+            "Should only attempt a single batch of retries per peer."
+        );
+        self.dial_and_schedule_message(&message, failed_peers);
     }
 
     #[cfg(test)]
     pub fn send_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
-        self.dial_and_schedule_message_except(msg, None);
+        self.dial_and_schedule_message(msg, HashSet::new());
     }
 
     #[cfg(test)]
@@ -406,7 +428,15 @@ where
         peer_id: PeerId,
         msg: &EncapsulatedMessageWithVerifiedPublicHeader,
     ) {
-        self.dial_and_schedule_message_except(msg, Some(peer_id));
+        self.dial_and_schedule_message(msg, HashSet::from([peer_id]));
+    }
+
+    #[cfg(test)]
+    pub fn failed_peers_for(&self, peer_id: &PeerId) -> Option<&HashSet<PeerId>> {
+        self.pending_dials
+            .iter()
+            .find(|((pid, _), _)| pid == peer_id)
+            .map(|(_, attempt)| &attempt.failed_peers)
     }
 
     pub(super) async fn run(mut self) {

--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -185,6 +185,10 @@ where
     /// The peer to send the message to is chosen at random, excluding the peers
     /// in `failed_peers`. If all available peers have already been tried, the
     /// set is cleared and peers are chosen from scratch.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "TODO: Address this at some point."
+    )]
     fn dial_and_schedule_message(
         &mut self,
         msg: &EncapsulatedMessageWithVerifiedPublicHeader,

--- a/services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -152,8 +152,8 @@ async fn edge_remembers_failed_peers_across_retries() {
         },
     ]);
 
-    // Use max_dial_attempts=1 and replication_factor=1 so each peer fails immediately
-    // and only one peer is chosen at a time.
+    // Use max_dial_attempts=1 and replication_factor=1 so each peer fails
+    // immediately and only one peer is chosen at a time.
     let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(membership)
         .with_max_dial_attempts(1)
         .with_replication_factor(1)
@@ -176,10 +176,7 @@ async fn edge_remembers_failed_peers_across_retries() {
     };
 
     // The first dial has no failed peers memory.
-    assert_eq!(
-        swarm.failed_peers_for(&first_peer),
-        Some(&HashSet::new()),
-    );
+    assert_eq!(swarm.failed_peers_for(&first_peer), Some(&HashSet::new()),);
 
     // Let the first peer fail.
     swarm
@@ -193,7 +190,10 @@ async fn edge_remembers_failed_peers_across_retries() {
 
     // The second peer should now be dialed, with the first peer in the failed set.
     assert!(
-        swarm.pending_dials().keys().any(|(pid, _)| *pid == second_peer),
+        swarm
+            .pending_dials()
+            .keys()
+            .any(|(pid, _)| *pid == second_peer),
         "Second peer should be dialed after first peer failed"
     );
     assert_eq!(

--- a/services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -1,4 +1,5 @@
 use core::slice::from_ref;
+use std::collections::HashSet;
 
 use lb_blend::{
     message::crypto::key_ext::Ed25519SecretKeyExt as _,
@@ -68,9 +69,17 @@ async fn edge_redial_same_peer() {
             .await;
     }
 
-    // All attempts exhausted. Storage map should be cleared up, and since there
-    // is no other peer, no new peer is dialed.
-    assert!(swarm.pending_dials().is_empty());
+    // All attempts exhausted. Since there is only one peer in the membership,
+    // the failed peers memory is cleared and the same peer is retried from scratch.
+    assert!(
+        !swarm.pending_dials().is_empty(),
+        "Peer should be retried after failed peers memory is cleared"
+    );
+    assert_eq!(
+        swarm.failed_peers_for(&random_peer_id),
+        Some(&HashSet::new()),
+        "Failed peers memory should be empty after reset"
+    );
 }
 
 #[test(tokio::test)]
@@ -120,6 +129,144 @@ async fn edge_redial_different_peer_after_redial_limit() {
         core_swarm_incoming_message_receiver.recv().await.unwrap();
     assert_eq!(received_message, message.into_inner().into());
     assert_eq!(received_message_session, 1);
+}
+
+/// Verifies that when a peer fails all dial attempts, it is added to the failed
+/// peers set, preventing it from being chosen again on the next attempt.
+#[test(tokio::test)]
+async fn edge_remembers_failed_peers_across_retries() {
+    let unreachable_peer_1 = PeerId::random();
+    let unreachable_peer_2 = PeerId::random();
+    let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
+
+    let membership = Membership::new_without_local(&[
+        Node {
+            address: empty_multiaddr.clone(),
+            id: unreachable_peer_1,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        },
+        Node {
+            address: empty_multiaddr.clone(),
+            id: unreachable_peer_2,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        },
+    ]);
+
+    // Use max_dial_attempts=1 and replication_factor=1 so each peer fails immediately
+    // and only one peer is chosen at a time.
+    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(membership)
+        .with_max_dial_attempts(1)
+        .with_replication_factor(1)
+        .build();
+
+    let message = TestEncapsulatedMessage::new(b"test-payload");
+    swarm.send_message(&message);
+
+    // Determine which peer was chosen first.
+    let first_peer = swarm
+        .pending_dials()
+        .keys()
+        .next()
+        .expect("should have a pending dial")
+        .0;
+    let second_peer = if first_peer == unreachable_peer_1 {
+        unreachable_peer_2
+    } else {
+        unreachable_peer_1
+    };
+
+    // The first dial has no failed peers memory.
+    assert_eq!(
+        swarm.failed_peers_for(&first_peer),
+        Some(&HashSet::new()),
+    );
+
+    // Let the first peer fail.
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(first_peer)
+        })
+        .await;
+
+    // The second peer should now be dialed, with the first peer in the failed set.
+    assert!(
+        swarm.pending_dials().keys().any(|(pid, _)| *pid == second_peer),
+        "Second peer should be dialed after first peer failed"
+    );
+    assert_eq!(
+        swarm.failed_peers_for(&second_peer),
+        Some(&HashSet::from([first_peer])),
+    );
+}
+
+/// Verifies that when all peers have been tried and failed, the failed peers
+/// memory is cleared and peers are retried from scratch.
+#[test(tokio::test)]
+async fn edge_clears_failed_peers_memory_when_all_exhausted() {
+    let unreachable_peer_1 = PeerId::random();
+    let unreachable_peer_2 = PeerId::random();
+    let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
+
+    let membership = Membership::new_without_local(&[
+        Node {
+            address: empty_multiaddr.clone(),
+            id: unreachable_peer_1,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        },
+        Node {
+            address: empty_multiaddr.clone(),
+            id: unreachable_peer_2,
+            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
+        },
+    ]);
+
+    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(membership)
+        .with_max_dial_attempts(1)
+        .with_replication_factor(1)
+        .build();
+
+    let message = TestEncapsulatedMessage::new(b"test-payload");
+    swarm.send_message(&message);
+
+    // Fail the first peer.
+    let first_peer = swarm.pending_dials().keys().next().unwrap().0;
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(first_peer)
+        })
+        .await;
+
+    // Fail the second peer.
+    let second_peer = swarm.pending_dials().keys().next().unwrap().0;
+    assert_ne!(first_peer, second_peer);
+    swarm
+        .poll_next_until(|event| {
+            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
+                return false;
+            };
+            *peer_id == Some(second_peer)
+        })
+        .await;
+
+    // Both peers have been tried. The memory should be cleared and a new dial
+    // should be attempted (one of the two peers picked again with an empty
+    // failed_peers set).
+    assert!(
+        !swarm.pending_dials().is_empty(),
+        "A new dial should be attempted after clearing failed peers memory"
+    );
+    let retried_peer = swarm.pending_dials().keys().next().unwrap().0;
+    assert_eq!(
+        swarm.failed_peers_for(&retried_peer),
+        Some(&HashSet::new()),
+        "Failed peers memory should be cleared after all peers have been tried"
+    );
 }
 
 /// Verifies that retries use exponential backoff by measuring the elapsed time


### PR DESCRIPTION
## 1. What does this PR implement?

PR on top of https://github.com/logos-blockchain/logos-blockchain/pull/2542.

Previously, we were only excluding the latest failed peer from a re-attempt. This means that if attempt 1 with peer A fails, attempt 2 will try any peer but peer A, and if attempt 2 fails, attempt 3 could pick peer A again. This optimization avoids this, enforcing that we try to iterate over all peers before resetting the list and retry with peers with which there was a previous failure. This is a rather edge case, but it's an optimization nonetheless.

This mechanism is used in the edge swarm to pick peers to send a message to, and in the core swarm to pick peers to connect to.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.
