### PR TITLE
chore(tests): use test name as prefix instead of suffix

### DIFF
--- a/tests/src/nodes/mod.rs
+++ b/tests/src/nodes/mod.rs
@@ -18,9 +18,8 @@ fn create_tempdir() -> std::io::Result<TempDir> {
     // It's easier to use the current location instead of OS-default tempfile
     // location because Github Actions can easily access files in the current
     // location using wildcard to upload them as artifacts.
-    let mut suffix = "_".to_owned();
-    suffix.push_str(std::thread::current().name().unwrap_or("NODE"));
-    TempDir::with_suffix_in(&suffix, std::env::current_dir()?)
+    let prefix = format!("{}_", std::thread::current().name().unwrap_or("NODE"));
+    TempDir::with_prefix_in(prefix, std::env::current_dir()?)
 }
 
 fn persist_tempdir(tempdir: &mut TempDir, label: &str) -> std::io::Result<()> {


### PR DESCRIPTION
## 1. What does this PR implement?

I find it easier if failing test folders are grouped by test name instead of being sorted by the random string used for each node in each test. So I made the test name a prefix instead of a suffix.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?
No.