### PR TITLE
fix(tests): change tests artifacts folder

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -235,4 +235,4 @@ jobs:
         with:
           name: integration-test-artifacts-${{ runner.os }}-${{ github.sha }}
           include-hidden-files: true
-          path: tests/.tmp*
+          path: tests/.run_*

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -42,7 +42,7 @@ jobs:
         if: failure()
         with:
           name: integration-test-artifacts
-          path: tests/.tmp*
+          path: tests/.run_*
       - name: Run codecov analysis
         uses: codecov/codecov-action@ea99328d1c4d5f39fda7cbffe104afd6906c50b0  # Version 5.4.0
         with:

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           name: integration-test-artifacts-${{ runner.os }}-${{ github.sha }}
           include-hidden-files: true
-          path: tests/.tmp*
+          path: tests/.run_*
 
       # Run cucumber integration tests with environment variables for binaries and test params
       # Special exclusion tags (we want to run the rest of the tests and not fail the workflow):

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ sim_config.json
 null
 
 # Integration test temp dirs
-tests/.tmp*
-/.tmp*
+tests/.run_*
 
 # Wildcard for any file that contains ignore
 *ignore*

--- a/tests/src/nodes/mod.rs
+++ b/tests/src/nodes/mod.rs
@@ -18,7 +18,7 @@ fn create_tempdir() -> std::io::Result<TempDir> {
     // It's easier to use the current location instead of OS-default tempfile
     // location because Github Actions can easily access files in the current
     // location using wildcard to upload them as artifacts.
-    let prefix = format!("{}_", std::thread::current().name().unwrap_or("NODE"));
+    let prefix = format!(".run_{}_", std::thread::current().name().unwrap_or("NODE"));
     TempDir::with_prefix_in(prefix, std::env::current_dir()?)
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Changing the naming of the test artifacts messed up with our `.gitignore` as well as with our test results upload step on GH runners. To maintain the test name as the prefix, we need to introduce some other scheme. I propose we pre-pend test artifacts with `.run_` so that they remain hidden files, all have the same prefix and are hence easy to ignore. At the same time, I did not feel just uploading everything starting with `.` was the right way as we might have other hidden files in that folder in the future.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.