### PR TITLE
fix: failing tests align block fetch client with api block shape

### DIFF
--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -4,7 +4,6 @@ use futures::{Stream, StreamExt as _};
 pub use lb_chain_broadcast_service::BlockInfo;
 pub use lb_chain_service::{CryptarchiaInfo, Slot, State};
 use lb_core::{
-    block::Block,
     header::{ContentId, HeaderId},
     mantle::SignedMantleTx,
     proofs::leader_proof::Groth16LeaderProof,
@@ -188,12 +187,31 @@ impl CommonHttpClient {
         &self,
         base_url: Url,
         id: HeaderId,
-    ) -> Result<Option<Block<SignedMantleTx>>, Error> {
+    ) -> Result<Option<ApiBlock>, Error> {
         let path = BLOCKS_DETAIL
             .trim_start_matches('/')
             .replace(":id", &id.to_string());
         let request_url = base_url.join(path.as_str()).map_err(Error::Url)?;
-        self.get(request_url, None::<&()>).await
+
+        let mut request = self.client.get(request_url);
+        if let Some(basic_auth) = &self.basic_auth {
+            request = request.basic_auth(&basic_auth.username, basic_auth.password.as_deref());
+        }
+
+        let response = request.send().await.map_err(Error::Request)?;
+        let status = response.status();
+        let body = response.text().await.map_err(Error::Request)?;
+
+        match status {
+            StatusCode::OK => serde_json::from_str::<ApiBlock>(&body)
+                .map(Some)
+                .map_err(|e| Error::Server(format!("Failed to parse response: {e}"))),
+            StatusCode::NOT_FOUND => Ok(None),
+            StatusCode::INTERNAL_SERVER_ERROR => Err(Error::Server(body)),
+            _ => Err(Error::Server(format!(
+                "Unexpected response [{status}]: {body}",
+            ))),
+        }
     }
 
     pub async fn post_transaction<Tx>(&self, base_url: Url, transaction: Tx) -> Result<(), Error>

--- a/testnet/l2-sequencer-archival-demo/archiver/src/block.rs
+++ b/testnet/l2-sequencer-archival-demo/archiver/src/block.rs
@@ -65,10 +65,10 @@ impl BlockStream {
                         ).dimmed());
 
                         let block = http_client.get_block_by_id(endpoint_url.clone(), header_id).await.unwrap().unwrap();
-                        for (l2_block, l1_transaction_id) in extract_l2_blocks(block.transactions().cloned(), channel_id, token_name) {
+                        for (l2_block, l1_transaction_id) in extract_l2_blocks(block.transactions.iter().cloned(), channel_id, token_name) {
                             yield L2BlockInfo {
                                 data: l2_block,
-                                l1_block_id: block.header().id(),
+                                l1_block_id: block.header.id,
                                 l1_transaction_id,
                             };
                         }

--- a/testnet/l2-sequencer-archival-demo/sequencer/src/sequencer.rs
+++ b/testnet/l2-sequencer-archival-demo/sequencer/src/sequencer.rs
@@ -201,11 +201,11 @@ impl Sequencer {
     }
 
     fn block_contains_inscription(
-        block: &lb_core::block::Block<SignedMantleTx>,
+        block: &lb_common_http_client::ApiBlock,
         expected: &InscriptionOp,
         block_id: HeaderId,
     ) -> bool {
-        for tx in block.transactions() {
+        for tx in &block.transactions {
             for op in &tx.mantle_tx.ops {
                 if let Op::ChannelInscribe(inscribe) = op {
                     tracing::debug!(
@@ -257,14 +257,14 @@ impl Sequencer {
                 "Checking block {} (depth {}): {} transactions",
                 block_id,
                 depth,
-                block.transactions().len()
+                block.transactions.len()
             );
 
             if Self::block_contains_inscription(&block, expected, block_id) {
                 return Ok(true);
             }
 
-            current_id = Some(block.header().parent());
+            current_id = Some(block.header.parent_block);
         }
 
         Ok(false)

--- a/tests/cucumber_tests/features/cryptarchia.feature
+++ b/tests/cucumber_tests/features/cryptarchia.feature
@@ -10,10 +10,12 @@ Feature: Cryptarchia
 
   @cryptarchia_ci
   Scenario: IBD staggered start
-    Given I have a cluster with capacity of 4 nodes
+    Given I have a cluster with capacity of 5 nodes
+    And no nodes are declared as blend providers
     And we use IBD peers
     And all peers must be mode online after startup in 30 seconds
     And I start node "NODE_1"
+    And I start peer node "NODE_1B" connected to node "NODE_1"
     When node "NODE_1" is at height 1 in 300 seconds
     And I start peer node "NODE_2" connected to node "NODE_1"
     When node "NODE_2" is at height 2 in 300 seconds
@@ -25,8 +27,10 @@ Feature: Cryptarchia
 
   @cryptarchia_ci
   Scenario: Orphan staggered start
-    Given I have a cluster with capacity of 4 nodes
+    Given I have a cluster with capacity of 5 nodes
+    And no nodes are declared as blend providers
     And I start node "NODE_1"
+    And I start peer node "NODE_1B" connected to node "NODE_1"
     When node "NODE_1" is at height 1 in 300 seconds
     And I start peer node "NODE_2" connected to node "NODE_1"
     When node "NODE_2" is at height 2 in 300 seconds

--- a/tests/src/cucumber/steps/manual_transactions/best_node.rs
+++ b/tests/src/cucumber/steps/manual_transactions/best_node.rs
@@ -477,7 +477,7 @@ async fn is_tip_still_on_canonical_chain(
         let Some(block) = client.block(&current_header_id).await? else {
             return Ok(false);
         };
-        current_header_id = block.header().parent();
+        current_header_id = block.header.parent_block;
         remaining_steps -= 1;
     }
 

--- a/tests/src/cucumber/steps/manual_transactions/utils.rs
+++ b/tests/src/cucumber/steps/manual_transactions/utils.rs
@@ -407,13 +407,13 @@ pub async fn wait_for_transactions_inclusion(
                 break;
             };
 
-            for tx in block.transactions() {
+            for tx in &block.transactions {
                 let hash = tx.hash();
                 if tx_hashes.contains(&hash) {
                     found.insert(hash);
                 }
             }
-            current = block.header().parent();
+            current = block.header.parent_block;
         }
 
         if tx_hashes.iter().all(|hash| found.contains(hash)) {
@@ -1359,7 +1359,7 @@ async fn collect_multiple_wallets_utxos(
             break;
         };
 
-        let header_id = block.header().id().to_string();
+        let header_id = block.header.id.to_string();
 
         // Cache represents the post-state after evaluating this block.
         refresh_owned_per_wallet_from_cache(world, &header_id, &wallet_pks, &mut owned_per_wallet);
@@ -1374,7 +1374,7 @@ async fn collect_multiple_wallets_utxos(
             break;
         }
 
-        let parent = block.header().parent();
+        let parent = block.header.parent_block;
         tail_blocks.push(block);
         current = parent;
     }
@@ -1392,7 +1392,7 @@ async fn collect_multiple_wallets_utxos(
         reached_chain_start,
     );
     for (i, block) in tail_blocks.iter().enumerate() {
-        let header_id = block.header().id().to_string();
+        let header_id = block.header.id.to_string();
         let height = base_height + i as u64;
         record_header_height(
             &mut world.node_header_heights,
@@ -1407,11 +1407,11 @@ async fn collect_multiple_wallets_utxos(
                 "Evaluating block {height_prefix}{height} for {} wallets on `{best_node_name}`: \
                 {header_id}, transactions len: {}",
                 wallet_pks.len(),
-                block.transactions().len(),
+                block.transactions.len(),
             );
         }
 
-        for tx in block.transactions() {
+        for tx in &block.transactions {
             for transfer in tx.mantle_tx.transfers() {
                 for utxo in transfer.utxos() {
                     if let Some(wallet_name) = wallets_by_pk.get(&utxo.note.pk)
@@ -1564,7 +1564,7 @@ async fn collect_wallet_utxos(
             break;
         };
 
-        let header_id = block.header().id().to_string();
+        let header_id = block.header.id.to_string();
 
         // Cache represents the post-state after evaluating this block.
         refresh_owned_from_cache_single_wallet(world, &header_id, wallet_name, &mut wallet_owned);
@@ -1574,7 +1574,7 @@ async fn collect_wallet_utxos(
             break;
         }
 
-        let parent = block.header().parent();
+        let parent = block.header.parent_block;
         tail_blocks.push(block);
         current = parent;
     }
@@ -1594,7 +1594,7 @@ async fn collect_wallet_utxos(
         reached_chain_start,
     );
     for (i, block) in tail_blocks.iter().enumerate() {
-        let header_id = block.header().id().to_string();
+        let header_id = block.header.id.to_string();
         let height = base_height + i as u64;
         record_header_height(
             &mut world.node_header_heights,
@@ -1609,11 +1609,11 @@ async fn collect_wallet_utxos(
                 "Evaluating block {height_prefix}{height} for `{wallet_name}/{wallet_node_name}`: \
                 {}, transactions len: {}",
                 header_id,
-                block.transactions().len(),
+                block.transactions.len(),
             );
         }
 
-        for tx in block.transactions() {
+        for tx in &block.transactions {
             // Unspent outputs
             for transfer in tx.mantle_tx.transfers() {
                 for utxo in transfer.utxos() {

--- a/tests/testing_framework/src/framework/block_feed.rs
+++ b/tests/testing_framework/src/framework/block_feed.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
-use lb_core::{block::Block, mantle::SignedMantleTx};
+use common_http_client::ApiBlock;
 use lb_node::HeaderId;
 use testing_framework_core::scenario::{DynError, Feed, FeedRuntime, NodeClients};
 use tokio::{
@@ -73,7 +73,7 @@ pub struct ObservedBlock {
     /// Parent header identifier referenced by this block.
     pub parent: HeaderId,
     /// Full block body with transactions.
-    pub block: Arc<Block<SignedMantleTx>>,
+    pub block: Arc<ApiBlock>,
 }
 
 /// Fork-agnostic feed emission.
@@ -187,7 +187,7 @@ struct BackfillEntry {
     source_node: String,
     header: HeaderId,
     height: u64,
-    block: Block<SignedMantleTx>,
+    block: ApiBlock,
 }
 
 impl BlockScanner {
@@ -306,7 +306,7 @@ impl BlockScanner {
                 .block(&cursor)
                 .await?
                 .context("missing block while catching up")?;
-            let parent = block.header().parent();
+            let parent = block.header.parent_block;
 
             stack.push(BackfillEntry {
                 source_node: source_node.to_owned(),
@@ -340,7 +340,7 @@ impl BlockScanner {
             block,
         }) = backfill.pop()
         {
-            let parent = block.header().parent();
+            let parent = block.header.parent_block;
             self.parents.insert(header, parent);
             self.seen.insert(header);
             self.heights.insert(header, height);
@@ -522,9 +522,9 @@ pub struct BlockStats {
 }
 
 impl BlockStats {
-    fn record_block(&self, block: &Block<SignedMantleTx>) {
+    fn record_block(&self, block: &ApiBlock) {
         self.total_transactions
-            .fetch_add(block.transactions().len() as u64, Ordering::Relaxed);
+            .fetch_add(block.transactions.len() as u64, Ordering::Relaxed);
     }
 
     #[must_use]

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -1,9 +1,11 @@
 use std::{net::SocketAddr, pin::Pin};
 
-use common_http_client::{BasicAuthCredentials, CommonHttpClient, Error, ProcessedBlockEvent};
+use common_http_client::{
+    ApiBlock, BasicAuthCredentials, CommonHttpClient, Error, ProcessedBlockEvent,
+};
 use futures::Stream;
 use lb_chain_service::CryptarchiaInfo;
-use lb_core::{block::Block, header::HeaderId, mantle::SignedMantleTx};
+use lb_core::{header::HeaderId, mantle::SignedMantleTx};
 use lb_http_api_common::{
     bodies::wallet::transfer_funds::{
         WalletTransferFundsRequestBody, WalletTransferFundsResponseBody,
@@ -70,7 +72,7 @@ impl NodeHttpClient {
         }
     }
 
-    pub async fn block(&self, id: &HeaderId) -> Result<Option<Block<SignedMantleTx>>, Error> {
+    pub async fn block(&self, id: &HeaderId) -> Result<Option<ApiBlock>, Error> {
         self.http_client
             .get_block_by_id(self.base_url.clone(), *id)
             .await

--- a/tests/testing_framework/src/workloads/inscription/workload.rs
+++ b/tests/testing_framework/src/workloads/inscription/workload.rs
@@ -284,7 +284,7 @@ impl<'a, E: LbcScenarioEnv + LbcBlockFeedEnv> InscriptionRunner<'a, E> {
 
     fn process_block(&mut self, block: &BlockRecord) {
         for observed in &block.new_blocks {
-            for tx in observed.block.transactions() {
+            for tx in &observed.block.transactions {
                 let tx_hash = tx.hash();
                 let Some(channel_idx) = self.pending_by_hash.remove(&tx_hash) else {
                     continue;

--- a/tests/testing_framework/src/workloads/transaction/expectation.rs
+++ b/tests/testing_framework/src/workloads/transaction/expectation.rs
@@ -10,10 +10,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use lb_core::{
-    block::Block,
-    mantle::{AuthenticatedMantleTx as _, SignedMantleTx},
-};
+use common_http_client::ApiBlock;
+use lb_core::mantle::AuthenticatedMantleTx as _;
 use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_node::HeaderId;
 use testing_framework_core::scenario::{DynError, Expectation, RunContext};
@@ -106,7 +104,7 @@ where
                 match receiver.recv().await {
                     Ok(record) => {
                         for observed in &record.new_blocks {
-                            if observed.block.header().parent() == genesis_parent {
+                            if observed.block.header.parent_block == genesis_parent {
                                 continue;
                             }
 
@@ -233,11 +231,11 @@ fn catchup_wait_budget<E: LbcBlockFeedEnv>(ctx: &RunContext<E>) -> Duration {
 }
 
 fn capture_tx_outputs(
-    block: &Block<SignedMantleTx>,
+    block: &ApiBlock,
     tracked_accounts: &HashSet<ZkPublicKey>,
     observed: &AtomicU64,
 ) {
-    for tx in block.transactions() {
+    for tx in &block.transactions {
         for transfer in &tx.mantle_tx().transfers() {
             for note in &transfer.outputs {
                 if tracked_accounts.contains(&note.pk) {

--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -4,7 +4,6 @@ use lb_common_http_client::{
     ApiBlock, BlockInfo, CommonHttpClient, CryptarchiaInfo, Error, ProcessedBlockEvent, Slot,
 };
 use lb_core::{
-    block::Block,
     header::HeaderId,
     mantle::{Op, SignedMantleTx, ops::channel::ChannelId},
 };
@@ -22,7 +21,7 @@ pub trait Node {
 
     async fn lib_stream(&self) -> Result<impl Stream<Item = BlockInfo> + Send, Error>;
 
-    async fn block(&self, id: HeaderId) -> Result<Option<Block<SignedMantleTx>>, Error>;
+    async fn block(&self, id: HeaderId) -> Result<Option<ApiBlock>, Error>;
 
     async fn blocks(&self, slot_from: Slot, slot_to: Slot) -> Result<Vec<ApiBlock>, Error>;
 
@@ -71,7 +70,7 @@ impl Node for NodeHttpClient {
         self.client.get_lib_stream(self.base_url.clone()).await
     }
 
-    async fn block(&self, id: HeaderId) -> Result<Option<Block<SignedMantleTx>>, Error> {
+    async fn block(&self, id: HeaderId) -> Result<Option<ApiBlock>, Error> {
         self.client.get_block_by_id(self.base_url.clone(), id).await
     }
 
@@ -94,7 +93,7 @@ impl Node for NodeHttpClient {
             .client
             .get_block_by_id(self.base_url.clone(), id)
             .await?
-            .map_or_else(|| Vec::with_capacity(0), Block::into_transactions);
+            .map_or_else(|| Vec::with_capacity(0), |block| block.transactions);
 
         Ok(stream::iter(
             transactions

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -145,7 +145,7 @@ fn should_skip(message: &ZoneMessage, slot: Slot, skip_until: &mut Option<(MsgId
 mod tests {
     use async_trait::async_trait;
     use lb_common_http_client::{ApiBlock, BlockInfo, CryptarchiaInfo, ProcessedBlockEvent};
-    use lb_core::{block::Block, header::HeaderId, mantle::SignedMantleTx};
+    use lb_core::{header::HeaderId, mantle::SignedMantleTx};
 
     use super::*;
     use crate::{Deposit, ZoneBlock};
@@ -365,7 +365,7 @@ mod tests {
         async fn block(
             &self,
             _id: HeaderId,
-        ) -> Result<Option<Block<SignedMantleTx>>, lb_common_http_client::Error> {
+        ) -> Result<Option<ApiBlock>, lb_common_http_client::Error> {
             Ok(None)
         }
 

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -909,7 +909,7 @@ async fn backfill_canonical<Node>(
     while !state.has_block(&current) && current != lib {
         match node.block(current).await {
             Ok(Some(block)) => {
-                let parent = block.header().parent_block();
+                let parent = block.header.parent_block;
                 blocks_to_process.push(block);
                 current = parent;
             }
@@ -930,11 +930,12 @@ async fn backfill_canonical<Node>(
     // Process blocks in forward order (oldest first)
     blocks_to_process.reverse();
     for block in blocks_to_process {
-        let block_id = block.header().id();
-        let parent_id = block.header().parent_block();
+        let block_id = block.header.id;
+        let parent_id = block.header.parent_block;
 
         let our_txs: Vec<TxHash> = block
-            .transactions()
+            .transactions
+            .iter()
             .filter(|tx| matches_channel(tx, channel_id))
             .map(|tx| tx.mantle_tx.hash())
             .collect();
@@ -1102,7 +1103,6 @@ mod tests {
     use futures::Stream;
     use lb_common_http_client::{ApiBlock, ApiHeader, BlockInfo, CryptarchiaInfo, State};
     use lb_core::{
-        block::Block,
         header::ContentId,
         mantle::{
             Note, Utxo,
@@ -1254,7 +1254,7 @@ mod tests {
         async fn block(
             &self,
             _id: HeaderId,
-        ) -> Result<Option<Block<SignedMantleTx>>, lb_common_http_client::Error> {
+        ) -> Result<Option<ApiBlock>, lb_common_http_client::Error> {
             unimplemented!()
         }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Return `ApiBlock` from block-by-id instead of deserializing into domain `Block<SignedMantleTx>`, which failed because the HTTP API omits internal header fields like `version`.

- update node/test clients and zone-sdk to consume `ApiBlock`
- switch cucumber/testing-framework block walkers to field-based access
- treat block-by-id 404 as `Ok(None)` for parent-chain traversal
- preserve existing block range/stream behavior

This fixes the failing e2e transaction and cucumber transaction tests.
Also adapted `Scenario: XXX staggered start` to be more robust, as both were failing, although their root cause failing is still not fixed. with this PR

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
