### PR TITLE
feat(blend): add HTTP endpoint for currently connected peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,7 @@ dependencies = [
  "bytes",
  "futures",
  "hyper",
+ "logos-blockchain-blend-service",
  "logos-blockchain-chain-broadcast-service",
  "logos-blockchain-chain-leader-service",
  "logos-blockchain-chain-service",

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -378,6 +378,14 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
         &self.negotiated_peers
     }
 
+    /// Returns the peer IDs of the old session's negotiated peers, if a
+    /// session transition is in progress.
+    pub fn old_session_peer_ids(&self) -> Option<Vec<PeerId>> {
+        self.old_session
+            .as_ref()
+            .map(|old| old.negotiated_peer_ids().copied().collect())
+    }
+
     fn try_wake(&mut self) {
         if let Some(waker) = self.waker.take() {
             waker.wake();

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -380,10 +380,10 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
 
     /// Returns the peer IDs of the old session's negotiated peers, if a
     /// session transition is in progress.
-    pub fn old_session_peer_ids(&self) -> Option<Vec<PeerId>> {
+    pub fn old_session_peer_ids(&self) -> Option<impl Iterator<Item = &PeerId> + '_> {
         self.old_session
             .as_ref()
-            .map(|old| old.negotiated_peer_ids().copied().collect())
+            .map(OldSession::negotiated_peer_ids)
     }
 
     fn try_wake(&mut self) {

--- a/blend/network/src/core/with_core/behaviour/old_session.rs
+++ b/blend/network/src/core/with_core/behaviour/old_session.rs
@@ -189,6 +189,11 @@ impl OldSession {
             .is_some_and(|&id| id == *connection_id)
     }
 
+    /// Returns the peer IDs of all negotiated peers in the old session.
+    pub fn negotiated_peer_ids(&self) -> impl Iterator<Item = &PeerId> {
+        self.negotiated_peers.keys()
+    }
+
     /// Should be called when a connection is detected as closed.
     ///
     /// It removes the connection from the states and returns [`true`]

--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -5,6 +5,7 @@ pub const CRYPTARCHIA_INFO: &str = "/cryptarchia/info";
 pub const CRYPTARCHIA_HEADERS: &str = "/cryptarchia/headers";
 pub const CRYPTARCHIA_LIB_STREAM: &str = "/cryptarchia/lib-stream";
 pub const NETWORK_INFO: &str = "/network/info";
+pub const BLEND_NETWORK_INFO: &str = "/blend/info";
 pub const MEMPOOL_ADD_TX: &str = "/mempool/add/tx";
 pub const CHANNEL: &str = "/channel/:id";
 pub const CHANNEL_DEPOSIT: &str = "/channel/deposit";

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -40,11 +40,11 @@ use utoipa::OpenApi as _;
 use utoipa_swagger_ui::SwaggerUi;
 
 use super::handlers::{
-    add_tx, block, blocks, blocks_stream, cryptarchia_headers, cryptarchia_info,
+    add_tx, blend_info, block, blocks, blocks_stream, cryptarchia_headers, cryptarchia_info,
     cryptarchia_lib_stream, libp2p_info, mantle_metrics, mantle_status, transaction, wallet,
 };
 use crate::{
-    WalletService,
+    BlendBroadcastSettings, BlendService, WalletService,
     api::{
         handlers::{
             channel, channel_deposit, leader_claim, post_activity, post_declaration,
@@ -153,7 +153,8 @@ where
             >,
         >
         + AsServiceId<WalletService>
-        + AsServiceId<ChainLeader>,
+        + AsServiceId<ChainLeader>
+        + AsServiceId<BlendService>,
 {
     type Error = std::io::Error;
     type Settings = AxumBackendSettings;
@@ -209,6 +210,10 @@ where
             .route(
                 paths::NETWORK_INFO,
                 routing::get(libp2p_info::<RuntimeServiceId>),
+            )
+            .route(
+                paths::BLEND_NETWORK_INFO,
+                routing::get(blend_info::<BlendService, BlendBroadcastSettings, RuntimeServiceId>),
             )
             .route(
                 paths::MEMPOOL_ADD_TX,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -284,18 +284,20 @@ where
         (status = 500, description = "Internal server error", body = String),
     )
 )]
-pub async fn blend_info<S, BroadcastSettings, RuntimeServiceId>(
+pub async fn blend_info<BlendService, BroadcastSettings, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
 ) -> Response
 where
-    S: ServiceData<Message = lb_blend_service::message::ServiceMessage<BroadcastSettings, PeerId>>
+    BlendService: ServiceData<Message = lb_blend_service::message::ServiceMessage<BroadcastSettings, PeerId>>
         + 'static,
     BroadcastSettings: Send + 'static,
-    RuntimeServiceId: Debug + Sync + Display + 'static + AsServiceId<S>,
+    RuntimeServiceId: Debug + Sync + Display + 'static + AsServiceId<BlendService>,
 {
-    make_request_and_return_response!(blend::blend_info::<S, BroadcastSettings, RuntimeServiceId>(
-        &handle
-    ))
+    make_request_and_return_response!(blend::blend_info::<
+        BlendService,
+        BroadcastSettings,
+        RuntimeServiceId,
+    >(&handle))
 }
 
 #[utoipa::path(

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use futures::FutureExt as _;
 use lb_api_service::http::{
-    DynError,
+    DynError, blend,
     consensus::{self, Cryptarchia},
     libp2p, mantle, mempool,
     storage::StorageAdapter,
@@ -273,6 +273,28 @@ where
         >,
 {
     make_request_and_return_response!(libp2p::libp2p_info::<RuntimeServiceId>(&handle))
+}
+
+#[utoipa::path(
+    get,
+    path = paths::BLEND_NETWORK_INFO,
+    responses(
+        (status = 200, description = "Query the blend network information", body = Option<lb_blend_service::message::BlendNetworkInfo>),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
+pub async fn blend_info<S, BroadcastSettings, RuntimeServiceId>(
+    State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+) -> Response
+where
+    S: ServiceData<Message = lb_blend_service::message::ServiceMessage<BroadcastSettings>>
+        + 'static,
+    BroadcastSettings: Send + 'static,
+    RuntimeServiceId: Debug + Sync + Display + 'static + AsServiceId<S>,
+{
+    make_request_and_return_response!(blend::blend_info::<S, BroadcastSettings, RuntimeServiceId>(
+        &handle
+    ))
 }
 
 #[utoipa::path(

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Display};
 
+use ::libp2p::PeerId;
 use axum::{
     Json,
     extract::{Path, Query, State},
@@ -287,7 +288,7 @@ pub async fn blend_info<S, BroadcastSettings, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
 ) -> Response
 where
-    S: ServiceData<Message = lb_blend_service::message::ServiceMessage<BroadcastSettings>>
+    S: ServiceData<Message = lb_blend_service::message::ServiceMessage<BroadcastSettings, PeerId>>
         + 'static,
     BroadcastSettings: Send + 'static,
     RuntimeServiceId: Debug + Sync + Display + 'static + AsServiceId<S>,

--- a/nodes/node/binary/src/generic_services/blend/mod.rs
+++ b/nodes/node/binary/src/generic_services/blend/mod.rs
@@ -43,3 +43,6 @@ pub type BlendService<RuntimeServiceId> = lb_blend_service::BlendService<
     BlendEdgeService<RuntimeServiceId>,
     RuntimeServiceId,
 >;
+
+pub type BlendBroadcastSettings<RuntimeServiceId> =
+    <lb_blend_service::core::network::libp2p::Libp2pAdapter<RuntimeServiceId> as lb_blend_service::core::network::NetworkAdapter<RuntimeServiceId>>::BroadcastSettings;

--- a/nodes/node/binary/src/lib.rs
+++ b/nodes/node/binary/src/lib.rs
@@ -72,6 +72,8 @@ pub(crate) type NetworkService =
 pub(crate) type BlendCoreService = generic_services::blend::BlendCoreService<RuntimeServiceId>;
 pub(crate) type BlendEdgeService = generic_services::blend::BlendEdgeService<RuntimeServiceId>;
 pub(crate) type BlendService = generic_services::blend::BlendService<RuntimeServiceId>;
+pub(crate) type BlendBroadcastSettings =
+    generic_services::blend::BlendBroadcastSettings<RuntimeServiceId>;
 
 pub(crate) type BlockBroadcastService =
     lb_chain_broadcast_service::BlockBroadcastService<RuntimeServiceId>;

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -24,6 +24,7 @@ instrumentation = []
 async-trait                = "0.1"
 bytes                      = { workspace = true }
 futures                    = { workspace = true }
+lb-blend-service           = { features = ["libp2p"], workspace = true }
 lb-chain-broadcast-service = { workspace = true }
 lb-chain-leader-service    = { workspace = true }
 lb-chain-service           = { features = ["libp2p"], workspace = true }

--- a/services/api/src/http/blend.rs
+++ b/services/api/src/http/blend.rs
@@ -1,0 +1,26 @@
+use std::fmt::{Debug, Display};
+
+use lb_blend_service::message::{BlendNetworkInfo, ServiceMessage};
+use overwatch::services::{AsServiceId, ServiceData};
+use tokio::sync::oneshot;
+
+pub async fn blend_info<S, BroadcastSettings, RuntimeServiceId>(
+    handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
+) -> Result<Option<BlendNetworkInfo>, overwatch::DynError>
+where
+    S: ServiceData<Message = ServiceMessage<BroadcastSettings>>,
+    RuntimeServiceId: AsServiceId<S> + Debug + Sync + Display + 'static,
+    BroadcastSettings: Send + 'static,
+{
+    let relay = handle.relay::<S>().await?;
+    let (sender, receiver) = oneshot::channel();
+
+    relay
+        .send(ServiceMessage::NetworkInfo { reply: sender })
+        .await
+        .map_err(|(e, _)| e)?;
+
+    receiver
+        .await
+        .map_err(|e| Box::new(e) as overwatch::DynError)
+}

--- a/services/api/src/http/blend.rs
+++ b/services/api/src/http/blend.rs
@@ -5,19 +5,19 @@ use lb_network_service::backends::libp2p::PeerId;
 use overwatch::services::{AsServiceId, ServiceData};
 use tokio::sync::oneshot;
 
-pub async fn blend_info<S, BroadcastSettings, RuntimeServiceId>(
+pub async fn blend_info<BlendService, BroadcastSettings, RuntimeServiceId>(
     handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
 ) -> Result<Option<NetworkInfo<PeerId>>, overwatch::DynError>
 where
-    S: ServiceData<Message = ServiceMessage<BroadcastSettings, PeerId>>,
-    RuntimeServiceId: AsServiceId<S> + Debug + Sync + Display + 'static,
+    BlendService: ServiceData<Message = ServiceMessage<BroadcastSettings, PeerId>>,
+    RuntimeServiceId: AsServiceId<BlendService> + Debug + Sync + Display + 'static,
     BroadcastSettings: Send + 'static,
 {
-    let relay = handle.relay::<S>().await?;
+    let relay = handle.relay::<BlendService>().await?;
     let (sender, receiver) = oneshot::channel();
 
     relay
-        .send(ServiceMessage::NetworkInfo { reply: sender })
+        .send(ServiceMessage::GetNetworkInfo { reply: sender })
         .await
         .map_err(|(e, _)| e)?;
 

--- a/services/api/src/http/blend.rs
+++ b/services/api/src/http/blend.rs
@@ -1,14 +1,15 @@
 use std::fmt::{Debug, Display};
 
-use lb_blend_service::message::{BlendNetworkInfo, ServiceMessage};
+use lb_blend_service::message::{NetworkInfo, ServiceMessage};
+use lb_network_service::backends::libp2p::PeerId;
 use overwatch::services::{AsServiceId, ServiceData};
 use tokio::sync::oneshot;
 
 pub async fn blend_info<S, BroadcastSettings, RuntimeServiceId>(
     handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
-) -> Result<Option<BlendNetworkInfo>, overwatch::DynError>
+) -> Result<Option<NetworkInfo<PeerId>>, overwatch::DynError>
 where
-    S: ServiceData<Message = ServiceMessage<BroadcastSettings>>,
+    S: ServiceData<Message = ServiceMessage<BroadcastSettings, PeerId>>,
     RuntimeServiceId: AsServiceId<S> + Debug + Sync + Display + 'static,
     BroadcastSettings: Send + 'static,
 {

--- a/services/api/src/http/mod.rs
+++ b/services/api/src/http/mod.rs
@@ -1,4 +1,5 @@
 pub type DynError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub mod blend;
 pub mod consensus;
 pub mod libp2p;
 pub mod mantle;

--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -134,6 +134,20 @@ where
                 .filter_map(async |event| event.ok()),
         )
     }
+
+    async fn network_info(&self) -> Option<crate::message::BlendNetworkInfo> {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        if self
+            .swarm_message_sender
+            .send(BlendSwarmMessage::NetworkInfo { reply: sender })
+            .await
+            .is_err()
+        {
+            tracing::error!(target: LOG_TARGET, "Failed to send NetworkInfo request to BlendSwarm");
+            return None;
+        }
+        receiver.await.unwrap_or(None)
+    }
 }
 
 impl Drop for Libp2pBlendBackend {

--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -11,18 +11,21 @@ use lb_blend::message::encap::validated::{
 use libp2p::PeerId;
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::wrappers::BroadcastStream;
 
-use crate::core::{
-    backends::{
-        BlendBackend, PublicInfo, SessionInfo,
-        libp2p::{
-            swarm::{BlendSwarm, BlendSwarmMessage, SwarmParams},
-            tokio_provider::ObservationWindowTokioIntervalProvider,
+use crate::{
+    core::{
+        backends::{
+            BlendBackend, PublicInfo, SessionInfo,
+            libp2p::{
+                swarm::{BlendSwarm, BlendSwarmMessage, SwarmParams},
+                tokio_provider::ObservationWindowTokioIntervalProvider,
+            },
         },
+        settings::RunningBlendConfig as BlendConfig,
     },
-    settings::RunningBlendConfig as BlendConfig,
+    message::NetworkInfo,
 };
 
 const LOG_TARGET: &str = "blend::backend::libp2p";
@@ -135,8 +138,8 @@ where
         )
     }
 
-    async fn network_info(&self) -> Option<crate::message::BlendNetworkInfo> {
-        let (sender, receiver) = tokio::sync::oneshot::channel();
+    async fn network_info(&self) -> Option<NetworkInfo<PeerId>> {
+        let (sender, receiver) = oneshot::channel();
         if self
             .swarm_message_sender
             .send(BlendSwarmMessage::NetworkInfo { reply: sender })

--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -142,7 +142,7 @@ where
         let (sender, receiver) = oneshot::channel();
         if self
             .swarm_message_sender
-            .send(BlendSwarmMessage::NetworkInfo { reply: sender })
+            .send(BlendSwarmMessage::GetNetworkInfo { reply: sender })
             .await
             .is_err()
         {

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -42,6 +42,7 @@ use crate::{
         },
         settings::RunningBlendConfig as BlendConfig,
     },
+    message::BlendNetworkInfo,
     metrics,
 };
 
@@ -53,6 +54,9 @@ pub enum BlendSwarmMessage {
     },
     StartNewSession(SessionInfo<PeerId>),
     CompleteSessionTransition,
+    NetworkInfo {
+        reply: tokio::sync::oneshot::Sender<Option<BlendNetworkInfo>>,
+    },
 }
 
 pub struct DialAttempt {
@@ -247,6 +251,22 @@ where
         self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
     }
 
+    fn collect_network_info(&self) -> BlendNetworkInfo {
+        let with_core = self.swarm.behaviour().blend.with_core();
+        let current_session_peers = with_core
+            .negotiated_peers()
+            .keys()
+            .map(|p| p.to_string())
+            .collect();
+        let old_session_peers = with_core
+            .old_session_peer_ids()
+            .map(|peers| peers.into_iter().map(|p| p.to_string()).collect());
+        BlendNetworkInfo {
+            current_session_peers,
+            old_session_peers,
+        }
+    }
+
     fn handle_unhealthy_peer(&mut self, peer_id: PeerId) {
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} is unhealthy");
         self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
@@ -384,6 +404,10 @@ where
             }
             BlendSwarmMessage::CompleteSessionTransition => {
                 self.swarm.behaviour_mut().blend.finish_session_transition();
+            }
+            BlendSwarmMessage::NetworkInfo { reply } => {
+                let info = self.collect_network_info();
+                let _ = reply.send(Some(info));
             }
         }
     }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -29,7 +29,7 @@ use lb_blend::{
 use lb_libp2p::{DialOpts, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::{
     core::{
@@ -42,7 +42,7 @@ use crate::{
         },
         settings::RunningBlendConfig as BlendConfig,
     },
-    message::BlendNetworkInfo,
+    message::NetworkInfo,
     metrics,
 };
 
@@ -55,7 +55,7 @@ pub enum BlendSwarmMessage {
     StartNewSession(SessionInfo<PeerId>),
     CompleteSessionTransition,
     NetworkInfo {
-        reply: tokio::sync::oneshot::Sender<Option<BlendNetworkInfo>>,
+        reply: oneshot::Sender<Option<NetworkInfo<PeerId>>>,
     },
 }
 
@@ -251,17 +251,17 @@ where
         self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
     }
 
-    fn collect_network_info(&self) -> BlendNetworkInfo {
+    fn collect_network_info(&self) -> NetworkInfo<PeerId> {
         let with_core = self.swarm.behaviour().blend.with_core();
         let current_session_peers = with_core
             .negotiated_peers()
-            .keys()
-            .map(|p| p.to_string())
+            .iter()
+            .map(|(peer_id, peer_state)| (*peer_id, peer_state.negotiated_state().is_healthy()))
             .collect();
         let old_session_peers = with_core
             .old_session_peer_ids()
-            .map(|peers| peers.into_iter().map(|p| p.to_string()).collect());
-        BlendNetworkInfo {
+            .map(|peers| peers.into_iter().collect());
+        NetworkInfo {
             current_session_peers,
             old_session_peers,
         }
@@ -407,7 +407,7 @@ where
             }
             BlendSwarmMessage::NetworkInfo { reply } => {
                 let info = self.collect_network_info();
-                let _ = reply.send(Some(info));
+                drop(reply.send(Some(info)));
             }
         }
     }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -54,7 +54,7 @@ pub enum BlendSwarmMessage {
     },
     StartNewSession(SessionInfo<PeerId>),
     CompleteSessionTransition,
-    NetworkInfo {
+    GetNetworkInfo {
         reply: oneshot::Sender<Option<NetworkInfo<PeerId>>>,
     },
 }
@@ -252,15 +252,15 @@ where
     }
 
     fn collect_network_info(&self) -> NetworkInfo<PeerId> {
-        let with_core = self.swarm.behaviour().blend.with_core();
-        let current_session_peers = with_core
+        let core_behaviour = self.swarm.behaviour().blend.with_core();
+        let current_session_peers = core_behaviour
             .negotiated_peers()
             .iter()
             .map(|(peer_id, peer_state)| (*peer_id, peer_state.negotiated_state().is_healthy()))
             .collect();
-        let old_session_peers = with_core
+        let old_session_peers = core_behaviour
             .old_session_peer_ids()
-            .map(|peers| peers.into_iter().collect());
+            .map(|peers| peers.copied().collect());
         NetworkInfo {
             current_session_peers,
             old_session_peers,
@@ -405,7 +405,7 @@ where
             BlendSwarmMessage::CompleteSessionTransition => {
                 self.swarm.behaviour_mut().blend.finish_session_transition();
             }
-            BlendSwarmMessage::NetworkInfo { reply } => {
+            BlendSwarmMessage::GetNetworkInfo { reply } => {
                 let info = self.collect_network_info();
                 drop(reply.send(Some(info)));
             }

--- a/services/blend/src/core/backends/mod.rs
+++ b/services/blend/src/core/backends/mod.rs
@@ -13,7 +13,7 @@ use lb_blend::{
 };
 use overwatch::overwatch::handle::OverwatchHandle;
 
-use crate::{core::settings::RunningBlendConfig as BlendConfig, message::BlendNetworkInfo};
+use crate::{core::settings::RunningBlendConfig as BlendConfig, message::NetworkInfo};
 
 #[cfg(feature = "libp2p")]
 pub mod libp2p;
@@ -148,5 +148,5 @@ pub trait BlendBackend<NodeId, Rng, RuntimeServiceId> {
 
     /// Return network info about the current blend peers.
     /// Returns `None` if the backend does not support this operation.
-    async fn network_info(&self) -> Option<BlendNetworkInfo>;
+    async fn network_info(&self) -> Option<NetworkInfo<NodeId>>;
 }

--- a/services/blend/src/core/backends/mod.rs
+++ b/services/blend/src/core/backends/mod.rs
@@ -13,7 +13,7 @@ use lb_blend::{
 };
 use overwatch::overwatch::handle::OverwatchHandle;
 
-use crate::core::settings::RunningBlendConfig as BlendConfig;
+use crate::{core::settings::RunningBlendConfig as BlendConfig, message::BlendNetworkInfo};
 
 #[cfg(feature = "libp2p")]
 pub mod libp2p;
@@ -145,4 +145,8 @@ pub trait BlendBackend<NodeId, Rng, RuntimeServiceId> {
     fn listen_to_incoming_messages(
         &mut self,
     ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedSignature, u64)> + Send>>;
+
+    /// Return network info about the current blend peers.
+    /// Returns `None` if the backend does not support this operation.
+    async fn network_info(&self) -> Option<BlendNetworkInfo>;
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -197,7 +197,7 @@ where
             StartingBlendConfig<Backend::Settings>,
         >,
     >;
-    type Message = ServiceMessage<Network::BroadcastSettings>;
+    type Message = ServiceMessage<Network::BroadcastSettings, NodeId>;
 }
 
 #[async_trait]
@@ -828,7 +828,9 @@ async fn run_event_loop<
     CorePoQGenerator,
     RuntimeServiceId,
 >(
-    mut inbound_relay: impl Stream<Item = ServiceMessage<NetAdapter::BroadcastSettings>> + Send + Unpin,
+    mut inbound_relay: impl Stream<Item = ServiceMessage<NetAdapter::BroadcastSettings, NodeId>>
+    + Send
+    + Unpin,
     blend_messages: &mut (
              impl Stream<Item = (EncapsulatedMessageWithVerifiedSignature, u64)> + Send + Unpin + 'static
          ),
@@ -915,7 +917,7 @@ where
                     }
                     ServiceMessage::NetworkInfo { reply } => {
                         let info = backend.network_info().await;
-                        let _ = reply.send(info);
+                        drop(reply.send(info));
                     }
                 }
             }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -817,6 +817,10 @@ where
 //
 // Returns the old session components when the node is no longer a core node.
 #[expect(clippy::too_many_arguments, reason = "categorize args")]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "TODO: address this at some point"
+)]
 async fn run_event_loop<
     NodeId,
     Backend,
@@ -915,7 +919,7 @@ where
                             recovery_checkpoint = handle_serialized_local_data_message(&serialized_data_message, &mut crypto_processor, &mut message_scheduler, recovery_checkpoint).await;
                         }
                     }
-                    ServiceMessage::NetworkInfo { reply } => {
+                    ServiceMessage::GetNetworkInfo { reply } => {
                         let info = backend.network_info().await;
                         drop(reply.send(info));
                     }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -902,13 +902,21 @@ where
 
     loop {
         tokio::select! {
-            Some(ServiceMessage::Blend(message_payload)) = inbound_relay.next() => {
-                // We serialize here, outside of the handler function, so that we can serialize only once for all replicas.
-                let serialized_data_message = NetworkMessage::<NetAdapter::BroadcastSettings>::to_bytes(&message_payload).expect("NetworkMessage should be able to be serialized");
+            Some(msg) = inbound_relay.next() => {
+                match msg {
+                    ServiceMessage::Blend(message_payload) => {
+                        // We serialize here, outside of the handler function, so that we can serialize only once for all replicas.
+                        let serialized_data_message = NetworkMessage::<NetAdapter::BroadcastSettings>::to_bytes(&message_payload).expect("NetworkMessage should be able to be serialized");
 
-                let message_copies = blend_config.data_replication_factor.checked_add(1).unwrap();
-                for _ in 0..message_copies {
-                    recovery_checkpoint = handle_serialized_local_data_message(&serialized_data_message, &mut crypto_processor, &mut message_scheduler, recovery_checkpoint).await;
+                        let message_copies = blend_config.data_replication_factor.checked_add(1).unwrap();
+                        for _ in 0..message_copies {
+                            recovery_checkpoint = handle_serialized_local_data_message(&serialized_data_message, &mut crypto_processor, &mut message_scheduler, recovery_checkpoint).await;
+                        }
+                    }
+                    ServiceMessage::NetworkInfo { reply } => {
+                        let info = backend.network_info().await;
+                        let _ = reply.send(info);
+                    }
                 }
             }
             Some(incoming_message) = blend_messages.next() => {

--- a/services/blend/src/core/service_components.rs
+++ b/services/blend/src/core/service_components.rs
@@ -89,7 +89,7 @@ impl<BroadcastSettings, NodeId> MessageComponents<NodeId>
             Self::Blend(network_message) => {
                 (network_message.message, network_message.broadcast_settings)
             }
-            Self::NetworkInfo { .. } => {
+            Self::GetNetworkInfo { .. } => {
                 panic!("NetworkInfo messages should be handled before calling into_components")
             }
         }
@@ -99,7 +99,7 @@ impl<BroadcastSettings, NodeId> MessageComponents<NodeId>
         self,
     ) -> Result<oneshot::Sender<Option<NetworkInfo<NodeId>>>, Self> {
         match self {
-            Self::NetworkInfo { reply } => Ok(reply),
+            Self::GetNetworkInfo { reply } => Ok(reply),
             other @ Self::Blend(_) => Err(other),
         }
     }

--- a/services/blend/src/core/service_components.rs
+++ b/services/blend/src/core/service_components.rs
@@ -1,4 +1,5 @@
 use lb_utils::blake_rng::BlakeRng;
+use tokio::sync::oneshot;
 
 use crate::{
     core::{BlendService, backends::BlendBackend},
@@ -59,11 +60,22 @@ pub type NetworkBackendOfService<Service, RuntimeServiceId> = <<Service as Servi
 pub type BlendBackendSettingsOfService<Service, RuntimeServiceId> =
     <Service as ServiceComponents<RuntimeServiceId>>::BackendSettings;
 
+use crate::message::BlendNetworkInfo;
+
 pub trait MessageComponents {
     type Payload;
     type BroadcastSettings;
 
     fn into_components(self) -> (Self::Payload, Self::BroadcastSettings);
+
+    /// Try to extract a network info request from the message.
+    /// Returns `Ok(sender)` if the message is a `NetworkInfo` request,
+    /// or `Err(self)` if it is not.
+    fn try_into_network_info_request(
+        self,
+    ) -> Result<oneshot::Sender<Option<BlendNetworkInfo>>, Self>
+    where
+        Self: Sized;
 }
 
 impl<BroadcastSettings> MessageComponents for ServiceMessage<BroadcastSettings> {
@@ -71,7 +83,22 @@ impl<BroadcastSettings> MessageComponents for ServiceMessage<BroadcastSettings> 
     type BroadcastSettings = BroadcastSettings;
 
     fn into_components(self) -> (Self::Payload, Self::BroadcastSettings) {
-        let Self::Blend(network_message) = self;
-        (network_message.message, network_message.broadcast_settings)
+        match self {
+            Self::Blend(network_message) => {
+                (network_message.message, network_message.broadcast_settings)
+            }
+            Self::NetworkInfo { .. } => {
+                panic!("NetworkInfo messages should be handled before calling into_components")
+            }
+        }
+    }
+
+    fn try_into_network_info_request(
+        self,
+    ) -> Result<oneshot::Sender<Option<BlendNetworkInfo>>, Self> {
+        match self {
+            Self::NetworkInfo { reply } => Ok(reply),
+            other => Err(other),
+        }
     }
 }

--- a/services/blend/src/core/service_components.rs
+++ b/services/blend/src/core/service_components.rs
@@ -60,9 +60,9 @@ pub type NetworkBackendOfService<Service, RuntimeServiceId> = <<Service as Servi
 pub type BlendBackendSettingsOfService<Service, RuntimeServiceId> =
     <Service as ServiceComponents<RuntimeServiceId>>::BackendSettings;
 
-use crate::message::BlendNetworkInfo;
+use crate::message::NetworkInfo;
 
-pub trait MessageComponents {
+pub trait MessageComponents<NodeId> {
     type Payload;
     type BroadcastSettings;
 
@@ -73,12 +73,14 @@ pub trait MessageComponents {
     /// or `Err(self)` if it is not.
     fn try_into_network_info_request(
         self,
-    ) -> Result<oneshot::Sender<Option<BlendNetworkInfo>>, Self>
+    ) -> Result<oneshot::Sender<Option<NetworkInfo<NodeId>>>, Self>
     where
         Self: Sized;
 }
 
-impl<BroadcastSettings> MessageComponents for ServiceMessage<BroadcastSettings> {
+impl<BroadcastSettings, NodeId> MessageComponents<NodeId>
+    for ServiceMessage<BroadcastSettings, NodeId>
+{
     type Payload = Vec<u8>;
     type BroadcastSettings = BroadcastSettings;
 
@@ -95,10 +97,10 @@ impl<BroadcastSettings> MessageComponents for ServiceMessage<BroadcastSettings> 
 
     fn try_into_network_info_request(
         self,
-    ) -> Result<oneshot::Sender<Option<BlendNetworkInfo>>, Self> {
+    ) -> Result<oneshot::Sender<Option<NetworkInfo<NodeId>>>, Self> {
         match self {
             Self::NetworkInfo { reply } => Ok(reply),
-            other => Err(other),
+            other @ Self::Blend(_) => Err(other),
         }
     }
 }

--- a/services/blend/src/core/tests/utils.rs
+++ b/services/blend/src/core/tests/utils.rs
@@ -67,6 +67,7 @@ use crate::{
         state::RecoveryServiceState,
         tests::RuntimeServiceId,
     },
+    message::NetworkInfo,
     settings::TimingSettings,
     test_utils,
 };
@@ -194,6 +195,10 @@ where
     fn listen_to_incoming_messages(
         &mut self,
     ) -> Pin<Box<dyn Stream<Item = (EncapsulatedMessageWithVerifiedSignature, u64)> + Send>> {
+        unimplemented!()
+    }
+
+    async fn network_info(&self) -> Option<NetworkInfo<NodeId>> {
         unimplemented!()
     }
 }

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -256,11 +256,20 @@ where
         }
         .await;
 
-        let messages_to_blend_stream = inbound_relay.map(|ServiceMessage::Blend(message)| {
-            NetworkMessage::<BroadcastSettings>::to_bytes(&message)
-                .expect("NetworkMessage should be able to be serialized")
-                .to_vec()
-        });
+        let messages_to_blend_stream = Box::pin(inbound_relay.filter_map(|msg| async {
+            match msg {
+                ServiceMessage::Blend(message) => Some(
+                    NetworkMessage::<BroadcastSettings>::to_bytes(&message)
+                        .expect("NetworkMessage should be able to be serialized")
+                        .to_vec(),
+                ),
+                ServiceMessage::NetworkInfo { reply } => {
+                    // Edge nodes don't have blend peer info.
+                    let _ = reply.send(None);
+                    None
+                }
+            }
+        }));
 
         let epoch_handler = async {
             let chain_service = CryptarchiaServiceApi::<ChainService, _>::new(

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -263,8 +263,8 @@ where
                         .expect("NetworkMessage should be able to be serialized")
                         .to_vec(),
                 ),
-                ServiceMessage::NetworkInfo { reply } => {
-                    // Edge nodes don't have blend peer info.
+                ServiceMessage::GetNetworkInfo { reply } => {
+                    // Edge nodes don't return any Blend peer info.
                     drop(reply.send(None));
                     None
                 }

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -122,7 +122,7 @@ where
     type Settings = StartingBlendConfig<Backend::Settings>;
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State>;
-    type Message = ServiceMessage<BroadcastSettings>;
+    type Message = ServiceMessage<BroadcastSettings, NodeId>;
 }
 
 #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
@@ -256,7 +256,7 @@ where
         }
         .await;
 
-        let messages_to_blend_stream = Box::pin(inbound_relay.filter_map(|msg| async {
+        let messages_to_blend_stream = Box::pin(inbound_relay.filter_map(async |msg| {
             match msg {
                 ServiceMessage::Blend(message) => Some(
                     NetworkMessage::<BroadcastSettings>::to_bytes(&message)
@@ -265,7 +265,7 @@ where
                 ),
                 ServiceMessage::NetworkInfo { reply } => {
                     // Edge nodes don't have blend peer info.
-                    let _ = reply.send(None);
+                    drop(reply.send(None));
                     None
                 }
             }

--- a/services/blend/src/instance.rs
+++ b/services/blend/src/instance.rs
@@ -36,9 +36,9 @@ where
         // Keep the previous core mode for the session transition period.
         prev: CoreMode<CoreService, RuntimeServiceId>,
     },
-    Broadcast(BroadcastMode<CoreService::NetworkAdapter, RuntimeServiceId>),
+    Broadcast(BroadcastMode<CoreService::NetworkAdapter, CoreService::NodeId, RuntimeServiceId>),
     BroadcastAfterCore {
-        mode: BroadcastMode<CoreService::NetworkAdapter, RuntimeServiceId>,
+        mode: BroadcastMode<CoreService::NetworkAdapter, CoreService::NodeId, RuntimeServiceId>,
         // Keep the previous core mode for the session transition period.
         prev: CoreMode<CoreService, RuntimeServiceId>,
     },
@@ -49,8 +49,9 @@ impl<CoreService, EdgeService, RuntimeServiceId>
 where
     CoreService: ServiceData<
             Message: MessageComponents<
+                CoreService::NodeId,
                 Payload: Into<Vec<u8>>,
-                BroadcastSettings: Into<BroadcastSettings<CoreService>>,
+                BroadcastSettings: Into<BroadcastSettings<CoreService, RuntimeServiceId>>,
             > + Send
                          + Sync
                          + 'static,
@@ -58,11 +59,11 @@ where
             RuntimeServiceId,
             NetworkAdapter: NetworkAdapterTrait<
                 RuntimeServiceId,
-                BroadcastSettings = BroadcastSettings<CoreService>,
+                BroadcastSettings = BroadcastSettings<CoreService, RuntimeServiceId>,
             > + Send
                                 + Sync
                                 + 'static,
-            NodeId: Eq + Hash,
+            NodeId: Eq + Hash + Send + Sync,
         > + 'static,
     EdgeService: ServiceData<Message = CoreService::Message> + 'static,
     RuntimeServiceId: AsServiceId<CoreService>
@@ -107,7 +108,10 @@ where
 
     async fn new_broadcast_mode(
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
-    ) -> Result<BroadcastMode<CoreService::NetworkAdapter, RuntimeServiceId>, modes::Error> {
+    ) -> Result<
+        BroadcastMode<CoreService::NetworkAdapter, CoreService::NodeId, RuntimeServiceId>,
+        modes::Error,
+    > {
         BroadcastMode::new::<
             NetworkService<
                 NetworkBackendOfService<CoreService, RuntimeServiceId>,

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -84,12 +84,16 @@ where
 impl<CoreService, EdgeService, RuntimeServiceId> ServiceCore<RuntimeServiceId>
     for BlendService<CoreService, EdgeService, RuntimeServiceId>
 where
-    CoreService: ServiceData<Message: MessageComponents<Payload: Into<Vec<u8>>> + Send + Sync + 'static>
-        + CoreServiceComponents<
+    CoreService: ServiceData<
+            Message: MessageComponents<CoreService::NodeId, Payload: Into<Vec<u8>>>
+                         + Send
+                         + Sync
+                         + 'static,
+        > + CoreServiceComponents<
             RuntimeServiceId,
             NetworkAdapter: NetworkAdapterTrait<
                 RuntimeServiceId,
-                BroadcastSettings = BroadcastSettings<CoreService>,
+                BroadcastSettings = BroadcastSettings<CoreService, RuntimeServiceId>,
             > + Send
                                 + Sync
                                 + 'static,
@@ -226,8 +230,10 @@ where
     }
 }
 
-type BroadcastSettings<CoreService> =
-    <<CoreService as ServiceData>::Message as MessageComponents>::BroadcastSettings;
+type BroadcastSettings<CoreService, RuntimeServiceId> =
+    <<CoreService as ServiceData>::Message as MessageComponents<
+        <CoreService as CoreServiceComponents<RuntimeServiceId>>::NodeId,
+    >>::BroadcastSettings;
 
 type MembershipAdapter<EdgeService> = <EdgeService as edge::ServiceComponents>::MembershipAdapter;
 

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -2,13 +2,40 @@ use core::fmt::{self, Debug, Formatter};
 
 use lb_blend::message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
 use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+
+/// Information about the current blend network peers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlendNetworkInfo {
+    /// Negotiated peers for the current session.
+    pub current_session_peers: Vec<String>,
+    /// Negotiated peers for the old session, if a session transition is in
+    /// progress.
+    pub old_session_peers: Option<Vec<String>>,
+}
 
 /// A message that is handled by [`BlendService`].
-#[derive(Debug)]
 pub enum ServiceMessage<BroadcastSettings> {
     /// To send a message to the blend network and eventually broadcast it to
     /// the [`NetworkService`].
     Blend(NetworkMessage<BroadcastSettings>),
+    /// Request the current blend network info (connected peers).
+    /// The reply will be `None` if the node is not in core mode.
+    NetworkInfo {
+        reply: oneshot::Sender<Option<BlendNetworkInfo>>,
+    },
+}
+
+impl<BroadcastSettings> Debug for ServiceMessage<BroadcastSettings>
+where
+    BroadcastSettings: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Blend(msg) => f.debug_tuple("Blend").field(msg).finish(),
+            Self::NetworkInfo { .. } => f.debug_struct("NetworkInfo").finish(),
+        }
+    }
 }
 
 /// A message that is sent to the blend network.

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -4,29 +4,31 @@ use lb_blend::message::encap::validated::EncapsulatedMessageWithVerifiedPublicHe
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
-/// Information about the current blend network peers.
+/// Information about the curren
+/// t blend network peers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlendNetworkInfo {
-    /// Negotiated peers for the current session.
-    pub current_session_peers: Vec<String>,
+pub struct NetworkInfo<NodeId> {
+    /// Negotiated peers for the current session, with a flag indicating whether
+    /// they are healthy (`true`) or not (`false`).
+    pub current_session_peers: Vec<(NodeId, bool)>,
     /// Negotiated peers for the old session, if a session transition is in
     /// progress.
-    pub old_session_peers: Option<Vec<String>>,
+    pub old_session_peers: Option<Vec<NodeId>>,
 }
 
 /// A message that is handled by [`BlendService`].
-pub enum ServiceMessage<BroadcastSettings> {
+pub enum ServiceMessage<BroadcastSettings, NodeId> {
     /// To send a message to the blend network and eventually broadcast it to
     /// the [`NetworkService`].
     Blend(NetworkMessage<BroadcastSettings>),
     /// Request the current blend network info (connected peers).
     /// The reply will be `None` if the node is not in core mode.
     NetworkInfo {
-        reply: oneshot::Sender<Option<BlendNetworkInfo>>,
+        reply: oneshot::Sender<Option<NetworkInfo<NodeId>>>,
     },
 }
 
-impl<BroadcastSettings> Debug for ServiceMessage<BroadcastSettings>
+impl<BroadcastSettings, NodeId> Debug for ServiceMessage<BroadcastSettings, NodeId>
 where
     BroadcastSettings: Debug,
 {

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -4,8 +4,7 @@ use lb_blend::message::encap::validated::EncapsulatedMessageWithVerifiedPublicHe
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
-/// Information about the curren
-/// t blend network peers.
+/// Information about the current Blend network peers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkInfo<NodeId> {
     /// Negotiated peers for the current session, with a flag indicating whether
@@ -23,7 +22,7 @@ pub enum ServiceMessage<BroadcastSettings, NodeId> {
     Blend(NetworkMessage<BroadcastSettings>),
     /// Request the current blend network info (connected peers).
     /// The reply will be `None` if the node is not in core mode.
-    NetworkInfo {
+    GetNetworkInfo {
         reply: oneshot::Sender<Option<NetworkInfo<NodeId>>>,
     },
 }
@@ -35,7 +34,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Blend(msg) => f.debug_tuple("Blend").field(msg).finish(),
-            Self::NetworkInfo { .. } => f.debug_struct("NetworkInfo").finish(),
+            Self::GetNetworkInfo { .. } => f.debug_struct("GetNetworkInfo").finish(),
         }
     }
 }

--- a/services/blend/src/modes/broadcast.rs
+++ b/services/blend/src/modes/broadcast.rs
@@ -62,11 +62,21 @@ where
             + Sync
             + 'static,
     {
-        let (payload, broadcast_settings) = message.into_components();
-        self.adapter
-            .broadcast(payload.into(), broadcast_settings.into())
-            .await;
-        Ok(())
+        // If this is a network info request, respond with None (broadcast mode
+        // has no blend peers).
+        match message.try_into_network_info_request() {
+            Ok(reply) => {
+                let _ = reply.send(None);
+                return Ok(());
+            }
+            Err(message) => {
+                let (payload, broadcast_settings) = message.into_components();
+                self.adapter
+                    .broadcast(payload.into(), broadcast_settings.into())
+                    .await;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/services/blend/src/modes/broadcast.rs
+++ b/services/blend/src/modes/broadcast.rs
@@ -16,12 +16,12 @@ use crate::{
     modes::Error,
 };
 
-pub struct BroadcastMode<Adapter, RuntimeServiceId> {
+pub struct BroadcastMode<Adapter, NodeId, RuntimeServiceId> {
     adapter: Adapter,
-    _phantom: PhantomData<RuntimeServiceId>,
+    _phantom: PhantomData<(NodeId, RuntimeServiceId)>,
 }
 
-impl<Adapter, RuntimeServiceId> BroadcastMode<Adapter, RuntimeServiceId>
+impl<Adapter, NodeId, RuntimeServiceId> BroadcastMode<Adapter, NodeId, RuntimeServiceId>
 where
     Adapter: NetworkAdapter<RuntimeServiceId> + Send + Sync,
 {
@@ -48,14 +48,16 @@ where
     }
 }
 
-impl<Adapter, RuntimeServiceId> BroadcastMode<Adapter, RuntimeServiceId>
+impl<Adapter, NodeId, RuntimeServiceId> BroadcastMode<Adapter, NodeId, RuntimeServiceId>
 where
     Adapter: NetworkAdapter<RuntimeServiceId> + Send + Sync + 'static,
+    NodeId: Send + Sync,
     RuntimeServiceId: Send + Sync + 'static,
 {
     pub async fn handle_inbound_message<Message>(&self, message: Message) -> Result<(), Error>
     where
         Message: MessageComponents<
+                NodeId,
                 Payload: Into<Vec<u8>>,
                 BroadcastSettings: Into<Adapter::BroadcastSettings>,
             > + Send
@@ -66,8 +68,8 @@ where
         // has no blend peers).
         match message.try_into_network_info_request() {
             Ok(reply) => {
-                let _ = reply.send(None);
-                return Ok(());
+                drop(reply.send(None));
+                Ok(())
             }
             Err(message) => {
                 let (payload, broadcast_settings) = message.into_components();
@@ -114,7 +116,7 @@ pub mod tests {
             .unwrap();
 
             // Create the BroadcastMode
-            let mut mode = BroadcastMode::<TestNetworkAdapter, RuntimeServiceId>::new::<
+            let mut mode = BroadcastMode::<TestNetworkAdapter, (), RuntimeServiceId>::new::<
                 TestNetworkService,
             >(app.handle())
             .await
@@ -134,7 +136,7 @@ pub mod tests {
             );
 
             // Check if the mode can be created again.
-            let mut mode = BroadcastMode::<TestNetworkAdapter, RuntimeServiceId>::new::<
+            let mut mode = BroadcastMode::<TestNetworkAdapter, (), RuntimeServiceId>::new::<
                 TestNetworkService,
             >(app.handle())
             .await

--- a/services/blend/src/modes/broadcast.rs
+++ b/services/blend/src/modes/broadcast.rs
@@ -95,11 +95,12 @@ pub mod tests {
             state::{NoOperator, NoState},
         },
     };
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, oneshot};
     use tokio_stream::wrappers::BroadcastStream;
     use tracing::{debug, info};
 
     use super::*;
+    use crate::message::NetworkInfo;
 
     #[test_log::test(test)]
     fn broadcast_mode() {
@@ -271,12 +272,21 @@ pub mod tests {
     #[derive(Debug)]
     pub struct TestMessage(Vec<u8>);
 
-    impl MessageComponents for TestMessage {
+    impl<NodeId> MessageComponents<NodeId> for TestMessage {
         type Payload = Vec<u8>;
         type BroadcastSettings = ();
 
         fn into_components(self) -> (Self::Payload, Self::BroadcastSettings) {
             (self.0, ())
+        }
+
+        fn try_into_network_info_request(
+            self,
+        ) -> Result<oneshot::Sender<Option<NetworkInfo<NodeId>>>, Self>
+        where
+            Self: Sized,
+        {
+            Err(self)
         }
     }
 

--- a/services/blend/src/service_components.rs
+++ b/services/blend/src/service_components.rs
@@ -8,6 +8,7 @@ pub trait ServiceComponents {
     /// Settings for broadcasting messages that have passed through the blend
     /// network.
     type BroadcastSettings;
+    type NodeId;
 }
 
 impl<CoreService, EdgeService, RuntimeServiceId> ServiceComponents
@@ -17,4 +18,5 @@ where
     EdgeService: ServiceData + edge::service_components::ServiceComponents,
 {
     type BroadcastSettings = EdgeService::BroadcastSettings;
+    type NodeId = CoreService::NodeId;
 }

--- a/services/chain/chain-leader/src/blend.rs
+++ b/services/chain/chain-leader/src/blend.rs
@@ -35,7 +35,7 @@ where
 
 impl<BlendService> BlendAdapter<BlendService>
 where
-    BlendService: ServiceData<Message = ServiceMessage<BlendService::BroadcastSettings>>
+    BlendService: ServiceData<Message = ServiceMessage<BlendService::BroadcastSettings, BlendService::NodeId>>
         + lb_blend_service::ServiceComponents
         + Sync,
     <BlendService as ServiceData>::Message: Send,

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -228,8 +228,11 @@ impl<
     >
 where
     BlendService: ServiceData<
-            Message = lb_blend_service::message::ServiceMessage<BlendService::BroadcastSettings>,
-        > + lb_blend_service::ServiceComponents
+            Message = lb_blend_service::message::ServiceMessage<
+                BlendService::BroadcastSettings,
+                BlendService::NodeId,
+            >,
+        > + lb_blend_service::ServiceComponents<NodeId: Send + Sync>
         + Send
         + Sync
         + 'static,
@@ -508,8 +511,11 @@ impl<
     >
 where
     BlendService: ServiceData<
-            Message = lb_blend_service::message::ServiceMessage<BlendService::BroadcastSettings>,
-        > + lb_blend_service::ServiceComponents
+            Message = lb_blend_service::message::ServiceMessage<
+                BlendService::BroadcastSettings,
+                BlendService::NodeId,
+            >,
+        > + lb_blend_service::ServiceComponents<NodeId: Send + Sync>
         + Send
         + Sync
         + 'static,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds an HTTP endpoint at `/blend/info` that returns the following:
* If the node is a core node, a list of `(peer ID, is_healthy flag)` for each peer with which a connection is negotiated. If we are within the session transition period, also a list of IDs for those peers still connected from the old session.
* If the core is an edge node or if Blend is disabled (minimum network size is higher than the current number of core nodes), the endpoint returns `null`, to distinguish from the case where a core node has no peers at all.

Given the current Blend structure, it was extremely hard to come up with a design that was somehow acceptable. Once we finalize the spec to remove sessions, I will take the chance to do a big refactoring of the Blend codebase to have a single service and an internal state machine, which will make this logic also easier to implement. For the time being, also because I do not want to mess around too much with code that seems to work quite well now, I will let it be as it is.

So, this PR introduces a very basic HTTP endpoint to query the state of a running node.

## 2. Does the code have enough context to be clearly understood?

It was hard to implement a somewhat easy-to-read solution, but I tried my best given the Blend huge size and large amount of connected pieces.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.