### PR TITLE
fix(mempool): delay transaction deletion

### DIFF
--- a/services/tx-service/src/backend/pool.rs
+++ b/services/tx-service/src/backend/pool.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fmt::Debug,
     hash::Hash,
     pin::Pin,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
@@ -17,17 +17,21 @@ use crate::{
     storage::MempoolStorageAdapter,
 };
 
+const REMOVED_ITEM_GRACE_PERIOD: Duration = Duration::from_mins(10);
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PoolRecoveryState<Key>
 where
     Key: Hash + Eq + Ord,
 {
     pub pending_items: BTreeSet<Key>,
+    pub removed_items: BTreeMap<Key, u64>,
     pub last_item_timestamp: u64,
 }
 
 pub struct Mempool<BlockId, Item, Key, Storage, RuntimeServiceId> {
     pending_items: BTreeSet<Key>,
+    removed_items: BTreeMap<Key, u64>,
     last_item_timestamp: u64,
     storage_adapter: Storage,
     _phantom: std::marker::PhantomData<(BlockId, Item, RuntimeServiceId)>,
@@ -43,6 +47,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Mempool")
             .field("pending_items", &self.pending_items)
+            .field("removed_items", &self.removed_items)
             .field("last_item_timestamp", &self.last_item_timestamp)
             .field("storage_adapter", &"<StorageAdapter>")
             .finish()
@@ -70,6 +75,7 @@ where
     fn new(_settings: Self::Settings, storage: Self::Storage) -> Self {
         Self {
             pending_items: BTreeSet::new(),
+            removed_items: BTreeMap::new(),
             last_item_timestamp: 0,
             storage_adapter: storage,
             _phantom: std::marker::PhantomData,
@@ -81,14 +87,13 @@ where
         key: Self::Key,
         item: I,
     ) -> Result<(), MempoolError> {
+        self.prune_removed_items().await;
+
         if self.pending_items.contains(&key) {
             return Err(MempoolError::ExistingItem);
         }
 
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        let timestamp = current_timestamp_millis();
 
         if let Err(e) = self
             .storage_adapter
@@ -98,6 +103,7 @@ where
             tracing::warn!("Failed to store item in storage: {:?}", e);
         }
 
+        self.removed_items.remove(&key);
         self.pending_items.insert(key);
         self.last_item_timestamp = timestamp;
 
@@ -130,17 +136,18 @@ where
     }
 
     async fn remove(&mut self, keys: &[Self::Key]) {
+        self.prune_removed_items().await;
+
         let removed_count = keys.len();
+        let removed_at = current_timestamp_millis();
+
         for key in keys {
             self.pending_items.remove(key);
+            self.removed_items.insert(key.clone(), removed_at);
         }
 
         metrics::mempool_transactions_removed(removed_count);
         metrics::mempool_transactions_pending(self.pending_items.len());
-
-        if let Err(e) = self.storage_adapter.remove_items(keys).await {
-            tracing::warn!("Failed to remove items from storage: {e:?}");
-        }
     }
 
     fn pending_item_count(&self) -> usize {
@@ -181,6 +188,7 @@ where
     fn save(&self) -> Self::RecoveryState {
         PoolRecoveryState {
             pending_items: self.pending_items.clone(),
+            removed_items: self.removed_items.clone(),
             last_item_timestamp: self.last_item_timestamp,
         }
     }
@@ -192,9 +200,54 @@ where
     ) -> Self {
         Self {
             pending_items: state.pending_items,
+            removed_items: state.removed_items,
             last_item_timestamp: state.last_item_timestamp,
             storage_adapter: storage,
             _phantom: std::marker::PhantomData,
         }
     }
+}
+
+impl<BlockId, Item, Key, Storage, RuntimeServiceId>
+    Mempool<BlockId, Item, Key, Storage, RuntimeServiceId>
+where
+    Key: Hash + Eq + Ord + Clone + Send + Sync + 'static,
+    Item: Clone + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de>,
+    BlockId: Hash + Eq + Copy + Send + Sync + 'static + Serialize + for<'de> Deserialize<'de>,
+    Storage:
+        MempoolStorageAdapter<RuntimeServiceId, Key = Key, Item = Item> + Send + Sync + 'static,
+    Storage::Error: Debug,
+    RuntimeServiceId: Send + Sync,
+{
+    async fn prune_removed_items(&mut self) {
+        let now = current_timestamp_millis();
+        let grace_period_millis = REMOVED_ITEM_GRACE_PERIOD.as_millis() as u64;
+
+        let expired_keys = self
+            .removed_items
+            .iter()
+            .filter(|(_, removed_at)| now.saturating_sub(**removed_at) >= grace_period_millis)
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+
+        if expired_keys.is_empty() {
+            return;
+        }
+
+        if let Err(e) = self.storage_adapter.remove_items(&expired_keys).await {
+            tracing::warn!("Failed to prune removed items from storage: {e:?}");
+            return;
+        }
+
+        for key in expired_keys {
+            self.removed_items.remove(&key);
+        }
+    }
+}
+
+fn current_timestamp_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
 }

--- a/services/tx-service/tests/mock.rs
+++ b/services/tx-service/tests/mock.rs
@@ -1,10 +1,13 @@
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
+    convert::Infallible,
     path::{Path, PathBuf},
-    sync::Arc,
+    pin::Pin,
+    sync::{Arc, Mutex, atomic::AtomicBool},
 };
 
-use futures::StreamExt as _;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt as _, stream};
 use lb_core::{
     codec::{DeserializeOp as _, SerializeOp as _},
     header::HeaderId,
@@ -28,12 +31,15 @@ use lb_tracing_service::{Tracing, TracingSettings};
 use lb_utils::noop_service::NoService;
 use logos_blockchain_tx_service::{
     MempoolMsg, TxMempoolSettings,
-    backend::{Mempool, PoolRecoveryState},
+    backend::{MemPool as _, Mempool, PoolRecoveryState, RecoverableMempool as _, Status},
     network::adapters::mock::{MOCK_TX_CONTENT_TOPIC, MockAdapter},
-    storage::adapters::rocksdb::RocksStorageAdapter,
+    storage::{MempoolStorageAdapter, adapters::rocksdb::RocksStorageAdapter},
     tx::{service::GenericTxMempoolService, state::TxMempoolState},
 };
-use overwatch::overwatch::OverwatchRunner;
+use overwatch::{
+    overwatch::OverwatchRunner,
+    services::{ServiceData, relay::OutboundRelay},
+};
 use overwatch_derive::*;
 use rand::distributions::{Alphanumeric, DistString as _};
 use tempfile::TempDir;
@@ -73,10 +79,76 @@ fn get_test_random_path() -> PathBuf {
     PathBuf::from(Alphanumeric.sample_string(&mut rand::thread_rng(), 5)).with_extension(".json")
 }
 
+fn sample_removed_tx() -> MockTransaction<MockMessage> {
+    MockTransaction::new(MockMessage {
+        payload: "removed-but-fetchable".to_owned(),
+        content_topic: MOCK_TX_CONTENT_TOPIC,
+        version: 0,
+        timestamp: 0,
+    })
+}
+
+#[derive(Clone, Default)]
+struct InMemoryStorageAdapter {
+    items: Arc<Mutex<BTreeMap<MockTxId, MockTransaction<MockMessage>>>>,
+}
+
+#[async_trait]
+impl MempoolStorageAdapter<RuntimeServiceId> for InMemoryStorageAdapter {
+    type Backend = RocksBackend;
+    type Item = MockTransaction<MockMessage>;
+    type Key = MockTxId;
+    type Error = Infallible;
+
+    fn new(
+        _storage_relay: OutboundRelay<
+            <StorageService<Self::Backend, RuntimeServiceId> as ServiceData>::Message,
+        >,
+    ) -> Self {
+        Self::default()
+    }
+
+    async fn store_item(&mut self, key: Self::Key, item: Self::Item) -> Result<(), Self::Error> {
+        self.items
+            .lock()
+            .expect("in-memory storage adapter lock should not be poisoned")
+            .insert(key, item);
+        Ok(())
+    }
+
+    async fn get_items(
+        &self,
+        keys: &BTreeSet<Self::Key>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Self::Item> + Send>>, Self::Error> {
+        let items = {
+            let storage = self
+                .items
+                .lock()
+                .expect("in-memory storage adapter lock should not be poisoned");
+            keys.iter()
+                .filter_map(|key| storage.get(key).cloned())
+                .collect::<Vec<_>>()
+        };
+
+        Ok(Box::pin(stream::iter(items)))
+    }
+
+    async fn remove_items(&mut self, keys: &[Self::Key]) -> Result<(), Self::Error> {
+        for key in keys {
+            self.items
+                .lock()
+                .expect("in-memory storage adapter lock should not be poisoned")
+                .remove(key);
+        }
+        Ok(())
+    }
+}
+
 #[test]
 fn test_mock_pool_recovery_state() {
     let recovery_state = PoolRecoveryState::<MockTxId> {
         pending_items: BTreeSet::new(),
+        removed_items: BTreeMap::new(),
         last_item_timestamp: 1_234_567_890,
     };
 
@@ -86,10 +158,106 @@ fn test_mock_pool_recovery_state() {
         PoolRecoveryState::from_bytes(&serialized).expect("Should deserialize");
 
     assert_eq!(deserialized.pending_items, recovery_state.pending_items);
+    assert_eq!(deserialized.removed_items, recovery_state.removed_items);
     assert_eq!(
         deserialized.last_item_timestamp,
         recovery_state.last_item_timestamp
     );
+}
+
+#[tokio::test]
+async fn removed_items_are_not_pending_but_still_fetchable() {
+    let storage = InMemoryStorageAdapter::default();
+    let mut pool = Mempool::<
+        HeaderId,
+        MockTransaction<MockMessage>,
+        MockTxId,
+        InMemoryStorageAdapter,
+        RuntimeServiceId,
+    >::new((), storage.clone());
+
+    let tx = sample_removed_tx();
+    let tx_id = tx.id();
+
+    pool.add_item(tx_id, tx.clone())
+        .await
+        .expect("tx should be added");
+
+    assert_eq!(pool.pending_item_count(), 1);
+    assert_eq!(pool.status(&[tx_id]), vec![Status::Pending]);
+
+    let pending_before_remove = pool
+        .view([0; 32].into())
+        .await
+        .expect("pending view should load")
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(pending_before_remove, vec![tx.clone()]);
+
+    pool.remove(&[tx_id]).await;
+
+    assert_eq!(pool.pending_item_count(), 0);
+    assert_eq!(pool.status(&[tx_id]), vec![Status::Unknown]);
+
+    let pending_after_remove = pool
+        .view([0; 32].into())
+        .await
+        .expect("pending view should still work")
+        .collect::<Vec<_>>()
+        .await;
+    assert!(pending_after_remove.is_empty());
+
+    let fetched_after_remove = pool
+        .get_items_by_keys([tx_id])
+        .await
+        .expect("removed tx should still be fetchable")
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(fetched_after_remove, vec![tx.clone()]);
+}
+
+#[tokio::test]
+async fn removed_items_remain_fetchable_after_recovery() {
+    let storage = InMemoryStorageAdapter::default();
+    let mut pool = Mempool::<
+        HeaderId,
+        MockTransaction<MockMessage>,
+        MockTxId,
+        InMemoryStorageAdapter,
+        RuntimeServiceId,
+    >::new((), storage.clone());
+
+    let tx = sample_removed_tx();
+    let tx_id = tx.id();
+
+    pool.add_item(tx_id, tx.clone())
+        .await
+        .expect("tx should be added");
+    pool.remove(&[tx_id]).await;
+
+    let saved_state = pool.save();
+    assert!(saved_state.pending_items.is_empty());
+    assert!(saved_state.removed_items.contains_key(&tx_id));
+
+    let recovered_pool = Mempool::<
+        HeaderId,
+        MockTransaction<MockMessage>,
+        MockTxId,
+        InMemoryStorageAdapter,
+        RuntimeServiceId,
+    >::recover((), saved_state, storage);
+
+    assert_eq!(recovered_pool.pending_item_count(), 0);
+    assert_eq!(recovered_pool.status(&[tx_id]), vec![Status::Unknown]);
+
+    let fetched_after_recovery = recovered_pool
+        .get_items_by_keys([tx_id])
+        .await
+        .expect("removed tx should still be fetchable after recovery")
+        .collect::<Vec<_>>()
+        .await;
+    assert_eq!(fetched_after_recovery, vec![tx]);
 }
 
 #[test]
@@ -97,7 +265,7 @@ fn test_mock_pool_recovery_state() {
 fn test_mock_mempool() {
     let recovery_file_path = get_test_random_path();
     run_with_recovery_teardown(&recovery_file_path, || {
-        let exist = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let exist = Arc::new(AtomicBool::new(false));
         let exist2 = Arc::clone(&exist);
 
         let predefined_messages = vec![


### PR DESCRIPTION
## 1. What does this PR implement?

Fix proposal reconstruction for competing blocks that reference the same transaction hash.

We were removing transaction bodies from mempool storage too early. That meant one competing block could consume the body, and another proposal referring to the same hash could no longer be reconstructed.

This PR keeps those transactions out of the pending mempool while retaining their bodies in storage briefly for reconstruction.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
