### PR TITLE
chore(release): update release templates to allow for release candidates

### DIFF
--- a/.env.playground
+++ b/.env.playground
@@ -1,6 +1,7 @@
 # Environment variables for compose.yml file config.
 DOCKER_COMPOSE_LIBP2P_REPLICAS=3
-IMAGE_LABEL=playground
+IMAGE_LABEL=devnet
+ENV_TITLE_STRING=playground
 PUBLIC_IP_ADDR=65.108.203.235
 
 # NODE 0

--- a/.env.testnet
+++ b/.env.testnet
@@ -1,6 +1,7 @@
 # Environment variables for compose.yml file config.
 DOCKER_COMPOSE_LIBP2P_REPLICAS=3
 IMAGE_LABEL=testnet
+ENV_TITLE_STRING=testnet
 PUBLIC_IP_ADDR=65.109.51.37
 
 # NODE 0

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,8 +9,10 @@ labels: release
 
 **READ THIS BEFORE STARTING WITH THE RELEASE**
 
-* If any changes other than release-specific ones are needed, e.g. a bugfix or some ceremony-related fix that is useful also for future releases, they should be merged with a PR against `master` and not pushed to the release branch. Then, a new release process must start by forking off from `master` using the same branch name as before (by force-pushing the branch to point to the new fork of `master`).
-* If the release candidate process needs to start over again for any reason, restart from the checklist point that makes most sense, by documenting why we needed a new release candidate.
+* If any changes other than release-specific ones are needed, e.g. a bugfix or some ceremony-related fix that is useful also for future releases, they should be merged with a PR against `master` and not pushed to the release branch. Then, there are two possible strategies:
+    * the release continues with a new release candidate, in which case the fix is cherry-picked from `master` into the release branch
+    * the release is aborted if favor of a new version forked from `master`: in this case the release branch is merged into master to update any devnet-related changes, before starting the process for the new release with the next logical release version
+* If the release candidate process needs to start over again for any reason without starting a whole new release, restart from the checklist point that makes most sense, by documenting why we needed a new release candidate.
 * Progress on the checklist must be provided as comments to the issue.
 
 ---
@@ -62,7 +64,25 @@ labels: release
 
 ## Release publication
 
+- [ ] Bump the Cargo workspace version to match the new release version `X.Y.Z`
+- [ ] Bump the version value for the C bindings (`logos-blockchain-c`) in the root `flake.nix` file to match the new release version `X.Y.Z`
+- [ ] Verify the HEAD of the release branch has green CI ✅
+- [ ] Tag the commit with `X.Y.Z` and push the tag
+- [ ] Manually trigger the [bundling workflow][release-bundling-workflow] from the `X.Y.Z` tag on GitHub
+- [ ] Post the link to the workflow run to this issue for easier review
+- [ ] Wait for the bundling workflow to complete and generate a draft GitHub pre-release. While the release is in progress, follow the steps in the [Testnet deployment][testnet-deployment-section] section below.
+- [ ] Address checklist of the generated GitHub release
+- [ ] Publish release
+- [ ] Post the link to the published release to this issue for easier review
+
 ## Testnet deployment
+
+- [ ] Checkout `testnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml`
+- [ ] Commit and push the changes to trigger environment re-deployment. Environment is now live.
+- [ ] Wait around 1 minute for deployment to be updated
+- [ ] If needed, at any time you can download fleet nodes' configs and logs from [https://testnet.blockchain.logos.co/internal/node-data/](https://testnet.blockchain.logos.co/internal/node-data/)
+- [ ] Go back to the [GitHub Release][github-release-section] section and finalize the release
+- [ ] Merge the release branch into `master`. Make sure the diff between the two (minus any commits that landed on `master` in the meanwhile) show only release-relevant changes. I.e., make sure no unrelated changes, e.g., bug-fixes have landed on the release branch instead of landing on `master`.
 
 ## Post-Release
 
@@ -74,4 +94,5 @@ labels: release
 [build-logos-tools-docker-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/build-logos-tools.yml 
 [release-bundling-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/prepare-release.yml
 [devnet-deployment-section]: #devnet-deployment
+[testnet-deployment-section]: #testnet-deployment
 [github-release-section]: #github-release

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -5,40 +5,45 @@ title: Release Checklist for X.Y.Z
 labels: release
 ---
 
-Progress on the checklist must be provided as comments to the issue.
+# IMPORTANT
+
+**READ THIS BEFORE STARTING WITH THE RELEASE**
+
+* If any changes other than release-specific ones are needed, e.g. a bugfix or some ceremony-related fix that is useful also for future releases, they should be merged with a PR against `master` and not pushed to the release branch. Then, a new release process must start by forking off from `master` using the same branch name as before (by force-pushing the branch to point to the new fork of `master`).
+* If the release candidate process needs to start over again for any reason, restart from the checklist point that makes most sense, by documenting why we needed a new release candidate.
+* Progress on the checklist must be provided as comments to the issue.
 
 ---
 
-## Ceremony (optional, only whenever a ceremony is required)
+## Branch Setup 
 
-- [ ] <span style="color:red">**!! IMPORTANT: Make sure that *ALL* the deployment settings are committed to `master` before starting the ceremony. The only value that is *expected* to be out-of-sync is the cryptarchia genesis state, which will be a result of running the ceremony**</span>.
-- [ ] Checkout `master` and tag commit with `pre-X.Y.Z` and push the tag
-- [ ] Manually trigger the [testnet Docker workflow][testnet-docker-workflow] using the `pre-X.Y.Z` tag and using the `testnet` image tag.
+- [ ] Branch out from the latest `master` commit with a branch `release/0.1.3`
+- [ ] Apply and push any changes to the devnet deployment settings. If a ceremony will be run, stuff like genesis block can be ignored since it will be overridden as the outcome of the ceremony
+
+## Devnet ceremony (optional, only whenever a devnet ceremony is required)
+
+- [ ] Manually trigger the [ceremony tools Docker build workflow][build-logos-tools-docker-workflow] from the `HEAD` of the release branch (with the latest changes) specifying the `devnet` image tag.
 - [ ] Post the link to the workflow run to this issue for easier review
 - [ ] Wait for the workflow run to complete
-- [ ] Verify the right image with the right tag was pushed to the [GitHub container registry][devnet-image-container-registry]
-- [ ] Checkout and force reset the `testnet` branch to point to the tagged commit
+- [ ] Verify the right image with the right tag was pushed to the [GitHub container registry][logos-tools-image-container-registry]
+- [ ] Checkout and hard reset the `devnet` branch to point to the latest commit on the current release branch
 - [ ] Create a new symlink `compose.static.yml` -> `compose.setup.yml`
-- [ ] Add a file called `entropy` in the `testnet` folder with any content. Using the same entropy content as a previous deployment will result in the same faucet keys. We recommend using the release version as the tag corresponding to the release commit (i.e., `X.Y.Z`)
-- [ ] Push to `testnet` branch to trigger a new deployment
-- [ ] Wait around 1 minute for deployment to be updated with the new changes and for the ceremony to happen. Until ready, you should see a `502` error while the containers restart.
-- [ ] Download the new deployment configuration from [https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings](https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings)
+- [ ] Add a file called `entropy` in the `testnet` folder with any content. Using the same entropy content as a previous deployment will result in the same faucet keys. We recommend using the current release candidate version (i.e., `X.Y.Z-rc.N`)
+- [ ] Push to `devnet` branch to trigger a new deployment
+- [ ] Wait around 1 minute for deployment to be updated with the new changes and for the ceremony to happen. Until ready, you should see a `502` error while the containers restart when visiting [https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings](https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings
+- [ ] Download the new deployment configuration from the link above
 - [ ] Verify that the `time.chain_start_time` value in the deployment file indicates the right start time, which should be within the last few minutes
 - [ ] Copy-paste or attach the content of the deployment file to this issue for easier review
-
-## Deployment Settings Update
-
-- [ ] Checkout `master` and push a new commit on top of `pre-X.Y.Z` with the following changes:
-    - [ ] the updated devnet deployment settings
-    - [ ] the bumped up Cargo workspace version matching the new release
-    - [ ] the bumped up version for the C bindings in the root `flake.nix` file
+- [ ] Override the existing devnet deployment settings with the generated ones on the release branch
 - [ ] Verify `git` shows a diff for the deployment file, otherwise it means something went wrong when downloading the new one from the deployment settings endpoint
-- [ ] Verify the HEAD of `master` has green CI ✅
-- [ ] Tag the commit with `X.Y.Z` and push the tag
 
-## GitHub Release
+## Release candidate publication
 
-- [ ] Manually trigger the [bundling workflow][bundling-workflow] from the `X.Y.Z` tag on GitHub
+- [ ] Bump the Cargo workspace version to match the new release version `X.Y.Z-rc.N`
+- [ ] Bump the version value for the C bindings (`logos-blockchain-c`) in the root `flake.nix` file to match the new release version `X.Y.Z-rc.N`
+- [ ] Verify the HEAD of the release branch has green CI ✅
+- [ ] Tag the commit with `X.Y.Z-rc.N` and push the tag
+- [ ] Manually trigger the [bundling workflow][release-bundling-workflow] from the `X.Y.Z-rc.N` tag on GitHub
 - [ ] Post the link to the workflow run to this issue for easier review
 - [ ] Wait for the bundling workflow to complete and generate a draft GitHub pre-release. While the release is in progress, follow the steps in the [Devnet deployment][devnet-deployment-section] section below.
 - [ ] Address checklist of the generated GitHub release
@@ -47,11 +52,17 @@ Progress on the checklist must be provided as comments to the issue.
 
 ## Devnet deployment
 
-- [ ] Checkout `testnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml`
+- [ ] Checkout `devnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml`
 - [ ] Commit and push the changes to trigger environment re-deployment. Environment is now live.
 - [ ] Wait around 1 minute for deployment to be updated
 - [ ] If needed, at any time you can download fleet nodes' configs and logs from [https://devnet.blockchain.logos.co/internal/node-data/](https://devnet.blockchain.logos.co/internal/node-data/)
-- [ ] Go back to the [GitHub Release][github-release-section] section and finalize the release
+- [ ] Go back to the [GitHub Release][github-release-section] section and finalize the release candidate
+
+## Testnet ceremony (optional, only whenever a testnet ceremony is required)
+
+## Release publication
+
+## Testnet deployment
 
 ## Post-Release
 
@@ -59,10 +70,8 @@ Progress on the checklist must be provided as comments to the issue.
 
 ---
 
-[devnet-image-container-registry]: https://github.com/logos-blockchain/logos-blockchain/pkgs/container/logos-blockchain
-[testnet-docker-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/publish-testnet-image.yml 
-[bundling-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/prepare-release.yml
-[docker-build-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/publish-node-image.yml
+[logos-tools-image-container-registry]: https://github.com/logos-blockchain/logos-blockchain/pkgs/container/logos-blockchain
+[build-logos-tools-docker-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/build-logos-tools.yml 
+[release-bundling-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/prepare-release.yml
 [devnet-deployment-section]: #devnet-deployment
 [github-release-section]: #github-release
-[devnet-release-notion-page-installation]: https://www.notion.so/nomos-tech/Internal-Devnet-Launch-February-2026-2fe261aa09df8025ad94e380933b4cf9?source=copy_link#2ff261aa09df8044b27dcaaf222baacc

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -18,7 +18,7 @@ labels: release
 
 # Branch Setup (done once per full release cycle - skipped for new release candidates)
 
-- [ ] Branch out from the latest `master` commit with a branch `release/0.1.3`
+- [ ] Branch out from the latest `master` commit with a release branch, e.g., `release/0.1.3`
 - [ ] Apply and push any changes to the devnet deployment settings. If a ceremony will be run, stuff like genesis block can be ignored since it will be overridden as the outcome of the ceremony
 
 # Devnet (release candidates)
@@ -31,7 +31,6 @@ labels: release
 - [ ] Verify the right image with the right tag was pushed to the [GitHub container registry][logos-tools-image-container-registry]
 - [ ] Checkout and hard reset the `devnet` branch to point to the latest commit on the current release branch
 - [ ] Create a new symlink `compose.static.yml` -> `compose.setup.yml` with `ln -s -f compose.setup.yml compose.static.yml`
-- [ ] Add a file called `entropy` in the `testnet` folder with any content. Using the same entropy content as a previous deployment will result in the same faucet keys. We recommend using the current release candidate version (i.e., `X.Y.Z-rc.N`)
 - [ ] Push to `devnet` branch to trigger a new deployment
 - [ ] Wait around 1 minute for deployment to be updated with the new changes and for the ceremony to happen. Until ready, you should see a `502` error while the containers restart when visiting [https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings](https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings
 - [ ] Download the new deployment configuration from the link above
@@ -71,7 +70,6 @@ labels: release
 - [ ] Verify the right image with the right tag was pushed to the [GitHub container registry][logos-tools-image-container-registry]
 - [ ] Checkout and hard reset the `testnet` branch to point to the latest commit on the current release branch
 - [ ] Create a new symlink `compose.static.yml` -> `compose.setup.yml` with `ln -s -f compose.setup.yml compose.static.yml`
-- [ ] Add a file called `entropy` in the `testnet` folder with any content. Using the same entropy content as a previous deployment will result in the same faucet keys. We recommend using the current release version (i.e., `X.Y.Z`)
 - [ ] Push to `testnet` branch to trigger a new deployment
 - [ ] Wait around 1 minute for deployment to be updated with the new changes and for the ceremony to happen. Until ready, you should see a `502` error while the containers restart when visiting [https://testnet.blockchain.logos.co/web/cfgsync/deployment-settings](https://testnet.blockchain.logos.co/web/cfgsync/deployment-settings
 - [ ] Download the new deployment configuration from the link above

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -11,16 +11,17 @@ labels: release
 
 * If any changes other than release-specific ones are needed, e.g. a bugfix or some ceremony-related fix that is useful also for future releases, they should be merged with a PR against `master` and not pushed to the release branch. Then, there are two possible strategies:
     * the release continues with a new release candidate, in which case the fix is cherry-picked from `master` into the release branch
-    * the release is aborted if favor of a new version forked from `master`: in this case the release branch is merged into master to update any devnet-related changes, before starting the process for the new release with the next logical release version
-* If the release candidate process needs to start over again for any reason without starting a whole new release, restart from the checklist point that makes most sense, by documenting why we needed a new release candidate.
+    * the release is aborted in favor of a new version forked from `master`: in this case the release branch is merged into master to update any devnet-related changes, before starting the process for the new release with the next release version `X.Y.(Z+1)`
 * Progress on the checklist must be provided as comments to the issue.
 
 ---
 
-## Branch Setup 
+# Branch Setup (done once per full release cycle - skipped for new release candidates)
 
 - [ ] Branch out from the latest `master` commit with a branch `release/0.1.3`
 - [ ] Apply and push any changes to the devnet deployment settings. If a ceremony will be run, stuff like genesis block can be ignored since it will be overridden as the outcome of the ceremony
+
+# Devnet (release candidates)
 
 ## Devnet ceremony (optional, only whenever a devnet ceremony is required)
 
@@ -29,7 +30,7 @@ labels: release
 - [ ] Wait for the workflow run to complete
 - [ ] Verify the right image with the right tag was pushed to the [GitHub container registry][logos-tools-image-container-registry]
 - [ ] Checkout and hard reset the `devnet` branch to point to the latest commit on the current release branch
-- [ ] Create a new symlink `compose.static.yml` -> `compose.setup.yml`
+- [ ] Create a new symlink `compose.static.yml` -> `compose.setup.yml` with `ln -s -f compose.setup.yml compose.static.yml`
 - [ ] Add a file called `entropy` in the `testnet` folder with any content. Using the same entropy content as a previous deployment will result in the same faucet keys. We recommend using the current release candidate version (i.e., `X.Y.Z-rc.N`)
 - [ ] Push to `devnet` branch to trigger a new deployment
 - [ ] Wait around 1 minute for deployment to be updated with the new changes and for the ceremony to happen. Until ready, you should see a `502` error while the containers restart when visiting [https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings](https://devnet.blockchain.logos.co/web/cfgsync/deployment-settings
@@ -54,13 +55,30 @@ labels: release
 
 ## Devnet deployment
 
-- [ ] Checkout `devnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml`
+- [ ] Checkout `devnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml` with `ln -s -f compose.run.yml compose.static.yml`
 - [ ] Commit and push the changes to trigger environment re-deployment. Environment is now live.
 - [ ] Wait around 1 minute for deployment to be updated
 - [ ] If needed, at any time you can download fleet nodes' configs and logs from [https://devnet.blockchain.logos.co/internal/node-data/](https://devnet.blockchain.logos.co/internal/node-data/)
-- [ ] Go back to the [GitHub Release][github-release-section] section and finalize the release candidate
+- [ ] Go back to the [GitHub Release][github-release-candidate-section] section and finalize the release candidate
+
+# Testnet (releases)
 
 ## Testnet ceremony (optional, only whenever a testnet ceremony is required)
+
+- [ ] Manually trigger the [ceremony tools Docker build workflow][build-logos-tools-docker-workflow] from the `HEAD` of the release branch (with the latest changes) specifying the `testnet` image tag.
+- [ ] Post the link to the workflow run to this issue for easier review
+- [ ] Wait for the workflow run to complete
+- [ ] Verify the right image with the right tag was pushed to the [GitHub container registry][logos-tools-image-container-registry]
+- [ ] Checkout and hard reset the `testnet` branch to point to the latest commit on the current release branch
+- [ ] Create a new symlink `compose.static.yml` -> `compose.setup.yml` with `ln -s -f compose.setup.yml compose.static.yml`
+- [ ] Add a file called `entropy` in the `testnet` folder with any content. Using the same entropy content as a previous deployment will result in the same faucet keys. We recommend using the current release version (i.e., `X.Y.Z`)
+- [ ] Push to `testnet` branch to trigger a new deployment
+- [ ] Wait around 1 minute for deployment to be updated with the new changes and for the ceremony to happen. Until ready, you should see a `502` error while the containers restart when visiting [https://testnet.blockchain.logos.co/web/cfgsync/deployment-settings](https://testnet.blockchain.logos.co/web/cfgsync/deployment-settings
+- [ ] Download the new deployment configuration from the link above
+- [ ] Verify that the `time.chain_start_time` value in the deployment file indicates the right start time, which should be within the last few minutes
+- [ ] Copy-paste or attach the content of the deployment file to this issue for easier review
+- [ ] Override the existing testnet deployment settings with the generated ones on the release branch
+- [ ] Verify `git` shows a diff for the deployment file, otherwise it means something went wrong when downloading the new one from the deployment settings endpoint
 
 ## Release publication
 
@@ -70,21 +88,21 @@ labels: release
 - [ ] Tag the commit with `X.Y.Z` and push the tag
 - [ ] Manually trigger the [bundling workflow][release-bundling-workflow] from the `X.Y.Z` tag on GitHub
 - [ ] Post the link to the workflow run to this issue for easier review
-- [ ] Wait for the bundling workflow to complete and generate a draft GitHub pre-release. While the release is in progress, follow the steps in the [Testnet deployment][testnet-deployment-section] section below.
+- [ ] Wait for the bundling workflow to complete and generate a draft GitHub release. While the release is in progress, follow the steps in the [Testnet deployment][testnet-deployment-section] section below.
 - [ ] Address checklist of the generated GitHub release
 - [ ] Publish release
 - [ ] Post the link to the published release to this issue for easier review
 
 ## Testnet deployment
 
-- [ ] Checkout `testnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml`
+- [ ] Checkout `testnet` branch again and change the `compose.static.yml` symlink to now point to `compose.run.yml` with `ln -s -f compose.run.yml compose.static.yml`
 - [ ] Commit and push the changes to trigger environment re-deployment. Environment is now live.
 - [ ] Wait around 1 minute for deployment to be updated
 - [ ] If needed, at any time you can download fleet nodes' configs and logs from [https://testnet.blockchain.logos.co/internal/node-data/](https://testnet.blockchain.logos.co/internal/node-data/)
 - [ ] Go back to the [GitHub Release][github-release-section] section and finalize the release
 - [ ] Merge the release branch into `master`. Make sure the diff between the two (minus any commits that landed on `master` in the meanwhile) show only release-relevant changes. I.e., make sure no unrelated changes, e.g., bug-fixes have landed on the release branch instead of landing on `master`.
 
-## Post-Release
+# Post-Release
 
 - [ ] Update the release checklist template (this file) or the GitHub release template with anything that was missing or that was fixed during the release process
 
@@ -95,4 +113,5 @@ labels: release
 [release-bundling-workflow]: https://github.com/logos-blockchain/logos-blockchain/actions/workflows/prepare-release.yml
 [devnet-deployment-section]: #devnet-deployment
 [testnet-deployment-section]: #testnet-deployment
-[github-release-section]: #github-release
+[github-release-candidate-section]: #release-candidate-publication
+[github-release-section]: #release-publication

--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -23,10 +23,10 @@ Generate a default configuration by connecting to the bootstrap peers.
 
 ```bash
 ./logos-blockchain-node init \
-    -p /ip4/65.109.51.37/udp/3000/quic-v1/p2p/{TODO} \
-    -p /ip4/65.109.51.37/udp/3001/quic-v1/p2p/{TODO} \
-    -p /ip4/65.109.51.37/udp/3002/quic-v1/p2p/{TODO} \
-    -p /ip4/65.109.51.37/udp/3003/quic-v1/p2p/{TODO}
+    -p /ip4/65.108.203.235/udp/3000/quic-v1/p2p/{TODO} \
+    -p /ip4/65.108.203.235/udp/3001/quic-v1/p2p/{TODO} \
+    -p /ip4/65.108.203.235/udp/3002/quic-v1/p2p/{TODO} \
+    -p /ip4/65.108.203.235/udp/3003/quic-v1/p2p/{TODO}
 ```
 
 #### Testnet peers

--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -138,7 +138,9 @@ Having issues? Reach out to the Logos Blockchain team on [Discord][testnet-disco
     * If this is an actual release, then the previous tag is the latest release. E.g., `0.1.3` compares against `0.1.2`
 - [ ] Verify binaries are present for **Mac** and **Linux**
 - [ ] Verify circuits of the expected version are present for **Mac** and **Linux**
-- [ ] Replace `{TODO}` peer IDs by visiting the [testnet dashboard][testnet-dashboard] and copying each node's address + peer ID from their network info
+- [ ] Replace `{TODO}` peer IDs for both devnet and testnet depending on the release type.
+    * For a release candidate (for devnet), copy-paste the new addresses from the [devnet dashboard][devnet-dashboard] and the existing testnet addresses from the [testnet dashboard][testnet-dashboard]
+    * For a release (for testnet), copy-paste the addresses of the latest deployed devnet by taking them from the [devnet dashboard][devnet-dashboard] and the new testnet addresses from the [testnet dashboard][testnet-dashboard]
 - [ ] Set the release type: mark the release as **pre-release** if a devnet release (i.e. release candidate) while set the release as **latest** if a testnet release (i.e. regular release)
 - [ ] Delete this checklist and publish
 

--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -138,10 +138,10 @@ Having issues? Reach out to the Logos Blockchain team on [Discord][testnet-disco
     * If this is an actual release, then the previous tag is the latest release. E.g., `0.1.3` compares against `0.1.2`
 - [ ] Verify binaries are present for **Mac** and **Linux**
 - [ ] Verify circuits of the expected version are present for **Mac** and **Linux**
-- [ ] Replace `{TODO}` peer IDs for both devnet and testnet depending on the release type.
-    * For a release candidate (for devnet), copy-paste the new addresses from the [devnet dashboard][devnet-dashboard] and the existing testnet addresses from the [testnet dashboard][testnet-dashboard]
-    * For a release (for testnet), copy-paste the addresses of the latest deployed devnet by taking them from the [devnet dashboard][devnet-dashboard] and the new testnet addresses from the [testnet dashboard][testnet-dashboard]
-- [ ] Set the release type: mark the release as **pre-release** if a devnet release (i.e. release candidate) while set the release as **latest** if a testnet release (i.e. regular release)
+- [ ] Replace `{TODO}` peer IDs for both devnet and testnet:
+    * For a release candidate (for devnet), copy-paste the new devnet addresses from the [devnet dashboard][devnet-dashboard] and the existing testnet addresses from the [testnet dashboard][testnet-dashboard]
+    * For a release (for testnet), copy-paste the addresses of the latest deployed devnet from the [devnet dashboard][devnet-dashboard] and the new testnet addresses from the [testnet dashboard][testnet-dashboard]
+- [ ] Set the release type: mark the release as **pre-release** if a devnet release (i.e. release candidate), or set the release as **latest** if a testnet release (i.e. regular release)
 - [ ] Delete this checklist and publish
 
 [release-notion]: https://www.notion.so/nomos-tech/Internal-Devnet-Launch-February-2026-2fe261aa09df8025ad94e380933b4cf9#2ff261aa09df8058935ecb85aa587564

--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -132,9 +132,9 @@ Having issues? Reach out to the Logos Blockchain team on [Discord][testnet-disco
 > **Internal — remove this section before publishing.**
 
 - [ ] Generate the changelog (GitHub feature) using the tag of the previous release.
-    * If this is the first release candidate, then the previous tag is the version of the latest release. E.g. `0.1.3-rc.1` compares against `0.1.2`
-    * If this is a release candidate but not the first one that has a GH release, then the previous tag is the version of previous release candidate for this release. E.g., `0.1.3-rc.2` compares against `0.1.3-rc.1`
-    * If this is an actual release, then the previous tag is the latest release. E.g., `0.1.3` compares against `0.1.2`
+    * If this is the first release candidate, then the previous tag is the version of the latest release, e.g. `0.1.3-rc.1` compares against `0.1.2`
+    * If this is a release candidate but not the first one that has a GH release, then the previous tag is the version of previous release candidate for this release, e.g., `0.1.3-rc.2` compares against `0.1.3-rc.1`
+    * If this is an actual release, then the previous tag is the latest release, e.g., `0.1.3` compares against `0.1.2`
 - [ ] Verify binaries are present for **Mac** and **Linux**
 - [ ] Verify circuits of the expected version are present for **Mac** and **Linux**
 - [ ] Replace `{TODO}` peer IDs for both devnet and testnet:

--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -17,8 +17,7 @@
 
 ### ⚙️ Initialize Your Node
 
-Generate a default configuration by connecting to the testnet bootstrap peers.
-
+Generate a default configuration by connecting to the bootstrap peers.
 
 #### Devnet peers
 
@@ -64,7 +63,7 @@ curl -w "\n" http://localhost:8080/cryptarchia/info
 
 Your node should be in `Bootstrapping` mode for a few minutes, with both `slot` and `height` steadily increasing.
 
-After boostrapping is complete, your node will move to `Online` mode.
+After bootstrapping is complete, your node will move to `Online` mode.
 If you have joined the devnet, you can compare against the fleet nodes at the [Logos devnet dashboard][devnet-dashboard].
 For testnet, you can check the [Logos testnet dashboard][testnet-dashboard].
 
@@ -141,7 +140,7 @@ Having issues? Reach out to the Logos Blockchain team on [Discord][testnet-disco
 - [ ] Replace `{TODO}` peer IDs for both devnet and testnet:
     * For a release candidate (for devnet), copy-paste the new devnet addresses from the [devnet dashboard][devnet-dashboard] and the existing testnet addresses from the [testnet dashboard][testnet-dashboard]
     * For a release (for testnet), copy-paste the addresses of the latest deployed devnet from the [devnet dashboard][devnet-dashboard] and the new testnet addresses from the [testnet dashboard][testnet-dashboard]
-- [ ] Set the release type: mark the release as **pre-release** if a devnet release (i.e. release candidate), or set the release as **latest** if a testnet release (i.e. regular release)
+- [ ] Set the release type: mark the release as **pre-release** for release candidates (`X.Y.Z-rc.N`), **latest** for final releases (`X.Y.Z`)
 - [ ] Delete this checklist and publish
 
 [release-notion]: https://www.notion.so/nomos-tech/Internal-Devnet-Launch-February-2026-2fe261aa09df8025ad94e380933b4cf9#2ff261aa09df8058935ecb85aa587564

--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -17,7 +17,20 @@
 
 ### ⚙️ Initialize Your Node
 
-Generate a default configuration by connecting to the testnet bootstrap peers:
+Generate a default configuration by connecting to the testnet bootstrap peers.
+
+
+#### Devnet peers
+
+```bash
+./logos-blockchain-node init \
+    -p /ip4/65.109.51.37/udp/3000/quic-v1/p2p/{TODO} \
+    -p /ip4/65.109.51.37/udp/3001/quic-v1/p2p/{TODO} \
+    -p /ip4/65.109.51.37/udp/3002/quic-v1/p2p/{TODO} \
+    -p /ip4/65.109.51.37/udp/3003/quic-v1/p2p/{TODO}
+```
+
+#### Testnet peers
 
 ```bash
 ./logos-blockchain-node init \
@@ -52,7 +65,8 @@ curl -w "\n" http://localhost:8080/cryptarchia/info
 Your node should be in `Bootstrapping` mode for a few minutes, with both `slot` and `height` steadily increasing.
 
 After boostrapping is complete, your node will move to `Online` mode.
-You can compare against the fleet nodes at the [Logos testnet dashboard][testnet-dashboard].
+If you have joined the devnet, you can compare against the fleet nodes at the [Logos devnet dashboard][devnet-dashboard].
+For testnet, you can check the [Logos testnet dashboard][testnet-dashboard].
 
 ---
 
@@ -76,7 +90,7 @@ Either key can be used.
 
 **2. 🚰 Request funds from the faucet**
 
-Visit the [testnet faucet][testnet-faucet] and enter the credentials provided by the Logos Blockchain team (you can reach out to them on [Discord][testnet-discord-public]), then paste your wallet key.
+Visit the [devnet faucet][devnet-faucet] or [testnet faucet][testnet-faucet] and enter the credentials provided by the Logos Blockchain team (you can reach out to them on [Discord][testnet-discord-public]), then paste your wallet key.
 
 A word of caution - do not _powerclick_ your way through as only one request can be made per block! So if you want to receive funds more than once, wait until your balance increases before requesting new funds.
 
@@ -118,14 +132,19 @@ Having issues? Reach out to the Logos Blockchain team on [Discord][testnet-disco
 
 > **Internal — remove this section before publishing.**
 
-- [ ] Auto-generate the changelog (GitHub feature) using the tag of the previous release, then move the changelog section to the **top** of the release notes
+- [ ] Generate the changelog (GitHub feature) using the tag of the previous release.
+    * If this is the first release candidate, then the previous tag is the version of the latest release. E.g. `0.1.3-rc.1` compares against `0.1.2`
+    * If this is a release candidate but not the first one that has a GH release, then the previous tag is the version of previous release candidate for this release. E.g., `0.1.3-rc.2` compares against `0.1.3-rc.1`
+    * If this is an actual release, then the previous tag is the latest release. E.g., `0.1.3` compares against `0.1.2`
 - [ ] Verify binaries are present for **Mac** and **Linux**
 - [ ] Verify circuits of the expected version are present for **Mac** and **Linux**
 - [ ] Replace `{TODO}` peer IDs by visiting the [testnet dashboard][testnet-dashboard] and copying each node's address + peer ID from their network info
-- [ ] Set the release type: check **pre-release** or **latest** as appropriate
+- [ ] Set the release type: mark the release as **pre-release** if a devnet release (i.e. release candidate) while set the release as **latest** if a testnet release (i.e. regular release)
 - [ ] Delete this checklist and publish
 
 [release-notion]: https://www.notion.so/nomos-tech/Internal-Devnet-Launch-February-2026-2fe261aa09df8025ad94e380933b4cf9#2ff261aa09df8058935ecb85aa587564
 [testnet-faucet]: https://testnet.blockchain.logos.co/web/faucet/
+[devnet-faucet]: https://devnet.blockchain.logos.co/web/faucet/
 [testnet-dashboard]: https://testnet.blockchain.logos.co/web/
+[devnet-dashboard]: https://devnet.blockchain.logos.co/web/
 [testnet-discord-public]: https://discord.com/channels/973324189794697286/1468535289604735038

--- a/.github/workflows/build-logos-tools.yml
+++ b/.github/workflows/build-logos-tools.yml
@@ -1,4 +1,4 @@
-name: Publish Testnet Docker Image
+name: Build and Publish Logos Tools Docker Images
 
 on:
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Print run info
         run: |
-          echo "Building testnet Docker image with tag: ${{ inputs.tag }}"
+          echo "Building Logos tools Docker image with tag: ${{ inputs.tag }}"
 
       - name: Check out the repo
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2  # Version 4.2.2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,11 +29,11 @@ jobs:
           if [[ "$TAG_NAME" == "${{ env.TEST_TAG_NAME }}" ]]; then
             echo "Test workflow run. Setting version to 0.0.0 for testing."
             VERSION=0.0.0
-          elif [[ "$TAG_NAME" =~ ^([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
+          elif [[ "$TAG_NAME" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$ ]]; then
             echo "Release workflow run for tag '$TAG_NAME'. Setting version to '$TAG_NAME'."
             VERSION="$TAG_NAME"
           else
-            echo "Tag name '$TAG_NAME' is not valid. It must either be '${{ env.TEST_TAG_NAME }}' or follow the format 'X.Y.Z'."
+            echo "Tag name '$TAG_NAME' is not valid. It must either be '${{ env.TEST_TAG_NAME }}' or follow the format 'X.Y.Z[-rc.N]'."
             exit 1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-api-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-blend-crypto",
  "logos-blockchain-blend-message",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-crypto"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "blake2",
  "logos-blockchain-groth16",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-message"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "blake2",
  "derivative",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-network"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "either",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-proofs"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "const-hex",
  "ed25519-dalek",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-scheduling"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "derivative",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-blend-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "fork_stream",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-c"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "cbindgen",
  "log",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-cfgsync"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "axum 0.7.9",
  "blake2",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-broadcast-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "derivative",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-leader-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-network-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-chain-service-common"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-core",
  "serde",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-circuits-prover"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-circuits-utils",
  "tempfile",
@@ -4562,14 +4562,14 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-circuits-utils"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "logos-blockchain-circuits-verifier"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-circuits-utils",
  "tempfile",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-common-http-client"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "hex",
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-core"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "ark-ff 0.4.2",
  "bincode",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-cryptarchia-engine"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "cfg_eval",
  "logos-blockchain-pol",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-cryptarchia-sync"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "futures",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-demo-archiver"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-stream",
  "axum 0.8.9",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-demo-sequencer"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "axum 0.7.9",
  "hex",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-faucet"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "axum 0.7.9",
  "clap",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-groth16"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-http-api-common"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "axum 0.7.9",
  "logos-blockchain-core",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-keys"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-macros"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-operators"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "logos-blockchain-blend-proofs",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-ledger"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "derivative",
  "logos-blockchain-blend-crypto",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-libp2p"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "backon",
@@ -4887,7 +4887,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-mmr"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "ark-ff 0.4.2",
  "logos-blockchain-groth16",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-network-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-node"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poc"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-pol"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "astro-float",
  "logos-blockchain-circuits-prover",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poq"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poseidon2"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-sdp-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-services-utils"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-storage-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5098,7 +5098,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-system-sig-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-ctrlc",
  "async-trait",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tests"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cucumber",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-time-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "cfg_eval",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tracing"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tracing-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "console-subscriber",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tui-zone"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "hex",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tx-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-utils"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "blake2",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-utxotree"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "ark-ff 0.4.2",
  "logos-blockchain-groth16",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-wallet"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-core",
  "logos-blockchain-cryptarchia-engine",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-wallet-http-client"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "hex",
  "logos-blockchain-common-http-client",
@@ -5326,7 +5326,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-wallet-service"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5350,14 +5350,14 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-witness-generator"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "logos-blockchain-zksign"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-zone-sdk"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -8306,7 +8306,7 @@ dependencies = [
 
 [[package]]
 name = "testing_framework"
-version = "0.2.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords    = ["blockchain", "privacy"]
 license     = "MIT or Apache-2.0"
 readme      = "README.md"
 repository  = "https://github.com/logos-blockchain/logos-blockchain"
-version     = "0.2.1"
+version     = "0.1.2"
 
 [profile.release]
 codegen-units = 1     # (Much) slower build time, much better performances

--- a/compose.run.yml
+++ b/compose.run.yml
@@ -133,7 +133,7 @@ services:
       - explorer
       - faucet
     environment:
-      - ENV_TITLE_STRING=${IMAGE_LABEL}
+      - ENV_TITLE_STRING=${ENV_TITLE_STRING}
     volumes:
       - node-data:/node-data
       - ./testnet/nginx/run.conf:/etc/nginx/nginx.conf

--- a/compose.setup.yml
+++ b/compose.setup.yml
@@ -87,7 +87,7 @@ services:
     depends_on:
       - cfgsync
     environment:
-      - ENV_TITLE_STRING=${IMAGE_LABEL}
+      - ENV_TITLE_STRING=${ENV_TITLE_STRING}
     volumes:
       - node-data:/node-data
       - ./testnet/nginx/setup.conf:/etc/nginx/nginx.conf

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           commonArgs = {
             pname = "logos-blockchain-c";
             cargoExtraArgs = "-p logos-blockchain-c";
-            version = "0.2.1";
+            version = "0.1.2";
 
             inherit src;
 


### PR DESCRIPTION
## 1. What does this PR implement?

Update release checklists, templates, and GH actions to distinguish between `devnet` and `testnet` as well as release candidate and regular release. Based on the process followed today for the [`0.1.3-rc.1` release](https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.1.3-rc.1).

This process does not yet specify what to do with breaking changes or how to test whether a new version is breaking or not. That will be part of a separate discussion.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.