### PR TITLE
fix: use absolute link for logging guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/specification.md
+++ b/.github/PULL_REQUEST_TEMPLATE/specification.md
@@ -45,4 +45,4 @@
 * [ ] 4. Main contact(s) (developers and specification authors) added
 * [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
 * [ ] 6. Link PR to a specific milestone.
-* [ ] 7. New or changed logs were reviewed against the [logging guidelines](../../CONTRIBUTING.md#logging-guidelines).
+* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).


### PR DESCRIPTION
## 1. What does this PR implement?

Fix logging guideline link, use absolute path.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](../../CONTRIBUTING.md#logging-guidelines).
