### PR TITLE
feat(chain): MMR(4/4): GetHeaders with storage fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4515,6 +4515,7 @@ version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "derivative",
  "futures",
  "logos-blockchain-chain-broadcast-service",
  "logos-blockchain-core",

--- a/services/api/src/http/consensus/cryptarchia.rs
+++ b/services/api/src/http/consensus/cryptarchia.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Display};
 
+use futures::{StreamExt as _, TryStreamExt as _};
 use lb_chain_service::{ConsensusMsg, CryptarchiaConsensus, CryptarchiaInfo};
 use lb_core::{header::HeaderId, mantle::SignedMantleTx};
 use lb_ledger::LedgerState;
@@ -30,10 +31,12 @@ where
     Ok(receiver.await?)
 }
 
+const HEADERS_LIMIT: usize = 512;
+
 pub async fn cryptarchia_headers<RuntimeServiceId>(
     handle: &OverwatchHandle<RuntimeServiceId>,
-    from: Option<HeaderId>,
-    to: Option<HeaderId>,
+    from_descendant: Option<HeaderId>,
+    to_ancestor: Option<HeaderId>,
 ) -> Result<Vec<HeaderId>, DynError>
 where
     RuntimeServiceId:
@@ -43,14 +46,15 @@ where
     let (sender, receiver) = oneshot::channel();
     relay
         .send(ConsensusMsg::GetHeaders {
-            from,
-            to,
+            from_descendant,
+            to_ancestor,
             tx: sender,
         })
         .await
         .map_err(|(e, _)| e)?;
 
-    Ok(receiver.await?)
+    let stream = receiver.await?;
+    Ok(stream.take(HEADERS_LIMIT).try_collect().await?)
 }
 
 pub async fn cryptarchia_ledger_state<RuntimeServiceId>(

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 async-trait                = "0.1"
 bytes                      = { workspace = true }
+derivative                 = "2"
 futures                    = { workspace = true }
 lb-chain-broadcast-service = { workspace = true }
 lb-core                    = { workspace = true }

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -1,3 +1,6 @@
+use std::pin::Pin;
+
+use futures::{Stream, TryStreamExt as _};
 use lb_core::{block::Block, header::HeaderId};
 use lb_network_service::message::ChainSyncEvent;
 use overwatch::services::{ServiceData, relay::OutboundRelay};
@@ -115,36 +118,36 @@ where
         })
     }
 
-    /// Get headers in the range from `from` to `to`
-    /// If `from` is None, defaults to tip
-    /// If `to` is None, defaults to LIB
+    /// Get headers in the range from descendant (inclusive) to ancestor
+    /// (inclusive).
+    ///
+    /// If `from_descendant` is None, defaults to tip
+    /// If `to_ancestor` is None, defaults to LIB
     pub async fn get_headers(
         &self,
-        from: Option<HeaderId>,
-        to: Option<HeaderId>,
-    ) -> Result<Vec<HeaderId>, ApiError> {
+        from_descendant: HeaderId,
+        to_ancestor: HeaderId,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<HeaderId, ApiError>> + Send>>, ApiError> {
         let (tx, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::GetHeaders { from, to, tx })
+            .send(ConsensusMsg::GetHeaders {
+                from_descendant: Some(from_descendant),
+                to_ancestor: Some(to_ancestor),
+                tx,
+            })
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetHeaders"))
             })?;
 
-        rx.await.map_err(|relay_error| {
+        let stream = rx.await.map_err(|relay_error| {
             ApiError::CommsFailure(format!("{relay_error} while receiving GetHeaders"))
-        })
-    }
+        })?;
 
-    /// Get all headers from a specific block to LIB
-    pub async fn get_headers_to_lib(&self, from: HeaderId) -> Result<Vec<HeaderId>, ApiError> {
-        self.get_headers(Some(from), None).await
-    }
-
-    /// Get all headers from tip to a specific block
-    pub async fn get_headers_from_tip(&self, to: HeaderId) -> Result<Vec<HeaderId>, ApiError> {
-        self.get_headers(None, Some(to)).await
+        Ok(Box::pin(stream.map_err(|e| {
+            ApiError::Unexpected(format!("Error while fetching block IDs: {e}"))
+        })))
     }
 
     /// Get the ledger state at a specific block

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -103,6 +103,8 @@ pub enum Error {
     Mempool(String),
     #[error("Block header id not found: {0}")]
     HeaderIdNotFound(HeaderId),
+    #[error("Parent header ID not found for child={0}")]
+    ParentIdNotFound(HeaderId),
     #[error("Service session not found: {0:?}")]
     ServiceSessionNotFound(ServiceType),
 }
@@ -1085,10 +1087,19 @@ where
         let mut current = from_descendant;
         while let Some(branch) = branches.get(&current) {
             in_memory.push(Ok(branch.id()));
+
             if branch.id() == to_ancestor {
                 // All blocks are found in memory. Return immediately
                 return Box::pin(stream::iter(in_memory));
             }
+            if current == branch.parent() {
+                debug!(target: LOG_TARGET, ?to_ancestor, "reached genesis while looking for ancestor from memory");
+                // Return collected blocks and an error since we couldn't reach `to_ancestor`.
+                return Box::pin(stream::iter(in_memory).chain(stream::once(async move {
+                    Err(Error::ParentIdNotFound(current))
+                })));
+            }
+
             current = branch.parent();
         }
 
@@ -1110,34 +1121,34 @@ where
         to_ancestor: HeaderId,
         storage: StorageAdapter<Storage, Tx, RuntimeServiceId>,
     ) -> impl Stream<Item = Result<HeaderId, Error>> {
-        stream::try_unfold(
-            (Some(from_descendant), storage),
+        // Yield `from_descendant` first since we already know it,
+        // and yield subsequent parents by loading them from storage lazily.
+        stream::once(async move { Ok(from_descendant) }).chain(stream::try_unfold(
+            (from_descendant, storage),
             move |(current, storage)| async move {
-                let Some(current) = current else {
-                    return Ok(None);
-                };
-
-                // If we've reached ancestor, yield it and
-                // set stream to be terminated on the next iteration.
                 if current == to_ancestor {
-                    return Ok(Some((current, (None, storage))));
+                    // Reached `to_ancestor`. Terminate the stream
+                    return Ok(None);
                 }
 
                 let parent = storage
                     .get_block_parent(&current)
                     .await
-                    .ok_or(Error::HeaderIdNotFound(current))?;
+                    .ok_or(Error::ParentIdNotFound(current))?;
+
+                if parent == current {
+                    debug!(target: LOG_TARGET, ?to_ancestor, "reached genesis while looking for ancestor from storage");
+                    // Terminate the stream with an error since we couldn't reach `to_ancestor`.
+                    return Err(Error::ParentIdNotFound(current));
+                }
 
                 debug!(
-                    target: LOG_TARGET,
-                    id = ?current,
-                    parent = ?parent,
+                    target: LOG_TARGET, ?current, ?parent,
                     "loaded block parent from storage",
                 );
-
-                Ok(Some((current, (Some(parent), storage))))
+                Ok(Some((parent, (parent, storage))))
             },
-        )
+        ))
     }
 
     /// Initialize cryptarchia

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -14,11 +14,15 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Display,
     path::PathBuf,
+    pin::Pin,
     time::Duration,
 };
 
 use bytes::Bytes;
-use futures::{FutureExt as _, StreamExt as _, future::join_all};
+use derivative::Derivative;
+use futures::{
+    FutureExt as _, Stream, StreamExt as _, TryStreamExt as _, future::join_all, stream,
+};
 use lb_chain_broadcast_service::{
     BlockBroadcastMsg, BlockBroadcastService, BlockInfo, SessionUpdate,
 };
@@ -69,7 +73,6 @@ use crate::{
 };
 
 // Limit the number of blocks returned by GetHeaders
-const HEADERS_LIMIT: usize = 512;
 const SERVICE_ID: &str = "Chain";
 
 pub(crate) const LOG_TARGET: &str = "chain::service";
@@ -104,7 +107,8 @@ pub enum Error {
     ServiceSessionNotFound(ServiceType),
 }
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub enum ConsensusMsg<Tx> {
     Info {
         tx: oneshot::Sender<CryptarchiaInfo>,
@@ -116,9 +120,10 @@ pub enum ConsensusMsg<Tx> {
         sender: oneshot::Sender<broadcast::Receiver<LibUpdate>>,
     },
     GetHeaders {
-        from: Option<HeaderId>,
-        to: Option<HeaderId>,
-        tx: oneshot::Sender<Vec<HeaderId>>,
+        from_descendant: Option<HeaderId>,
+        to_ancestor: Option<HeaderId>,
+        #[derivative(Debug = "ignore")]
+        tx: oneshot::Sender<HeaderIdStream>,
     },
     GetLedgerState {
         block_id: HeaderId,
@@ -159,6 +164,9 @@ pub enum ConsensusMsg<Tx> {
         sender: oneshot::Sender<watch::Receiver<bool>>,
     },
 }
+
+pub(crate) type HeaderIdStream =
+    Pin<Box<dyn Stream<Item = Result<HeaderId, Error>> + Send + 'static>>;
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -594,7 +602,7 @@ where
         // The prolonged bootstrap timer will be started when chain-network notifies us
         // that IBD has completed. This ensures we don't transition to Online mode
         // before the node has caught up with the network.
-        let mut prolonged_bootstrap_timer: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+        let mut prolonged_bootstrap_timer: Option<Pin<Box<tokio::time::Sleep>>> = None;
 
         // Start the timer for periodic state recording for offline grace period
         let mut state_recording_timer = tokio::time::interval(
@@ -672,7 +680,7 @@ where
                                 }
                             }
                             msg => {
-                                Self::process_message(&cryptarchia, &self.new_block_subscription_sender, &self.lib_subscription_sender, &chain_online_notifier, msg);
+                                Self::process_message(&cryptarchia, &self.new_block_subscription_sender, &self.lib_subscription_sender, &chain_online_notifier, msg, relays.storage_adapter());
                             }
                         }
                     }
@@ -724,7 +732,7 @@ where
     <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
     <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
     TimeBackend: lb_time_service::backends::TimeBackend,
-    RuntimeServiceId: Display + AsServiceId<Self>,
+    RuntimeServiceId: Display + AsServiceId<Self> + 'static,
 {
     fn notify_service_ready(&self) {
         self.service_resources_handle.status_updater.notify_ready();
@@ -769,6 +777,7 @@ where
         lib_channel: &broadcast::Sender<LibUpdate>,
         chain_online_notifier: &ChainOnlineNotifier,
         msg: ConsensusMsg<Tx>,
+        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
     ) {
         match msg {
             ConsensusMsg::Info { tx } => {
@@ -788,29 +797,24 @@ where
                     error!("Could not subscribe to LIB updates channel");
                 });
             }
-            ConsensusMsg::GetHeaders { from, to, tx } => {
+            ConsensusMsg::GetHeaders {
+                from_descendant,
+                to_ancestor,
+                tx,
+            } => {
                 // default to tip block if not present
-                let from = from.unwrap_or_else(|| cryptarchia.tip());
+                let from_descendant = from_descendant.unwrap_or_else(|| cryptarchia.tip());
                 // default to LIB block if not present
-                // TODO: for a full history, we should use genesis, but we don't want to
-                // keep it all in memory, headers past LIB should be fetched from storage
-                let to = to.unwrap_or_else(|| cryptarchia.lib());
+                let to_ancestor = to_ancestor.unwrap_or_else(|| cryptarchia.lib());
 
-                let mut res = Vec::new();
-                let mut cur = from;
-
-                let branches = cryptarchia.consensus.branches();
-                while let Some(h) = branches.get(&cur) {
-                    res.push(h.id());
-                    // limit the response size
-                    if cur == to || cur == cryptarchia.lib() || res.len() >= HEADERS_LIMIT {
-                        break;
-                    }
-                    cur = h.parent();
-                }
-
-                tx.send(res)
-                    .unwrap_or_else(|_| error!("could not send blocks through channel"));
+                let stream = Self::get_block_ids(
+                    from_descendant,
+                    to_ancestor,
+                    cryptarchia,
+                    storage_adapter.clone(),
+                );
+                tx.send(stream)
+                    .unwrap_or_else(|_| error!("could not send block stream through channel"));
             }
             ConsensusMsg::GetLedgerState { block_id, tx } => {
                 let ledger_state = cryptarchia.ledger.state(&block_id).cloned();
@@ -1064,55 +1068,76 @@ where
             .map_err(|e| Error::Storage(format!("Failed to store immutable block ids: {e}")))
     }
 
-    /// Retrieves the block IDs in the range from `from` (exclusive) to `to`
-    /// (inclusive) from the storage.
+    /// Returns block IDs from descendant (inclusive) to ancestor
+    /// (inclusive) in child-to-parent order.
+    ///
+    /// First tries to find blocks from memory. If any block is missing from
+    /// memory, it falls back to loading all subsequent blocks from storage.
+    fn get_block_ids(
+        from_descendant: HeaderId,
+        to_ancestor: HeaderId,
+        cryptarchia: &Cryptarchia,
+        storage_adapter: StorageAdapter<Storage, Tx, RuntimeServiceId>,
+    ) -> Pin<Box<dyn Stream<Item = Result<HeaderId, Error>> + Send>> {
+        let branches = cryptarchia.consensus.branches();
+
+        let mut in_memory = Vec::new();
+        let mut current = from_descendant;
+        while let Some(branch) = branches.get(&current) {
+            in_memory.push(Ok(branch.id()));
+            if branch.id() == to_ancestor {
+                // All blocks are found in memory. Return immediately
+                return Box::pin(stream::iter(in_memory));
+            }
+            current = branch.parent();
+        }
+
+        let storage_stream = stream::once(async move {
+            Self::load_block_ids_from_storage(current, to_ancestor, storage_adapter)
+        })
+        .flatten();
+        Box::pin(stream::iter(in_memory).chain(storage_stream))
+    }
+
+    /// Retrieves the block IDs from descendant (inclusive) to ancestor
+    /// (inclusive) from the storage, in child-to-parent order.
+    ///
     /// This is implemented here, and not as a method of `StorageAdapter`, to
     /// simplify the panic and error message handling.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the blocks in the range are not found in the storage.
-    ///
-    /// # Parameters
-    ///
-    /// * `from` - The header id of the first block in the range. Must be a
-    ///   valid header.
-    /// * `to` - The header id of the last block in the range. Must be a valid
-    ///   header.
-    ///
-    /// # Returns
-    ///
-    /// A vector of block IDs in the range from `from` (exclusive) to `to`
-    /// (inclusive), in lib-to-tip order.
-    /// If no blocks are found, returns an empty vector.
-    async fn get_block_ids_in_range(
-        from: HeaderId,
-        to: HeaderId,
-        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> Vec<HeaderId> {
-        // Traverse from `to` back to `from`, reading only the parent index
-        // (a lightweight 32-byte lookup) instead of deserializing full blocks.
-        let mut ids = Vec::new();
-        let mut current = to;
-        while current != from {
-            let parent = storage_adapter
-                .get_block_parent(&current)
-                .await
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Could not retrieve block parent for {current} from storage during recovery"
-                    )
-                });
-            debug!(
-                target: LOG_TARGET, id = ?current, parent = ?parent,
-                "loaded block parent from storage",
-            );
-            ids.push(current);
-            current = parent;
-        }
-        // Reverse so the order is the natural `(from..to]`
-        ids.reverse();
-        ids
+    #[expect(closure_returning_async_block, reason = "required by try_unfold")]
+    fn load_block_ids_from_storage(
+        from_descendant: HeaderId,
+        to_ancestor: HeaderId,
+        storage: StorageAdapter<Storage, Tx, RuntimeServiceId>,
+    ) -> impl Stream<Item = Result<HeaderId, Error>> {
+        stream::try_unfold(
+            (Some(from_descendant), storage),
+            move |(current, storage)| async move {
+                let Some(current) = current else {
+                    return Ok(None);
+                };
+
+                // If we've reached ancestor, yield it and
+                // set stream to be terminated on the next iteration.
+                if current == to_ancestor {
+                    return Ok(Some((current, (None, storage))));
+                }
+
+                let parent = storage
+                    .get_block_parent(&current)
+                    .await
+                    .ok_or(Error::HeaderIdNotFound(current))?;
+
+                debug!(
+                    target: LOG_TARGET,
+                    id = ?current,
+                    parent = ?parent,
+                    "loaded block parent from storage",
+                );
+
+                Ok(Some((current, (Some(parent), storage))))
+            },
+        )
     }
 
     /// Initialize cryptarchia
@@ -1177,19 +1202,29 @@ where
         }
         Self::broadcast_session_updates_for_block(&cryptarchia, &init_tip.id(), relays, None).await;
 
-        // Phase 1: Collect only block IDs from LIB to tip.
+        // Phase 1: Collect only block IDs in (LIB, tip].
         info!(
             target: LOG_TARGET, lib = ?lib_id, tip = ?self.state.tip,
             "loading block IDs from storage: (lib, tip]",
         );
-        let ids =
-            Self::get_block_ids_in_range(lib_id, self.state.tip, relays.storage_adapter()).await;
+        let ids: Vec<HeaderId> = Self::load_block_ids_from_storage(
+            self.state.tip,
+            lib_id,
+            relays.storage_adapter().clone(),
+        )
+        .try_collect()
+        .await
+        .unwrap_or_else(|e| {
+            panic!("Failed to load block IDs from storage during initialization: {e:?}");
+        });
+        // Reverse to get LIB->tip order, and skip LIB since we already have it
+        let ids = ids.into_iter().rev().skip(1);
         info!(target: LOG_TARGET, "collected {} block IDs from storage: (lib, tip]", ids.len());
 
         // Phase 2: Load each block individually (lib→tip order) and apply it.
         let mut pruned_blocks = PrunedBlocks::new();
         let n_blocks = ids.len();
-        for (i, id) in ids.into_iter().enumerate() {
+        for (i, id) in ids.enumerate() {
             let block = relays
                 .storage_adapter()
                 .get_block(&id)

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -1,5 +1,11 @@
-use std::{collections::HashSet, num::NonZero, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::{self, Display},
+    num::NonZero,
+    sync::Arc,
+};
 
+use futures::StreamExt as _;
 use lb_core::{
     block::Block,
     mantle::{
@@ -17,11 +23,25 @@ use lb_ledger::{
     LedgerState,
     mantle::sdp::{ServiceRewardsParameters, rewards},
 };
+use lb_storage_service::{
+    StorageMsg, StorageService,
+    backends::{
+        StorageBackend as _,
+        rocksdb::{RocksBackend, RocksBackendSettings},
+    },
+};
+use lb_time_service::backends::SystemTimeBackend;
 use lb_utils::math::NonNegativeRatio;
 use num_bigint::BigUint;
+use overwatch::services::{AsServiceId, relay::OutboundRelay, state::StateUpdater};
 use rand::{RngCore as _, thread_rng};
+use tempfile::TempDir;
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::JoinHandle,
+};
 
-use crate::Cryptarchia;
+use crate::{Cryptarchia, CryptarchiaConsensus, Error, relays::CryptarchiaConsensusRelays};
 
 #[test]
 fn cryptarchia_switch_to_online() {
@@ -84,9 +104,145 @@ fn cryptarchia_switch_to_online() {
     assert!(cryptarchia.ledger.state(&block_ids[1]).is_none());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "better to have one comprehensive test"
+)]
+async fn get_block_ids() {
+    // Init dummy relays for chain service
+    let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
+    let (storage_tx, storage_rx) = mpsc::channel(10);
+    let _storage_svc = spawn_storage_service(storage_rx);
+    let (time_tx, _time_rx) = mpsc::channel(10);
+    let relays =
+        CryptarchiaConsensusRelays::<SignedMantleTx, RocksBackend, TestRuntimeServiceId>::new(
+            OutboundRelay::new(broadcast_tx),
+            OutboundRelay::new(storage_tx),
+            OutboundRelay::new(time_tx),
+        )
+        .await;
+    let (state_tx, _state_rx) = watch::channel(None);
+    let state_updater = StateUpdater::new(Arc::new(state_tx));
+    let (new_block_tx, _new_block_rx) = broadcast::channel(10);
+    let (lib_tx, _lib_rx) = broadcast::channel(10);
+
+    // Init `Cryptarchia`
+    let k = 3.try_into().unwrap();
+    let config = ledger_config(k);
+    let genesis_id = [0; 32].into();
+    let (zk_key, utxo) = utxo();
+    let mut cryptarchia = Cryptarchia::from_lib(
+        genesis_id,
+        LedgerState::from_utxos([utxo], &config),
+        genesis_id,
+        config,
+        lb_cryptarchia_engine::State::Online,
+        Slot::genesis(),
+        0,
+    );
+
+    // Add 2 blocks (not finalized yet since k=3)
+    let mut slot = Slot::genesis() + 1;
+    let mut block_ids = vec![genesis_id];
+    for _ in 0..2 {
+        let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
+        CryptarchiaConsensus::<_, RocksBackend, SystemTimeBackend, TestRuntimeServiceId>::process_block_and_update_state(
+            &mut cryptarchia,
+            block.clone(),
+            block.header().slot(),
+            &HashSet::new(),
+            &relays,
+            &new_block_tx,
+            &lib_tx,
+            &state_updater,
+        )
+        .await
+        .unwrap();
+        block_ids.push(block.header().id());
+        slot = block.header().slot() + 1;
+    }
+
+    // get_block_ids when all blocks are in memory.
+    let mut stream = CryptarchiaConsensus::get_block_ids(
+        block_ids[2],
+        block_ids[0],
+        &cryptarchia,
+        relays.storage_adapter().clone(),
+    );
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[2]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[1]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[0]);
+    assert!(stream.next().await.is_none());
+
+    // Hitting genesis before reaching `to_ancestor`
+    let mut stream = CryptarchiaConsensus::get_block_ids(
+        block_ids[2],
+        [99; 32].into(), // unknown block ID
+        &cryptarchia,
+        relays.storage_adapter().clone(),
+    );
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[2]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[1]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[0]);
+    assert!(matches!(
+        stream.next().await.unwrap(),
+        Err(Error::ParentIdNotFound(_))
+    ));
+
+    // Add 3 more blocks.
+    // Now G, b1 are in storage, and b2~5 are in memory.
+    for _ in 0..3 {
+        let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
+        CryptarchiaConsensus::<_, RocksBackend, SystemTimeBackend, TestRuntimeServiceId>::process_block_and_update_state(
+            &mut cryptarchia,
+            block.clone(),
+            block.header().slot(),
+            &HashSet::new(),
+            &relays,
+            &new_block_tx,
+            &lib_tx,
+            &state_updater,
+        )
+        .await
+        .unwrap();
+        block_ids.push(block.header().id());
+        slot = block.header().slot() + 1;
+    }
+
+    // All blocks are loaded from memory + storage.
+    let mut stream = CryptarchiaConsensus::get_block_ids(
+        block_ids[5],
+        block_ids[0],
+        &cryptarchia,
+        relays.storage_adapter().clone(),
+    );
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[5]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[4]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[3]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[2]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[1]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[0]);
+    assert!(stream.next().await.is_none());
+
+    // Hitting genesis in storage before reaching `to_ancestor`
+    let mut stream = CryptarchiaConsensus::get_block_ids(
+        block_ids[1],
+        [99; 32].into(), // unknown block ID
+        &cryptarchia,
+        relays.storage_adapter().clone(),
+    );
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[1]);
+    assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[0]);
+    assert!(matches!(
+        stream.next().await.unwrap(),
+        Err(Error::ParentIdNotFound(_))
+    ));
+}
+
 #[must_use]
 fn ledger_config(security_param: NonZero<u32>) -> lb_ledger::Config {
-    let mut service_params = std::collections::HashMap::new();
+    let mut service_params = HashMap::new();
     service_params.insert(
         lb_core::sdp::ServiceType::BlendNetwork,
         ServiceParameters {
@@ -194,4 +350,42 @@ fn utxo() -> (ZkKey, Utxo) {
         note: Note::new(10000, zk_sk.to_public_key()),
     };
     (zk_sk, utxo)
+}
+
+fn spawn_storage_service(
+    mut rx: mpsc::Receiver<StorageMsg<RocksBackend>>,
+) -> (JoinHandle<()>, TempDir) {
+    let db_dir = TempDir::new().unwrap();
+    let mut backend = RocksBackend::new(RocksBackendSettings {
+        db_path: db_dir.path().join("db"),
+        read_only: false,
+        column_family: None,
+    })
+    .unwrap();
+
+    let handle = tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            StorageService::<RocksBackend, TestRuntimeServiceId>::handle_storage_message(
+                msg,
+                &mut backend,
+            )
+            .await;
+        }
+    });
+
+    (handle, db_dir)
+}
+
+struct TestRuntimeServiceId;
+
+impl AsServiceId<CryptarchiaConsensus<SignedMantleTx, RocksBackend, SystemTimeBackend, Self>>
+    for TestRuntimeServiceId
+{
+    const SERVICE_ID: Self = Self;
+}
+
+impl Display for TestRuntimeServiceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TestRuntimeServiceId")
+    }
 }

--- a/services/storage/src/lib.rs
+++ b/services/storage/src/lib.rs
@@ -277,7 +277,7 @@ impl<Backend, RuntimeServiceId> StorageService<Backend, RuntimeServiceId>
 where
     Backend: StorageBackend + Send + Sync + 'static,
 {
-    async fn handle_storage_message(msg: StorageMsg<Backend>, backend: &mut Backend) {
+    pub async fn handle_storage_message(msg: StorageMsg<Backend>, backend: &mut Backend) {
         let started_at = Instant::now();
 
         let result = match msg {

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::StreamExt as _;
+use futures::{StreamExt as _, TryStreamExt as _};
 use lb_chain_service::{
     Epoch, LibUpdate, Slot,
     api::{CryptarchiaServiceApi, CryptarchiaServiceData},
@@ -1131,15 +1131,17 @@ where
 
         // Fetch block IDs in [state.lib, tip]
         let missing_headers = cryptarchia_api
-            .get_headers(Some(tip), Some(state.lib()))
+            .get_headers(tip, state.lib())
             .await
             .map_err(WalletServiceError::CryptarchiaApi)
             .inspect_err(|e| {
                 error!(block_id = ?tip, err = %e, "Failed to fetch missing headers for backfill");
-            })?;
+            })?
+            .try_collect::<Vec<_>>()
+            .await?;
 
         // Load/apply blocks in order from `state.lib` to `tip`
-        for header_id in missing_headers.iter().rev().copied() {
+        for header_id in missing_headers.into_iter().rev() {
             if state.wallet().has_processed_block(header_id) {
                 debug!("skipping already processed block");
                 continue;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -36,8 +36,8 @@ lb-cryptarchia-engine            = { features = ["serde"], workspace = true }
 lb-groth16                       = { workspace = true }
 lb-http-api-common               = { workspace = true }
 lb-key-management-system-service = { workspace = true }
-lb-mmr                           = { workspace = true }
 lb-libp2p                        = { workspace = true }
+lb-mmr                           = { workspace = true }
 lb-network-service               = { features = ["libp2p"], workspace = true }
 lb-node                          = { default-features = false, features = ["testing"], workspace = true }
 lb-testing-framework             = { workspace = true }


### PR DESCRIPTION
## 1. What does this PR implement?

This is PR 4/4 in the series. For detailed background, please see the 1st PR #2585.

### Background
This PR fixes chain service to support wallet service fetching blocks from its last LIB, which is not guaranteed to always match with the chain's LIB.
Chain service already has `GetHeaders` API, but it provides blocks only up to (down to?) the current chain's LIB, which may be newer than the last LIB that wallet service remembers. So, with this API, wallet service cannot catch up the chain.

### Solution
- GetHeaders now walks in-memory branches first, then falls back to storage for blocks pruned below LIB.
  - This allows wallet svc to backfill from its persisted LIB, which is not guaranteed to always match the chain's LIB.
- Also, removed LIMIT=512 in chain service. Instead, defined LIMIT only for REST API.


## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
