### PR TITLE
fix: handle cases of 1-node networks for both blend and gossipsub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3500,6 +3500,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "kinded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4bdbb2f423660b19f0e9f7115182214732d8dd5f840cd0a3aee3e22562f34c"
+dependencies = [
+ "kinded_macros",
+]
+
+[[package]]
+name = "kinded_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13b4ddc5dcb32f45dac3d6f606da2a52fdb9964a18427e63cd5ef6c0d13288d"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "kube"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4957,6 +4978,7 @@ dependencies = [
  "logos-blockchain-utils",
  "logos-blockchain-wallet-service",
  "num-bigint",
+ "nutype",
  "overwatch",
  "rand 0.8.5",
  "serde",
@@ -5962,6 +5984,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "nutype"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70587a780088c67dad31bf722b875c5616096b4d8c0ded8b7de03294ffb9bbb5"
+dependencies = [
+ "nutype_macros",
+]
+
+[[package]]
+name = "nutype_macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148934b975faeddd8f0679d7cf11280b50c4c5495d6fe72bdaf07c932874b404"
+dependencies = [
+ "cfg-if",
+ "kinded",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "urlencoding",
 ]
 
 [[package]]
@@ -9113,6 +9159,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ kube              = { default-features = false, features = ["client", "rustls-tl
 libp2p            = { default-features = false, version = "0.55" }
 libp2p-stream     = { default-features = false, version = "0.3.0-alpha" }
 log               = { default-features = false, version = "0.4" }
+nutype            = { default-features = false, version = "0.6.2" }
 overwatch         = { default-features = false, git = "https://github.com/logos-co/Overwatch", rev = "448c192" }
 overwatch-derive  = { default-features = false, git = "https://github.com/logos-co/Overwatch", rev = "448c192" }
 rand              = { default-features = false, version = "0.8" }

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -57,6 +57,7 @@ lb-wallet-service                = { workspace = true }
 libp2p                           = { features = ["autonat", "gossipsub", "identify", "kad", "macros"], workspace = true }
 logos-blockchain-tui-zone        = { path = "../../../testnet/tui-zone" }
 num-bigint                       = { default-features = false, version = "0.4" }
+nutype                           = { workspace = true, features = ["serde"] }
 overwatch                        = { workspace = true }
 rand                             = { workspace = true }
 serde                            = { workspace = true }

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -57,7 +57,7 @@ lb-wallet-service                = { workspace = true }
 libp2p                           = { features = ["autonat", "gossipsub", "identify", "kad", "macros"], workspace = true }
 logos-blockchain-tui-zone        = { path = "../../../testnet/tui-zone" }
 num-bigint                       = { default-features = false, version = "0.4" }
-nutype                           = { workspace = true, features = ["serde"] }
+nutype                           = { features = ["serde"], workspace = true }
 overwatch                        = { workspace = true }
 rand                             = { workspace = true }
 serde                            = { workspace = true }

--- a/nodes/node/binary/src/config/blend/deployment.rs
+++ b/nodes/node/binary/src/config/blend/deployment.rs
@@ -2,7 +2,7 @@ use core::{num::NonZeroU64, time::Duration};
 
 use lb_ledger::mantle::sdp::rewards::blend::RewardsParameters;
 use lb_libp2p::protocol_name::StreamProtocol;
-use lb_utils::math::{NonLessThan, NonNegativeF64, U64Bound};
+use lb_utils::math::{AtLeast, NonNegativeF64, U64Bound};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
@@ -126,7 +126,7 @@ pub struct CommonSettings {
     /// `ß_c`: expected number of blending operations for each locally generated
     /// message.
     pub num_blend_layers: NonZeroU64,
-    pub minimum_network_size: NonLessThan<U64Bound<2>>,
+    pub minimum_network_size: AtLeast<U64Bound<2>>,
     pub protocol_name: StreamProtocol,
     pub data_replication_factor: u64,
 }

--- a/nodes/node/binary/src/config/blend/deployment.rs
+++ b/nodes/node/binary/src/config/blend/deployment.rs
@@ -2,7 +2,7 @@ use core::{num::NonZeroU64, time::Duration};
 
 use lb_ledger::mantle::sdp::rewards::blend::RewardsParameters;
 use lb_libp2p::protocol_name::StreamProtocol;
-use lb_utils::math::NonNegativeF64;
+use lb_utils::math::{NonLessThan, NonNegativeF64, U64Bound};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
@@ -106,7 +106,12 @@ impl Settings {
             activity_threshold_sensitivity: self.core.activity_threshold_sensitivity,
             data_replication_factor: self.common.data_replication_factor,
             message_frequency_per_round: self.core.scheduler.cover.message_frequency_per_round,
-            minimum_network_size: self.common.minimum_network_size,
+            minimum_network_size: self
+                .common
+                .minimum_network_size
+                .get()
+                .try_into()
+                .expect("Minimum network size is at least 2, which is >= than 0."),
             num_blend_layers: self.common.num_blend_layers,
             rounds_per_session: self.rounds_per_session(
                 cryptarchia_deployment.slots_per_epoch(),
@@ -121,7 +126,7 @@ pub struct CommonSettings {
     /// `ß_c`: expected number of blending operations for each locally generated
     /// message.
     pub num_blend_layers: NonZeroU64,
-    pub minimum_network_size: NonZeroU64,
+    pub minimum_network_size: NonLessThan<U64Bound<2>>,
     pub protocol_name: StreamProtocol,
     pub data_replication_factor: u64,
 }

--- a/nodes/node/binary/src/config/blend/deployment.rs
+++ b/nodes/node/binary/src/config/blend/deployment.rs
@@ -2,7 +2,8 @@ use core::{num::NonZeroU64, time::Duration};
 
 use lb_ledger::mantle::sdp::rewards::blend::RewardsParameters;
 use lb_libp2p::protocol_name::StreamProtocol;
-use lb_utils::math::{AtLeast, NonNegativeF64, U64Bound};
+use lb_utils::math::NonNegativeF64;
+use nutype::nutype;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
@@ -106,12 +107,7 @@ impl Settings {
             activity_threshold_sensitivity: self.core.activity_threshold_sensitivity,
             data_replication_factor: self.common.data_replication_factor,
             message_frequency_per_round: self.core.scheduler.cover.message_frequency_per_round,
-            minimum_network_size: self
-                .common
-                .minimum_network_size
-                .get()
-                .try_into()
-                .expect("Minimum network size is at least 2, which is >= than 0."),
+            minimum_network_size: self.common.minimum_network_size.into(),
             num_blend_layers: self.common.num_blend_layers,
             rounds_per_session: self.rounds_per_session(
                 cryptarchia_deployment.slots_per_epoch(),
@@ -126,9 +122,24 @@ pub struct CommonSettings {
     /// `ß_c`: expected number of blending operations for each locally generated
     /// message.
     pub num_blend_layers: NonZeroU64,
-    pub minimum_network_size: AtLeast<U64Bound<2>>,
+    pub minimum_network_size: MinimumNetworkSize,
     pub protocol_name: StreamProtocol,
     pub data_replication_factor: u64,
+}
+
+#[nutype(
+    validate(greater_or_equal = 2),
+    derive(Serialize, Deserialize, Debug, Clone, Copy)
+)]
+pub struct MinimumNetworkSize(u64);
+
+impl From<MinimumNetworkSize> for NonZeroU64 {
+    fn from(value: MinimumNetworkSize) -> Self {
+        value
+            .into_inner()
+            .try_into()
+            .expect("Minimum network size is at least 2, which is > than 0.")
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/nodes/node/binary/src/config/blend/mod.rs
+++ b/nodes/node/binary/src/config/blend/mod.rs
@@ -38,6 +38,7 @@ pub struct ServiceConfig {
 }
 
 impl ServiceConfig {
+    #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
     #[must_use]
     pub fn into_blend_services_settings(
         self,
@@ -62,7 +63,13 @@ impl ServiceConfig {
             common: CommonSettings {
                 non_ephemeral_signing_key_id: self.user.non_ephemeral_signing_key_id,
                 num_blend_layers: self.deployment.common.num_blend_layers,
-                minimum_network_size: self.deployment.common.minimum_network_size,
+                minimum_network_size: self
+                    .deployment
+                    .common
+                    .minimum_network_size
+                    .get()
+                    .try_into()
+                    .expect("Minimum network size is at least 2, which is >= than 0."),
                 recovery_path_prefix,
                 time: TimingSettings {
                     epoch_transition_period_in_slots: self

--- a/nodes/node/binary/src/config/blend/mod.rs
+++ b/nodes/node/binary/src/config/blend/mod.rs
@@ -38,7 +38,6 @@ pub struct ServiceConfig {
 }
 
 impl ServiceConfig {
-    #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
     #[must_use]
     pub fn into_blend_services_settings(
         self,
@@ -63,13 +62,7 @@ impl ServiceConfig {
             common: CommonSettings {
                 non_ephemeral_signing_key_id: self.user.non_ephemeral_signing_key_id,
                 num_blend_layers: self.deployment.common.num_blend_layers,
-                minimum_network_size: self
-                    .deployment
-                    .common
-                    .minimum_network_size
-                    .get()
-                    .try_into()
-                    .expect("Minimum network size is at least 2, which is >= than 0."),
+                minimum_network_size: self.deployment.common.minimum_network_size.into(),
                 recovery_path_prefix,
                 time: TimingSettings {
                     epoch_transition_period_in_slots: self

--- a/services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -64,8 +64,11 @@ impl<R: Clone + Send + RngCore + 'static> SwarmHandler<R> {
         match self.swarm.broadcast(&topic, message.to_vec()) {
             Ok(id) => {
                 tracing::trace!("Broadcasted message with id: {id} to topic: {topic}");
-                // self-notification because libp2p doesn't do it
-                if self.swarm.is_subscribed(&topic) {
+                // self-notification because libp2p doesn't do it.
+                // Only do this on first attempt; if a previous attempt already
+                // injected the message locally due to InsufficientPeers, avoid
+                // notifying local subscribers twice.
+                if retry_count == 0 && self.swarm.is_subscribed(&topic) {
                     log_error!(self.pubsub_messages_tx.send(gossipsub::Message {
                         source: None,
                         data: message.into(),

--- a/services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -75,6 +75,21 @@ impl<R: Clone + Send + RngCore + 'static> SwarmHandler<R> {
                 }
             }
             Err(gossipsub::PublishError::InsufficientPeers) if retry_count < MAX_RETRY => {
+                // TODO: Remove this logic once we start re-applying blocks produced locally. In
+                // that case, we don't need to bubble this up since we have already applied the
+                // block before broadcasting it. In single-node or transiently isolated setups,
+                // publish can fail with InsufficientPeers. Still surface the
+                // message locally once so higher layers can progress while
+                // retries continue for eventual dissemination.
+                if retry_count == 0 && self.swarm.is_subscribed(&topic) {
+                    log_error!(self.pubsub_messages_tx.send(gossipsub::Message {
+                        source: None,
+                        data: message.clone().into(),
+                        sequence_number: None,
+                        topic: topic_hash(&topic),
+                    }));
+                }
+
                 let wait = exp_backoff(retry_count);
                 tracing::trace!(
                     "failed to broadcast message to topic due to insufficient peers, trying again in {wait:?}"

--- a/services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -68,6 +68,9 @@ impl<R: Clone + Send + RngCore + 'static> SwarmHandler<R> {
                 // Only do this on first attempt; if a previous attempt already
                 // injected the message locally due to InsufficientPeers, avoid
                 // notifying local subscribers twice.
+                // TODO: Remove this logic once we start re-applying blocks produced locally. In
+                // that case, we don't need to bubble this up since we have already applied the
+                // block before broadcasting it.
                 if retry_count == 0 && self.swarm.is_subscribed(&topic) {
                     log_error!(self.pubsub_messages_tx.send(gossipsub::Message {
                         source: None,

--- a/tests/cucumber_tests/features/cryptarchia.feature
+++ b/tests/cucumber_tests/features/cryptarchia.feature
@@ -1,6 +1,13 @@
 Feature: Cryptarchia
 
   @cryptarchia_ci
+  Scenario: One node happy path
+    Given I have a cluster with capacity of 1 nodes
+    And I start node "NODE_1"
+    Then all nodes have at least 5 blocks and converged to within 1 blocks in 300 seconds
+    Then I stop all nodes
+
+  @cryptarchia_ci
   Scenario: Two nodes happy path
     Given I have a cluster with capacity of 2 nodes
     And I start node "NODE_1"

--- a/tests/src/common/time.rs
+++ b/tests/src/common/time.rs
@@ -35,7 +35,7 @@ pub fn max_block_propagation_time(
 /// Calculates the maximum time for a block to be fully blended.
 /// This ignores the gossiping latency in the blend network.
 fn max_blend_latency_per_block(network_size: u64, deployment: &DeploymentSettings) -> Duration {
-    if network_size < deployment.blend.common.minimum_network_size.get() {
+    if network_size < deployment.blend.common.minimum_network_size.into_inner() {
         return Duration::ZERO;
     }
 

--- a/tests/testing_framework/src/workloads/fork_monitor.rs
+++ b/tests/testing_framework/src/workloads/fork_monitor.rs
@@ -314,22 +314,23 @@ fn propagation_budget(
         .slot_duration
         .div_f64(deployment.cryptarchia.slot_activation_coeff.as_f64());
 
-    let blend_latency = if blend_network_size < deployment.blend.common.minimum_network_size.get() {
-        Duration::ZERO
-    } else {
-        deployment.blend_round_duration().saturating_mul(
-            (deployment
-                .blend
-                .core
-                .scheduler
-                .delayer
-                .maximum_release_delay_in_rounds
-                .get()
-                * deployment.blend.common.num_blend_layers.get())
-            .try_into()
-            .expect("blend latency multiplier must fit u32"),
-        )
-    };
+    let blend_latency =
+        if blend_network_size < deployment.blend.common.minimum_network_size.into_inner() {
+            Duration::ZERO
+        } else {
+            deployment.blend_round_duration().saturating_mul(
+                (deployment
+                    .blend
+                    .core
+                    .scheduler
+                    .delayer
+                    .maximum_release_delay_in_rounds
+                    .get()
+                    * deployment.blend.common.num_blend_layers.get())
+                .try_into()
+                .expect("blend latency multiplier must fit u32"),
+            )
+        };
 
     proposal_interval
         .saturating_add(blend_latency)

--- a/tools/config/src/deployment.rs
+++ b/tools/config/src/deployment.rs
@@ -20,7 +20,7 @@ use lb_node::config::{
     network::deployment::Settings as NetworkDeploymentSettings,
     time::deployment::Settings as TimeDeploymentSettings,
 };
-use lb_utils::math::{NonLessThan, NonNegativeF64, NonNegativeRatio, U64Bound};
+use lb_utils::math::{AtLeast, NonNegativeF64, NonNegativeRatio, U64Bound};
 use time::OffsetDateTime;
 
 use crate::{
@@ -79,7 +79,7 @@ pub fn e2e_deployment_settings_with_genesis_tx(genesis_tx: GenesisTx) -> Deploym
     DeploymentSettings {
         blend: BlendDeploymentSettings {
             common: BlendCommonSettings {
-                minimum_network_size: NonLessThan::<U64Bound<2>>::checked_from(
+                minimum_network_size: AtLeast::<U64Bound<2>>::checked_from(
                     MINIMUM_BLEND_NETWORK_SIZE,
                 )
                 .expect("Minimum network size cannot be less than 2."),

--- a/tools/config/src/deployment.rs
+++ b/tools/config/src/deployment.rs
@@ -20,7 +20,7 @@ use lb_node::config::{
     network::deployment::Settings as NetworkDeploymentSettings,
     time::deployment::Settings as TimeDeploymentSettings,
 };
-use lb_utils::math::{NonNegativeF64, NonNegativeRatio};
+use lb_utils::math::{NonLessThan, NonNegativeF64, NonNegativeRatio, U64Bound};
 use time::OffsetDateTime;
 
 use crate::{
@@ -30,7 +30,7 @@ use crate::{
 
 static CHAIN_START_TIME: OnceLock<OffsetDateTime> = OnceLock::new();
 
-const MINIMUM_BLEND_NETWORK_SIZE: u64 = 1;
+const MINIMUM_BLEND_NETWORK_SIZE: u64 = 2;
 const NUM_BLEND_LAYERS: u64 = 3;
 const BLEND_PROTOCOL_NAME: &str = "/blend/integration-tests";
 const DATA_REPLICATION_FACTOR: u64 = 0;
@@ -79,8 +79,10 @@ pub fn e2e_deployment_settings_with_genesis_tx(genesis_tx: GenesisTx) -> Deploym
     DeploymentSettings {
         blend: BlendDeploymentSettings {
             common: BlendCommonSettings {
-                minimum_network_size: NonZeroU64::try_from(MINIMUM_BLEND_NETWORK_SIZE)
-                    .expect("Minimum network size cannot be zero."),
+                minimum_network_size: NonLessThan::<U64Bound<2>>::checked_from(
+                    MINIMUM_BLEND_NETWORK_SIZE,
+                )
+                .expect("Minimum network size cannot be less than 2."),
                 num_blend_layers: NonZeroU64::try_from(NUM_BLEND_LAYERS)
                     .expect("Number of blend layers cannot be zero."),
                 protocol_name: StreamProtocol::new(BLEND_PROTOCOL_NAME),

--- a/tools/config/src/deployment.rs
+++ b/tools/config/src/deployment.rs
@@ -9,7 +9,7 @@ use lb_libp2p::protocol_name::StreamProtocol;
 use lb_node::config::{
     blend::deployment::{
         CommonSettings as BlendCommonSettings, CoreSettings as BlendCoreSettings,
-        CoverTrafficSettings, MessageDelayerSettings, SchedulerSettings,
+        CoverTrafficSettings, MessageDelayerSettings, MinimumNetworkSize, SchedulerSettings,
         Settings as BlendDeploymentSettings,
     },
     cryptarchia::deployment::{
@@ -20,7 +20,7 @@ use lb_node::config::{
     network::deployment::Settings as NetworkDeploymentSettings,
     time::deployment::Settings as TimeDeploymentSettings,
 };
-use lb_utils::math::{AtLeast, NonNegativeF64, NonNegativeRatio, U64Bound};
+use lb_utils::math::{NonNegativeF64, NonNegativeRatio};
 use time::OffsetDateTime;
 
 use crate::{
@@ -79,10 +79,8 @@ pub fn e2e_deployment_settings_with_genesis_tx(genesis_tx: GenesisTx) -> Deploym
     DeploymentSettings {
         blend: BlendDeploymentSettings {
             common: BlendCommonSettings {
-                minimum_network_size: AtLeast::<U64Bound<2>>::checked_from(
-                    MINIMUM_BLEND_NETWORK_SIZE,
-                )
-                .expect("Minimum network size cannot be less than 2."),
+                minimum_network_size: MinimumNetworkSize::try_new(MINIMUM_BLEND_NETWORK_SIZE)
+                    .expect("Minimum network size cannot be less than 2."),
                 num_blend_layers: NonZeroU64::try_from(NUM_BLEND_LAYERS)
                     .expect("Number of blend layers cannot be zero."),
                 protocol_name: StreamProtocol::new(BLEND_PROTOCOL_NAME),

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -275,139 +275,11 @@ impl NonNegativeRatio {
     }
 }
 
-pub trait MinValue {
-    type Type;
-
-    const MIN: Self::Type;
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(::serde::Serialize, ::serde::Deserialize),
-    serde(bound(deserialize = "Min::Type: ::serde::Deserialize<'de> + PartialOrd"))
-)]
-pub struct AtLeast<Min>(
-    #[cfg_attr(
-        feature = "serde",
-        serde(deserialize_with = "serde::deserialize_with_min_value::<_, Min>")
-    )]
-    Min::Type,
-)
-where
-    Min: MinValue;
-
-impl<Min> AtLeast<Min>
-where
-    Min: MinValue<Type: PartialOrd>,
-{
-    pub fn checked_from(value: Min::Type) -> Option<Self> {
-        (value >= Min::MIN).then(|| Self(value))
-    }
-}
-
-impl<Min> AtLeast<Min>
-where
-    Min: MinValue,
-{
-    pub fn get(self) -> Min::Type {
-        self.0
-    }
-}
-
-pub trait MaxValue {
-    type Type;
-
-    const MAX: Self::Type;
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(::serde::Serialize, ::serde::Deserialize),
-    serde(bound(deserialize = "Max::Type: ::serde::Deserialize<'de> + PartialOrd"))
-)]
-pub struct AtMost<Max>(
-    #[cfg_attr(
-        feature = "serde",
-        serde(deserialize_with = "serde::deserialize_with_max_value::<_, Max>")
-    )]
-    Max::Type,
-)
-where
-    Max: MaxValue;
-
-impl<Max> AtMost<Max>
-where
-    Max: MaxValue<Type: PartialOrd>,
-{
-    pub fn checked_from(value: Max::Type) -> Option<Self> {
-        (value <= Max::MAX).then(|| Self(value))
-    }
-}
-
-impl<Max> AtMost<Max>
-where
-    Max: MaxValue,
-{
-    pub fn get(self) -> Max::Type {
-        self.0
-    }
-}
-
-/// A macro to define a newtype wrapper around an unsigned integer type that
-/// enforces a minimum or maximum value constraint. The generated type
-/// implements the `MinValue` and `MaxValue` traits, and provides conversion
-/// methods to and from the underlying integer type. The macro takes the name of
-/// the new type and the underlying unsigned integer type as parameters.
-macro_rules! uint_bound {
-    ($name:ident, $ty:ty) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-        pub struct $name<const N: $ty>;
-        impl<const N: $ty> MinValue for $name<N> {
-            type Type = $ty;
-            const MIN: Self::Type = N;
-        }
-        impl<const N: $ty> MaxValue for $name<N> {
-            type Type = $ty;
-            const MAX: Self::Type = N;
-        }
-        impl<const MIN: $ty> From<AtLeast<$name<MIN>>> for $ty {
-            fn from(value: AtLeast<$name<MIN>>) -> Self {
-                value.0
-            }
-        }
-        impl<const MIN: $ty> TryFrom<$ty> for AtLeast<$name<MIN>> {
-            type Error = ();
-            fn try_from(value: $ty) -> Result<Self, Self::Error> {
-                (value >= MIN).then_some(Self(value)).ok_or(())
-            }
-        }
-        impl<const MAX: $ty> From<AtMost<$name<MAX>>> for $ty {
-            fn from(value: AtMost<$name<MAX>>) -> Self {
-                value.0
-            }
-        }
-        impl<const MAX: $ty> TryFrom<$ty> for AtMost<$name<MAX>> {
-            type Error = ();
-            fn try_from(value: $ty) -> Result<Self, Self::Error> {
-                (value <= MAX).then_some(Self(value)).ok_or(())
-            }
-        }
-    };
-}
-
-uint_bound!(U8Bound, u8);
-uint_bound!(U16Bound, u16);
-uint_bound!(U32Bound, u32);
-uint_bound!(U64Bound, u64);
-uint_bound!(U128Bound, u128);
-
 #[cfg(feature = "serde")]
 mod serde {
-    use serde::Deserialize;
+    use serde::Deserialize as _;
 
-    use crate::math::{F64Ge1, FiniteF64, MaxValue, MinValue, NonNegativeF64, PositiveF64};
+    use crate::math::{F64Ge1, FiniteF64, NonNegativeF64, PositiveF64};
 
     pub(super) fn deserialize<'de, Deserializer>(
         deserializer: Deserializer,
@@ -456,40 +328,6 @@ mod serde {
         F64Ge1::try_from(inner)
             .map_err(|()| serde::de::Error::custom("Deserialized f64 must be >= 1.0"))?;
         Ok(inner)
-    }
-
-    pub(super) fn deserialize_with_min_value<'de, Deserializer, Min>(
-        deserializer: Deserializer,
-    ) -> Result<Min::Type, Deserializer::Error>
-    where
-        Deserializer: serde::Deserializer<'de>,
-        Min: MinValue<Type: PartialOrd + Deserialize<'de>>,
-    {
-        let value = Min::Type::deserialize(deserializer)?;
-        if value >= Min::MIN {
-            Ok(value)
-        } else {
-            Err(serde::de::Error::custom(
-                "Deserialized value is less than the minimum allowed.",
-            ))
-        }
-    }
-
-    pub(super) fn deserialize_with_max_value<'de, Deserializer, Max>(
-        deserializer: Deserializer,
-    ) -> Result<Max::Type, Deserializer::Error>
-    where
-        Deserializer: serde::Deserializer<'de>,
-        Max: MaxValue<Type: PartialOrd + Deserialize<'de>>,
-    {
-        let value = Max::Type::deserialize(deserializer)?;
-        if value <= Max::MAX {
-            Ok(value)
-        } else {
-            Err(serde::de::Error::custom(
-                "Deserialized value is greater than the maximum allowed.",
-            ))
-        }
     }
 }
 
@@ -545,30 +383,6 @@ mod tests {
         assert!(F64Ge1::try_from(2u64).is_ok());
         assert!(F64Ge1::try_from(FiniteF64::MAX_REPRESENTABLE_U64).is_ok());
         assert!(F64Ge1::try_from(FiniteF64::MAX_REPRESENTABLE_U64 + 1).is_err());
-    }
-
-    #[test]
-    fn non_less_than_impl() {
-        assert!(AtLeast::<U8Bound<2>>::checked_from(1).is_none());
-        assert_eq!(AtLeast::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(AtLeast::<U16Bound<2>>::checked_from(1).is_none());
-        assert_eq!(AtLeast::<U16Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(AtLeast::<U32Bound<2>>::checked_from(1).is_none());
-        assert_eq!(AtLeast::<U32Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(AtLeast::<U64Bound<2>>::checked_from(1).is_none());
-        assert_eq!(AtLeast::<U64Bound<2>>::checked_from(2).unwrap().get(), 2);
-    }
-
-    #[test]
-    fn non_more_than_impl() {
-        assert!(AtMost::<U8Bound<2>>::checked_from(3).is_none());
-        assert_eq!(AtMost::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(AtMost::<U16Bound<2>>::checked_from(3).is_none());
-        assert_eq!(AtMost::<U16Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(AtMost::<U32Bound<2>>::checked_from(3).is_none());
-        assert_eq!(AtMost::<U32Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(AtMost::<U64Bound<2>>::checked_from(3).is_none());
-        assert_eq!(AtMost::<U64Bound<2>>::checked_from(2).unwrap().get(), 2);
     }
 
     #[cfg(feature = "serde")]
@@ -627,76 +441,6 @@ mod tests {
             assert!((*ok.value - 1.0).abs() < f64::EPSILON);
 
             assert!(serde_json::from_str::<F64Ge1>(r#"{"value": 1.1}"#).is_err());
-        }
-
-        #[test]
-        fn deser_no_less_than() {
-            assert!(serde_json::from_str::<AtLeast<U8Bound<2>>>("1").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtLeast<U8Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-
-            assert!(serde_json::from_str::<AtLeast<U16Bound<2>>>("1").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtLeast<U16Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-
-            assert!(serde_json::from_str::<AtLeast<U32Bound<2>>>("1").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtLeast<U32Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-
-            assert!(serde_json::from_str::<AtLeast<U64Bound<2>>>("1").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtLeast<U64Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-        }
-
-        #[test]
-        fn deser_no_more_than() {
-            assert!(serde_json::from_str::<AtMost<U8Bound<2>>>("3").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtMost<U8Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-
-            assert!(serde_json::from_str::<AtMost<U16Bound<2>>>("3").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtMost<U16Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-
-            assert!(serde_json::from_str::<AtMost<U32Bound<2>>>("3").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtMost<U32Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
-
-            assert!(serde_json::from_str::<AtMost<U64Bound<2>>>("3").is_err());
-            assert_eq!(
-                serde_json::from_str::<AtMost<U64Bound<2>>>("2")
-                    .unwrap()
-                    .get(),
-                2
-            );
         }
     }
 }

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -287,7 +287,7 @@ pub trait MinValue {
     derive(::serde::Serialize, ::serde::Deserialize),
     serde(bound(deserialize = "Min::Type: ::serde::Deserialize<'de> + PartialOrd"))
 )]
-pub struct NonLessThan<Min>(
+pub struct AtLeast<Min>(
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "serde::deserialize_with_min_value::<_, Min>")
@@ -297,7 +297,7 @@ pub struct NonLessThan<Min>(
 where
     Min: MinValue;
 
-impl<Min> NonLessThan<Min>
+impl<Min> AtLeast<Min>
 where
     Min: MinValue<Type: PartialOrd>,
 {
@@ -306,7 +306,7 @@ where
     }
 }
 
-impl<Min> NonLessThan<Min>
+impl<Min> AtLeast<Min>
 where
     Min: MinValue,
 {
@@ -327,7 +327,7 @@ pub trait MaxValue {
     derive(::serde::Serialize, ::serde::Deserialize),
     serde(bound(deserialize = "Max::Type: ::serde::Deserialize<'de> + PartialOrd"))
 )]
-pub struct NonMoreThan<Max>(
+pub struct AtMost<Max>(
     #[cfg_attr(
         feature = "serde",
         serde(deserialize_with = "serde::deserialize_with_max_value::<_, Max>")
@@ -337,7 +337,7 @@ pub struct NonMoreThan<Max>(
 where
     Max: MaxValue;
 
-impl<Max> NonMoreThan<Max>
+impl<Max> AtMost<Max>
 where
     Max: MaxValue<Type: PartialOrd>,
 {
@@ -346,7 +346,7 @@ where
     }
 }
 
-impl<Max> NonMoreThan<Max>
+impl<Max> AtMost<Max>
 where
     Max: MaxValue,
 {
@@ -355,54 +355,53 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct U8Bound<const MIN: u8>;
-impl<const MIN: u8> MinValue for U8Bound<MIN> {
-    type Type = u8;
-
-    const MIN: Self::Type = MIN;
+/// A macro to define a newtype wrapper around an unsigned integer type that
+/// enforces a minimum or maximum value constraint. The generated type
+/// implements the `MinValue` and `MaxValue` traits, and provides conversion
+/// methods to and from the underlying integer type. The macro takes the name of
+/// the new type and the underlying unsigned integer type as parameters.
+macro_rules! uint_bound {
+    ($name:ident, $ty:ty) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        pub struct $name<const N: $ty>;
+        impl<const N: $ty> MinValue for $name<N> {
+            type Type = $ty;
+            const MIN: Self::Type = N;
+        }
+        impl<const N: $ty> MaxValue for $name<N> {
+            type Type = $ty;
+            const MAX: Self::Type = N;
+        }
+        impl<const MIN: $ty> From<AtLeast<$name<MIN>>> for $ty {
+            fn from(value: AtLeast<$name<MIN>>) -> Self {
+                value.0
+            }
+        }
+        impl<const MIN: $ty> TryFrom<$ty> for AtLeast<$name<MIN>> {
+            type Error = ();
+            fn try_from(value: $ty) -> Result<Self, Self::Error> {
+                (value >= MIN).then_some(Self(value)).ok_or(())
+            }
+        }
+        impl<const MAX: $ty> From<AtMost<$name<MAX>>> for $ty {
+            fn from(value: AtMost<$name<MAX>>) -> Self {
+                value.0
+            }
+        }
+        impl<const MAX: $ty> TryFrom<$ty> for AtMost<$name<MAX>> {
+            type Error = ();
+            fn try_from(value: $ty) -> Result<Self, Self::Error> {
+                (value <= MAX).then_some(Self(value)).ok_or(())
+            }
+        }
+    };
 }
-impl<const MAX: u8> MaxValue for U8Bound<MAX> {
-    type Type = u8;
 
-    const MAX: Self::Type = MAX;
-}
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct U16Bound<const MIN: u16>;
-impl<const MIN: u16> MinValue for U16Bound<MIN> {
-    type Type = u16;
-
-    const MIN: Self::Type = MIN;
-}
-impl<const MAX: u16> MaxValue for U16Bound<MAX> {
-    type Type = u16;
-
-    const MAX: Self::Type = MAX;
-}
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct U32Bound<const MIN: u32>;
-impl<const MIN: u32> MinValue for U32Bound<MIN> {
-    type Type = u32;
-
-    const MIN: Self::Type = MIN;
-}
-impl<const MAX: u32> MaxValue for U32Bound<MAX> {
-    type Type = u32;
-
-    const MAX: Self::Type = MAX;
-}
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct U64Bound<const MIN: u64>;
-impl<const MIN: u64> MinValue for U64Bound<MIN> {
-    type Type = u64;
-
-    const MIN: Self::Type = MIN;
-}
-impl<const MAX: u64> MaxValue for U64Bound<MAX> {
-    type Type = u64;
-
-    const MAX: Self::Type = MAX;
-}
+uint_bound!(U8Bound, u8);
+uint_bound!(U16Bound, u16);
+uint_bound!(U32Bound, u32);
+uint_bound!(U64Bound, u64);
+uint_bound!(U128Bound, u128);
 
 #[cfg(feature = "serde")]
 mod serde {
@@ -550,44 +549,26 @@ mod tests {
 
     #[test]
     fn non_less_than_impl() {
-        assert!(NonLessThan::<U8Bound<2>>::checked_from(1).is_none());
-        assert_eq!(NonLessThan::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(NonLessThan::<U16Bound<2>>::checked_from(1).is_none());
-        assert_eq!(
-            NonLessThan::<U16Bound<2>>::checked_from(2).unwrap().get(),
-            2
-        );
-        assert!(NonLessThan::<U32Bound<2>>::checked_from(1).is_none());
-        assert_eq!(
-            NonLessThan::<U32Bound<2>>::checked_from(2).unwrap().get(),
-            2
-        );
-        assert!(NonLessThan::<U64Bound<2>>::checked_from(1).is_none());
-        assert_eq!(
-            NonLessThan::<U64Bound<2>>::checked_from(2).unwrap().get(),
-            2
-        );
+        assert!(AtLeast::<U8Bound<2>>::checked_from(1).is_none());
+        assert_eq!(AtLeast::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(AtLeast::<U16Bound<2>>::checked_from(1).is_none());
+        assert_eq!(AtLeast::<U16Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(AtLeast::<U32Bound<2>>::checked_from(1).is_none());
+        assert_eq!(AtLeast::<U32Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(AtLeast::<U64Bound<2>>::checked_from(1).is_none());
+        assert_eq!(AtLeast::<U64Bound<2>>::checked_from(2).unwrap().get(), 2);
     }
 
     #[test]
     fn non_more_than_impl() {
-        assert!(NonMoreThan::<U8Bound<2>>::checked_from(3).is_none());
-        assert_eq!(NonMoreThan::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(NonMoreThan::<U16Bound<2>>::checked_from(3).is_none());
-        assert_eq!(
-            NonMoreThan::<U16Bound<2>>::checked_from(2).unwrap().get(),
-            2
-        );
-        assert!(NonMoreThan::<U32Bound<2>>::checked_from(3).is_none());
-        assert_eq!(
-            NonMoreThan::<U32Bound<2>>::checked_from(2).unwrap().get(),
-            2
-        );
-        assert!(NonMoreThan::<U64Bound<2>>::checked_from(3).is_none());
-        assert_eq!(
-            NonMoreThan::<U64Bound<2>>::checked_from(2).unwrap().get(),
-            2
-        );
+        assert!(AtMost::<U8Bound<2>>::checked_from(3).is_none());
+        assert_eq!(AtMost::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(AtMost::<U16Bound<2>>::checked_from(3).is_none());
+        assert_eq!(AtMost::<U16Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(AtMost::<U32Bound<2>>::checked_from(3).is_none());
+        assert_eq!(AtMost::<U32Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(AtMost::<U64Bound<2>>::checked_from(3).is_none());
+        assert_eq!(AtMost::<U64Bound<2>>::checked_from(2).unwrap().get(), 2);
     }
 
     #[cfg(feature = "serde")]
@@ -650,33 +631,33 @@ mod tests {
 
         #[test]
         fn deser_no_less_than() {
-            assert!(serde_json::from_str::<NonLessThan<U8Bound<2>>>("1").is_err());
+            assert!(serde_json::from_str::<AtLeast<U8Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U8Bound<2>>>("2")
+                serde_json::from_str::<AtLeast<U8Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonLessThan<U16Bound<2>>>("1").is_err());
+            assert!(serde_json::from_str::<AtLeast<U16Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U16Bound<2>>>("2")
+                serde_json::from_str::<AtLeast<U16Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonLessThan<U32Bound<2>>>("1").is_err());
+            assert!(serde_json::from_str::<AtLeast<U32Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U32Bound<2>>>("2")
+                serde_json::from_str::<AtLeast<U32Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonLessThan<U64Bound<2>>>("1").is_err());
+            assert!(serde_json::from_str::<AtLeast<U64Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U64Bound<2>>>("2")
+                serde_json::from_str::<AtLeast<U64Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
@@ -685,33 +666,33 @@ mod tests {
 
         #[test]
         fn deser_no_more_than() {
-            assert!(serde_json::from_str::<NonMoreThan<U8Bound<2>>>("3").is_err());
+            assert!(serde_json::from_str::<AtMost<U8Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U8Bound<2>>>("2")
+                serde_json::from_str::<AtMost<U8Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonMoreThan<U16Bound<2>>>("3").is_err());
+            assert!(serde_json::from_str::<AtMost<U16Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U16Bound<2>>>("2")
+                serde_json::from_str::<AtMost<U16Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonMoreThan<U32Bound<2>>>("3").is_err());
+            assert!(serde_json::from_str::<AtMost<U32Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U32Bound<2>>>("2")
+                serde_json::from_str::<AtMost<U32Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonMoreThan<U64Bound<2>>>("3").is_err());
+            assert!(serde_json::from_str::<AtMost<U64Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U64Bound<2>>>("2")
+                serde_json::from_str::<AtMost<U64Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,6 +1,5 @@
 use core::{
     marker::PhantomData,
-    num::{self, NonZero},
     ops::{Deref, DerefMut},
 };
 use std::num::NonZeroU32;
@@ -297,7 +296,6 @@ pub struct NonLessThan<Min>(
         serde(deserialize_with = "serde::deserialize_with_min_value::<_, Min>")
     )]
     Min::Type,
-    #[cfg_attr(feature = "serde", serde(skip))] PhantomData<Min>,
 )
 where
     Min: MinValue;
@@ -307,7 +305,7 @@ where
     Min: MinValue<Type: PartialOrd>,
 {
     pub fn try_from(value: Min::Type) -> Option<Self> {
-        (value >= Min::MIN).then(|| Self(value, PhantomData))
+        (value >= Min::MIN).then(|| Self(value))
     }
 }
 
@@ -320,38 +318,100 @@ where
     }
 }
 
-pub struct GetMinU8<const MIN: u8>;
-impl<const MIN: u8> MinValue for GetMinU8<MIN> {
+pub trait MaxValue {
+    type Type;
+
+    const MAX: Self::Type;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(::serde::Serialize, ::serde::Deserialize),
+    serde(bound(deserialize = "Max::Type: ::serde::Deserialize<'de> + PartialOrd"))
+)]
+pub struct NonMoreThan<Max>(
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "serde::deserialize_with_max_value::<_, Max>")
+    )]
+    Max::Type,
+)
+where
+    Max: MaxValue;
+
+impl<Max> NonMoreThan<Max>
+where
+    Max: MaxValue<Type: PartialOrd>,
+{
+    pub fn checked_from(value: Max::Type) -> Option<Self> {
+        (value <= Max::MAX).then(|| Self(value))
+    }
+}
+
+impl<Max> NonMoreThan<Max>
+where
+    Max: MaxValue,
+{
+    pub fn get(self) -> Max::Type {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct U8<const MIN: u8>;
+impl<const MIN: u8> MinValue for U8<MIN> {
     type Type = u8;
 
     const MIN: Self::Type = MIN;
 }
-pub struct GetMinU16<const MIN: u16>;
-impl<const MIN: u16> MinValue for GetMinU16<MIN> {
+impl<const MAX: u8> MaxValue for U8<MAX> {
+    type Type = u8;
+
+    const MAX: Self::Type = MAX;
+}
+#[derive(Debug)]
+pub struct U16<const MIN: u16>;
+impl<const MIN: u16> MinValue for U16<MIN> {
     type Type = u16;
 
     const MIN: Self::Type = MIN;
 }
-pub struct GetMinU32<const MIN: u32>;
-impl<const MIN: u32> MinValue for GetMinU32<MIN> {
+impl<const MAX: u16> MaxValue for U16<MAX> {
+    type Type = u16;
+
+    const MAX: Self::Type = MAX;
+}
+#[derive(Debug)]
+pub struct U32<const MIN: u32>;
+impl<const MIN: u32> MinValue for U32<MIN> {
     type Type = u32;
 
     const MIN: Self::Type = MIN;
 }
-pub struct GetMinU64<const MIN: u64>;
-impl<const MIN: u64> MinValue for GetMinU64<MIN> {
+impl<const MAX: u32> MaxValue for U32<MAX> {
+    type Type = u32;
+
+    const MAX: Self::Type = MAX;
+}
+#[derive(Debug)]
+pub struct U64<const MIN: u64>;
+impl<const MIN: u64> MinValue for U64<MIN> {
     type Type = u64;
 
     const MIN: Self::Type = MIN;
 }
+impl<const MAX: u64> MaxValue for U64<MAX> {
+    type Type = u64;
 
-pub type NonLessThan2U64 = NonLessThan<GetMinU64<2>>;
+    const MAX: Self::Type = MAX;
+}
 
 #[cfg(feature = "serde")]
 mod serde {
     use serde::Deserialize;
 
-    use crate::math::{F64Ge1, FiniteF64, MinValue, NonNegativeF64, PositiveF64};
+    use crate::math::{F64Ge1, FiniteF64, MaxValue, MinValue, NonNegativeF64, PositiveF64};
 
     pub(super) fn deserialize<'de, Deserializer>(
         deserializer: Deserializer,
@@ -418,6 +478,23 @@ mod serde {
             ))
         }
     }
+
+    pub(super) fn deserialize_with_max_value<'de, Deserializer, Max>(
+        deserializer: Deserializer,
+    ) -> Result<Max::Type, Deserializer::Error>
+    where
+        Deserializer: serde::Deserializer<'de>,
+        Max: MaxValue<Type: PartialOrd + Deserialize<'de>>,
+    {
+        let value = Max::Type::deserialize(deserializer)?;
+        if value <= Max::MAX {
+            Ok(value)
+        } else {
+            Err(serde::de::Error::custom(
+                "Deserialized value is greater than the maximum allowed.",
+            ))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -472,6 +549,30 @@ mod tests {
         assert!(F64Ge1::try_from(2u64).is_ok());
         assert!(F64Ge1::try_from(FiniteF64::MAX_REPRESENTABLE_U64).is_ok());
         assert!(F64Ge1::try_from(FiniteF64::MAX_REPRESENTABLE_U64 + 1).is_err());
+    }
+
+    #[test]
+    fn non_less_than_impl() {
+        assert!(NonLessThan::<U8<2>>::try_from(1).is_none());
+        assert_eq!(NonLessThan::<U8<2>>::try_from(2).unwrap().get(), 2);
+        assert!(NonLessThan::<U16<2>>::try_from(1).is_none());
+        assert_eq!(NonLessThan::<U16<2>>::try_from(2).unwrap().get(), 2);
+        assert!(NonLessThan::<U32<2>>::try_from(1).is_none());
+        assert_eq!(NonLessThan::<U32<2>>::try_from(2).unwrap().get(), 2);
+        assert!(NonLessThan::<U64<2>>::try_from(1).is_none());
+        assert_eq!(NonLessThan::<U64<2>>::try_from(2).unwrap().get(), 2);
+    }
+
+    #[test]
+    fn non_more_than_impl() {
+        assert!(NonMoreThan::<U8<2>>::checked_from(3).is_none());
+        assert_eq!(NonMoreThan::<U8<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(NonMoreThan::<U16<2>>::checked_from(3).is_none());
+        assert_eq!(NonMoreThan::<U16<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(NonMoreThan::<U32<2>>::checked_from(3).is_none());
+        assert_eq!(NonMoreThan::<U32<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(NonMoreThan::<U64<2>>::checked_from(3).is_none());
+        assert_eq!(NonMoreThan::<U64<2>>::checked_from(2).unwrap().get(), 2);
     }
 
     #[cfg(feature = "serde")]
@@ -530,6 +631,76 @@ mod tests {
             assert!((*ok.value - 1.0).abs() < f64::EPSILON);
 
             assert!(serde_json::from_str::<F64Ge1>(r#"{"value": 1.1}"#).is_err());
+        }
+
+        #[test]
+        fn deser_no_less_than() {
+            assert!(serde_json::from_str::<NonLessThan<U8<2>>>("1").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonLessThan<U8<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+
+            assert!(serde_json::from_str::<NonLessThan<U16<2>>>("1").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonLessThan<U16<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+
+            assert!(serde_json::from_str::<NonLessThan<U32<2>>>("1").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonLessThan<U32<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+
+            assert!(serde_json::from_str::<NonLessThan<U64<2>>>("1").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonLessThan<U64<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+        }
+
+        #[test]
+        fn deser_no_more_than() {
+            assert!(serde_json::from_str::<NonMoreThan<U8<2>>>("3").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonMoreThan<U8<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+
+            assert!(serde_json::from_str::<NonMoreThan<U16<2>>>("3").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonMoreThan<U16<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+
+            assert!(serde_json::from_str::<NonMoreThan<U32<2>>>("3").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonMoreThan<U32<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
+
+            assert!(serde_json::from_str::<NonMoreThan<U64<2>>>("3").is_err());
+            assert_eq!(
+                serde_json::from_str::<NonMoreThan<U64<2>>>("2")
+                    .unwrap()
+                    .get(),
+                2
+            );
         }
     }
 }

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,7 +1,4 @@
-use core::{
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-};
+use core::ops::{Deref, DerefMut};
 use std::num::NonZeroU32;
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
@@ -304,7 +301,7 @@ impl<Min> NonLessThan<Min>
 where
     Min: MinValue<Type: PartialOrd>,
 {
-    pub fn try_from(value: Min::Type) -> Option<Self> {
+    pub fn checked_from(value: Min::Type) -> Option<Self> {
         (value >= Min::MIN).then(|| Self(value))
     }
 }
@@ -358,50 +355,50 @@ where
     }
 }
 
-#[derive(Debug)]
-pub struct U8<const MIN: u8>;
-impl<const MIN: u8> MinValue for U8<MIN> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U8Bound<const MIN: u8>;
+impl<const MIN: u8> MinValue for U8Bound<MIN> {
     type Type = u8;
 
     const MIN: Self::Type = MIN;
 }
-impl<const MAX: u8> MaxValue for U8<MAX> {
+impl<const MAX: u8> MaxValue for U8Bound<MAX> {
     type Type = u8;
 
     const MAX: Self::Type = MAX;
 }
-#[derive(Debug)]
-pub struct U16<const MIN: u16>;
-impl<const MIN: u16> MinValue for U16<MIN> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U16Bound<const MIN: u16>;
+impl<const MIN: u16> MinValue for U16Bound<MIN> {
     type Type = u16;
 
     const MIN: Self::Type = MIN;
 }
-impl<const MAX: u16> MaxValue for U16<MAX> {
+impl<const MAX: u16> MaxValue for U16Bound<MAX> {
     type Type = u16;
 
     const MAX: Self::Type = MAX;
 }
-#[derive(Debug)]
-pub struct U32<const MIN: u32>;
-impl<const MIN: u32> MinValue for U32<MIN> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U32Bound<const MIN: u32>;
+impl<const MIN: u32> MinValue for U32Bound<MIN> {
     type Type = u32;
 
     const MIN: Self::Type = MIN;
 }
-impl<const MAX: u32> MaxValue for U32<MAX> {
+impl<const MAX: u32> MaxValue for U32Bound<MAX> {
     type Type = u32;
 
     const MAX: Self::Type = MAX;
 }
-#[derive(Debug)]
-pub struct U64<const MIN: u64>;
-impl<const MIN: u64> MinValue for U64<MIN> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U64Bound<const MIN: u64>;
+impl<const MIN: u64> MinValue for U64Bound<MIN> {
     type Type = u64;
 
     const MIN: Self::Type = MIN;
 }
-impl<const MAX: u64> MaxValue for U64<MAX> {
+impl<const MAX: u64> MaxValue for U64Bound<MAX> {
     type Type = u64;
 
     const MAX: Self::Type = MAX;
@@ -553,26 +550,44 @@ mod tests {
 
     #[test]
     fn non_less_than_impl() {
-        assert!(NonLessThan::<U8<2>>::try_from(1).is_none());
-        assert_eq!(NonLessThan::<U8<2>>::try_from(2).unwrap().get(), 2);
-        assert!(NonLessThan::<U16<2>>::try_from(1).is_none());
-        assert_eq!(NonLessThan::<U16<2>>::try_from(2).unwrap().get(), 2);
-        assert!(NonLessThan::<U32<2>>::try_from(1).is_none());
-        assert_eq!(NonLessThan::<U32<2>>::try_from(2).unwrap().get(), 2);
-        assert!(NonLessThan::<U64<2>>::try_from(1).is_none());
-        assert_eq!(NonLessThan::<U64<2>>::try_from(2).unwrap().get(), 2);
+        assert!(NonLessThan::<U8Bound<2>>::checked_from(1).is_none());
+        assert_eq!(NonLessThan::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(NonLessThan::<U16Bound<2>>::checked_from(1).is_none());
+        assert_eq!(
+            NonLessThan::<U16Bound<2>>::checked_from(2).unwrap().get(),
+            2
+        );
+        assert!(NonLessThan::<U32Bound<2>>::checked_from(1).is_none());
+        assert_eq!(
+            NonLessThan::<U32Bound<2>>::checked_from(2).unwrap().get(),
+            2
+        );
+        assert!(NonLessThan::<U64Bound<2>>::checked_from(1).is_none());
+        assert_eq!(
+            NonLessThan::<U64Bound<2>>::checked_from(2).unwrap().get(),
+            2
+        );
     }
 
     #[test]
     fn non_more_than_impl() {
-        assert!(NonMoreThan::<U8<2>>::checked_from(3).is_none());
-        assert_eq!(NonMoreThan::<U8<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(NonMoreThan::<U16<2>>::checked_from(3).is_none());
-        assert_eq!(NonMoreThan::<U16<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(NonMoreThan::<U32<2>>::checked_from(3).is_none());
-        assert_eq!(NonMoreThan::<U32<2>>::checked_from(2).unwrap().get(), 2);
-        assert!(NonMoreThan::<U64<2>>::checked_from(3).is_none());
-        assert_eq!(NonMoreThan::<U64<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(NonMoreThan::<U8Bound<2>>::checked_from(3).is_none());
+        assert_eq!(NonMoreThan::<U8Bound<2>>::checked_from(2).unwrap().get(), 2);
+        assert!(NonMoreThan::<U16Bound<2>>::checked_from(3).is_none());
+        assert_eq!(
+            NonMoreThan::<U16Bound<2>>::checked_from(2).unwrap().get(),
+            2
+        );
+        assert!(NonMoreThan::<U32Bound<2>>::checked_from(3).is_none());
+        assert_eq!(
+            NonMoreThan::<U32Bound<2>>::checked_from(2).unwrap().get(),
+            2
+        );
+        assert!(NonMoreThan::<U64Bound<2>>::checked_from(3).is_none());
+        assert_eq!(
+            NonMoreThan::<U64Bound<2>>::checked_from(2).unwrap().get(),
+            2
+        );
     }
 
     #[cfg(feature = "serde")]
@@ -635,33 +650,33 @@ mod tests {
 
         #[test]
         fn deser_no_less_than() {
-            assert!(serde_json::from_str::<NonLessThan<U8<2>>>("1").is_err());
+            assert!(serde_json::from_str::<NonLessThan<U8Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U8<2>>>("2")
+                serde_json::from_str::<NonLessThan<U8Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonLessThan<U16<2>>>("1").is_err());
+            assert!(serde_json::from_str::<NonLessThan<U16Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U16<2>>>("2")
+                serde_json::from_str::<NonLessThan<U16Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonLessThan<U32<2>>>("1").is_err());
+            assert!(serde_json::from_str::<NonLessThan<U32Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U32<2>>>("2")
+                serde_json::from_str::<NonLessThan<U32Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonLessThan<U64<2>>>("1").is_err());
+            assert!(serde_json::from_str::<NonLessThan<U64Bound<2>>>("1").is_err());
             assert_eq!(
-                serde_json::from_str::<NonLessThan<U64<2>>>("2")
+                serde_json::from_str::<NonLessThan<U64Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
@@ -670,33 +685,33 @@ mod tests {
 
         #[test]
         fn deser_no_more_than() {
-            assert!(serde_json::from_str::<NonMoreThan<U8<2>>>("3").is_err());
+            assert!(serde_json::from_str::<NonMoreThan<U8Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U8<2>>>("2")
+                serde_json::from_str::<NonMoreThan<U8Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonMoreThan<U16<2>>>("3").is_err());
+            assert!(serde_json::from_str::<NonMoreThan<U16Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U16<2>>>("2")
+                serde_json::from_str::<NonMoreThan<U16Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonMoreThan<U32<2>>>("3").is_err());
+            assert!(serde_json::from_str::<NonMoreThan<U32Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U32<2>>>("2")
+                serde_json::from_str::<NonMoreThan<U32Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2
             );
 
-            assert!(serde_json::from_str::<NonMoreThan<U64<2>>>("3").is_err());
+            assert!(serde_json::from_str::<NonMoreThan<U64Bound<2>>>("3").is_err());
             assert_eq!(
-                serde_json::from_str::<NonMoreThan<U64<2>>>("2")
+                serde_json::from_str::<NonMoreThan<U64Bound<2>>>("2")
                     .unwrap()
                     .get(),
                 2

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,4 +1,8 @@
-use core::ops::{Deref, DerefMut};
+use core::{
+    marker::PhantomData,
+    num::{self, NonZero},
+    ops::{Deref, DerefMut},
+};
 use std::num::NonZeroU32;
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
@@ -275,11 +279,79 @@ impl NonNegativeRatio {
     }
 }
 
+pub trait MinValue {
+    type Type;
+
+    const MIN: Self::Type;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(::serde::Serialize, ::serde::Deserialize),
+    serde(bound(deserialize = "Min::Type: ::serde::Deserialize<'de> + PartialOrd"))
+)]
+pub struct NonLessThan<Min>(
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "serde::deserialize_with_min_value::<_, Min>")
+    )]
+    Min::Type,
+    #[cfg_attr(feature = "serde", serde(skip))] PhantomData<Min>,
+)
+where
+    Min: MinValue;
+
+impl<Min> NonLessThan<Min>
+where
+    Min: MinValue<Type: PartialOrd>,
+{
+    pub fn try_from(value: Min::Type) -> Option<Self> {
+        (value >= Min::MIN).then(|| Self(value, PhantomData))
+    }
+}
+
+impl<Min> NonLessThan<Min>
+where
+    Min: MinValue,
+{
+    pub fn get(self) -> Min::Type {
+        self.0
+    }
+}
+
+pub struct GetMinU8<const MIN: u8>;
+impl<const MIN: u8> MinValue for GetMinU8<MIN> {
+    type Type = u8;
+
+    const MIN: Self::Type = MIN;
+}
+pub struct GetMinU16<const MIN: u16>;
+impl<const MIN: u16> MinValue for GetMinU16<MIN> {
+    type Type = u16;
+
+    const MIN: Self::Type = MIN;
+}
+pub struct GetMinU32<const MIN: u32>;
+impl<const MIN: u32> MinValue for GetMinU32<MIN> {
+    type Type = u32;
+
+    const MIN: Self::Type = MIN;
+}
+pub struct GetMinU64<const MIN: u64>;
+impl<const MIN: u64> MinValue for GetMinU64<MIN> {
+    type Type = u64;
+
+    const MIN: Self::Type = MIN;
+}
+
+pub type NonLessThan2U64 = NonLessThan<GetMinU64<2>>;
+
 #[cfg(feature = "serde")]
 mod serde {
-    use serde::Deserialize as _;
+    use serde::Deserialize;
 
-    use crate::math::{F64Ge1, FiniteF64, NonNegativeF64, PositiveF64};
+    use crate::math::{F64Ge1, FiniteF64, MinValue, NonNegativeF64, PositiveF64};
 
     pub(super) fn deserialize<'de, Deserializer>(
         deserializer: Deserializer,
@@ -328,6 +400,23 @@ mod serde {
         F64Ge1::try_from(inner)
             .map_err(|()| serde::de::Error::custom("Deserialized f64 must be >= 1.0"))?;
         Ok(inner)
+    }
+
+    pub(super) fn deserialize_with_min_value<'de, Deserializer, Min>(
+        deserializer: Deserializer,
+    ) -> Result<Min::Type, Deserializer::Error>
+    where
+        Deserializer: serde::Deserializer<'de>,
+        Min: MinValue<Type: PartialOrd + Deserialize<'de>>,
+    {
+        let value = Min::Type::deserialize(deserializer)?;
+        if value >= Min::MIN {
+            Ok(value)
+        } else {
+            Err(serde::de::Error::custom(
+                "Deserialized value is less than the minimum allowed.",
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

With a libp2p backend, a network size of 1 is problematic, because the peer will try to blend a message but it won't since there are no peers. So we enforce in the deployment deserialization that the value is at least `2`, so that single-node deployments will always bypass Blend and use gossipsub directly.

As for gossipsub, even with Blend disabled, sending a message to peers will fail if there is no peers. So only on the first failure we notify the node about its own block before scheduling it for retry. On success, we only notify the node about its own message if it never failed, otherwise it means the node was already notified and we avoid double-notifying it.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.