### PR TITLE
test(e2e): add system monitor diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1247,7 +1247,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1793,7 +1793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2799,7 +2799,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2978,7 +2978,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3136,7 +3136,7 @@ dependencies = [
  "smol",
  "system-configuration 0.7.0",
  "tokio",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3276,7 +3276,7 @@ dependencies = [
  "socket2 0.6.3",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3641,7 +3641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5869,6 +5869,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5973,10 +5982,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -6224,7 +6252,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8110,6 +8138,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8334,6 +8376,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sysinfo",
  "tempfile",
  "testing-framework-core",
  "testing-framework-runner-compose",
@@ -9454,14 +9497,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9470,7 +9535,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -9481,9 +9559,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -9492,9 +9581,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -9521,9 +9610,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -9531,8 +9636,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9541,9 +9646,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -9552,7 +9666,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -9561,7 +9684,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9597,7 +9720,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9622,7 +9745,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -9635,11 +9758,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/tests/cucumber_tests/cucumber.rs
+++ b/tests/cucumber_tests/cucumber.rs
@@ -27,7 +27,8 @@ use cucumber::{
     writer::Verbosity,
 };
 use lb_testing_framework::{
-    hash_str, is_truthy_env, reap_all_stale_port_blocks, release_reserved_port_block,
+    hash_str, is_truthy_env, reap_all_stale_port_blocks, record_system_monitor_event,
+    register_system_monitor_output_file, release_reserved_port_block,
 };
 use logos_blockchain_tests::cucumber::{
     defaults::{
@@ -220,6 +221,12 @@ fn prepare_world_for_scenario(
 
     let scenario_dir =
         scenario_output_dir(output_dir, scenario_attempts, feature_name, scenario_name);
+
+    register_system_monitor_output_file(&scenario_dir.join("system_stats.ndjson"));
+    record_system_monitor_event(
+        "cucumber_scenario_prepared",
+        scenario_dir.display().to_string(),
+    );
 
     world.set_scenario_base_dir(&scenario_dir, &deployer);
     world.apply_deployment_config_override_path();

--- a/tests/cucumber_tests/cucumber.rs
+++ b/tests/cucumber_tests/cucumber.rs
@@ -29,6 +29,7 @@ use cucumber::{
 use lb_testing_framework::{
     hash_str, is_truthy_env, reap_all_stale_port_blocks, record_system_monitor_event,
     register_system_monitor_output_file, release_reserved_port_block,
+    unregister_system_monitor_output_file,
 };
 use logos_blockchain_tests::cucumber::{
     defaults::{
@@ -159,6 +160,10 @@ async fn main() {
                             println!("{e}");
                         }
                     }
+
+                    unregister_system_monitor_output_file(
+                        &world.scenario_base_dir.join("system_stats.ndjson"),
+                    );
                 }
             })
         })
@@ -221,6 +226,13 @@ fn prepare_world_for_scenario(
 
     let scenario_dir =
         scenario_output_dir(output_dir, scenario_attempts, feature_name, scenario_name);
+
+    if let Err(err) = std::fs::create_dir_all(&scenario_dir) {
+        println!(
+            "Failed to create scenario artifact directory '{}': {err}",
+            scenario_dir.display()
+        );
+    }
 
     register_system_monitor_output_file(&scenario_dir.join("system_stats.ndjson"));
     record_system_monitor_event(

--- a/tests/src/common/manual_cluster.rs
+++ b/tests/src/common/manual_cluster.rs
@@ -9,7 +9,8 @@ use lb_libp2p::Multiaddr;
 use lb_node::{UserConfig, config::RunConfig};
 use lb_testing_framework::{
     DeploymentBuilder, LbcEnv, LbcLocalDeployer, LbcManualCluster, NodeHttpClient,
-    USER_CONFIG_FILE, internal::DeploymentPlan,
+    USER_CONFIG_FILE, internal::DeploymentPlan, record_system_monitor_event,
+    register_system_monitor_output_file,
 };
 use reqwest::Url;
 use testing_framework_core::scenario::{DynError, PeerSelection, StartNodeOptions, StartedNode};
@@ -37,6 +38,12 @@ pub fn build_local_manual_cluster(
     ensure_local_node_binary_env();
 
     let scenario_base_dir = unique_scenario_base_dir(&format!("{prefix}-{test_name}"));
+    register_system_monitor_output_file(&scenario_base_dir.join("system_stats.ndjson"));
+    record_system_monitor_event(
+        "manual_cluster_prepared",
+        scenario_base_dir.display().to_string(),
+    );
+
     let deployment = builder
         .scenario_base_dir(scenario_base_dir.clone())
         .build()

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -586,6 +586,7 @@ impl CucumberWorld {
     pub fn set_scenario_base_dir(&mut self, log_dir: &Path, deployer: &DeployerKind) {
         let log_dir = PathBuf::from(log_dir);
         init_node_log_dir_defaults(deployer, Some(&log_dir));
+
         self.scenario_base_dir.clone_from(&log_dir);
         if let Some(topology) = self.spec.topology.as_mut() {
             topology.scenario_base_dir = log_dir;

--- a/tests/src/nodes/mod.rs
+++ b/tests/src/nodes/mod.rs
@@ -35,6 +35,21 @@ fn persist_tempdir(tempdir: &mut TempDir, label: &str) -> std::io::Result<()> {
 }
 
 #[must_use]
+pub fn current_test_system_stats_file() -> PathBuf {
+    let current_thread = std::thread::current();
+    let thread_name = current_thread.name().unwrap_or("NODE");
+    let thread_slug = thread_name
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect::<String>();
+
+    std::env::current_dir().unwrap().join(format!(
+        ".run_{thread_slug}_{}_system_stats.ndjson",
+        std::process::id()
+    ))
+}
+
+#[must_use]
 pub fn get_exe_path() -> PathBuf {
     let debug_binary = std::env::current_dir().unwrap().join(BIN_PATH_DEBUG);
     let release_binary = std::env::current_dir().unwrap().join(BIN_PATH_RELEASE);

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -33,13 +33,17 @@ use lb_node::{
         wallet::serde::RequiredValues as WalletConfigRequiredValues,
     },
 };
-use lb_testing_framework::release_reserved_port_block;
+use lb_testing_framework::{
+    record_system_monitor_event, register_system_monitor_output_file, release_reserved_port_block,
+};
 use lb_tx_service::MempoolMetrics;
 use reqwest::Url;
 use tempfile::NamedTempFile;
 use tokio::time::error::Elapsed;
 
-use super::{CLIENT, create_tempdir, get_exe_path, persist_tempdir};
+use super::{
+    CLIENT, create_tempdir, current_test_system_stats_file, get_exe_path, persist_tempdir,
+};
 use crate::{
     IS_DEBUG_TRACING, get_reserved_available_tcp_port, nodes::LOGS_PREFIX,
     topology::configs::GeneralConfig,
@@ -191,6 +195,11 @@ impl Validator {
 
     pub async fn spawn(mut config: RunConfig) -> Result<Self, Elapsed> {
         let dir = create_tempdir().unwrap();
+        register_system_monitor_output_file(&current_test_system_stats_file());
+        record_system_monitor_event(
+            "validator_runtime_prepared",
+            dir.path().display().to_string(),
+        );
 
         if !*IS_DEBUG_TRACING {
             // setup logging so that we can intercept it later in testing

--- a/tests/testing_framework/Cargo.toml
+++ b/tests/testing_framework/Cargo.toml
@@ -24,6 +24,7 @@ reqwest                          = { features = ["json"], workspace = true }
 serde                            = { workspace = true }
 serde_json                       = { workspace = true }
 serde_yaml                       = { workspace = true }
+sysinfo                          = "0.37"
 tempfile                         = { workspace = true }
 testing-framework-core           = { workspace = true }
 testing-framework-runner-compose = { workspace = true }

--- a/tests/testing_framework/src/diagnostics.rs
+++ b/tests/testing_framework/src/diagnostics.rs
@@ -1,5 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+#[path = "diagnostics/system_monitor/mod.rs"]
+mod system_monitor;
+
 use async_trait::async_trait;
 use futures::future::join_all;
 use lb_blend_service::message::NetworkInfo as BlendNetworkInfo;
@@ -10,6 +13,21 @@ use testing_framework_core::scenario::{
 use thiserror::Error;
 
 use crate::{BlockFeed, LbcEnv, NodeHttpClient, node::DeploymentPlan};
+
+#[doc(hidden)]
+pub fn register_system_monitor_output_file(path: &std::path::Path) {
+    system_monitor::register_output_file(path);
+}
+
+#[doc(hidden)]
+pub fn record_system_monitor_event(label: &str, detail: impl Into<String>) {
+    system_monitor::record_event(label, detail);
+}
+
+fn render_system_monitor() -> String {
+    system_monitor::render_recent_summary()
+        .unwrap_or_else(|| "system_monitor:\n  unavailable".to_owned())
+}
 
 #[derive(Debug, Error)]
 pub enum ScenarioRunDiagnosticsError {
@@ -50,10 +68,14 @@ where
         Err(source) if scenario_error_has_diagnostics(&source) => {
             Err(ScenarioRunDiagnosticsError::AlreadyCaptured { source })
         }
-        Err(source) => Err(ScenarioRunDiagnosticsError::Captured {
-            report: sources.render().await,
-            source,
-        }),
+        Err(source) => {
+            record_system_monitor_event("scenario_failure", source.to_string());
+
+            Err(ScenarioRunDiagnosticsError::Captured {
+                report: sources.render().await,
+                source,
+            })
+        }
     }
 }
 
@@ -120,6 +142,8 @@ async fn add_failure_diagnostics(ctx: &RunContext<LbcEnv>, source: DynError) -> 
         return source;
     }
 
+    record_system_monitor_event("expectation_failure", source.to_string());
+
     Box::new(FailureDiagnosticsError {
         report: collect_failure_report(ctx).await,
         source,
@@ -164,6 +188,7 @@ impl DiagnosticSources {
             summary.render(),
             summary.render_connectivity(),
             self.render_block_feed(),
+            render_system_monitor(),
             render_nodes(&diagnostics),
         ];
 

--- a/tests/testing_framework/src/diagnostics.rs
+++ b/tests/testing_framework/src/diagnostics.rs
@@ -20,6 +20,11 @@ pub fn register_system_monitor_output_file(path: &std::path::Path) {
 }
 
 #[doc(hidden)]
+pub fn unregister_system_monitor_output_file(path: &std::path::Path) {
+    system_monitor::unregister_output_file(path);
+}
+
+#[doc(hidden)]
 pub fn record_system_monitor_event(label: &str, detail: impl Into<String>) {
     system_monitor::record_event(label, detail);
 }

--- a/tests/testing_framework/src/diagnostics/system_monitor/collector.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/collector.rs
@@ -1,0 +1,77 @@
+use std::path::{Path, PathBuf};
+
+use sysinfo::{DiskRefreshKind, Disks, ProcessesToUpdate, RefreshKind, System};
+use time::OffsetDateTime;
+
+use super::records::{
+    DiskSnapshot, HostSnapshot, SystemSample, collect_node_process_summary, collect_thread_count,
+    collect_top_cpu_processes, collect_top_rss_processes, finite_f32, finite_f64,
+};
+
+/// `sysinfo`-backed collector for one host sample.
+pub(super) struct SystemCollector {
+    system: System,
+    disks: Disks,
+    cwd: PathBuf,
+}
+
+impl SystemCollector {
+    pub(super) fn new() -> Self {
+        let mut system = System::new_with_specifics(RefreshKind::everything());
+        system.refresh_all();
+
+        Self {
+            system,
+            disks: Disks::new_with_refreshed_list_specifics(DiskRefreshKind::everything()),
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        }
+    }
+
+    pub(super) fn capture(&mut self) -> SystemSample {
+        self.system.refresh_memory();
+        self.system.refresh_cpu_usage();
+        self.system.refresh_processes(ProcessesToUpdate::All, true);
+        self.disks
+            .refresh_specifics(false, DiskRefreshKind::everything());
+
+        let processes = self.system.processes().values().collect::<Vec<_>>();
+        let logical_cpus = self.system.cpus().len().max(1);
+        let load_average = System::load_average();
+        let load1 = finite_f64(load_average.one);
+
+        SystemSample {
+            ts_unix: OffsetDateTime::now_utc().unix_timestamp(),
+            os: std::env::consts::OS,
+            host: HostSnapshot {
+                logical_cpus,
+                process_count: processes.len(),
+                thread_count: collect_thread_count(&processes),
+                cpu_usage_percent: finite_f32(self.system.global_cpu_usage()).unwrap_or(0.0),
+                load1,
+                load5: finite_f64(load_average.five),
+                load15: finite_f64(load_average.fifteen),
+                norm_load1: load1.and_then(|value| finite_f64(value / logical_cpus as f64)),
+                memory_used_bytes: Some(self.system.used_memory()),
+                memory_total_bytes: Some(self.system.total_memory()),
+                swap_used_bytes: Some(self.system.used_swap()),
+            },
+            disk: select_workspace_disk(&self.disks, &self.cwd),
+            node_processes: collect_node_process_summary(&processes),
+            top_cpu_processes: collect_top_cpu_processes(&processes),
+            top_rss_processes: collect_top_rss_processes(&processes),
+        }
+    }
+}
+
+fn select_workspace_disk(disks: &Disks, cwd: &Path) -> Option<DiskSnapshot> {
+    disks
+        .list()
+        .iter()
+        .filter(|disk| cwd.starts_with(disk.mount_point()))
+        .max_by_key(|disk| disk.mount_point().as_os_str().len())
+        .map(|disk| DiskSnapshot {
+            mount_point: disk.mount_point().display().to_string(),
+            available_bytes: disk.available_space(),
+            total_bytes: disk.total_space(),
+        })
+}

--- a/tests/testing_framework/src/diagnostics/system_monitor/mod.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/mod.rs
@@ -20,7 +20,10 @@ use crate::env as tf_env;
 
 static SYSTEM_MONITOR: OnceLock<SystemMonitor> = OnceLock::new();
 
-/// Registers one NDJSON output file for the shared monitor.
+/// Registers one monitor output path.
+///
+/// The shared monitor writes the full stream to the provided NDJSON path and
+/// writes flat sample rows to a sibling CSV file.
 pub(super) fn register_output_file(path: &Path) {
     if !tf_env::logos_blockchain_system_monitor_enabled() {
         return;
@@ -29,7 +32,7 @@ pub(super) fn register_output_file(path: &Path) {
     system_monitor().register_output(path);
 }
 
-/// Stops writing the shared monitor stream to one NDJSON output file.
+/// Stops writing the shared monitor stream to one registered output path.
 pub(super) fn unregister_output_file(path: &Path) {
     if !tf_env::logos_blockchain_system_monitor_enabled() {
         return;
@@ -73,12 +76,19 @@ impl SystemMonitor {
     }
 
     fn register_output(&self, path: &Path) {
-        if !self.shared.register_output(path.to_path_buf()) {
+        if !self.shared.register_output(path) {
             return;
         }
 
         self.shared
             .publish_event(SystemEvent::output_registered(path));
+
+        if let Some(sample) = self.shared.latest_sample() {
+            self.shared.append_sample_to_output(path, sample);
+            return;
+        }
+
+        self.shared.publish_sample(SystemCollector::new().capture());
     }
 
     fn unregister_output(&self, path: &Path) {
@@ -131,7 +141,7 @@ struct SystemMonitorShared {
 }
 
 impl SystemMonitorShared {
-    fn register_output(&self, path: PathBuf) -> bool {
+    fn register_output(&self, path: &Path) -> bool {
         self.outputs
             .lock()
             .expect("system monitor lock poisoned")
@@ -163,6 +173,11 @@ impl SystemMonitorShared {
         let _guard = self.io.lock().expect("system monitor lock poisoned");
 
         sink::SystemStatsLog::append(path, record);
+    }
+
+    fn append_sample_to_output(&self, path: &Path, sample: SystemSample) {
+        let record = SystemMonitorRecord::Sample(Box::new(sample));
+        self.append_record(path, &record);
     }
 
     fn publish_sample(&self, sample: SystemSample) {
@@ -217,6 +232,13 @@ impl SystemMonitorShared {
             .expect("system monitor lock poisoned")
             .paths()
     }
+
+    fn latest_sample(&self) -> Option<SystemSample> {
+        self.samples
+            .lock()
+            .expect("system monitor lock poisoned")
+            .latest()
+    }
 }
 
 /// Background worker that periodically captures and publishes system samples.
@@ -267,9 +289,13 @@ mod tests {
     }
 
     #[test]
-    fn registering_output_file_creates_event_log() {
+    fn registering_output_file_bootstraps_ndjson_and_csv() {
         let tempdir = tempdir().expect("tempdir should be created");
         let path = tempdir.path().join("system_stats.ndjson");
+        let csv_path = tempdir.path().join("system_stats.csv");
+
+        fs::write(&path, "stale-ndjson\n").expect("stale ndjson should be written");
+        fs::write(&csv_path, "stale-csv\n").expect("stale csv should be written");
 
         register_output_file(&path);
         std::thread::sleep(Duration::from_millis(50));
@@ -287,5 +313,15 @@ mod tests {
                 == Some(&serde_json::Value::String("event".to_owned())),
             "first monitor record should be the registration event"
         );
+
+        let csv = fs::read_to_string(tempdir.path().join("system_stats.csv"))
+            .expect("csv log should be created for new outputs");
+
+        assert!(
+            csv.starts_with("ts_unix,os,logical_cpus"),
+            "csv log should contain the header row"
+        );
+        assert!(!contents.contains("stale-ndjson"));
+        assert!(!csv.contains("stale-csv"));
     }
 }

--- a/tests/testing_framework/src/diagnostics/system_monitor/mod.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/mod.rs
@@ -29,6 +29,15 @@ pub(super) fn register_output_file(path: &Path) {
     system_monitor().register_output(path);
 }
 
+/// Stops writing the shared monitor stream to one NDJSON output file.
+pub(super) fn unregister_output_file(path: &Path) {
+    if !tf_env::logos_blockchain_system_monitor_enabled() {
+        return;
+    }
+
+    system_monitor().unregister_output(path);
+}
+
 /// Records one lifecycle marker in the shared monitor stream.
 pub(super) fn record_event(label: &str, detail: impl Into<String>) {
     if !tf_env::logos_blockchain_system_monitor_enabled() {
@@ -70,6 +79,17 @@ impl SystemMonitor {
 
         self.shared
             .publish_event(SystemEvent::output_registered(path));
+    }
+
+    fn unregister_output(&self, path: &Path) {
+        if !self.shared.unregister_output(path) {
+            return;
+        }
+
+        self.shared.publish_event(SystemEvent::new(
+            "output_unregistered",
+            path.display().to_string(),
+        ));
     }
 
     fn record_event(&self, event: SystemEvent) {
@@ -116,6 +136,13 @@ impl SystemMonitorShared {
             .lock()
             .expect("system monitor lock poisoned")
             .register(path)
+    }
+
+    fn unregister_output(&self, path: &Path) -> bool {
+        self.outputs
+            .lock()
+            .expect("system monitor lock poisoned")
+            .unregister(path)
     }
 
     fn record_sample(&self, sample: SystemSample) {

--- a/tests/testing_framework/src/diagnostics/system_monitor/mod.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/mod.rs
@@ -1,0 +1,264 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+    thread,
+    time::Duration,
+};
+
+mod collector;
+mod records;
+mod sink;
+mod state;
+mod summary;
+
+use collector::SystemCollector;
+use records::{SystemEvent, SystemMonitorRecord, SystemSample};
+use state::{EventHistory, MonitorSnapshot, OutputRegistry, SampleHistory};
+use summary::SystemSummary;
+
+use crate::env as tf_env;
+
+static SYSTEM_MONITOR: OnceLock<SystemMonitor> = OnceLock::new();
+
+/// Registers one NDJSON output file for the shared monitor.
+pub(super) fn register_output_file(path: &Path) {
+    if !tf_env::logos_blockchain_system_monitor_enabled() {
+        return;
+    }
+
+    system_monitor().register_output(path);
+}
+
+/// Records one lifecycle marker in the shared monitor stream.
+pub(super) fn record_event(label: &str, detail: impl Into<String>) {
+    if !tf_env::logos_blockchain_system_monitor_enabled() {
+        return;
+    }
+
+    system_monitor().record_event(SystemEvent::new(label, detail));
+}
+
+/// Renders a compact summary of the most recent samples for failure reports.
+pub(super) fn render_recent_summary() -> Option<String> {
+    system_monitor().render_recent_summary()
+}
+
+fn system_monitor() -> &'static SystemMonitor {
+    SYSTEM_MONITOR.get_or_init(SystemMonitor::new)
+}
+
+/// Process-wide orchestrator for sampling and diagnostics rendering.
+struct SystemMonitor {
+    config: SystemMonitorConfig,
+    shared: Arc<SystemMonitorShared>,
+}
+
+impl SystemMonitor {
+    fn new() -> Self {
+        let config = SystemMonitorConfig::from_env();
+        let shared = Arc::new(SystemMonitorShared::default());
+
+        SamplerThread::spawn(config, Arc::clone(&shared));
+
+        Self { config, shared }
+    }
+
+    fn register_output(&self, path: &Path) {
+        if !self.shared.register_output(path.to_path_buf()) {
+            return;
+        }
+
+        self.shared
+            .publish_event(SystemEvent::output_registered(path));
+    }
+
+    fn record_event(&self, event: SystemEvent) {
+        self.shared.publish_event(event);
+    }
+
+    fn render_recent_summary(&self) -> Option<String> {
+        let snapshot = self.shared.snapshot();
+
+        SystemSummary::build(self.config.interval_secs, &snapshot).map(SystemSummary::render)
+    }
+}
+
+#[derive(Clone, Copy)]
+/// Environment-derived monitor settings shared by the sampler and reporters.
+struct SystemMonitorConfig {
+    interval_secs: u64,
+}
+
+impl SystemMonitorConfig {
+    fn from_env() -> Self {
+        Self {
+            interval_secs: tf_env::logos_blockchain_system_monitor_interval_secs(),
+        }
+    }
+
+    const fn sample_interval(self) -> Duration {
+        Duration::from_secs(self.interval_secs)
+    }
+}
+
+#[derive(Default)]
+/// Shared monitor state accessed by registration, sampling, and reporting.
+struct SystemMonitorShared {
+    io: Mutex<()>,
+    outputs: Mutex<OutputRegistry>,
+    samples: Mutex<SampleHistory>,
+    events: Mutex<EventHistory>,
+}
+
+impl SystemMonitorShared {
+    fn register_output(&self, path: PathBuf) -> bool {
+        self.outputs
+            .lock()
+            .expect("system monitor lock poisoned")
+            .register(path)
+    }
+
+    fn record_sample(&self, sample: SystemSample) {
+        self.samples
+            .lock()
+            .expect("system monitor lock poisoned")
+            .record(sample);
+    }
+
+    fn record_event(&self, event: SystemEvent) {
+        self.events
+            .lock()
+            .expect("system monitor lock poisoned")
+            .record(event);
+    }
+
+    fn append_record(&self, path: &Path, record: &SystemMonitorRecord) {
+        let _guard = self.io.lock().expect("system monitor lock poisoned");
+
+        sink::SystemStatsLog::append(path, record);
+    }
+
+    fn publish_sample(&self, sample: SystemSample) {
+        let outputs = self.output_paths();
+        let record = SystemMonitorRecord::Sample(Box::new(sample.clone()));
+
+        self.record_sample(sample);
+
+        for output in outputs {
+            self.append_record(&output, &record);
+        }
+    }
+
+    fn publish_event(&self, event: SystemEvent) {
+        let outputs = self.output_paths();
+        let record = SystemMonitorRecord::Event(event.clone());
+
+        self.record_event(event);
+
+        for output in outputs {
+            self.append_record(&output, &record);
+        }
+    }
+
+    fn snapshot(&self) -> MonitorSnapshot {
+        let output_count = self
+            .outputs
+            .lock()
+            .expect("system monitor lock poisoned")
+            .len();
+        let samples = self
+            .samples
+            .lock()
+            .expect("system monitor lock poisoned")
+            .window();
+        let events = self
+            .events
+            .lock()
+            .expect("system monitor lock poisoned")
+            .window();
+
+        MonitorSnapshot {
+            output_count,
+            samples,
+            events,
+        }
+    }
+
+    fn output_paths(&self) -> Vec<PathBuf> {
+        self.outputs
+            .lock()
+            .expect("system monitor lock poisoned")
+            .paths()
+    }
+}
+
+/// Background worker that periodically captures and publishes system samples.
+struct SamplerThread {
+    collector: SystemCollector,
+    config: SystemMonitorConfig,
+    shared: Arc<SystemMonitorShared>,
+}
+
+impl SamplerThread {
+    fn spawn(config: SystemMonitorConfig, shared: Arc<SystemMonitorShared>) {
+        thread::Builder::new()
+            .name("logos-test-system-monitor".to_owned())
+            .spawn(move || {
+                Self {
+                    collector: SystemCollector::new(),
+                    config,
+                    shared,
+                }
+                .run();
+            })
+            .expect("system monitor thread should start");
+    }
+
+    fn run(mut self) {
+        loop {
+            self.shared.publish_sample(self.collector.capture());
+
+            thread::sleep(self.config.sample_interval());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, time::Duration};
+
+    use tempfile::tempdir;
+
+    use super::{collector::SystemCollector, register_output_file};
+
+    #[test]
+    fn captured_sample_is_json_serializable() {
+        let mut collector = SystemCollector::new();
+        let sample = collector.capture();
+
+        serde_json::to_string(&sample).expect("captured sample should serialize");
+    }
+
+    #[test]
+    fn registering_output_file_creates_event_log() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("system_stats.ndjson");
+
+        register_output_file(&path);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let contents = fs::read_to_string(&path).expect("monitor log should be created");
+        let first_record = contents
+            .lines()
+            .next()
+            .expect("monitor log should contain at least one record");
+
+        assert!(
+            serde_json::from_str::<serde_json::Value>(first_record)
+                .expect("monitor record should deserialize")
+                .get("record_type")
+                == Some(&serde_json::Value::String("event".to_owned())),
+            "first monitor record should be the registration event"
+        );
+    }
+}

--- a/tests/testing_framework/src/diagnostics/system_monitor/records.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/records.rs
@@ -15,6 +15,15 @@ pub(super) enum SystemMonitorRecord {
     Event(SystemEvent),
 }
 
+impl SystemMonitorRecord {
+    pub(super) fn as_sample(&self) -> Option<&SystemSample> {
+        match self {
+            Self::Sample(sample) => Some(sample),
+            Self::Event(_) => None,
+        }
+    }
+}
+
 /// One point-in-time host sample captured from `sysinfo`.
 #[derive(Clone, Debug, Serialize)]
 pub(super) struct SystemSample {
@@ -75,6 +84,107 @@ impl ProcessSnapshot {
             cpu_usage_percent: finite_f32(process.cpu_usage()),
             rss_bytes: Some(process.memory()),
         }
+    }
+}
+
+/// Flat CSV projection of one system sample for spreadsheet-friendly analysis.
+pub(super) struct CsvSampleRow {
+    ts_unix: i64,
+    os: String,
+    logical_cpus: usize,
+    process_count: usize,
+    thread_count: Option<usize>,
+    cpu_usage_percent: f32,
+    load1: Option<f64>,
+    load5: Option<f64>,
+    load15: Option<f64>,
+    norm_load1: Option<f64>,
+    memory_used_bytes: Option<u64>,
+    memory_total_bytes: Option<u64>,
+    swap_used_bytes: Option<u64>,
+    disk_mount_point: Option<String>,
+    disk_available_bytes: Option<u64>,
+    disk_total_bytes: Option<u64>,
+    node_process_count: usize,
+    node_process_rss_bytes: u64,
+    top_cpu_processes: String,
+    top_rss_processes: String,
+}
+
+impl CsvSampleRow {
+    pub(super) const HEADER: &[&str] = &[
+        "ts_unix",
+        "os",
+        "logical_cpus",
+        "process_count",
+        "thread_count",
+        "cpu_usage_percent",
+        "load1",
+        "load5",
+        "load15",
+        "norm_load1",
+        "memory_used_bytes",
+        "memory_total_bytes",
+        "swap_used_bytes",
+        "disk_mount_point",
+        "disk_available_bytes",
+        "disk_total_bytes",
+        "node_process_count",
+        "node_process_rss_bytes",
+        "top_cpu_processes",
+        "top_rss_processes",
+    ];
+
+    pub(super) fn from_sample(sample: &SystemSample) -> Self {
+        let disk = sample.disk.as_ref();
+
+        Self {
+            ts_unix: sample.ts_unix,
+            os: sample.os.to_owned(),
+            logical_cpus: sample.host.logical_cpus,
+            process_count: sample.host.process_count,
+            thread_count: sample.host.thread_count,
+            cpu_usage_percent: sample.host.cpu_usage_percent,
+            load1: sample.host.load1,
+            load5: sample.host.load5,
+            load15: sample.host.load15,
+            norm_load1: sample.host.norm_load1,
+            memory_used_bytes: sample.host.memory_used_bytes,
+            memory_total_bytes: sample.host.memory_total_bytes,
+            swap_used_bytes: sample.host.swap_used_bytes,
+            disk_mount_point: disk.map(|value| value.mount_point.clone()),
+            disk_available_bytes: disk.map(|value| value.available_bytes),
+            disk_total_bytes: disk.map(|value| value.total_bytes),
+            node_process_count: sample.node_processes.count,
+            node_process_rss_bytes: sample.node_processes.total_rss_bytes,
+            top_cpu_processes: render_process_list(&sample.top_cpu_processes),
+            top_rss_processes: render_process_list(&sample.top_rss_processes),
+        }
+    }
+
+    pub(super) fn values(&self) -> Vec<String> {
+        vec![
+            self.ts_unix.to_string(),
+            self.os.clone(),
+            self.logical_cpus.to_string(),
+            self.process_count.to_string(),
+            format_opt_usize(self.thread_count),
+            self.cpu_usage_percent.to_string(),
+            format_opt_f64(self.load1),
+            format_opt_f64(self.load5),
+            format_opt_f64(self.load15),
+            format_opt_f64(self.norm_load1),
+            format_opt_u64(self.memory_used_bytes),
+            format_opt_u64(self.memory_total_bytes),
+            format_opt_u64(self.swap_used_bytes),
+            self.disk_mount_point.clone().unwrap_or_default(),
+            format_opt_u64(self.disk_available_bytes),
+            format_opt_u64(self.disk_total_bytes),
+            self.node_process_count.to_string(),
+            self.node_process_rss_bytes.to_string(),
+            self.top_cpu_processes.clone(),
+            self.top_rss_processes.clone(),
+        ]
     }
 }
 
@@ -198,4 +308,37 @@ fn truncate_string(mut value: String, limit: usize) -> String {
     value = value.chars().take(limit.saturating_sub(1)).collect();
     value.push('\u{2026}');
     value
+}
+
+fn render_process_list(processes: &[ProcessSnapshot]) -> String {
+    processes
+        .iter()
+        .map(render_process_summary)
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+fn render_process_summary(process: &ProcessSnapshot) -> String {
+    let cpu = process
+        .cpu_usage_percent
+        .map(|value| format!("{value:.1}"))
+        .unwrap_or_default();
+    let rss = process
+        .rss_bytes
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+
+    format!("{}#{}#{}#{}", process.name, process.pid, cpu, rss)
+}
+
+fn format_opt_f64(value: Option<f64>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
+fn format_opt_u64(value: Option<u64>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
+fn format_opt_usize(value: Option<usize>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
 }

--- a/tests/testing_framework/src/diagnostics/system_monitor/records.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/records.rs
@@ -1,0 +1,201 @@
+use std::{ffi::OsStr, path::Path};
+
+use serde::Serialize;
+use sysinfo::Process;
+use time::OffsetDateTime;
+
+const TOP_PROCESS_LIMIT: usize = 3;
+const EVENT_DETAIL_LIMIT: usize = 160;
+
+/// Persisted monitor stream entry.
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "record_type", rename_all = "snake_case")]
+pub(super) enum SystemMonitorRecord {
+    Sample(Box<SystemSample>),
+    Event(SystemEvent),
+}
+
+/// One point-in-time host sample captured from `sysinfo`.
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct SystemSample {
+    pub(super) ts_unix: i64,
+    pub(super) os: &'static str,
+    pub(super) host: HostSnapshot,
+    pub(super) disk: Option<DiskSnapshot>,
+    pub(super) node_processes: NodeProcessSummary,
+    pub(super) top_cpu_processes: Vec<ProcessSnapshot>,
+    pub(super) top_rss_processes: Vec<ProcessSnapshot>,
+}
+
+/// Host-wide resource usage at one point in time.
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct HostSnapshot {
+    pub(super) logical_cpus: usize,
+    pub(super) process_count: usize,
+    pub(super) thread_count: Option<usize>,
+    pub(super) cpu_usage_percent: f32,
+    pub(super) load1: Option<f64>,
+    pub(super) load5: Option<f64>,
+    pub(super) load15: Option<f64>,
+    pub(super) norm_load1: Option<f64>,
+    pub(super) memory_used_bytes: Option<u64>,
+    pub(super) memory_total_bytes: Option<u64>,
+    pub(super) swap_used_bytes: Option<u64>,
+}
+
+/// Disk capacity view for the workspace or test artifact mount.
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct DiskSnapshot {
+    pub(super) mount_point: String,
+    pub(super) available_bytes: u64,
+    pub(super) total_bytes: u64,
+}
+
+/// Summary of currently running `logos-blockchain-node` processes.
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct NodeProcessSummary {
+    pub(super) count: usize,
+    pub(super) total_rss_bytes: u64,
+}
+
+/// Compact view of one busy process.
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ProcessSnapshot {
+    pub(super) pid: String,
+    pub(super) name: String,
+    pub(super) cpu_usage_percent: Option<f32>,
+    pub(super) rss_bytes: Option<u64>,
+}
+
+impl ProcessSnapshot {
+    pub(super) fn from_process(process: &Process) -> Self {
+        Self {
+            pid: process.pid().to_string(),
+            name: process_display_name(process),
+            cpu_usage_percent: finite_f32(process.cpu_usage()),
+            rss_bytes: Some(process.memory()),
+        }
+    }
+}
+
+/// One lifecycle marker written alongside samples in the monitor stream.
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct SystemEvent {
+    pub(super) ts_unix: i64,
+    pub(super) label: String,
+    pub(super) detail: String,
+}
+
+impl SystemEvent {
+    pub(super) fn new(label: &str, detail: impl Into<String>) -> Self {
+        Self {
+            ts_unix: OffsetDateTime::now_utc().unix_timestamp(),
+            label: label.to_owned(),
+            detail: truncate_string(detail.into(), EVENT_DETAIL_LIMIT),
+        }
+    }
+
+    pub(super) fn output_registered(path: &Path) -> Self {
+        Self::new("output_registered", path.display().to_string())
+    }
+}
+
+pub(super) fn collect_node_process_summary(processes: &[&Process]) -> NodeProcessSummary {
+    let mut count = 0usize;
+    let mut total_rss_bytes = 0u64;
+
+    for process in processes
+        .iter()
+        .copied()
+        .filter(|process| is_logos_node_process(process))
+    {
+        count += 1;
+        total_rss_bytes += process.memory();
+    }
+
+    NodeProcessSummary {
+        count,
+        total_rss_bytes,
+    }
+}
+
+pub(super) fn collect_top_cpu_processes(processes: &[&Process]) -> Vec<ProcessSnapshot> {
+    top_processes_by(processes, |process| {
+        finite_f32(process.cpu_usage()).map_or(0.0, f64::from)
+    })
+}
+
+pub(super) fn collect_top_rss_processes(processes: &[&Process]) -> Vec<ProcessSnapshot> {
+    top_processes_by(processes, |process| process.memory() as f64)
+}
+
+pub(super) fn collect_thread_count(processes: &[&Process]) -> Option<usize> {
+    let mut total = 0usize;
+    let mut observed = false;
+
+    for process in processes {
+        let Some(tasks) = process.tasks() else {
+            continue;
+        };
+
+        observed = true;
+        total += tasks.len();
+    }
+
+    observed.then_some(total)
+}
+
+pub(super) fn finite_f32(value: f32) -> Option<f32> {
+    value.is_finite().then_some(value)
+}
+
+pub(super) fn finite_f64(value: f64) -> Option<f64> {
+    value.is_finite().then_some(value)
+}
+
+fn top_processes_by<F>(processes: &[&Process], metric: F) -> Vec<ProcessSnapshot>
+where
+    F: Fn(&Process) -> f64,
+{
+    let mut processes = processes.to_vec();
+    processes.sort_by(|left, right| metric(right).total_cmp(&metric(left)));
+
+    processes
+        .into_iter()
+        .filter(|process| metric(process) > 0.0)
+        .take(TOP_PROCESS_LIMIT)
+        .map(ProcessSnapshot::from_process)
+        .collect()
+}
+
+fn is_logos_node_process(process: &Process) -> bool {
+    process.exe().is_some_and(|exe| {
+        exe.file_name()
+            .is_some_and(|name| name == OsStr::new("logos-blockchain-node"))
+    }) || process.name() == OsStr::new("logos-blockchain-node")
+}
+
+fn process_display_name(process: &Process) -> String {
+    process
+        .exe()
+        .and_then(|exe| exe.file_name())
+        .or_else(|| {
+            process
+                .cmd()
+                .first()
+                .and_then(|cmd| Path::new(cmd).file_name())
+        })
+        .unwrap_or_else(|| process.name())
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn truncate_string(mut value: String, limit: usize) -> String {
+    if value.chars().count() <= limit {
+        return value;
+    }
+
+    value = value.chars().take(limit.saturating_sub(1)).collect();
+    value.push('\u{2026}');
+    value
+}

--- a/tests/testing_framework/src/diagnostics/system_monitor/sink.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/sink.rs
@@ -1,0 +1,36 @@
+use std::{
+    fs,
+    io::{self, Write as _},
+    path::Path,
+};
+
+use super::records::SystemMonitorRecord;
+
+/// NDJSON sink for persisted monitor records.
+pub(super) struct SystemStatsLog;
+
+impl SystemStatsLog {
+    pub(super) fn ensure_parent_dir(path: &Path) {
+        if let Some(parent) = path.parent() {
+            drop(fs::create_dir_all(parent));
+        }
+    }
+
+    pub(super) fn append(path: &Path, record: &SystemMonitorRecord) {
+        if let Err(error) = Self::append_impl(path, record) {
+            eprintln!(
+                "failed to append system monitor record to {}: {error}",
+                path.display()
+            );
+        }
+    }
+
+    fn append_impl(path: &Path, record: &SystemMonitorRecord) -> io::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        serde_json::to_writer(&mut file, record).map_err(io::Error::other)?;
+        file.write_all(b"\n")
+    }
+}

--- a/tests/testing_framework/src/diagnostics/system_monitor/sink.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/sink.rs
@@ -1,12 +1,12 @@
 use std::{
     fs,
     io::{self, Write as _},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
-use super::records::SystemMonitorRecord;
+use super::records::{CsvSampleRow, SystemMonitorRecord};
 
-/// NDJSON sink for persisted monitor records.
+/// Persisted monitor sinks for structured logs and flat spreadsheet exports.
 pub(super) struct SystemStatsLog;
 
 impl SystemStatsLog {
@@ -14,6 +14,13 @@ impl SystemStatsLog {
         if let Some(parent) = path.parent() {
             drop(fs::create_dir_all(parent));
         }
+    }
+
+    pub(super) fn reset_output(path: &Path) {
+        Self::ensure_parent_dir(path);
+
+        let _unused = fs::remove_file(path);
+        let _unused = fs::remove_file(csv_path(path));
     }
 
     pub(super) fn append(path: &Path, record: &SystemMonitorRecord) {
@@ -26,11 +33,121 @@ impl SystemStatsLog {
     }
 
     fn append_impl(path: &Path, record: &SystemMonitorRecord) -> io::Result<()> {
+        Self::append_ndjson(path, record)?;
+
+        if let Some(sample) = record.as_sample() {
+            Self::append_csv(&csv_path(path), &CsvSampleRow::from_sample(sample))?;
+        }
+
+        Ok(())
+    }
+
+    fn append_ndjson(path: &Path, record: &SystemMonitorRecord) -> io::Result<()> {
         let mut file = fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)?;
         serde_json::to_writer(&mut file, record).map_err(io::Error::other)?;
         file.write_all(b"\n")
+    }
+
+    fn append_csv(path: &Path, row: &CsvSampleRow) -> io::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+
+        if file.metadata()?.len() == 0 {
+            write_csv_row(&mut file, CsvSampleRow::HEADER)?;
+        }
+
+        write_csv_row(&mut file, &row.values())
+    }
+}
+
+fn csv_path(path: &Path) -> PathBuf {
+    path.with_extension("csv")
+}
+
+fn write_csv_row(file: &mut fs::File, columns: &[impl AsRef<str>]) -> io::Result<()> {
+    let line = columns
+        .iter()
+        .map(|value| escape_csv_field(value.as_ref()))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    writeln!(file, "{line}")
+}
+
+fn escape_csv_field(value: &str) -> String {
+    if !value.contains([',', '"', '\n', '\r']) {
+        return value.to_owned();
+    }
+
+    let escaped = value.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::diagnostics::system_monitor::records::{
+        HostSnapshot, NodeProcessSummary, SystemSample,
+    };
+
+    #[test]
+    fn appending_sample_writes_ndjson_and_csv() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let ndjson_path = tempdir.path().join("system_stats.ndjson");
+        let record = SystemMonitorRecord::Sample(Box::new(SystemSample {
+            ts_unix: 42,
+            os: "linux",
+            host: HostSnapshot {
+                logical_cpus: 8,
+                process_count: 42,
+                thread_count: Some(128),
+                cpu_usage_percent: 75.5,
+                load1: Some(8.0),
+                load5: Some(7.0),
+                load15: Some(6.0),
+                norm_load1: Some(1.0),
+                memory_used_bytes: Some(100),
+                memory_total_bytes: Some(200),
+                swap_used_bytes: Some(10),
+            },
+            disk: None,
+            node_processes: NodeProcessSummary {
+                count: 2,
+                total_rss_bytes: 300,
+            },
+            top_cpu_processes: Vec::new(),
+            top_rss_processes: Vec::new(),
+        }));
+
+        SystemStatsLog::append(&ndjson_path, &record);
+
+        let ndjson = fs::read_to_string(&ndjson_path).expect("ndjson log should exist");
+        let csv = fs::read_to_string(tempdir.path().join("system_stats.csv"))
+            .expect("csv log should exist");
+
+        assert!(ndjson.contains("\"record_type\":\"sample\""));
+        assert!(csv.starts_with("ts_unix,os,logical_cpus"));
+        assert!(csv.contains("\n42,linux,8,42,128,75.5,8,7,6,1,100,200,10,,"));
+    }
+
+    #[test]
+    fn appending_event_does_not_create_csv() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let ndjson_path = tempdir.path().join("system_stats.ndjson");
+        let record = SystemMonitorRecord::Event(
+            crate::diagnostics::system_monitor::records::SystemEvent::new("test_event", "detail"),
+        );
+
+        SystemStatsLog::append(&ndjson_path, &record);
+
+        assert!(ndjson_path.exists());
+        assert!(!tempdir.path().join("system_stats.csv").exists());
     }
 }

--- a/tests/testing_framework/src/diagnostics/system_monitor/state.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/state.rs
@@ -1,0 +1,154 @@
+use std::{collections::VecDeque, path::PathBuf};
+
+use super::{
+    records::{SystemEvent, SystemSample},
+    sink::SystemStatsLog,
+};
+
+const RECENT_SAMPLE_LIMIT: usize = 12;
+const RECENT_EVENT_LIMIT: usize = 24;
+const RECENT_EVENT_SUMMARY_LIMIT: usize = 6;
+
+/// Registered output files that receive the NDJSON monitor stream.
+#[derive(Default)]
+pub(super) struct OutputRegistry {
+    paths: std::collections::BTreeSet<PathBuf>,
+}
+
+impl OutputRegistry {
+    pub(super) fn register(&mut self, path: PathBuf) -> bool {
+        SystemStatsLog::ensure_parent_dir(&path);
+        self.paths.insert(path)
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    pub(super) fn paths(&self) -> Vec<PathBuf> {
+        self.paths.iter().cloned().collect()
+    }
+}
+
+/// Fixed-size rolling window used for recent sample lookups.
+#[derive(Default)]
+pub(super) struct SampleHistory {
+    samples: VecDeque<SystemSample>,
+}
+
+impl SampleHistory {
+    pub(super) fn record(&mut self, sample: SystemSample) {
+        if self.samples.len() == RECENT_SAMPLE_LIMIT {
+            self.samples.pop_front();
+        }
+
+        self.samples.push_back(sample);
+    }
+
+    pub(super) fn window(&self) -> SampleWindow {
+        SampleWindow {
+            samples: self.samples.clone(),
+        }
+    }
+}
+
+/// Recent lifecycle markers retained alongside host samples.
+#[derive(Default)]
+pub(super) struct EventHistory {
+    events: VecDeque<SystemEvent>,
+}
+
+impl EventHistory {
+    pub(super) fn record(&mut self, event: SystemEvent) {
+        if self.events.len() == RECENT_EVENT_LIMIT {
+            self.events.pop_front();
+        }
+
+        self.events.push_back(event);
+    }
+
+    pub(super) fn window(&self) -> EventWindow {
+        EventWindow {
+            events: self.events.clone(),
+        }
+    }
+}
+
+/// Immutable view of the current monitor state used for reporting.
+pub(super) struct MonitorSnapshot {
+    pub(super) output_count: usize,
+    pub(super) samples: SampleWindow,
+    pub(super) events: EventWindow,
+}
+
+/// Query helpers over the retained recent sample window.
+pub(super) struct SampleWindow {
+    samples: VecDeque<SystemSample>,
+}
+
+impl SampleWindow {
+    pub(super) fn latest(&self) -> Option<&SystemSample> {
+        self.samples.back()
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    pub(super) fn norm_load_history(&self) -> Option<String> {
+        if self.samples.len() <= 1 {
+            return None;
+        }
+
+        Some(
+            self.samples
+                .iter()
+                .map(super::summary::format_sample_norm_load1)
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+
+    pub(super) fn cpu_history(&self) -> Option<String> {
+        if self.samples.len() <= 1 {
+            return None;
+        }
+
+        Some(
+            self.samples
+                .iter()
+                .map(super::summary::format_sample_cpu_used_pct)
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}
+
+/// Query helpers over the retained recent event window.
+pub(super) struct EventWindow {
+    events: VecDeque<SystemEvent>,
+}
+
+impl EventWindow {
+    pub(super) fn recent_summary(&self) -> Option<String> {
+        let events = self
+            .events
+            .iter()
+            .rev()
+            .take(RECENT_EVENT_SUMMARY_LIMIT)
+            .collect::<Vec<_>>();
+
+        if events.is_empty() {
+            return None;
+        }
+
+        Some(
+            events
+                .into_iter()
+                .rev()
+                .map(super::summary::render_event_summary_item)
+                .collect::<Vec<_>>()
+                .join(" | "),
+        )
+    }
+}

--- a/tests/testing_framework/src/diagnostics/system_monitor/state.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/state.rs
@@ -21,6 +21,10 @@ impl OutputRegistry {
         self.paths.insert(path)
     }
 
+    pub(super) fn unregister(&mut self, path: &std::path::Path) -> bool {
+        self.paths.remove(path)
+    }
+
     pub(super) fn len(&self) -> usize {
         self.paths.len()
     }

--- a/tests/testing_framework/src/diagnostics/system_monitor/state.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/state.rs
@@ -16,9 +16,13 @@ pub(super) struct OutputRegistry {
 }
 
 impl OutputRegistry {
-    pub(super) fn register(&mut self, path: PathBuf) -> bool {
-        SystemStatsLog::ensure_parent_dir(&path);
-        self.paths.insert(path)
+    pub(super) fn register(&mut self, path: &std::path::Path) -> bool {
+        if !self.paths.insert(path.to_path_buf()) {
+            return false;
+        }
+
+        SystemStatsLog::reset_output(path);
+        true
     }
 
     pub(super) fn unregister(&mut self, path: &std::path::Path) -> bool {
@@ -47,6 +51,10 @@ impl SampleHistory {
         }
 
         self.samples.push_back(sample);
+    }
+
+    pub(super) fn latest(&self) -> Option<SystemSample> {
+        self.samples.back().cloned()
     }
 
     pub(super) fn window(&self) -> SampleWindow {

--- a/tests/testing_framework/src/diagnostics/system_monitor/summary.rs
+++ b/tests/testing_framework/src/diagnostics/system_monitor/summary.rs
@@ -1,0 +1,206 @@
+use super::{
+    records::{DiskSnapshot, NodeProcessSummary, ProcessSnapshot, SystemEvent, SystemSample},
+    state::MonitorSnapshot,
+};
+
+/// Renderable diagnostics view derived from the latest monitor state.
+pub(super) struct SystemSummary {
+    output_count: usize,
+    sample_count: usize,
+    interval_secs: u64,
+    latest: SystemSample,
+    recent_norm_load1: Option<String>,
+    recent_cpu_used_pct: Option<String>,
+    recent_events: Option<String>,
+}
+
+impl SystemSummary {
+    pub(super) fn build(interval_secs: u64, snapshot: &MonitorSnapshot) -> Option<Self> {
+        let latest = snapshot.samples.latest()?.clone();
+
+        Some(Self {
+            output_count: snapshot.output_count,
+            sample_count: snapshot.samples.len(),
+            interval_secs,
+            latest,
+            recent_norm_load1: snapshot.samples.norm_load_history(),
+            recent_cpu_used_pct: snapshot.samples.cpu_history(),
+            recent_events: snapshot.events.recent_summary(),
+        })
+    }
+
+    pub(super) fn render(self) -> String {
+        let mut lines = vec![
+            "system_monitor:".to_owned(),
+            format!(
+                "  enabled=true outputs={} samples={} interval_secs={}",
+                self.output_count, self.sample_count, self.interval_secs
+            ),
+            render_host_summary_line(&self.latest),
+        ];
+
+        if let Some(line) = self.latest.disk.as_ref().map(render_disk_summary_line) {
+            lines.push(line);
+        }
+
+        lines.push(render_node_process_summary_line(
+            &self.latest.node_processes,
+        ));
+
+        if let Some(line) = render_cpu_process_summary_line(&self.latest.top_cpu_processes) {
+            lines.push(line);
+        }
+
+        if let Some(line) = render_rss_process_summary_line(&self.latest.top_rss_processes) {
+            lines.push(line);
+        }
+
+        if let Some(history) = self.recent_norm_load1 {
+            lines.push(format!("  recent norm_load1=[{history}]"));
+        }
+
+        if let Some(history) = self.recent_cpu_used_pct {
+            lines.push(format!("  recent cpu_used_pct=[{history}]"));
+        }
+
+        if let Some(events) = self.recent_events {
+            lines.push(format!("  recent events=[{events}]"));
+        }
+
+        lines.join("\n")
+    }
+}
+
+pub(super) fn render_event_summary_item(event: &SystemEvent) -> String {
+    format!("{}:{}({})", event.ts_unix, event.label, event.detail)
+}
+
+pub(super) fn render_host_summary_line(sample: &SystemSample) -> String {
+    format!(
+        "  latest ts_unix={} os={} cpus={} procs={} threads={} cpu_used_pct={} load1={} norm_load1={} mem={} swap={}",
+        sample.ts_unix,
+        sample.os,
+        sample.host.logical_cpus,
+        sample.host.process_count,
+        format_opt_usize(sample.host.thread_count),
+        format_sample_cpu_used_pct(sample),
+        format_opt_f64(sample.host.load1),
+        format_sample_norm_load1(sample),
+        format_bytes_pair(
+            sample.host.memory_used_bytes,
+            sample.host.memory_total_bytes
+        ),
+        format_opt_bytes(sample.host.swap_used_bytes),
+    )
+}
+
+pub(super) fn render_disk_summary_line(disk: &DiskSnapshot) -> String {
+    format!(
+        "  disk mount={} free={}",
+        disk.mount_point,
+        format_bytes_pair(Some(disk.available_bytes), Some(disk.total_bytes)),
+    )
+}
+
+pub(super) fn render_node_process_summary_line(summary: &NodeProcessSummary) -> String {
+    format!(
+        "  logos_nodes count={} rss={}",
+        summary.count,
+        format_bytes(summary.total_rss_bytes),
+    )
+}
+
+fn render_cpu_process_summary_item(process: &ProcessSnapshot) -> String {
+    format!(
+        "{}(pid={})={}",
+        process.name,
+        process.pid,
+        process
+            .cpu_usage_percent
+            .map_or_else(|| "n/a".to_owned(), |value| format!("{value:.1}%"))
+    )
+}
+
+fn render_rss_process_summary_item(process: &ProcessSnapshot) -> String {
+    format!(
+        "{}(pid={})={}",
+        process.name,
+        process.pid,
+        format_opt_bytes(process.rss_bytes)
+    )
+}
+
+pub(super) fn render_cpu_process_summary_line(processes: &[ProcessSnapshot]) -> Option<String> {
+    if processes.is_empty() {
+        return None;
+    }
+
+    let rendered = processes
+        .iter()
+        .map(render_cpu_process_summary_item)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Some(format!("  top cpu=[{rendered}]"))
+}
+
+pub(super) fn render_rss_process_summary_line(processes: &[ProcessSnapshot]) -> Option<String> {
+    if processes.is_empty() {
+        return None;
+    }
+
+    let rendered = processes
+        .iter()
+        .map(render_rss_process_summary_item)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Some(format!("  top rss=[{rendered}]"))
+}
+
+pub(super) fn format_sample_cpu_used_pct(sample: &SystemSample) -> String {
+    format!("{:.1}", sample.host.cpu_usage_percent)
+}
+
+pub(super) fn format_sample_norm_load1(sample: &SystemSample) -> String {
+    format_opt_f64(sample.host.norm_load1)
+}
+
+fn format_opt_f64(value: Option<f64>) -> String {
+    value.map_or_else(|| "n/a".to_owned(), |value| format!("{value:.2}"))
+}
+
+fn format_opt_usize(value: Option<usize>) -> String {
+    value.map_or_else(|| "n/a".to_owned(), |value| value.to_string())
+}
+
+fn format_opt_bytes(value: Option<u64>) -> String {
+    value.map_or_else(|| "n/a".to_owned(), format_bytes)
+}
+
+fn format_bytes_pair(used: Option<u64>, total: Option<u64>) -> String {
+    match (used, total) {
+        (Some(used), Some(total)) => format!("{}/{}", format_bytes(used), format_bytes(total)),
+        _ => "n/a".to_owned(),
+    }
+}
+
+fn format_bytes(value: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    const GIB: u64 = MIB * 1024;
+
+    if value >= GIB {
+        return format!("{:.1}GiB", value as f64 / GIB as f64);
+    }
+
+    if value >= MIB {
+        return format!("{:.1}MiB", value as f64 / MIB as f64);
+    }
+
+    if value >= KIB {
+        return format!("{:.1}KiB", value as f64 / KIB as f64);
+    }
+
+    format!("{value}B")
+}

--- a/tests/testing_framework/src/env.rs
+++ b/tests/testing_framework/src/env.rs
@@ -91,3 +91,18 @@ pub fn rust_log() -> Option<String> {
 pub fn lb_time_service_backend() -> Option<String> {
     std::env::var("LOGOS_BLOCKCHAIN_TIME_BACKEND").ok()
 }
+
+#[must_use]
+pub fn logos_blockchain_system_monitor_enabled() -> bool {
+    std::env::var("LOGOS_BLOCKCHAIN_SYSTEM_MONITOR").map_or(true, |raw| {
+        !matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        )
+    })
+}
+
+#[must_use]
+pub fn logos_blockchain_system_monitor_interval_secs() -> u64 {
+    env_u64("LOGOS_BLOCKCHAIN_SYSTEM_MONITOR_INTERVAL_SECS", 10)
+}

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -28,7 +28,9 @@ use testing_framework_runner_local::{
 use tracing::debug;
 
 use crate::{
-    LOGOS_BLOCKCHAIN_LOG_LEVEL, env as tf_env,
+    LOGOS_BLOCKCHAIN_LOG_LEVEL,
+    diagnostics::{record_system_monitor_event, register_system_monitor_output_file},
+    env as tf_env,
     framework::LbcEnv,
     node::{
         DeploymentPlan, NodeHttpClient, NodePlan,
@@ -99,6 +101,13 @@ impl LocalDeployerEnv for LbcEnv {
     fn build_initial_node_configs(
         topology: &Self::Deployment,
     ) -> Result<Vec<NodeConfigEntry<<Self as Application>::NodeConfig>>, ProcessSpawnError> {
+        register_system_monitor_output_file(
+            &topology
+                .config()
+                .scenario_base_dir
+                .join("system_stats.ndjson"),
+        );
+
         topology
             .nodes()
             .iter()
@@ -133,6 +142,12 @@ impl LocalDeployerEnv for LbcEnv {
     ) -> Result<LaunchSpec, DynError> {
         let mut config = config.clone();
         ensure_recovery_paths(dir).map_err(|source| -> DynError { source.into() })?;
+
+        record_system_monitor_event(
+            "node_runtime_prepared",
+            format!("{label}:{}", dir.display()),
+        );
+
         config.user.tracing.level = configured_node_log_level();
 
         if !tf_env::debug_tracing() {

--- a/tests/testing_framework/src/lib.rs
+++ b/tests/testing_framework/src/lib.rs
@@ -23,7 +23,8 @@ pub static IS_DEBUG_TRACING: LazyLock<bool> = LazyLock::new(env::debug_tracing);
 pub const LOGOS_BLOCKCHAIN_LOG_LEVEL: &str = "LOGOS_BLOCKCHAIN_LOG_LEVEL";
 
 pub use diagnostics::{
-    FailureDiagnosticsExpectation, ScenarioRunDiagnosticsError, run_with_failure_diagnostics,
+    FailureDiagnosticsExpectation, ScenarioRunDiagnosticsError, record_system_monitor_event,
+    register_system_monitor_output_file, run_with_failure_diagnostics,
 };
 pub use framework::{
     BlockFeed, BlockFeedExtensionFactory, BlockFeedObservation, BlockFeedObserver,

--- a/tests/testing_framework/src/lib.rs
+++ b/tests/testing_framework/src/lib.rs
@@ -25,6 +25,7 @@ pub const LOGOS_BLOCKCHAIN_LOG_LEVEL: &str = "LOGOS_BLOCKCHAIN_LOG_LEVEL";
 pub use diagnostics::{
     FailureDiagnosticsExpectation, ScenarioRunDiagnosticsError, record_system_monitor_event,
     register_system_monitor_output_file, run_with_failure_diagnostics,
+    unregister_system_monitor_output_file,
 };
 pub use framework::{
     BlockFeed, BlockFeedExtensionFactory, BlockFeedObservation, BlockFeedObserver,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds a system monitor to the e2e tests so CI runs capture host-level system statistics while tests are running.

We have had repeated cases where tests pass locally but fail in CI, and one of the main suspects is runner contention. Today we do not collect enough host-level context to verify that. The new monitor records system samples during the run and stores them alongside existing test artifacts, so failures can be correlated with system load, memory usage, disk state, process pressure, and key test events.

This should make CI failures easier to diagnose by letting us:
- correlate test failures with runner pressure
- see whether node processes were actually alive during failure windows
- compare node/test events with spikes in load or process activity

Below is a real sample record:

```json
{
  "record_type": "sample",
  "ts_unix": 1776943570,
  "os": "macos",
  "host": {
    "logical_cpus": 16,
    "process_count": 862,
    "thread_count": null,
    "cpu_usage_percent": 21.541952,
    "load1": 4.76025390625,
    "load5": 5.013671875,
    "load15": 5.26708984375,
    "norm_load1": 0.297515869140625,
    "memory_used_bytes": 73478144000,
    "memory_total_bytes": 137438953472,
    "swap_used_bytes": 3668705280
  },
  "disk": {
    "mount_point": "/",
    "available_bytes": 146115154960,
    "total_bytes": 994662584320
  },
  "node_processes": {
    "count": 0,
    "total_rss_bytes": 0
  },
  "top_cpu_processes": [
    {
      "pid": "7764",
      "name": "rustrover",
      "cpu_usage_percent": 63.504395,
      "rss_bytes": 18844729344
    },
    {
      "pid": "58144",
      "name": "test_mantle_channel-62393c8abd6f0665",
      "cpu_usage_percent": 59.51779,
      "rss_bytes": 103383040
    },
    {
      "pid": "40750",
      "name": "com.apple.Virtualization.VirtualMachine",
      "cpu_usage_percent": 19.08774,
      "rss_bytes": 41444638720
    }
  ],
  "top_rss_processes": [
    {
      "pid": "40750",
      "name": "com.apple.Virtualization.VirtualMachine",
      "cpu_usage_percent": 19.08774,
      "rss_bytes": 41444638720
    },
    {
      "pid": "7764",
      "name": "rustrover",
      "cpu_usage_percent": 63.504395,
      "rss_bytes": 18844729344
    }
  ]
}
```


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
