### PR TITLE
fix(cargo-hack): feature flag pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,17 +1192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cfg_eval"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "cfgsync-adapter"
 version = "0.1.0"
 source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=d3bb6348#d3bb6348e52a42a5b24eaf6b531dd5aa57610f52"
@@ -4646,7 +4635,6 @@ dependencies = [
 name = "logos-blockchain-cryptarchia-engine"
 version = "0.1.2"
 dependencies = [
- "cfg_eval",
  "logos-blockchain-pol",
  "logos-blockchain-utils",
  "serde",
@@ -5179,7 +5167,6 @@ name = "logos-blockchain-time-service"
 version = "0.1.2"
 dependencies = [
  "async-trait",
- "cfg_eval",
  "futures",
  "log",
  "logos-blockchain-cryptarchia-engine",

--- a/consensus/cryptarchia-engine/Cargo.toml
+++ b/consensus/cryptarchia-engine/Cargo.toml
@@ -17,16 +17,14 @@ ignored = ["logos-blockchain-utils"]
 workspace = true
 
 [dependencies]
-cfg_eval   = { optional = true, version = "0.1" }
 lb-pol     = { workspace = true }
-lb-utils   = { workspace = true }
-serde      = { optional = true, workspace = true }
-serde_with = { features = ["macros"], optional = true, workspace = true }
+lb-utils   = { features = ["time"], workspace = true }
+serde      = { workspace = true }
+serde_with = { features = ["macros"], workspace = true }
 thiserror  = "1"
 time       = { default-features = false, version = "0.3" }
 tokio      = { features = ["time"], optional = true, workspace = true }
 tracing    = { workspace = true }
 
 [features]
-serde = ["dep:cfg_eval", "dep:serde", "dep:serde_with", "lb-utils/serde", "lb-utils/time"]
 tokio = ["dep:tokio"]

--- a/consensus/cryptarchia-engine/src/config.rs
+++ b/consensus/cryptarchia-engine/src/config.rs
@@ -3,7 +3,7 @@ use std::num::NonZero;
 use lb_pol::LotteryConstants;
 use lb_utils::math::{NonNegativeF64, NonNegativeRatio};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(serde::Serialize)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Config {
     /// The `k` parameter in the Common Prefix property.
@@ -15,11 +15,10 @@ pub struct Config {
     slot_activation_coeff: NonNegativeRatio,
     stake_inference_learning_rate: NonNegativeF64,
     /// Lottery approximation constants computed from `slot_activation_coeff`
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[serde(skip)]
     lottery_constants: LotteryConstants,
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Config {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/consensus/cryptarchia-engine/src/config.rs
+++ b/consensus/cryptarchia-engine/src/config.rs
@@ -3,8 +3,7 @@ use std::num::NonZero;
 use lb_pol::LotteryConstants;
 use lb_utils::math::{NonNegativeF64, NonNegativeRatio};
 
-#[derive(serde::Serialize)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct Config {
     /// The `k` parameter in the Common Prefix property.
     /// Blocks deeper than k are generally considered stable and forks deeper

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -1,9 +1,3 @@
-#![expect(
-    clippy::disallowed_script_idents,
-    reason = "The crate `cfg_eval` contains Sinhala script identifiers. \
-    Using the `expect` or `allow` macro on top of their usage does not remove the warning"
-)]
-
 pub mod config;
 pub mod time;
 
@@ -19,7 +13,7 @@ pub use time::{Epoch, EpochConfig, Slot};
 
 pub(crate) const LOG_TARGET: &str = "cryptarchia::engine";
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum State {
     Bootstrapping,
@@ -175,7 +169,7 @@ where
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct Branch<Id> {
     id: Id,
     parent: Id,

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -13,8 +13,7 @@ pub use time::{Epoch, EpochConfig, Slot};
 
 pub(crate) const LOG_TARGET: &str = "cryptarchia::engine";
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum State {
     Bootstrapping,
     Online,
@@ -168,8 +167,7 @@ where
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Branch<Id> {
     id: Id,
     parent: Id,

--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -5,12 +5,24 @@ use time::OffsetDateTime;
 #[cfg(feature = "tokio")]
 use tokio::time::{Interval, MissedTickBehavior};
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, Default, Eq, PartialEq, Copy, Hash, PartialOrd, Ord)]
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Copy,
+    Hash,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct Slot(u64);
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, Eq, PartialEq, Copy, Hash, PartialOrd, Ord)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Copy, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct Epoch(u32);
 
 impl Epoch {
@@ -131,8 +143,7 @@ impl Add<u32> for Epoch {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EpochConfig {
     // The stake distribution is always taken at the beginning of the previous epoch.
     // This parameters controls how many slots to wait for it to be stabilized
@@ -184,8 +195,7 @@ pub const fn epoch_length(
 }
 
 #[serde_with::serde_as]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct SlotConfig {
     #[serde_as(as = "MinimalBoundedDuration<1, SECOND>")]
     pub slot_duration: Duration,

--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -1,16 +1,15 @@
 use std::{num::NonZero, ops::Add, time::Duration};
 
-#[cfg(feature = "serde")]
 use lb_utils::bounded_duration::{MinimalBoundedDuration, SECOND};
 use time::OffsetDateTime;
 #[cfg(feature = "tokio")]
 use tokio::time::{Interval, MissedTickBehavior};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, Copy, Hash, PartialOrd, Ord)]
 pub struct Slot(u64);
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, Eq, PartialEq, Copy, Hash, PartialOrd, Ord)]
 pub struct Epoch(u32);
 
@@ -132,7 +131,7 @@ impl Add<u32> for Epoch {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct EpochConfig {
     // The stake distribution is always taken at the beginning of the previous epoch.
@@ -184,11 +183,11 @@ pub const fn epoch_length(
     .saturating_mul(base_period_length.get())
 }
 
-#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_with::serde_as)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[serde_with::serde_as]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Copy, Clone, Debug)]
 pub struct SlotConfig {
-    #[cfg_attr(feature = "serde", serde_as(as = "MinimalBoundedDuration<1, SECOND>"))]
+    #[serde_as(as = "MinimalBoundedDuration<1, SECOND>")]
     pub slot_duration: Duration,
     /// Start of the first epoch
     pub chain_start_time: OffsetDateTime,

--- a/consensus/cryptarchia-sync/Cargo.toml
+++ b/consensus/cryptarchia-sync/Cargo.toml
@@ -17,8 +17,8 @@ bytes                 = { features = ["serde"], workspace = true }
 futures               = { workspace = true }
 lb-core               = { workspace = true }
 lb-cryptarchia-engine = { workspace = true }
-libp2p                = { optional = true, workspace = true }
-libp2p-stream         = { optional = true, workspace = true }
+libp2p                = { workspace = true }
+libp2p-stream         = { workspace = true }
 rand                  = { workspace = true }
 serde                 = { workspace = true }
 serde_with            = { workspace = true }
@@ -29,7 +29,3 @@ tracing               = { default-features = false, version = "0.1" }
 [dev-dependencies]
 libp2p            = { features = ["dns", "quic", "tokio"], workspace = true }
 libp2p-swarm-test = { default-features = false, version = "0.5" }
-
-[features]
-default = []
-libp2p  = ["dep:libp2p", "dep:libp2p-stream"]

--- a/consensus/cryptarchia-sync/src/lib.rs
+++ b/consensus/cryptarchia-sync/src/lib.rs
@@ -1,7 +1,5 @@
 pub mod config;
-#[cfg(feature = "libp2p")]
 mod libp2p;
-#[cfg(feature = "libp2p")]
 pub use libp2p::messages::DownloadBlocksRequest;
 mod messages;
 pub use messages::{GetTipResponse, SerialisedBlock};
@@ -20,7 +18,6 @@ pub type BlocksResponse = ProviderResponse<BoxStream<'static, Result<SerialisedB
 pub use config::Config;
 use futures::stream::BoxStream;
 pub use lb_core::header::HeaderId;
-#[cfg(feature = "libp2p")]
 pub use libp2p::{
     behaviour::{Behaviour, BoxedStream, Event},
     errors::{ChainSyncError, ChainSyncErrorKind},

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,4 +52,3 @@ name    = "mantle_tx_components"
 
 [features]
 default = []
-mock    = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,8 +22,8 @@ const-hex                     = { default-features = false, features = ["alloc"]
 futures                       = { features = ["alloc"], workspace = true }
 hex                           = { default-features = false, features = ["alloc"], version = "0.4" }
 lb-blend-proofs               = { workspace = true }
-lb-cryptarchia-engine         = { features = ["serde"], workspace = true }
-lb-groth16                    = { features = ["deser"], workspace = true }
+lb-cryptarchia-engine         = { workspace = true }
+lb-groth16                    = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-poc                        = { workspace = true }
 lb-pol                        = { workspace = true }

--- a/core/src/mantle/genesis_tx.rs
+++ b/core/src/mantle/genesis_tx.rs
@@ -3,8 +3,6 @@ use lb_poseidon2::Digest;
 use serde::{Deserialize, Serialize};
 
 use super::{OpProof, SignedMantleTx, ops::sdp::SDPDeclareOp};
-#[cfg(feature = "mock")]
-use crate::mantle::tx::MantleTxContext;
 use crate::{
     crypto::ZkHasher,
     mantle::{
@@ -92,17 +90,6 @@ impl GenesisTx {
             _ => return Err(Error::MissingTransferAndInscription),
         }
         Ok(Self(signed_mantle_tx))
-    }
-
-    #[cfg(feature = "mock")]
-    #[must_use]
-    pub fn new_mocked(context: MantleTxContext) -> Self {
-        use crate::mantle::tx_builder::MantleTxBuilder;
-
-        Self(SignedMantleTx::new_unverified(
-            MantleTxBuilder::new(context).build(),
-            vec![],
-        ))
     }
 }
 

--- a/core/src/mantle/mod.rs
+++ b/core/src/mantle/mod.rs
@@ -8,7 +8,6 @@ pub mod encoding;
 pub mod gas;
 pub mod genesis_tx;
 pub mod ledger;
-#[cfg(feature = "mock")]
 pub mod mock;
 pub mod ops;
 pub mod select;

--- a/kms/keys/Cargo.toml
+++ b/kms/keys/Cargo.toml
@@ -21,7 +21,7 @@ hex                             = { workspace = true }
 lb-groth16                      = { workspace = true }
 lb-key-management-system-macros = { workspace = true }
 lb-poseidon2                    = { workspace = true }
-lb-utils                        = { features = ["rng", "serde", "types"], workspace = true }
+lb-utils                        = { features = ["rng", "types"], workspace = true }
 lb-zksign                       = { workspace = true }
 num-bigint                      = { default-features = false, version = "0.4.6" }
 rand_core                       = { default-features = false, version = "0.6.4" }

--- a/kms/keys/Cargo.toml
+++ b/kms/keys/Cargo.toml
@@ -21,7 +21,7 @@ hex                             = { workspace = true }
 lb-groth16                      = { workspace = true }
 lb-key-management-system-macros = { workspace = true }
 lb-poseidon2                    = { workspace = true }
-lb-utils                        = { features = ["rng", "types"], workspace = true }
+lb-utils                        = { features = ["rng"], workspace = true }
 lb-zksign                       = { workspace = true }
 num-bigint                      = { default-features = false, version = "0.4.6" }
 rand_core                       = { default-features = false, version = "0.6.4" }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -27,16 +27,13 @@ lb-utxotree                   = { workspace = true }
 num-bigint                    = { default-features = false, version = "0.4" }
 rand                          = { workspace = true }
 rpds                          = { default-features = false, version = "1.1.1" }
-serde                         = { default-features = false, features = ["derive"], optional = true, workspace = true }
+serde                         = { default-features = false, features = ["derive"], workspace = true }
 serde_arrays                  = { default-features = false, version = "0.2.0" }
 thiserror                     = "1"
 tracing                       = { workspace = true }
 
 [dev-dependencies]
 rand = { features = ["std", "std_rng"], workspace = true }
-
-[features]
-serde = ["dep:serde", "lb-cryptarchia-engine/serde", "lb-groth16/deser", "lb-utils/serde", "lb-utxotree/serde"]
 
 [package.metadata.cargo-machete]
 ignored = ["serde_arrays"]

--- a/ledger/src/config.rs
+++ b/ledger/src/config.rs
@@ -4,8 +4,7 @@ use lb_cryptarchia_engine::{Epoch, Slot};
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_pol::LotteryConstants;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Config {
     pub epoch_config: lb_cryptarchia_engine::EpochConfig,
     pub consensus_config: lb_cryptarchia_engine::Config,

--- a/ledger/src/config.rs
+++ b/ledger/src/config.rs
@@ -4,13 +4,13 @@ use lb_cryptarchia_engine::{Epoch, Slot};
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_pol::LotteryConstants;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Config {
     pub epoch_config: lb_cryptarchia_engine::EpochConfig,
     pub consensus_config: lb_cryptarchia_engine::Config,
     pub sdp_config: crate::mantle::sdp::Config,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[serde(default)]
     pub faucet_pk: Option<ZkPublicKey>,
 }
 

--- a/ledger/src/cryptarchia/block_density.rs
+++ b/ledger/src/cryptarchia/block_density.rs
@@ -4,8 +4,7 @@ use lb_cryptarchia_engine::{Epoch, Slot};
 
 use crate::Config;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockDensity {
     period_range: RangeInclusive<Slot>,
     density: u64,

--- a/ledger/src/cryptarchia/block_density.rs
+++ b/ledger/src/cryptarchia/block_density.rs
@@ -4,7 +4,7 @@ use lb_cryptarchia_engine::{Epoch, Slot};
 
 use crate::Config;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone)]
 pub struct BlockDensity {
     period_range: RangeInclusive<Slot>,

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -50,8 +50,7 @@ pub type UtxoTree = lb_utxotree::UtxoTree<NoteId, Utxo, ZkHasher>;
 use super::{Balance, Config, LedgerError, mantle};
 use crate::WINDOW_SIZE;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct EpochState {
     /// The epoch this snapshot is for
     pub epoch: Epoch,
@@ -135,8 +134,7 @@ impl EpochState {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Derivative)]
+#[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Eq, PartialEq)]
 pub struct LedgerState {
     // All available Unspent Transtaction Outputs (UTXOs) at the current slot

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -50,14 +50,14 @@ pub type UtxoTree = lb_utxotree::UtxoTree<NoteId, Utxo, ZkHasher>;
 use super::{Balance, Config, LedgerError, mantle};
 use crate::WINDOW_SIZE;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EpochState {
     /// The epoch this snapshot is for
     pub epoch: Epoch,
     /// value of the ledger nonce after `epoch_period_nonce_buffer` slots from
     /// the beginning of the epoch
-    #[cfg_attr(feature = "serde", serde(with = "lb_groth16::serde::serde_fr"))]
+    #[serde(with = "lb_groth16::serde::serde_fr")]
     pub nonce: Fr,
     /// stake distribution snapshot taken at the beginning of the epoch
     /// (in practice, this is equivalent to the utxos the are spendable at the
@@ -65,9 +65,9 @@ pub struct EpochState {
     pub utxos: UtxoTree,
     pub total_stake: Value,
     /// Lottery values computed based on `total_stake`
-    #[cfg_attr(feature = "serde", serde(with = "lb_groth16::serde::serde_fr"))]
+    #[serde(with = "lb_groth16::serde::serde_fr")]
     pub lottery_0: Fr,
-    #[cfg_attr(feature = "serde", serde(with = "lb_groth16::serde::serde_fr"))]
+    #[serde(with = "lb_groth16::serde::serde_fr")]
     pub lottery_1: Fr,
 }
 
@@ -135,7 +135,7 @@ impl EpochState {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Derivative)]
 #[derivative(Clone, Eq, PartialEq)]
 pub struct LedgerState {
@@ -143,7 +143,7 @@ pub struct LedgerState {
     // TODO: move UTXOs in the mantle ledger. There is no reason to keep them here
     pub utxos: UtxoTree,
     // randomness contribution
-    #[cfg_attr(feature = "serde", serde(with = "lb_groth16::serde::serde_fr"))]
+    #[serde(with = "lb_groth16::serde::serde_fr")]
     pub nonce: Fr,
     pub slot: Slot,
     // rolling snapshot of the state for the next epoch, used for epoch transitions
@@ -155,7 +155,7 @@ pub struct LedgerState {
     #[derivative(PartialEq = "ignore")]
     stake_inference: Arc<StakeInference>,
     // rolling fee window of 120 blocks, used to derive block rewards
-    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
+    #[serde(with = "serde_arrays")]
     fee_window: [GasCost; WINDOW_SIZE],
     // Smoothed Average Execution Gas used up to the last block
     average_execution_gas: Gas,

--- a/ledger/src/cryptarchia/stake.rs
+++ b/ledger/src/cryptarchia/stake.rs
@@ -1,7 +1,6 @@
 pub const PRECISION: u64 = 1000;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StakeInference {
     learning_rate: f64,
     slot_activation_coefficient: f64,

--- a/ledger/src/cryptarchia/stake.rs
+++ b/ledger/src/cryptarchia/stake.rs
@@ -1,6 +1,6 @@
 pub const PRECISION: u64 = 1000;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Copy, Clone)]
 pub struct StakeInference {
     learning_rate: f64,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -206,7 +206,7 @@ where
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct LedgerState {
     block_number: BlockNumber,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -206,8 +206,7 @@ where
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LedgerState {
     block_number: BlockNumber,
     cryptarchia_ledger: CryptarchiaLedger,

--- a/ledger/src/mantle/leader.rs
+++ b/ledger/src/mantle/leader.rs
@@ -15,7 +15,7 @@ use rpds::{HashTrieMapSync, VectorSync};
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LeaderState {
     // current epoch

--- a/ledger/src/mantle/leader.rs
+++ b/ledger/src/mantle/leader.rs
@@ -15,8 +15,7 @@ use rpds::{HashTrieMapSync, VectorSync};
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LeaderState {
     // current epoch
     epoch: Epoch,

--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -54,7 +54,7 @@ pub enum Error {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, PartialEq, Debug)]
 pub struct LedgerState {
     channels: channel::Channels,

--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -54,8 +54,7 @@ pub enum Error {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct LedgerState {
     channels: channel::Channels,
     pub sdp: sdp::SdpLedger,

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -27,8 +27,7 @@ use crate::{EpochState, UtxoTree, mantle::sdp::rewards::blend};
 
 type Declarations = rpds::RedBlackTreeMapSync<DeclarationId, Declaration>;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 enum Service {
     BlendNetwork(ServiceState<blend::Rewards<RealProofsVerifier>>),
 }
@@ -102,16 +101,14 @@ impl Service {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Config {
     pub service_params: std::sync::Arc<HashMap<ServiceType, ServiceParameters>>,
     pub service_rewards_params: ServiceRewardsParameters,
     pub min_stake: MinStake,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ServiceRewardsParameters {
     pub blend: blend::RewardsParameters,
 }
@@ -165,15 +162,13 @@ pub enum Error {
 }
 
 // State at the beginning of this session
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SessionState {
     pub declarations: Declarations,
     pub session_n: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct ServiceState<R: Rewards> {
     // state of declarations at block b
     declarations: Declarations,
@@ -284,8 +279,7 @@ impl<R: Rewards> ServiceState<R> {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct SdpLedger {
     services: rpds::HashTrieMapSync<ServiceType, Service>,
     locked_notes: LockedNotes,

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -27,7 +27,7 @@ use crate::{EpochState, UtxoTree, mantle::sdp::rewards::blend};
 
 type Declarations = rpds::RedBlackTreeMapSync<DeclarationId, Declaration>;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq)]
 enum Service {
     BlendNetwork(ServiceState<blend::Rewards<RealProofsVerifier>>),
@@ -102,7 +102,7 @@ impl Service {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Config {
     pub service_params: std::sync::Arc<HashMap<ServiceType, ServiceParameters>>,
@@ -110,7 +110,7 @@ pub struct Config {
     pub min_stake: MinStake,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ServiceRewardsParameters {
     pub blend: blend::RewardsParameters,
@@ -165,14 +165,14 @@ pub enum Error {
 }
 
 // State at the beginning of this session
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SessionState {
     pub declarations: Declarations,
     pub session_n: u64,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ServiceState<R: Rewards> {
     // state of declarations at block b
@@ -284,7 +284,7 @@ impl<R: Rewards> ServiceState<R> {
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct SdpLedger {
     services: rpds::HashTrieMapSync<ServiceType, Service>,

--- a/ledger/src/mantle/sdp/rewards/blend/current_session.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/current_session.rs
@@ -25,7 +25,7 @@ use crate::{
 /// Immutable state of the current session.
 /// The current session is `s` if `s-1` is the target session for which rewards
 /// are being calculated.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CurrentSessionState {
     /// Current session randomness
@@ -45,7 +45,7 @@ impl CurrentSessionState {
 /// Collects epoch states seen in the current session.
 /// The current session is `s` if `s-1` is the target session for which rewards
 /// are being calculated.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CurrentSessionTracker {
     /// Collecting leader inputs derived from epoch states seen in the current

--- a/ledger/src/mantle/sdp/rewards/blend/current_session.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/current_session.rs
@@ -25,8 +25,7 @@ use crate::{
 /// Immutable state of the current session.
 /// The current session is `s` if `s-1` is the target session for which rewards
 /// are being calculated.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CurrentSessionState {
     /// Current session randomness
     session_randomness: SessionRandomness,
@@ -45,8 +44,7 @@ impl CurrentSessionState {
 /// Collects epoch states seen in the current session.
 /// The current session is `s` if `s-1` is the target session for which rewards
 /// are being calculated.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CurrentSessionTracker {
     /// Collecting leader inputs derived from epoch states seen in the current
     /// session. These will be used to create proof verifiers after the next

--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -35,7 +35,7 @@ const LOG_TARGET: &str = "ledger::mantle::rewards::blend";
 
 /// Tracks Blend rewards based on activity proofs submitted by providers.
 /// Activity proofs for the session `s-1` must be submitted during session `s`.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Rewards<ProofsVerifier> {
     /// State before the first target session is finalized, or if the target
@@ -252,7 +252,7 @@ where
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct RewardsParameters {
     pub rounds_per_session: NonZeroU64,

--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -35,8 +35,7 @@ const LOG_TARGET: &str = "ledger::mantle::rewards::blend";
 
 /// Tracks Blend rewards based on activity proofs submitted by providers.
 /// Activity proofs for the session `s-1` must be submitted during session `s`.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Rewards<ProofsVerifier> {
     /// State before the first target session is finalized, or if the target
     /// session has less than the minimum required number of declarations.
@@ -252,8 +251,7 @@ where
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RewardsParameters {
     pub rounds_per_session: NonZeroU64,
     pub message_frequency_per_round: NonNegativeF64,

--- a/ledger/src/mantle/sdp/rewards/blend/target_session.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/target_session.rs
@@ -19,7 +19,7 @@ use crate::mantle::sdp::rewards::{
 
 /// The immutable state of the target session for which rewards are being
 /// calculated. The target session is `s-1` if `s` is the current session.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TargetSessionState<ProofsVerifier> {
     /// The target session number
@@ -128,7 +128,7 @@ where
 
 /// Tracks activity proofs submitted for the target session whose rewards are
 /// being calculated. The target session is `s-1` if `s` is the current session.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TargetSessionTracker {
     /// Collecting proofs submitted by providers in the target session.
@@ -208,7 +208,7 @@ impl TargetSessionTracker {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MinHammingDistance {
     min_distance: HammingDistance,

--- a/ledger/src/mantle/sdp/rewards/blend/target_session.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/target_session.rs
@@ -19,8 +19,7 @@ use crate::mantle::sdp::rewards::{
 
 /// The immutable state of the target session for which rewards are being
 /// calculated. The target session is `s-1` if `s` is the current session.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TargetSessionState<ProofsVerifier> {
     /// The target session number
     session_number: SessionNumber,
@@ -128,8 +127,7 @@ where
 
 /// Tracks activity proofs submitted for the target session whose rewards are
 /// being calculated. The target session is `s-1` if `s` is the current session.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TargetSessionTracker {
     /// Collecting proofs submitted by providers in the target session.
     submitted_proofs: HashTrieMapSync<ProviderId, (ZkPublicKey, HammingDistance)>,
@@ -208,8 +206,7 @@ impl TargetSessionTracker {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MinHammingDistance {
     min_distance: HammingDistance,
     providers: HashTrieSetSync<ProviderId>,

--- a/ledger/src/utils.rs
+++ b/ledger/src/utils.rs
@@ -1,13 +1,11 @@
 macro_rules! serialize_bytes_newtype {
     ($newtype:ty) => {
-        #[cfg(feature = "serde")]
         impl serde::Serialize for $newtype {
             fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
                 lb_utils::serde::serialize_bytes_array(self.0, serializer)
             }
         }
 
-        #[cfg(feature = "serde")]
         impl<'de> serde::de::Deserialize<'de> for $newtype {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -20,7 +20,7 @@ either = { default-features = false, version = "1.13.0" }
 futures = { workspace = true }
 hex = { default-features = false, version = "0.4.3" }
 igd-next = { features = ["aio_tokio", "tokio"], version = "0.16.1" }
-lb-cryptarchia-sync = { features = ["libp2p"], workspace = true }
+lb-cryptarchia-sync = { workspace = true }
 lb-utils = { features = ["time"], workspace = true }
 libp2p = { features = [
   "autonat",

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -21,7 +21,7 @@ futures = { workspace = true }
 hex = { default-features = false, version = "0.4.3" }
 igd-next = { features = ["aio_tokio", "tokio"], version = "0.16.1" }
 lb-cryptarchia-sync = { features = ["libp2p"], workspace = true }
-lb-utils = { features = ["serde", "time"], workspace = true }
+lb-utils = { features = ["time"], workspace = true }
 libp2p = { features = [
   "autonat",
   "dns",

--- a/mmr/Cargo.toml
+++ b/mmr/Cargo.toml
@@ -13,8 +13,8 @@ version     = { workspace = true }
 ark-ff       = { default-features = false, features = ["std"], version = "0.4" }
 lb-groth16   = { workspace = true }
 lb-poseidon2 = { workspace = true }
-rpds         = { default-features = false, version = "1.1.1" }
-serde        = { features = ["derive"], optional = true, workspace = true }
+rpds         = { default-features = false, features = ["serde"], version = "1.1.1" }
+serde        = { features = ["derive"], workspace = true }
 thiserror    = { workspace = true }
 
 [dev-dependencies]
@@ -23,9 +23,6 @@ proptest-macro = "0.2"
 
 [lints]
 workspace = true
-
-[features]
-serde = ["dep:serde", "lb-groth16/deser", "rpds/serde"]
 
 [package.metadata.cargo-machete]
 # False positives.

--- a/mmr/src/lib.rs
+++ b/mmr/src/lib.rs
@@ -1,7 +1,6 @@
 use std::sync::OnceLock;
 
 use ark_ff::Field as _;
-#[cfg(feature = "serde")]
 use lb_groth16::serde::serde_fr;
 use lb_poseidon2::{Digest, Fr};
 use rpds::StackSync;
@@ -27,11 +26,10 @@ const ACCEPTABLE_MAX_HEIGHT: u8 = 33;
 /// (de)serialize one version of the tree, but if you dump multiple expect to
 /// find multiple copes of the same nodes in the deserialized output. If you
 /// need to preserve structural sharing, you should use a custom serialization.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MerkleMountainRange<T, Hash, const MAX_HEIGHT: u8 = ACCEPTABLE_MAX_HEIGHT> {
     roots: StackSync<Root>,
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[serde(skip)]
     _hash: std::marker::PhantomData<(T, Hash)>,
 }
 
@@ -43,10 +41,9 @@ impl<T, Hash, const MAX_HEIGHT: u8> PartialEq for MerkleMountainRange<T, Hash, M
 
 impl<T, Hash, const MAX_HEIGHT: u8> Eq for MerkleMountainRange<T, Hash, MAX_HEIGHT> {}
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Root {
-    #[cfg_attr(feature = "serde", serde(with = "serde_fr"))]
+    #[serde(with = "serde_fr")]
     pub(crate) root: Fr,
     pub(crate) height: u8,
 }

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -35,7 +35,7 @@ lb-chain-broadcast-service       = { workspace = true }
 lb-chain-leader-service          = { workspace = true }
 lb-chain-network-service         = { workspace = true }
 lb-chain-service                 = { workspace = true }
-lb-core                          = { features = ["mock"], workspace = true }
+lb-core                          = { workspace = true }
 lb-cryptarchia-engine            = { workspace = true }
 lb-groth16                       = { workspace = true }
 lb-http-api-common               = { workspace = true }

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -30,10 +30,10 @@ hex                              = { default-features = false, version = "0.4.3"
 http                             = "1.3"
 lb-api-service                   = { workspace = true }
 lb-blend                         = { workspace = true }
-lb-blend-service                 = { features = ["libp2p"], workspace = true }
+lb-blend-service                 = { workspace = true }
 lb-chain-broadcast-service       = { workspace = true }
 lb-chain-leader-service          = { workspace = true }
-lb-chain-network-service         = { features = ["libp2p"], workspace = true }
+lb-chain-network-service         = { workspace = true }
 lb-chain-service                 = { workspace = true }
 lb-core                          = { features = ["mock"], workspace = true }
 lb-cryptarchia-engine            = { workspace = true }

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -90,11 +90,10 @@ tikv-jemallocator = { optional = true, version = "0.6" }
 rand = { workspace = true }
 
 [features]
-config-gen      = ["lb-key-management-system-service/unsafe"]
-default         = ["config-gen", "tracing"]
-dhat-heap       = ["dep:dhat"]
-instrumentation = []
-jemalloc        = ["dep:tikv-jemallocator"]
-profiling       = ["lb-http-api-common/profiling", "lb-tracing-service/profiling"]
-testing         = ["lb-key-management-system-service/unsafe"]
-tracing         = []
+config-gen = ["lb-key-management-system-service/unsafe"]
+default    = ["config-gen", "tracing"]
+dhat-heap  = ["dep:dhat"]
+jemalloc   = ["dep:tikv-jemallocator"]
+profiling  = ["lb-http-api-common/profiling", "lb-tracing-service/profiling"]
+testing    = ["lb-key-management-system-service/unsafe"]
+tracing    = []

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -48,11 +48,11 @@ lb-sdp-service                   = { workspace = true }
 lb-services-utils                = { workspace = true }
 lb-storage-service               = { workspace = true }
 lb-system-sig-service            = { workspace = true }
-lb-time-service                  = { features = ["ntp", "serde"], workspace = true }
+lb-time-service                  = { features = ["ntp"], workspace = true }
 lb-tracing                       = { workspace = true }
 lb-tracing-service               = { workspace = true }
 lb-tx-service                    = { features = ["rocksdb-backend"], workspace = true }
-lb-utils                         = { features = ["serde", "time"], workspace = true }
+lb-utils                         = { features = ["time"], workspace = true }
 lb-wallet-service                = { workspace = true }
 libp2p                           = { features = ["autonat", "gossipsub", "identify", "kad", "macros"], workspace = true }
 logos-blockchain-tui-zone        = { path = "../../../testnet/tui-zone" }

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -22,11 +22,11 @@ futures                    = { workspace = true }
 lb-blend-service           = { features = ["libp2p"], workspace = true }
 lb-chain-broadcast-service = { workspace = true }
 lb-chain-leader-service    = { workspace = true }
-lb-chain-service           = { features = ["libp2p"], workspace = true }
+lb-chain-service           = { features = ["libp2p", "openapi"], workspace = true }
 lb-core                    = { workspace = true }
 lb-ledger                  = { workspace = true }
 lb-libp2p                  = { workspace = true }
-lb-network-service         = { workspace = true }
+lb-network-service         = { features = ["openapi"], workspace = true }
 lb-sdp-service             = { workspace = true }
 lb-storage-service         = { features = ["rocksdb-backend"], workspace = true }
 lb-time-service            = { workspace = true }

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -15,11 +15,6 @@ workspace = true
 [package.metadata.cargo-machete]
 ignored = ["serde_json"]
 
-[features]
-axum            = ["dep:axum", "dep:hyper", "utoipa-swagger-ui/axum"]
-default         = ["axum"]
-instrumentation = []
-
 [dependencies]
 async-trait                = "0.1"
 bytes                      = { workspace = true }
@@ -42,16 +37,6 @@ serde_json                 = { workspace = true }
 tokio                      = { features = ["net"], workspace = true }
 tokio-stream               = { workspace = true }
 tracing                    = { default-features = false, version = "0.1" }
-
-# axum related dependencies
-axum = { default-features = false, features = [
-  "http1",
-  "http2",
-  "json",
-  "query",
-  "tokio",
-], optional = true, version = "0.7.5" }
-hyper = { default-features = false, optional = true, version = "1.0" }
 
 # openapi related dependencies
 utoipa = { workspace = true }

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -19,10 +19,10 @@ ignored = ["serde_json"]
 async-trait                = "0.1"
 bytes                      = { workspace = true }
 futures                    = { workspace = true }
-lb-blend-service           = { features = ["libp2p"], workspace = true }
+lb-blend-service           = { workspace = true }
 lb-chain-broadcast-service = { workspace = true }
 lb-chain-leader-service    = { workspace = true }
-lb-chain-service           = { features = ["libp2p", "openapi"], workspace = true }
+lb-chain-service           = { features = ["openapi"], workspace = true }
 lb-core                    = { workspace = true }
 lb-ledger                  = { workspace = true }
 lb-libp2p                  = { workspace = true }
@@ -30,7 +30,7 @@ lb-network-service         = { features = ["openapi"], workspace = true }
 lb-sdp-service             = { workspace = true }
 lb-storage-service         = { features = ["rocksdb-backend"], workspace = true }
 lb-time-service            = { workspace = true }
-lb-tx-service              = { features = ["libp2p", "mock", "openapi"], workspace = true }
+lb-tx-service              = { features = ["mock", "openapi"], workspace = true }
 overwatch                  = { workspace = true }
 serde                      = { workspace = true }
 serde_json                 = { workspace = true }

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -30,7 +30,7 @@ lb-network-service         = { features = ["openapi"], workspace = true }
 lb-sdp-service             = { workspace = true }
 lb-storage-service         = { features = ["rocksdb-backend"], workspace = true }
 lb-time-service            = { workspace = true }
-lb-tx-service              = { features = ["mock", "openapi"], workspace = true }
+lb-tx-service              = { features = ["openapi"], workspace = true }
 overwatch                  = { workspace = true }
 serde                      = { workspace = true }
 serde_json                 = { workspace = true }

--- a/services/blend/Cargo.toml
+++ b/services/blend/Cargo.toml
@@ -32,7 +32,7 @@ lb-sdp-service                   = { workspace = true }
 lb-services-utils                = { workspace = true }
 lb-time-service                  = { workspace = true }
 lb-tracing                       = { workspace = true }
-lb-utils                         = { features = ["serde"], workspace = true }
+lb-utils                         = { workspace = true }
 libp2p                           = { features = ["dns"], optional = true, workspace = true }
 libp2p-stream                    = { optional = true, workspace = true }
 overwatch                        = { workspace = true }

--- a/services/blend/Cargo.toml
+++ b/services/blend/Cargo.toml
@@ -25,7 +25,7 @@ lb-cryptarchia-engine            = { workspace = true }
 lb-groth16                       = { default-features = false, workspace = true }
 lb-key-management-system-service = { features = ["unsafe"], workspace = true }
 lb-ledger                        = { workspace = true }
-lb-libp2p                        = { optional = true, workspace = true }
+lb-libp2p                        = { workspace = true }
 lb-network-service               = { workspace = true }
 lb-poq                           = { workspace = true }
 lb-sdp-service                   = { workspace = true }
@@ -33,8 +33,8 @@ lb-services-utils                = { workspace = true }
 lb-time-service                  = { workspace = true }
 lb-tracing                       = { workspace = true }
 lb-utils                         = { workspace = true }
-libp2p                           = { features = ["dns"], optional = true, workspace = true }
-libp2p-stream                    = { optional = true, workspace = true }
+libp2p                           = { features = ["dns"], workspace = true }
+libp2p-stream                    = { workspace = true }
 overwatch                        = { workspace = true }
 rand                             = { workspace = true }
 serde                            = { workspace = true }
@@ -53,4 +53,3 @@ test-log          = { default-features = false, features = ["trace"], version = 
 
 [features]
 default = []
-libp2p  = ["dep:lb-libp2p", "dep:libp2p", "dep:libp2p-stream", "lb-network-service/libp2p"]

--- a/services/blend/src/core/backends/mod.rs
+++ b/services/blend/src/core/backends/mod.rs
@@ -15,7 +15,6 @@ use overwatch::overwatch::handle::OverwatchHandle;
 
 use crate::{core::settings::RunningBlendConfig as BlendConfig, message::NetworkInfo};
 
-#[cfg(feature = "libp2p")]
 pub mod libp2p;
 
 pub type EpochInfo = LeaderInputs;

--- a/services/blend/src/core/network/mod.rs
+++ b/services/blend/src/core/network/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "libp2p")]
 pub mod libp2p;
 
 use std::fmt::Debug;

--- a/services/blend/src/edge/backends/mod.rs
+++ b/services/blend/src/edge/backends/mod.rs
@@ -6,7 +6,6 @@ use lb_key_management_system_service::keys::UnsecuredEd25519Key;
 use overwatch::overwatch::handle::OverwatchHandle;
 use rand::RngCore;
 
-#[cfg(feature = "libp2p")]
 pub mod libp2p;
 
 /// A trait for blend backends that send messages to the blend network.

--- a/services/blend/src/membership/node_id/mod.rs
+++ b/services/blend/src/membership/node_id/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "libp2p")]
 pub mod libp2p;
 
 pub trait TryFrom: Sized {

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "libp2p")]
 mod imp {
     const ACTION_PUBLISH: &str = "publish";
     const ACTION_FORWARD: &str = "forward";
@@ -61,11 +60,6 @@ mod imp {
             message_type = message_type.to_str()
         );
     }
-}
-
-#[cfg(not(feature = "libp2p"))]
-mod imp {
-    pub const fn mix_packets_processed_total() {}
 }
 
 pub use imp::*;

--- a/services/blend/src/test_utils/mod.rs
+++ b/services/blend/src/test_utils/mod.rs
@@ -2,7 +2,5 @@ pub mod crypto;
 pub mod epoch;
 pub mod membership;
 
-#[cfg(feature = "libp2p")]
 mod libp2p;
-#[cfg(feature = "libp2p")]
 pub use self::libp2p::*;

--- a/services/chain/chain-leader/Cargo.toml
+++ b/services/chain/chain-leader/Cargo.toml
@@ -42,4 +42,3 @@ lb-utils   = { workspace = true }
 
 [features]
 default = []
-libp2p  = ["lb-blend-service/libp2p"]

--- a/services/chain/chain-leader/Cargo.toml
+++ b/services/chain/chain-leader/Cargo.toml
@@ -22,7 +22,7 @@ lb-chain-service-common          = { workspace = true }
 lb-core                          = { workspace = true }
 lb-cryptarchia-engine            = { workspace = true }
 lb-key-management-system-service = { features = ["unsafe"], workspace = true }
-lb-ledger                        = { features = ["serde"], workspace = true }
+lb-ledger                        = { workspace = true }
 lb-services-utils                = { workspace = true }
 lb-time-service                  = { workspace = true }
 lb-tracing                       = { workspace = true }

--- a/services/chain/chain-network/Cargo.toml
+++ b/services/chain/chain-network/Cargo.toml
@@ -18,9 +18,9 @@ futures                 = { workspace = true }
 lb-chain-service        = { workspace = true }
 lb-chain-service-common = { workspace = true }
 lb-core                 = { workspace = true }
-lb-cryptarchia-engine   = { features = ["serde"], workspace = true }
+lb-cryptarchia-engine   = { workspace = true }
 lb-cryptarchia-sync     = { workspace = true }
-lb-ledger               = { features = ["serde"], workspace = true }
+lb-ledger               = { workspace = true }
 lb-network-service      = { workspace = true }
 lb-services-utils       = { workspace = true }
 lb-time-service         = { workspace = true }

--- a/services/chain/chain-network/Cargo.toml
+++ b/services/chain/chain-network/Cargo.toml
@@ -37,8 +37,8 @@ tracing                 = { workspace = true }
 tracing-futures         = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
-lb-core            = { features = ["mock"], workspace = true }
-lb-network-service = { features = ["mock"], workspace = true }
+lb-core            = { workspace = true }
+lb-network-service = { workspace = true }
 lb-utils           = { workspace = true }
 
 [features]

--- a/services/chain/chain-network/Cargo.toml
+++ b/services/chain/chain-network/Cargo.toml
@@ -43,4 +43,3 @@ lb-utils           = { workspace = true }
 
 [features]
 default = []
-libp2p  = ["lb-network-service/libp2p"]

--- a/services/chain/chain-network/src/network/adapters/mod.rs
+++ b/services/chain/chain-network/src/network/adapters/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(feature = "libp2p")]
 pub mod libp2p;

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -18,10 +18,10 @@ bytes                      = { workspace = true }
 futures                    = { workspace = true }
 lb-chain-broadcast-service = { workspace = true }
 lb-core                    = { workspace = true }
-lb-cryptarchia-engine      = { features = ["serde"], workspace = true }
+lb-cryptarchia-engine      = { workspace = true }
 lb-cryptarchia-sync        = { workspace = true }
 lb-groth16                 = { workspace = true }
-lb-ledger                  = { features = ["serde"], workspace = true }
+lb-ledger                  = { workspace = true }
 lb-network-service         = { workspace = true }
 lb-services-utils          = { workspace = true }
 lb-storage-service         = { workspace = true }

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -49,5 +49,4 @@ tempfile                      = { default-features = false, version = "3" }
 
 [features]
 default = []
-libp2p  = ["lb-network-service/libp2p"]
 openapi = ["dep:utoipa"]

--- a/services/chain/chain-service/Cargo.toml
+++ b/services/chain/chain-service/Cargo.toml
@@ -39,9 +39,9 @@ tracing-futures            = { default-features = false, features = ["std-future
 utoipa                     = { optional = true, workspace = true }
 
 [dev-dependencies]
-lb-core                       = { features = ["mock"], workspace = true }
+lb-core                       = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
-lb-network-service            = { features = ["mock"], workspace = true }
+lb-network-service            = { workspace = true }
 lb-storage-service            = { features = ["rocksdb-backend"], workspace = true }
 lb-utxotree                   = { workspace = true }
 rand                          = { workspace = true }

--- a/services/network/Cargo.toml
+++ b/services/network/Cargo.toml
@@ -17,11 +17,11 @@ async-trait         = "0.1"
 futures             = { workspace = true }
 lb-core             = { workspace = true }
 lb-cryptarchia-sync = { workspace = true }
-lb-libp2p           = { optional = true, workspace = true }
+lb-libp2p           = { workspace = true }
 lb-tracing          = { workspace = true }
 overwatch           = { workspace = true }
-rand                = { features = ["std"], optional = true, workspace = true }
-rand_chacha         = { default-features = false, optional = true, version = "0.3" }
+rand                = { features = ["std"], workspace = true }
+rand_chacha         = { default-features = false, version = "0.3" }
 serde               = { features = ["derive"], workspace = true }
 tokio               = { features = ["macros", "sync"], workspace = true }
 tokio-stream        = { workspace = true }
@@ -35,6 +35,5 @@ tracing-subscriber = { default-features = false, features = ["env-filter", "fmt"
 
 [features]
 default = []
-libp2p  = ["dep:lb-libp2p", "dep:rand", "dep:rand_chacha", "lb-cryptarchia-sync/libp2p"]
-mock    = ["dep:rand", "dep:rand_chacha"]
+mock    = []
 openapi = ["dep:utoipa"]

--- a/services/network/Cargo.toml
+++ b/services/network/Cargo.toml
@@ -35,5 +35,4 @@ tracing-subscriber = { default-features = false, features = ["env-filter", "fmt"
 
 [features]
 default = []
-mock    = []
 openapi = ["dep:utoipa"]

--- a/services/network/src/backends/mod.rs
+++ b/services/network/src/backends/mod.rs
@@ -3,7 +3,6 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use super::Debug;
 
-#[cfg(feature = "libp2p")]
 pub mod libp2p;
 
 #[cfg(feature = "mock")]

--- a/services/network/src/backends/mod.rs
+++ b/services/network/src/backends/mod.rs
@@ -4,8 +4,6 @@ use tokio_stream::wrappers::BroadcastStream;
 use super::Debug;
 
 pub mod libp2p;
-
-#[cfg(feature = "mock")]
 pub mod mock;
 
 #[async_trait::async_trait]

--- a/services/network/src/metrics.rs
+++ b/services/network/src/metrics.rs
@@ -1,12 +1,9 @@
-#[cfg(feature = "libp2p")]
 use lb_libp2p::libp2p::{Swarm, swarm::NetworkBehaviour};
 
-#[cfg(feature = "libp2p")]
 pub fn network_dial_failures() {
     lb_tracing::increase_counter_u64!(network_dial_failures_total, 1);
 }
 
-#[cfg(feature = "libp2p")]
 pub fn consensus_peers_connected(peers_connected: usize) {
     lb_tracing::metric_gauge_u64!(
         consensus_peers_connected,
@@ -14,12 +11,10 @@ pub fn consensus_peers_connected(peers_connected: usize) {
     );
 }
 
-#[cfg(feature = "libp2p")]
 pub fn consensus_connections(connections: u32) {
     lb_tracing::metric_gauge_u64!(consensus_connections, u64::from(connections));
 }
 
-#[cfg(feature = "libp2p")]
 pub fn consensus_report_connectivity<B: NetworkBehaviour>(swarm: &Swarm<B>) {
     let network_info = swarm.network_info();
     let counters = network_info.connection_counters();

--- a/services/storage/Cargo.toml
+++ b/services/storage/Cargo.toml
@@ -31,7 +31,6 @@ tempfile = { workspace = true }
 
 [features]
 default         = []
-mock            = []
 rocksdb-backend = ["dep:rocksdb"]
 
 [[bin]]

--- a/services/time/Cargo.toml
+++ b/services/time/Cargo.toml
@@ -14,15 +14,14 @@ workspace = true
 
 [dependencies]
 async-trait           = "0.1"
-cfg_eval              = { optional = true, version = "0.1" }
 futures               = { workspace = true }
 lb-cryptarchia-engine = { features = ["tokio"], workspace = true }
 lb-tracing            = { workspace = true }
-lb-utils              = { optional = true, workspace = true }
+lb-utils              = { workspace = true }
 log                   = { workspace = true }
 overwatch             = { workspace = true }
-serde                 = { features = ["derive"], optional = true, workspace = true }
-serde_with            = { optional = true, workspace = true }
+serde                 = { features = ["derive"], workspace = true }
+serde_with            = { workspace = true }
 sntpc                 = { default-features = false, features = ["std", "tokio-socket"], optional = true, version = "0.5" }
 thiserror             = { default-features = false, optional = true, version = "2.0" }
 time                  = { default-features = false, features = ["std"], version = "0.3" }
@@ -30,10 +29,5 @@ tokio                 = { workspace = true }
 tokio-stream          = { workspace = true }
 tracing               = { default-features = false, version = "0.1" }
 
-[dev-dependencies]
-lb-utils = { workspace = true }
-
 [features]
-ntp       = ["dep:sntpc", "dep:thiserror", "tokio/net"]
-serde     = ["dep:cfg_eval", "dep:lb-utils", "dep:serde", "dep:serde_with", "lb-cryptarchia-engine/serde"]
-testutils = []
+ntp = ["dep:sntpc", "dep:thiserror", "tokio/net"]

--- a/services/time/src/backends/ntp/async_client.rs
+++ b/services/time/src/backends/ntp/async_client.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use futures::{StreamExt as _, TryStreamExt as _, stream::FuturesUnordered};
-#[cfg(feature = "serde")]
 use lb_utils::bounded_duration::{MinimalBoundedDuration, NANO};
 use sntpc::{Error as SntpError, NtpContext, NtpResult, StdTimestampGen, get_time};
 use tokio::{
@@ -23,12 +22,12 @@ pub enum Error {
     Timeout(Elapsed),
 }
 
-#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_with::serde_as)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[serde_with::serde_as]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Debug, Copy, Clone)]
 pub struct NTPClientSettings {
     /// NTP server requests timeout duration
-    #[cfg_attr(feature = "serde", serde_as(as = "MinimalBoundedDuration<1, NANO>"))]
+    #[serde_as(as = "MinimalBoundedDuration<1, NANO>")]
     pub timeout: Duration,
     pub listening_interface: IpAddr,
 }

--- a/services/time/src/backends/ntp/async_client.rs
+++ b/services/time/src/backends/ntp/async_client.rs
@@ -23,8 +23,7 @@ pub enum Error {
 }
 
 #[serde_with::serde_as]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NTPClientSettings {
     /// NTP server requests timeout duration
     #[serde_as(as = "MinimalBoundedDuration<1, NANO>")]

--- a/services/time/src/backends/ntp/mod.rs
+++ b/services/time/src/backends/ntp/mod.rs
@@ -9,7 +9,6 @@ use std::{
 
 use futures::{Stream, StreamExt as _};
 use lb_cryptarchia_engine::{EpochConfig, Slot, time::SlotConfig};
-#[cfg(feature = "serde")]
 use lb_utils::bounded_duration::{MinimalBoundedDuration, NANO};
 use sntpc::{NtpResult, fraction_to_nanoseconds};
 use time::OffsetDateTime;
@@ -25,8 +24,8 @@ use crate::{
     },
 };
 
-#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_with::serde_as)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[serde_with::serde_as]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug)]
 pub struct NtpTimeBackendSettings {
     /// Ntp server address
@@ -34,7 +33,7 @@ pub struct NtpTimeBackendSettings {
     /// Ntp server settings
     pub ntp_client_settings: NTPClientSettings,
     /// Interval for the backend to contact the ntp server and update its time
-    #[cfg_attr(feature = "serde", serde_as(as = "MinimalBoundedDuration<1, NANO>"))]
+    #[serde_as(as = "MinimalBoundedDuration<1, NANO>")]
     pub update_interval: Duration,
 }
 

--- a/services/time/src/backends/ntp/mod.rs
+++ b/services/time/src/backends/ntp/mod.rs
@@ -25,8 +25,7 @@ use crate::{
 };
 
 #[serde_with::serde_as]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct NtpTimeBackendSettings {
     /// Ntp server address
     pub ntp_server: String,

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -48,8 +48,7 @@ impl Debug for TimeServiceMessage {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct TimeServiceSettings<BackendSettings> {
     /// Slot settings in order to compute proper slot times
     pub slot_config: SlotConfig,

--- a/services/time/src/lib.rs
+++ b/services/time/src/lib.rs
@@ -1,9 +1,3 @@
-#![allow(
-    clippy::disallowed_script_idents,
-    reason = "The crate `cfg_eval` contains Sinhala script identifiers. \
-    Using the `expect` or `allow` macro on top of their usage does not remove the warning"
-)]
-
 use core::num::NonZero;
 use std::{
     fmt::{Debug, Display, Formatter},
@@ -54,7 +48,7 @@ impl Debug for TimeServiceMessage {
     }
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Debug)]
 pub struct TimeServiceSettings<BackendSettings> {
     /// Slot settings in order to compute proper slot times

--- a/services/tx-service/Cargo.toml
+++ b/services/tx-service/Cargo.toml
@@ -46,7 +46,6 @@ tempfile                    = "3"
 
 [features]
 default         = []
-libp2p          = ["lb-network-service/libp2p"]
 mock            = ["lb-core/mock", "lb-network-service/mock"]
 rocksdb-backend = ["lb-storage-service/rocksdb-backend"]
 

--- a/services/tx-service/Cargo.toml
+++ b/services/tx-service/Cargo.toml
@@ -40,13 +40,12 @@ utoipa             = { optional = true, workspace = true }
 [dev-dependencies]
 lb-tracing-service          = { workspace = true }
 lb-utils                    = { workspace = true }
-logos-blockchain-tx-service = { features = ["mock", "rocksdb-backend"], path = "." }
+logos-blockchain-tx-service = { features = ["rocksdb-backend"], path = "." }
 overwatch-derive            = { workspace = true }
 tempfile                    = "3"
 
 [features]
 default         = []
-mock            = ["lb-core/mock", "lb-network-service/mock"]
 rocksdb-backend = ["lb-storage-service/rocksdb-backend"]
 
 # enable to help generate OpenAPI

--- a/services/tx-service/Cargo.toml
+++ b/services/tx-service/Cargo.toml
@@ -46,7 +46,6 @@ tempfile                    = "3"
 
 [features]
 default         = []
-instrumentation = []
 libp2p          = ["lb-network-service/libp2p"]
 mock            = ["lb-core/mock", "lb-network-service/mock"]
 rocksdb-backend = ["lb-storage-service/rocksdb-backend"]

--- a/services/tx-service/src/network/adapters/mod.rs
+++ b/services/tx-service/src/network/adapters/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "libp2p")]
 pub mod libp2p;
 
 #[cfg(feature = "mock")]

--- a/services/tx-service/src/network/adapters/mod.rs
+++ b/services/tx-service/src/network/adapters/mod.rs
@@ -1,4 +1,2 @@
 pub mod libp2p;
-
-#[cfg(feature = "mock")]
 pub mod mock;

--- a/services/wallet/Cargo.toml
+++ b/services/wallet/Cargo.toml
@@ -25,7 +25,7 @@ lb-groth16                       = { workspace = true }
 lb-key-management-system-service = { features = ["unsafe"], workspace = true }
 lb-ledger                        = { workspace = true }
 lb-services-utils                = { workspace = true }
-lb-storage-service               = { features = ["mock"], workspace = true }
+lb-storage-service               = { workspace = true }
 lb-utxotree                      = { workspace = true }
 lb-wallet                        = { workspace = true }
 overwatch                        = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,10 +37,10 @@ lb-groth16                       = { workspace = true }
 lb-http-api-common               = { workspace = true }
 lb-key-management-system-service = { workspace = true }
 lb-libp2p                        = { workspace = true }
-lb-network-service               = { features = ["libp2p"], workspace = true }
+lb-network-service               = { workspace = true }
 lb-node                          = { default-features = false, features = ["testing"], workspace = true }
 lb-testing-framework             = { workspace = true }
-lb-tx-service                    = { features = ["libp2p", "mock"], workspace = true }
+lb-tx-service                    = { features = ["mock"], workspace = true }
 lb-utils                         = { workspace = true }
 lb-wallet                        = { workspace = true }
 lb-zksign                        = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -32,7 +32,7 @@ lb-chain-broadcast-service       = { workspace = true }
 lb-chain-service                 = { workspace = true }
 lb-common-http-client            = { workspace = true }
 lb-core                          = { workspace = true }
-lb-cryptarchia-engine            = { features = ["serde"], workspace = true }
+lb-cryptarchia-engine            = { workspace = true }
 lb-groth16                       = { workspace = true }
 lb-http-api-common               = { workspace = true }
 lb-key-management-system-service = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -40,7 +40,7 @@ lb-libp2p                        = { workspace = true }
 lb-network-service               = { workspace = true }
 lb-node                          = { default-features = false, features = ["testing"], workspace = true }
 lb-testing-framework             = { workspace = true }
-lb-tx-service                    = { features = ["mock"], workspace = true }
+lb-tx-service                    = { workspace = true }
 lb-utils                         = { workspace = true }
 lb-wallet                        = { workspace = true }
 lb-zksign                        = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -30,7 +30,6 @@ tokio       = { optional = true, workspace = true }
 rng   = ["dep:blake2"]
 time  = ["dep:humantime", "dep:serde_with", "dep:time"]
 tokio = ["dep:futures", "dep:tokio"]
-types = []
 
 [dev-dependencies]
 nistrs      = "0.1.2"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -21,15 +21,14 @@ futures     = { optional = true, workspace = true }
 humantime   = { optional = true, version = "2.1" }
 overwatch   = { workspace = true }
 rand        = { features = ["getrandom"], workspace = true }
-serde       = { features = ["derive"], optional = true, workspace = true }
+serde       = { features = ["alloc", "derive"], workspace = true }
 serde_with  = { optional = true, workspace = true }
 time        = { default-features = false, features = ["serde-human-readable"], optional = true, version = "0.3" }
 tokio       = { optional = true, workspace = true }
 
 [features]
 rng   = ["dep:blake2"]
-serde = ["serde/alloc"]
-time  = ["dep:humantime", "dep:serde", "dep:serde_with", "dep:time"]
+time  = ["dep:humantime", "dep:serde_with", "dep:time"]
 tokio = ["dep:futures", "dep:tokio"]
 types = []
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -2,8 +2,6 @@ pub mod fisheryates;
 pub mod math;
 pub mod net;
 pub mod noop_service;
-
-#[cfg(feature = "types")]
 pub mod types;
 
 #[cfg(feature = "rng")]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -15,7 +15,6 @@ pub mod bounded_duration;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-#[cfg(feature = "serde")]
 pub mod serde {
     fn serialize_human_readable_bytes_array<const N: usize, S: serde::Serializer>(
         src: [u8; N],

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -2,9 +2,9 @@ use core::ops::{Deref, DerefMut};
 use std::num::NonZeroU32;
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 pub struct FiniteF64(
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde::deserialize"))] f64,
+    #[serde(deserialize_with = "serde::deserialize")] f64,
 );
 
 /// A wrapper around [`f64`] that guarantees the value is neither infinite nor
@@ -61,12 +61,9 @@ impl TryFrom<u64> for FiniteF64 {
 
 /// A wrapper around [`FiniteF64`] that guarantees the value is >= 0.0.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 pub struct NonNegativeF64(
-    #[cfg_attr(
-        feature = "serde",
-        serde(deserialize_with = "serde::deserialize_non_negative")
-    )]
+    #[serde(deserialize_with = "serde::deserialize_non_negative")]
     FiniteF64,
 );
 
@@ -123,12 +120,9 @@ impl TryFrom<u64> for NonNegativeF64 {
 
 /// A wrapper around [`NonNegativeF64`] that guarantees the value is > 0.0
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 pub struct PositiveF64(
-    #[cfg_attr(
-        feature = "serde",
-        serde(deserialize_with = "serde::deserialize_positive")
-    )]
+    #[serde(deserialize_with = "serde::deserialize_positive")]
     NonNegativeF64,
 );
 
@@ -194,9 +188,9 @@ impl TryFrom<u64> for PositiveF64 {
 
 /// A wrapper around [`PositiveF64`] that guarantees the value is >= 1.0
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 pub struct F64Ge1(
-    #[cfg_attr(feature = "serde", serde(deserialize_with = "serde::deserialize_ge1"))] PositiveF64,
+    #[serde(deserialize_with = "serde::deserialize_ge1")] PositiveF64,
 );
 
 impl F64Ge1 {
@@ -254,7 +248,7 @@ impl TryFrom<u64> for F64Ge1 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 pub struct NonNegativeRatio {
     pub numerator: u32,
     pub denominator: NonZeroU32,
@@ -275,7 +269,6 @@ impl NonNegativeRatio {
     }
 }
 
-#[cfg(feature = "serde")]
 mod serde {
     use serde::Deserialize as _;
 
@@ -385,7 +378,6 @@ mod tests {
         assert!(F64Ge1::try_from(FiniteF64::MAX_REPRESENTABLE_U64 + 1).is_err());
     }
 
-    #[cfg(feature = "serde")]
     mod serde_tests {
         use ::serde::Deserialize;
 

--- a/utils/src/math.rs
+++ b/utils/src/math.rs
@@ -1,11 +1,8 @@
 use core::ops::{Deref, DerefMut};
 use std::num::NonZeroU32;
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-pub struct FiniteF64(
-    #[serde(deserialize_with = "serde::deserialize")] f64,
-);
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, ::serde::Serialize, ::serde::Deserialize)]
+pub struct FiniteF64(#[serde(deserialize_with = "serde::deserialize")] f64);
 
 /// A wrapper around [`f64`] that guarantees the value is neither infinite nor
 /// NaN.
@@ -60,12 +57,8 @@ impl TryFrom<u64> for FiniteF64 {
 }
 
 /// A wrapper around [`FiniteF64`] that guarantees the value is >= 0.0.
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-pub struct NonNegativeF64(
-    #[serde(deserialize_with = "serde::deserialize_non_negative")]
-    FiniteF64,
-);
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, ::serde::Serialize, ::serde::Deserialize)]
+pub struct NonNegativeF64(#[serde(deserialize_with = "serde::deserialize_non_negative")] FiniteF64);
 
 impl NonNegativeF64 {
     #[must_use]
@@ -119,12 +112,8 @@ impl TryFrom<u64> for NonNegativeF64 {
 }
 
 /// A wrapper around [`NonNegativeF64`] that guarantees the value is > 0.0
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-pub struct PositiveF64(
-    #[serde(deserialize_with = "serde::deserialize_positive")]
-    NonNegativeF64,
-);
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, ::serde::Serialize, ::serde::Deserialize)]
+pub struct PositiveF64(#[serde(deserialize_with = "serde::deserialize_positive")] NonNegativeF64);
 
 impl PositiveF64 {
     #[must_use]
@@ -187,11 +176,8 @@ impl TryFrom<u64> for PositiveF64 {
 }
 
 /// A wrapper around [`PositiveF64`] that guarantees the value is >= 1.0
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-pub struct F64Ge1(
-    #[serde(deserialize_with = "serde::deserialize_ge1")] PositiveF64,
-);
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, ::serde::Serialize, ::serde::Deserialize)]
+pub struct F64Ge1(#[serde(deserialize_with = "serde::deserialize_ge1")] PositiveF64);
 
 impl F64Ge1 {
     #[must_use]
@@ -247,8 +233,7 @@ impl TryFrom<u64> for F64Ge1 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
 pub struct NonNegativeRatio {
     pub numerator: u32,
     pub denominator: NonZeroU32,

--- a/utxotree/Cargo.toml
+++ b/utxotree/Cargo.toml
@@ -11,11 +11,11 @@ version     = { workspace = true }
 
 [dependencies]
 ark-ff       = { default-features = false, version = "0.4" }
-lb-groth16   = { features = ["deser"], workspace = true }
+lb-groth16   = { workspace = true }
 lb-poseidon2 = { workspace = true }
 num-bigint   = { default-features = false, version = "0.4" }
 rpds         = { default-features = false, features = ["serde"], version = "1" }
-serde        = { features = ["alloc", "derive", "rc"], optional = true, workspace = true }
+serde        = { features = ["alloc", "derive", "rc"], workspace = true }
 thiserror    = "1.0"
 
 [dev-dependencies]
@@ -25,6 +25,3 @@ rand              = "0.9"
 
 [lints]
 workspace = true
-
-[features]
-serde = ["dep:serde"]

--- a/utxotree/src/lib.rs
+++ b/utxotree/src/lib.rs
@@ -187,16 +187,11 @@ where
     }
 }
 
-#[cfg_attr(
-    feature = "serde",
-    derive(::serde::Serialize, ::serde::Deserialize),
-    serde(transparent)
-)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]#[serde(transparent)]
 pub struct CompressedUtxoTree<Key, Item> {
     items: BTreeMap<usize, (Key, Item)>,
 }
 
-#[cfg(feature = "serde")]
 mod serde {
     use lb_poseidon2::{Digest, Fr};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/utxotree/src/lib.rs
+++ b/utxotree/src/lib.rs
@@ -187,7 +187,8 @@ where
     }
 }
 
-#[derive(::serde::Serialize, ::serde::Deserialize)]#[serde(transparent)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(transparent)]
 pub struct CompressedUtxoTree<Key, Item> {
     items: BTreeMap<usize, (Key, Item)>,
 }

--- a/utxotree/src/merkle.rs
+++ b/utxotree/src/merkle.rs
@@ -29,8 +29,7 @@ fn empty_subtree_root<Hash: Digest>(height: usize) -> Fr {
     })[height]
 }
 
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(::serde::Serialize, ::serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 enum Node<Item> {
     Inner {
         left: Arc<Self>,

--- a/utxotree/src/merkle.rs
+++ b/utxotree/src/merkle.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use ark_ff::Field;
-#[cfg(feature = "serde")]
 use lb_groth16::serde::serde_fr;
 use lb_poseidon2::{Digest, Fr};
 use rpds::RedBlackTreeSetSync;
@@ -30,13 +29,13 @@ fn empty_subtree_root<Hash: Digest>(height: usize) -> Fr {
     })[height]
 }
 
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Node<Item> {
     Inner {
         left: Arc<Self>,
         right: Arc<Self>,
-        #[cfg_attr(feature = "serde", serde(with = "serde_fr"))]
+        #[serde(with = "serde_fr")]
         value: Fr,
         right_subtree_size: usize,
         left_subtree_size: usize,
@@ -400,7 +399,6 @@ where
 {
 }
 
-#[cfg(feature = "serde")]
 pub mod serde {
     use std::{marker::PhantomData, sync::Arc};
 

--- a/zk/groth16/Cargo.toml
+++ b/zk/groth16/Cargo.toml
@@ -15,20 +15,15 @@ ark-ec        = "0.4"
 ark-ff        = { version = "0.4" }
 ark-groth16   = { default-features = false, features = ["std"], version = "0.4" }
 ark-serialize = { default-features = false, version = "0.4.2" }
-generic-array = { default-features = false, version = "1.2" }
+generic-array = { default-features = false, features = ["serde"], version = "1.2" }
 hex           = { default-features = false, features = ["alloc"], version = "0.4" }
 num-bigint    = { default-features = false, version = "0.4" }
-serde         = { features = ["derive"], optional = true, workspace = true }
-serde_json    = { default-features = false, features = ["alloc"], optional = true, version = "1.0" }
+serde         = { features = ["derive"], workspace = true }
+serde_json    = { default-features = false, features = ["alloc"], version = "1.0" }
 thiserror     = { default-features = false, version = "2.0" }
 
 [dev-dependencies]
-bincode    = { default-features = false, version = "1.3" }
-serde_json = { default-features = false, features = ["alloc"], version = "1.0" }
+bincode = { default-features = false, version = "1.3" }
 
 [lints]
 workspace = true
-
-[features]
-default = []
-deser   = ["dep:serde", "dep:serde_json", "generic-array/serde"]

--- a/zk/groth16/src/lib.rs
+++ b/zk/groth16/src/lib.rs
@@ -1,14 +1,10 @@
-#[cfg(feature = "deser")]
 mod curve;
-#[cfg(feature = "deser")]
 mod from_json_error;
 mod proof;
 pub use proof::{CompressSize, CompressedProof};
-#[cfg(feature = "deser")]
 mod protocol;
 mod public_input;
 
-#[cfg(feature = "deser")]
 pub mod serde;
 pub(crate) mod utils;
 mod verification_key;
@@ -31,14 +27,11 @@ impl CompressSize for Bn254 {
 
 pub type Groth16Proof = proof::Proof<Bn254>;
 pub type CompressedGroth16Proof = CompressedProof<Bn254>;
-#[cfg(feature = "deser")]
 pub type Groth16ProofJsonDeser = proof::ProofJsonDeser;
 pub type Groth16VerificationKey = verification_key::VerificationKey<Bn254>;
 pub type Groth16PreparedVerificationKey = verification_key::PreparedVerificationKey<Bn254>;
-#[cfg(feature = "deser")]
 pub type Groth16VerificationKeyJsonDeser = verification_key::VerificationKeyJsonDeser;
 pub type Groth16Input = public_input::Input<Bn254>;
-#[cfg(feature = "deser")]
 pub type Groth16InputDeser = public_input::InputDeser;
 
 pub type FrBytes = [u8; 32];

--- a/zk/groth16/src/proof/mod.rs
+++ b/zk/groth16/src/proof/mod.rs
@@ -7,10 +7,12 @@ use ark_ec::pairing::Pairing;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize as _, SerializationError};
 use generic_array::{ArrayLength, GenericArray, typenum::Unsigned as _};
 
-use crate::from_json_error::FromJsonError;
 pub use crate::proof::deserialize::ProofJsonDeser;
-use crate::protocol::Protocol;
-use crate::utils::{JsonG1, JsonG2, StringifiedG1, StringifiedG2};
+use crate::{
+    from_json_error::FromJsonError,
+    protocol::Protocol,
+    utils::{JsonG1, JsonG2, StringifiedG1, StringifiedG2},
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Proof<E: Pairing> {

--- a/zk/groth16/src/proof/mod.rs
+++ b/zk/groth16/src/proof/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "deser")]
 pub mod deserialize;
 
 use core::fmt::{self, Debug, Formatter};
@@ -8,13 +7,9 @@ use ark_ec::pairing::Pairing;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize as _, SerializationError};
 use generic_array::{ArrayLength, GenericArray, typenum::Unsigned as _};
 
-#[cfg(feature = "deser")]
 use crate::from_json_error::FromJsonError;
-#[cfg(feature = "deser")]
 pub use crate::proof::deserialize::ProofJsonDeser;
-#[cfg(feature = "deser")]
 use crate::protocol::Protocol;
-#[cfg(feature = "deser")]
 use crate::utils::{JsonG1, JsonG2, StringifiedG1, StringifiedG2};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -111,7 +106,6 @@ impl<E: Pairing> From<&Proof<E>> for ark_groth16::Proof<E> {
     }
 }
 
-#[cfg(feature = "deser")]
 impl TryFrom<ProofJsonDeser> for Proof<Bn254> {
     type Error = FromJsonError;
     fn try_from(value: ProofJsonDeser) -> Result<Self, Self::Error> {

--- a/zk/groth16/src/public_input/mod.rs
+++ b/zk/groth16/src/public_input/mod.rs
@@ -1,15 +1,11 @@
-#[cfg(feature = "deser")]
 use std::str::FromStr;
 
 use ark_bn254::{Bn254, Fr};
 use ark_ec::pairing::Pairing;
-#[cfg(feature = "deser")]
 use ark_ff::Zero as _;
 
-#[cfg(feature = "deser")]
 pub mod deserialize;
 
-#[cfg(feature = "deser")]
 pub use deserialize::InputDeser;
 
 #[derive(Copy, Clone, Debug)]
@@ -37,7 +33,6 @@ impl From<Fr> for Input<Bn254> {
     }
 }
 
-#[cfg(feature = "deser")]
 impl TryFrom<InputDeser> for Input<Bn254> {
     type Error = <<Bn254 as Pairing>::ScalarField as FromStr>::Err;
 
@@ -48,7 +43,6 @@ impl TryFrom<InputDeser> for Input<Bn254> {
     }
 }
 
-#[cfg(feature = "deser")]
 impl From<&Input<Bn254>> for InputDeser {
     fn from(value: &Input<Bn254>) -> Self {
         // Have to branch here, as by default it's an empty string, but we want "0"
@@ -61,12 +55,9 @@ impl From<&Input<Bn254>> for InputDeser {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "deser")]
     use ark_ff::Field as _;
 
-    #[cfg(feature = "deser")]
     use super::*;
-    #[cfg(feature = "deser")]
     #[test]
     fn serialize_zero() {
         let zero: Input<Bn254> = Fr::ZERO.into();

--- a/zk/groth16/src/utils.rs
+++ b/zk/groth16/src/utils.rs
@@ -2,9 +2,7 @@ use std::str::FromStr;
 
 use ark_bn254::{Fq, Fq2, G1Affine, G2Affine};
 
-#[cfg(feature = "deser")]
 pub type JsonG1 = [String; 3];
-#[cfg(feature = "deser")]
 pub type JsonG2 = [[String; 2]; 3];
 
 pub struct StringifiedG1(pub [String; 3]);

--- a/zk/groth16/src/verification_key/mod.rs
+++ b/zk/groth16/src/verification_key/mod.rs
@@ -1,15 +1,10 @@
-#[cfg(feature = "deser")]
 pub mod deserialize;
 use ark_ec::pairing::Pairing;
 use ark_serialize::CanonicalSerialize as _;
-#[cfg(feature = "deser")]
 pub use deserialize::VerificationKeyJsonDeser;
 
-#[cfg(feature = "deser")]
 use crate::from_json_error::FromJsonError;
-#[cfg(feature = "deser")]
 use crate::protocol::Protocol;
-#[cfg(feature = "deser")]
 use crate::utils::{StringifiedG1, StringifiedG2};
 
 #[derive(Eq, PartialEq)]
@@ -20,7 +15,6 @@ pub struct VerificationKey<E: Pairing> {
     pub delta_2: E::G2Affine,
     pub ic: Vec<E::G1Affine>,
 }
-#[cfg(feature = "deser")]
 impl TryFrom<VerificationKeyJsonDeser> for VerificationKey<ark_bn254::Bn254> {
     type Error = FromJsonError;
     fn try_from(value: VerificationKeyJsonDeser) -> Result<Self, Self::Error> {

--- a/zk/groth16/src/verification_key/mod.rs
+++ b/zk/groth16/src/verification_key/mod.rs
@@ -3,9 +3,11 @@ use ark_ec::pairing::Pairing;
 use ark_serialize::CanonicalSerialize as _;
 pub use deserialize::VerificationKeyJsonDeser;
 
-use crate::from_json_error::FromJsonError;
-use crate::protocol::Protocol;
-use crate::utils::{StringifiedG1, StringifiedG2};
+use crate::{
+    from_json_error::FromJsonError,
+    protocol::Protocol,
+    utils::{StringifiedG1, StringifiedG2},
+};
 
 #[derive(Eq, PartialEq)]
 pub struct VerificationKey<E: Pairing> {

--- a/zk/groth16/src/verifier.rs
+++ b/zk/groth16/src/verifier.rs
@@ -14,7 +14,7 @@ pub fn groth16_verify<E: Pairing>(
     Groth16::<E, LibsnarkReduction>::verify_proof(vk.as_ref(), &proof, public_inputs)
 }
 
-#[cfg(all(test, feature = "deser"))]
+#[cfg(test)]
 mod tests {
     use std::{ops::Deref as _, sync::LazyLock};
 

--- a/zk/groth16/tests/proof_of_claim_cpy_cycles.rs
+++ b/zk/groth16/tests/proof_of_claim_cpy_cycles.rs
@@ -1,15 +1,15 @@
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 use std::{hint::black_box, ops::Deref as _, sync::LazyLock};
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 use logos_blockchain_groth16::{
     Groth16Input, Groth16InputDeser, Groth16Proof, Groth16ProofJsonDeser, Groth16VerificationKey,
     Groth16VerificationKeyJsonDeser, groth16_verify,
 };
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 use serde_json::{Value, json};
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 static VK: LazyLock<Value> = LazyLock::new(|| {
     json!({
      "protocol": "groth16",
@@ -117,7 +117,7 @@ static VK: LazyLock<Value> = LazyLock::new(|| {
     })
 });
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 static PROOF: LazyLock<Value> = LazyLock::new(|| {
     json!({
       "pi_a": [
@@ -149,7 +149,7 @@ static PROOF: LazyLock<Value> = LazyLock::new(|| {
     })
 });
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 static PI: LazyLock<Value> = LazyLock::new(|| {
     json!([
         "18876773715140569969879940706526502898783381664583962060409399199413543299784",
@@ -159,7 +159,7 @@ static PI: LazyLock<Value> = LazyLock::new(|| {
 });
 
 // TODO: Remove this when we have the proper benches in the proofs
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 #[expect(
     clippy::undocumented_unsafe_blocks,
     reason = "This test is is just to measure cpu and should be run manually"

--- a/zk/groth16/tests/zk_signature_cpu_cycles.rs
+++ b/zk/groth16/tests/zk_signature_cpu_cycles.rs
@@ -1,15 +1,15 @@
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 use std::{hint::black_box, ops::Deref as _, sync::LazyLock};
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 use logos_blockchain_groth16::{
     Groth16Input, Groth16InputDeser, Groth16Proof, Groth16ProofJsonDeser, Groth16VerificationKey,
     Groth16VerificationKeyJsonDeser, groth16_verify,
 };
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 use serde_json::{Value, json};
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 static VK: LazyLock<Value> = LazyLock::new(|| {
     json!({
      "protocol": "groth16",
@@ -267,7 +267,7 @@ static VK: LazyLock<Value> = LazyLock::new(|| {
     })
 });
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 static PROOF: LazyLock<Value> = LazyLock::new(|| {
     json!({
       "pi_a": [
@@ -299,7 +299,7 @@ static PROOF: LazyLock<Value> = LazyLock::new(|| {
     })
 });
 
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 static PI: LazyLock<Value> = LazyLock::new(|| {
     json!([
         "11102268276218687325310228860756729608041551000326452964785954128433899301016",
@@ -339,7 +339,7 @@ static PI: LazyLock<Value> = LazyLock::new(|| {
 });
 
 // TODO: Remove this when we have the proper benches in the proofs
-#[cfg(all(target_arch = "x86_64", feature = "deser"))]
+#[cfg(target_arch = "x86_64")]
 #[expect(
     clippy::undocumented_unsafe_blocks,
     reason = "This test is is just to measure cpu and should be run manually"

--- a/zk/proofs/poc/Cargo.toml
+++ b/zk/proofs/poc/Cargo.toml
@@ -12,7 +12,7 @@ version     = { workspace = true }
 [dependencies]
 lb-circuits-prover   = { workspace = true }
 lb-circuits-utils    = { workspace = true }
-lb-groth16           = { features = ["deser"], workspace = true }
+lb-groth16           = { workspace = true }
 lb-witness-generator = { workspace = true }
 num-bigint           = "0.4"
 serde                = { features = ["derive", "std"], workspace = true }

--- a/zk/proofs/pol/Cargo.toml
+++ b/zk/proofs/pol/Cargo.toml
@@ -28,7 +28,3 @@ lb-circuits-utils = { workspace = true }
 
 [lints]
 workspace = true
-
-[features]
-build-verification-key = []
-default                = ["build-verification-key"]

--- a/zk/proofs/pol/Cargo.toml
+++ b/zk/proofs/pol/Cargo.toml
@@ -13,7 +13,7 @@ version     = { workspace = true }
 astro-float          = "0.9"
 lb-circuits-prover   = { workspace = true }
 lb-circuits-utils    = { workspace = true }
-lb-groth16           = { features = ["deser"], workspace = true }
+lb-groth16           = { workspace = true }
 lb-utils             = { workspace = true }
 lb-witness-generator = { workspace = true }
 num-bigint           = "0.4"

--- a/zk/proofs/poq/Cargo.toml
+++ b/zk/proofs/poq/Cargo.toml
@@ -12,7 +12,7 @@ version     = { workspace = true }
 [dependencies]
 lb-circuits-prover   = { workspace = true }
 lb-circuits-utils    = { workspace = true }
-lb-groth16           = { features = ["deser"], workspace = true }
+lb-groth16           = { workspace = true }
 lb-pol               = { workspace = true }
 lb-witness-generator = { workspace = true }
 num-bigint           = "0.4"

--- a/zk/proofs/zksign/Cargo.toml
+++ b/zk/proofs/zksign/Cargo.toml
@@ -12,7 +12,7 @@ version     = { workspace = true }
 [dependencies]
 lb-circuits-prover   = { workspace = true }
 lb-circuits-utils    = { workspace = true }
-lb-groth16           = { features = ["deser"], workspace = true }
+lb-groth16           = { workspace = true }
 lb-poseidon2         = { workspace = true }
 lb-witness-generator = { workspace = true }
 num-bigint           = { default-features = false, version = "0.4" }


### PR DESCRIPTION
## 1. What does this PR implement?

Removes unnecessary feature flags in order to bring cargo hack times down

## 2. Does the code have enough context to be clearly understood?
Cuts cargo-hack feature-powerset builds from 400 to 202 by removing feature flags that were dead, vestigial, or by making them always on.

  What changed

  - 8 dead flags deleted
  - 7 flags inlined as always-on: serde (5 crates), types (utils), and deser (groth16). 
  - 6 libp2p flags inlined 
  - Bug fix: added missing openapi activations on lb-chain-service and lb-network-service via lb-api-service. Handlers reference types from those crates in their utoipa::path bodies, so the served OpenAPI JSON had been silently missing schemas for CryptarchiaInfo, Libp2pInfo
  - Cleanup: dropped the cfg_eval dep (no longer needed after inlining serde)

## 3. Who are the specification authors and who is accountable for this PR?

NA

## 4. Is the specification accurate and complete?

NA

## 5. Does the implementation introduce changes in the specification?

NA

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
