### PR TITLE
ci(e2e): reduce nextest concurrency for heavy tests

### DIFF
--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -41,6 +41,10 @@ jobs:
           - os: [ self-hosted, macOS ]
             label: self-hosted-macos
     runs-on: ${{ matrix.platform.os }}
+    env:
+      # Heavy Rust e2e tests become less stable when nextest oversubscribes the
+      # self-hosted runners. Keep these lanes single-job to reduce retries.
+      E2E_NEXTEST_JOBS: 1
 
     steps:
       # Remove any rustup override to ensure default toolchain is used
@@ -104,7 +108,7 @@ jobs:
           USE_LOCAL_HOST_NTP_TIME_CONFIG: true # Ensure tests use local NTP server for time sync
         with:
           command: nextest
-          args: run --locked --jobs 3 --retries 2 -p logos-blockchain-tests --features mantle_sdp_ops --test test_mantle_sdp_ops --no-fail-fast
+          args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --features mantle_sdp_ops --test test_mantle_sdp_ops --no-fail-fast
 
       # Build release binaries for the remaining end-to-end tests.
       - name: Build binaries for remaining end-to-end tests
@@ -127,7 +131,7 @@ jobs:
         with:
           command: nextest
           # - We don't test benches as they take 6h+, leading to a timeout
-          args: run --locked --jobs 3 --retries 2 -p logos-blockchain-tests --no-fail-fast
+          args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --no-fail-fast
 
       - name: Upload integration tests results on failure
         if: ${{ failure() && (steps.mantle_sdp_ops_end_to_end.conclusion == 'failure' || steps.end_to_end.conclusion == 'failure') }}


### PR DESCRIPTION
## 1. What does this PR implement?

Testing the hypothesis that lower parallelism on heavy e2e jobs will reduce retries and flakiness, which should improve overall CI throughput and robustness. In order to test it, we need all PRs use it tho.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
