### PR TITLE
fix(cfgsync): Don't set entropy in compose files

### DIFF
--- a/compose.run.yml
+++ b/compose.run.yml
@@ -25,8 +25,6 @@ services:
       - ./testnet:/etc/logos-blockchain
     depends_on:
       - grafana
-    environment:
-      - ENTROPY_FILE=${ENTROPY_FILE:-/etc/logos-blockchain/entropy}
     ports:
       - "4400:4400/tcp"
     entrypoint: /etc/logos-blockchain/scripts/run_cfgsync_server.sh

--- a/compose.setup.yml
+++ b/compose.setup.yml
@@ -8,8 +8,6 @@ services:
     volumes:
       - node-data:/node-data
       - ./testnet:/etc/logos-blockchain
-    environment:
-      - ENTROPY_FILE=${ENTROPY_FILE:-/etc/logos-blockchain/entropy}
     ports:
       - "4400:4400/tcp"
     entrypoint: /etc/logos-blockchain/scripts/setup_cfgsync_server.sh

--- a/testnet/cfgsync/tests/server_client.rs
+++ b/testnet/cfgsync/tests/server_client.rs
@@ -11,8 +11,6 @@ async fn smoke_test_four_clients() {
     let mut server = std::process::Command::new(SERVER_BIN)
         .arg("--mode")
         .arg("setup")
-        .arg("--entropy-file")
-        .arg("tests/test_entropy")
         .arg(SERVER_CFG)
         .spawn()
         .expect("server failed");

--- a/testnet/cfgsync/tests/with_node.rs
+++ b/testnet/cfgsync/tests/with_node.rs
@@ -19,8 +19,6 @@ async fn test_deploy_setup_stage() {
     let mut server = std::process::Command::new(SERVER_BIN)
         .arg("--mode")
         .arg("setup")
-        .arg("--entropy-file")
-        .arg("tests/test_entropy")
         .arg(SERVER_CFG)
         .spawn()
         .expect("server failed");


### PR DESCRIPTION
## 1. What does this PR implement?

We removed entropy file, but it was still expected in compose file env vars.

## 2. Does the code have enough context to be clearly understood?

Don't require entropy file, use randomness to generate genesis in devnet.

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
