### PR TITLE
fix(mantle): accept valid leader claim proofs

### DIFF
--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -190,7 +190,7 @@ impl Operation for LeaderClaimOp {
         }
 
         // Check the proof of claim
-        if ctx.proof_of_claim.verify(&LeaderClaimPublic {
+        if !ctx.proof_of_claim.verify(&LeaderClaimPublic {
             voucher_root: ctx.claimable_vouchers_root.0,
             mantle_tx_hash: ctx.tx_hash.0,
         }) {
@@ -215,5 +215,46 @@ impl Operation for LeaderClaimOp {
         ctx.claimable_rewards -= ctx.reward_amount;
 
         Ok(ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_utxotree::DynamicMerkleTree;
+
+    use super::*;
+    use crate::proofs::leader_claim_proof::LeaderClaimPrivate;
+
+    #[test]
+    fn validate_accepts_valid_proof_of_claim() {
+        let voucher_secret = VoucherSecret::from(Fr::from(7u64));
+        let voucher_cm = VoucherCm::from_secret(voucher_secret);
+        let (voucher_tree, voucher_index) =
+            DynamicMerkleTree::<VoucherCm, ZkHasher>::new().insert(voucher_cm);
+        let voucher_root = RewardsRoot::from(voucher_tree.root());
+        let voucher_path = voucher_tree
+            .path(voucher_index)
+            .expect("voucher path should exist");
+        let tx_hash = TxHash::from(Fr::from(11u64));
+        let proof = Groth16LeaderClaimProof::prove(LeaderClaimPrivate::new(
+            LeaderClaimPublic::new(voucher_root.into(), tx_hash.0),
+            &voucher_path,
+            voucher_secret,
+        ))
+        .expect("proof generation should succeed");
+        let op = LeaderClaimOp {
+            rewards_root: voucher_root,
+            voucher_nullifier: VoucherNullifier::from_secret(voucher_secret),
+            pk: ZkPublicKey::zero(),
+        };
+        let nullifiers = rpds::HashTrieSetSync::new_sync();
+        let ctx = LeaderClaimValidationContext {
+            nullifiers: &nullifiers,
+            claimable_vouchers_root: &voucher_root,
+            proof_of_claim: &proof,
+            tx_hash: &tx_hash,
+        };
+
+        assert_eq!(op.validate(&ctx), Ok(()));
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes an inverted validity check in leader claim proof verification.

The current code rejects valid proofs and accepts invalid ones. This changes the check to reject only invalid proofs, and adds a focused unit test covering the valid-proof case.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
