### PR TITLE
fix(mantle): handle channel deposit input notes

### DIFF
--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -169,18 +169,20 @@ impl MantleTxBuilder {
         Ok(self.net_balance() - i128::from(self.gas_cost::<G>()?.into_inner()))
     }
 
-    /// Returns all note IDs used as inputs in the transaction, including
-    /// - Transfer operations already in the transaction
-    /// - Additional transfer operations that will be added to the transaction
+    /// Returns all note IDs already consumed by this transaction, plus the
+    /// funding inputs that will be appended as a transfer during build.
     pub fn input_notes(&self) -> impl Iterator<Item = NoteId> {
         self.mantle_tx
             .ops
             .iter()
-            .filter_map(|op| match op {
-                Op::Transfer(transfer) => Some(transfer.inputs.iter().copied()),
-                _ => None,
+            .flat_map(|op| {
+                let inputs: &[NoteId] = match op {
+                    Op::Transfer(transfer) => &transfer.inputs,
+                    Op::ChannelDeposit(deposit) => &deposit.inputs,
+                    _ => &[],
+                };
+                inputs.iter().copied()
             })
-            .flatten()
             .chain(self.ledger_inputs().iter().map(Utxo::id))
     }
 

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -94,6 +94,9 @@ pub enum WalletServiceError {
     #[error("Locked note {0:?} is missing in ledger")]
     MissingLockedNote(NoteId),
 
+    #[error("Input note {0:?} is missing in ledger")]
+    MissingInputNote(NoteId),
+
     #[error("PoC generation failed: {0:?}")]
     PoCGenerationFailed(#[from] lb_core::proofs::leader_claim_proof::Error),
 
@@ -586,16 +589,11 @@ where
         tx_hash: TxHash,
         note_ids: Vec<NoteId>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
-        tx_builder: MantleTxBuilder,
+        ledger: &LedgerState,
     ) -> Result<OpProof, WalletServiceError> {
-        let input_pks: Vec<ZkPublicKey> = tx_builder
-            .ledger_inputs()
-            .iter()
-            .filter(|&utxo| note_ids.contains(&utxo.id()))
-            .map(|utxo| utxo.note.pk)
-            .collect();
-
+        let input_pks = Self::resolve_note_input_pks(ledger, note_ids)?;
         let zk_sig = Self::sign_zksig(tx_hash, input_pks, kms).await?;
+
         Ok(OpProof::ZkSig(zk_sig))
     }
 
@@ -737,16 +735,11 @@ where
         tx_hash: TxHash,
         note_ids: Vec<NoteId>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
-        tx_builder: MantleTxBuilder,
+        ledger: &LedgerState,
     ) -> Result<OpProof, WalletServiceError> {
-        let input_pks: Vec<ZkPublicKey> = tx_builder
-            .ledger_inputs()
-            .iter()
-            .filter(|&utxo| note_ids.contains(&utxo.id()))
-            .map(|utxo| utxo.note.pk)
-            .collect();
-
+        let input_pks = Self::resolve_note_input_pks(ledger, note_ids)?;
         let zk_sig = Self::sign_zksig(tx_hash, input_pks, kms).await?;
+
         Ok(OpProof::ZkSig(zk_sig))
     }
 
@@ -776,7 +769,7 @@ where
                         tx_hash,
                         deposit_op.inputs.to_vec(),
                         kms,
-                        tx_builder.clone(),
+                        &tip_leader,
                     )
                     .await?
                 }
@@ -799,13 +792,8 @@ where
                     Self::sign_leader_claim(tx_hash, claim_op, tip, wallet, kms).await?
                 }
                 Op::Transfer(transfer_op) => {
-                    Self::sign_transfer(
-                        tx_hash,
-                        transfer_op.inputs.to_vec(),
-                        kms,
-                        tx_builder.clone(),
-                    )
-                    .await?
+                    Self::sign_transfer(tx_hash, transfer_op.inputs.to_vec(), kms, &tip_leader)
+                        .await?
                 }
             };
             ops_proofs.push(proof);
@@ -864,6 +852,23 @@ where
         };
 
         Ok(zk_sig)
+    }
+
+    fn resolve_note_input_pks(
+        ledger: &LedgerState,
+        note_ids: impl IntoIterator<Item = NoteId>,
+    ) -> Result<Vec<ZkPublicKey>, WalletServiceError> {
+        note_ids
+            .into_iter()
+            .map(|note_id| {
+                ledger
+                    .latest_utxos()
+                    .utxos()
+                    .get(&note_id)
+                    .map(|(utxo, _)| utxo.note.pk)
+                    .ok_or(WalletServiceError::MissingInputNote(note_id))
+            })
+            .collect()
     }
 
     fn generate_poc(

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -11,7 +11,10 @@ use lb_http_api_common::bodies::{
 };
 use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_node::config::RunConfig;
-use lb_testing_framework::{DeploymentBuilder, NodeHttpClient, TopologyConfig as TfTopologyConfig};
+use lb_testing_framework::{
+    DeploymentBuilder, NodeHttpClient, TopologyConfig as TfTopologyConfig,
+    configs::wallet::{WalletAccount, WalletConfig},
+};
 use lb_utils::math::NonNegativeRatio;
 use logos_blockchain_tests::common::manual_cluster::{
     ManualNodeLayout, api_url, get_wallet_balance, start_local_manual_cluster_with_layout,
@@ -30,13 +33,16 @@ use tokio::time::sleep;
 /// 6. Verify the channel balance increases.
 #[tokio::test]
 async fn channel_deposit() {
+    let (wallet_config, funding_pk) = channel_deposit_wallet_config();
     let (base, nodes) = start_local_manual_cluster_with_layout(
         "channel-deposit",
         "mantle-channel",
         DeploymentBuilder::new(
             TfTopologyConfig::with_node_numbers(2)
+                .with_allow_multiple_genesis_tokens(true)
                 .with_test_context(Some("channel_deposit".to_owned())),
-        ),
+        )
+        .with_wallet_config(wallet_config),
         2,
         ManualNodeLayout::SelectNodeSeed(0),
         |config| Ok::<_, DynError>(channel_test_config(config)),
@@ -44,10 +50,6 @@ async fn channel_deposit() {
     .await;
 
     let validator = &nodes[0];
-    let funding_pk = base.deployment.nodes()[0]
-        .general
-        .consensus_config
-        .funding_pk;
 
     wait_for_nodes_height(
         nodes
@@ -124,6 +126,22 @@ async fn channel_deposit() {
     );
 }
 
+fn channel_deposit_wallet_config() -> (WalletConfig, ZkPublicKey) {
+    let deposit_note =
+        WalletAccount::deterministic(0, 1, false).expect("deposit wallet should be valid");
+
+    let fee_note = WalletAccount::new(
+        "channel-deposit-fee-note".to_owned(),
+        deposit_note.secret_key.clone(),
+        100,
+        false,
+    )
+    .expect("fee wallet should be valid");
+    let funding_pk = deposit_note.public_key();
+
+    (WalletConfig::new(vec![deposit_note, fee_note]), funding_pk)
+}
+
 fn channel_test_config(mut config: RunConfig) -> RunConfig {
     config.deployment.time.slot_duration = Duration::from_secs(1);
     config.deployment.cryptarchia.security_param = NonZero::new(3).unwrap();
@@ -155,7 +173,8 @@ async fn get_wallet_note(node: &NodeHttpClient, pk: ZkPublicKey, min_value: u64)
 
     body.notes
         .into_iter()
-        .find(|(_, value)| *value >= min_value)
+        .filter(|(_, value)| *value >= min_value)
+        .min_by_key(|(_, value)| *value)
         .expect("should find a note with sufficient balance for deposit")
 }
 

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -33,7 +33,8 @@ use tokio::time::sleep;
 /// 6. Verify the channel balance increases.
 #[tokio::test]
 async fn channel_deposit() {
-    let (wallet_config, funding_pk) = channel_deposit_wallet_config();
+    let deposit_amount = 1;
+    let (wallet_config, funding_pk) = channel_deposit_wallet_config(deposit_amount, 100);
     let (base, nodes) = start_local_manual_cluster_with_layout(
         "channel-deposit",
         "mantle-channel",
@@ -74,13 +75,14 @@ async fn channel_deposit() {
         .channel_id;
     let channel_balance_before = get_channel_balance(&validator.client, channel_id).await;
 
-    let (note_id, deposit_amount) = get_wallet_note(&validator.client, funding_pk, 1).await;
+    let (note_id, selected_deposit_amount) =
+        get_wallet_note(&validator.client, funding_pk, deposit_amount).await;
     let body = ChannelDepositRequestBody {
         tip: None,
         deposit: DepositOp {
             channel_id,
             inputs: Inputs::new(vec![note_id]),
-            metadata: b"Mint 1 to Alice in Zone".to_vec(),
+            metadata: format!("Mint {selected_deposit_amount} to Alice in Zone").into_bytes(),
         },
         change_public_key: funding_pk,
         funding_public_keys: vec![funding_pk],
@@ -126,14 +128,17 @@ async fn channel_deposit() {
     );
 }
 
-fn channel_deposit_wallet_config() -> (WalletConfig, ZkPublicKey) {
-    let deposit_note =
-        WalletAccount::deterministic(0, 1, false).expect("deposit wallet should be valid");
+fn channel_deposit_wallet_config(
+    deposit_note_amount: u64,
+    fee_note_amount: u64,
+) -> (WalletConfig, ZkPublicKey) {
+    let deposit_note = WalletAccount::deterministic(0, deposit_note_amount, false)
+        .expect("deposit wallet should be valid");
 
     let fee_note = WalletAccount::new(
         "channel-deposit-fee-note".to_owned(),
         deposit_note.secret_key.clone(),
-        100,
+        fee_note_amount,
         false,
     )
     .expect("fee wallet should be valid");

--- a/tests/src/tests/zone_sdk/e2e.rs
+++ b/tests/src/tests/zone_sdk/e2e.rs
@@ -4,7 +4,8 @@ use futures::{StreamExt as _, future::join_all};
 use lb_common_http_client::{CommonHttpClient, Slot};
 use lb_core::{
     mantle::{
-        MantleTx, Note, NoteId, Op, OpProof, Value,
+        GenesisTx as _, MantleTx, Note, NoteId, Op, OpProof, Value,
+        genesis_tx::GenesisTx as GenesisTransaction,
         ledger::{Inputs, Outputs},
         ops::{
             channel::{ChannelId, deposit::DepositOp, withdraw::ChannelWithdrawOp},
@@ -12,6 +13,7 @@ use lb_core::{
         },
     },
     proofs::channel_withdraw_proof::{ChannelWithdrawProof, WithdrawSignature},
+    sdp::{Locator, ServiceType},
 };
 use lb_http_api_common::bodies::{
     channel::ChannelDepositRequestBody,
@@ -32,7 +34,10 @@ use lb_zone_sdk::{
 use logos_blockchain_tests::{
     nodes::{Validator, create_validator_config},
     topology::configs::{
-        create_general_configs, deployment::e2e_deployment_settings_with_genesis_tx,
+        GeneralConfig,
+        consensus::{ProviderInfo, create_genesis_tx_with_declarations},
+        create_general_configs,
+        deployment::e2e_deployment_settings_with_genesis_tx,
     },
 };
 use rand::{Rng as _, thread_rng};
@@ -598,9 +603,10 @@ async fn test_sequencer_stale_checkpoint_resume() {
 #[tokio::test]
 async fn test_subscribe_to_finalized_deposit() {
     // Setup network with faster block production
-    let validators = spawn_validators(
+    let validators = spawn_validators_with_extra_funding_notes(
         Some("test_subscribe_to_finalized_deposit"),
         2,
+        [1],
         |mut config| {
             config.deployment.time.slot_duration = Duration::from_secs(1);
             config
@@ -647,8 +653,9 @@ async fn test_subscribe_to_finalized_deposit() {
     wait_for_zone_block(&indexer, msg1, Duration::from_mins(1)).await;
 
     // Now, submit a deposit directly to Bedrock
+    let deposit_amount = 1;
     let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
-    let (note_id, _) = get_note(validator, pk, 1u64)
+    let (note_id, _) = get_note_with_value(validator, pk, deposit_amount)
         .await
         .expect("should find a note with sufficient balance for deposit");
     let deposit = DepositOp {
@@ -751,7 +758,7 @@ async fn test_atomic_deposit_inscription() {
     let inscription_data = b"Mint 1 to Alice".to_vec();
     let (tx, msg_id, sequencer_sig) = handle
         .prepare_tx(
-            vec![Op::ChannelDeposit(deposit.clone()), Op::Transfer(transfer)],
+            vec![Op::Transfer(transfer), Op::ChannelDeposit(deposit.clone())],
             inscription_data.clone(),
         )
         .await
@@ -784,9 +791,10 @@ async fn test_atomic_deposit_inscription() {
 #[tokio::test]
 async fn test_subscribe_to_finalized_withdraw() {
     // Setup network with faster block production
-    let validators = spawn_validators(
+    let validators = spawn_validators_with_extra_funding_notes(
         Some("test_subscribe_to_finalized_withdraw"),
         2,
+        [3],
         |mut config| {
             config.deployment.time.slot_duration = Duration::from_secs(1);
             config
@@ -837,8 +845,9 @@ async fn test_subscribe_to_finalized_withdraw() {
     wait_for_zone_block(&indexer, msg1, Duration::from_mins(1)).await;
 
     // Deposit 3 into the channel
+    let deposit_amount = 3;
     let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
-    let (deposit_note_id, _) = get_note(validator, pk, 3)
+    let (deposit_note_id, _) = get_note_with_value(validator, pk, deposit_amount)
         .await
         .expect("should find a note with sufficient balance for deposit");
     let deposit = DepositOp {
@@ -902,7 +911,26 @@ async fn spawn_validators(
     modify_run_config: impl Fn(RunConfig) -> RunConfig,
     target_block: u64,
 ) -> Vec<Validator> {
+    spawn_validators_with_extra_funding_notes(
+        test_context,
+        count,
+        [],
+        modify_run_config,
+        target_block,
+    )
+    .await
+}
+
+async fn spawn_validators_with_extra_funding_notes(
+    test_context: Option<&str>,
+    count: usize,
+    funding_note_values: impl IntoIterator<Item = Value>,
+    modify_run_config: impl Fn(RunConfig) -> RunConfig,
+    target_block: u64,
+) -> Vec<Validator> {
     let (configs, genesis_tx) = create_general_configs(count, test_context);
+    let genesis_tx =
+        add_extra_funding_notes_to_genesis(&configs, genesis_tx, funding_note_values, test_context);
     let deployment_settings = e2e_deployment_settings_with_genesis_tx(genesis_tx);
     let configs: Vec<_> = configs
         .into_iter()
@@ -923,6 +951,41 @@ async fn spawn_validators(
     assert!(wait_for_height(&validators[0], target_block, Duration::from_mins(2)).await);
 
     validators
+}
+
+fn add_extra_funding_notes_to_genesis(
+    configs: &[GeneralConfig],
+    genesis_tx: GenesisTransaction,
+    values: impl IntoIterator<Item = Value>,
+    test_context: Option<&str>,
+) -> GenesisTransaction {
+    let values = values.into_iter().collect::<Vec<_>>();
+    if values.is_empty() {
+        return genesis_tx;
+    }
+
+    let funding_pk = configs[0].consensus_config.funding_pk;
+    let mut transfer_op = genesis_tx.genesis_transfer().clone();
+    transfer_op
+        .outputs
+        .extend(values.into_iter().map(|value| Note::new(value, funding_pk)));
+
+    let providers = configs
+        .iter()
+        .map(|config| {
+            let (blend_config, provider_sk, zk_sk) = &config.blend_config;
+
+            ProviderInfo {
+                service_type: ServiceType::BlendNetwork,
+                provider_sk: provider_sk.clone(),
+                zk_sk: zk_sk.clone(),
+                locator: Locator(blend_config.core.backend.listening_address.clone()),
+                note: config.consensus_config.blend_note.clone(),
+            }
+        })
+        .collect();
+
+    create_genesis_tx_with_declarations(transfer_op, providers, test_context)
 }
 
 async fn wait_for_zone_block(
@@ -1038,6 +1101,26 @@ async fn get_note(
     pk: ZkPublicKey,
     min_value: Value,
 ) -> Option<(NoteId, Value)> {
+    get_wallet_balance(validator, pk)
+        .await
+        .notes
+        .into_iter()
+        .find(|(_, value)| *value >= min_value)
+}
+
+async fn get_note_with_value(
+    validator: &Validator,
+    pk: ZkPublicKey,
+    expected_value: Value,
+) -> Option<(NoteId, Value)> {
+    get_wallet_balance(validator, pk)
+        .await
+        .notes
+        .into_iter()
+        .find(|(_, value)| *value == expected_value)
+}
+
+async fn get_wallet_balance(validator: &Validator, pk: ZkPublicKey) -> WalletBalanceResponseBody {
     let resp = reqwest::Client::new()
         .get(format!(
             "http://{}/wallet/{}/balance",
@@ -1054,17 +1137,9 @@ async fn get_note(
         resp.status()
     );
 
-    let body: WalletBalanceResponseBody = resp
-        .json()
+    resp.json()
         .await
-        .expect("balance response should be valid JSON");
-    for (note_id, value) in body.notes {
-        if value >= min_value {
-            return Some((note_id, value));
-        }
-    }
-
-    None
+        .expect("balance response should be valid JSON")
 }
 
 async fn sign_tx_zk(validator: &Validator, tx: &MantleTx, pks: Vec<ZkPublicKey>) -> ZkSignature {

--- a/tests/src/tests/zone_sdk/e2e.rs
+++ b/tests/src/tests/zone_sdk/e2e.rs
@@ -603,10 +603,11 @@ async fn test_sequencer_stale_checkpoint_resume() {
 #[tokio::test]
 async fn test_subscribe_to_finalized_deposit() {
     // Setup network with faster block production
+    let deposit_amount = 1;
     let validators = spawn_validators_with_extra_funding_notes(
         Some("test_subscribe_to_finalized_deposit"),
         2,
-        [1],
+        [deposit_amount],
         |mut config| {
             config.deployment.time.slot_duration = Duration::from_secs(1);
             config
@@ -653,7 +654,6 @@ async fn test_subscribe_to_finalized_deposit() {
     wait_for_zone_block(&indexer, msg1, Duration::from_mins(1)).await;
 
     // Now, submit a deposit directly to Bedrock
-    let deposit_amount = 1;
     let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
     let (note_id, _) = get_note_with_value(validator, pk, deposit_amount)
         .await
@@ -661,7 +661,7 @@ async fn test_subscribe_to_finalized_deposit() {
     let deposit = DepositOp {
         channel_id,
         inputs: Inputs::new(vec![note_id]),
-        metadata: b"Mint 1 to Alice in Zone".to_vec(),
+        metadata: format!("Mint {deposit_amount} to Alice in Zone").into_bytes(),
     };
     let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
     submit_deposit(validator, deposit.clone(), pk).await;
@@ -753,9 +753,9 @@ async fn test_atomic_deposit_inscription() {
                 .expect("the first note of the transfer is the deposit_note")
                 .id(),
         ]),
-        metadata: b"Mint 1 to Alice in Zone".to_vec(),
+        metadata: format!("Mint {deposit_amount} to Alice in Zone").into_bytes(),
     };
-    let inscription_data = b"Mint 1 to Alice".to_vec();
+    let inscription_data = format!("Mint {deposit_amount} to Alice").into_bytes();
     let (tx, msg_id, sequencer_sig) = handle
         .prepare_tx(
             vec![Op::Transfer(transfer), Op::ChannelDeposit(deposit.clone())],
@@ -791,10 +791,11 @@ async fn test_atomic_deposit_inscription() {
 #[tokio::test]
 async fn test_subscribe_to_finalized_withdraw() {
     // Setup network with faster block production
+    let deposit_amount = 3;
     let validators = spawn_validators_with_extra_funding_notes(
         Some("test_subscribe_to_finalized_withdraw"),
         2,
-        [3],
+        [deposit_amount],
         |mut config| {
             config.deployment.time.slot_duration = Duration::from_secs(1);
             config
@@ -845,7 +846,6 @@ async fn test_subscribe_to_finalized_withdraw() {
     wait_for_zone_block(&indexer, msg1, Duration::from_mins(1)).await;
 
     // Deposit 3 into the channel
-    let deposit_amount = 3;
     let pk = validator.config().user.cryptarchia.leader.wallet.funding_pk;
     let (deposit_note_id, _) = get_note_with_value(validator, pk, deposit_amount)
         .await

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -16,6 +16,7 @@ use lb_core::{
     mantle::{
         AuthenticatedMantleTx, GasConstants, NoteId, Utxo, Value,
         ops::{
+            Op,
             leader_claim::{VoucherCm, VoucherNullifier},
             transfer::TransferOp,
         },
@@ -38,6 +39,7 @@ pub struct WalletBlock {
     pub parent: HeaderId,
     pub epoch: Epoch,
     pub voucher_cm: VoucherCm,
+    pub spent_notes: Vec<NoteId>,
     pub transfers: Vec<TransferOp>,
 }
 
@@ -47,15 +49,30 @@ impl WalletBlock {
     where
         Tx: AuthenticatedMantleTx,
     {
-        let transfers: Vec<TransferOp> = block
-            .transactions()
-            .flat_map(|auth_tx| auth_tx.mantle_tx().transfers())
-            .collect();
+        let mut spent_notes = Vec::new();
+        let mut transfers = Vec::new();
+
+        for auth_tx in block.transactions() {
+            for op in &auth_tx.mantle_tx().ops {
+                match op {
+                    Op::ChannelDeposit(deposit) => {
+                        spent_notes.extend(deposit.inputs.iter().copied());
+                    }
+                    Op::Transfer(transfer) => {
+                        spent_notes.extend(transfer.inputs.iter().copied());
+                        transfers.push(transfer.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         Self {
             id: block.header().id(),
             parent: block.header().parent(),
             epoch,
             voucher_cm: *block.header().leader_proof().voucher_cm(),
+            spent_notes,
             transfers,
         }
     }
@@ -197,25 +214,11 @@ impl WalletState {
         let mut utxos = self.utxos.clone();
         let mut pk_index = self.pk_index.clone();
 
-        // Process each transaction in the block
+        for spent_id in &block.spent_notes {
+            remove_spent_utxo(spent_id, &mut utxos, &mut pk_index);
+        }
+
         for transfer in &block.transfers {
-            // Remove spent UTXOs (inputs)
-            for spent_id in &*transfer.inputs {
-                if let Some(utxo) = utxos.get(spent_id) {
-                    let pk = utxo.note.pk;
-                    utxos = utxos.remove(spent_id);
-
-                    if let Some(note_set) = pk_index.get(&pk) {
-                        let updated_set = note_set.remove(spent_id);
-                        if updated_set.is_empty() {
-                            pk_index = pk_index.remove(&pk);
-                        } else {
-                            pk_index = pk_index.insert(pk, updated_set);
-                        }
-                    }
-                }
-            }
-
             // Add new UTXOs (outputs) - only if they belong to our known keys
             for utxo in transfer.outputs.utxos(transfer) {
                 if known_keys.contains_key(&utxo.note.pk) {
@@ -295,6 +298,30 @@ impl WalletState {
         }
 
         (vouchers, voucher_paths, snapshot)
+    }
+}
+
+fn remove_spent_utxo(
+    spent_id: &NoteId,
+    utxos: &mut rpds::HashTrieMapSync<NoteId, Utxo>,
+    pk_index: &mut rpds::HashTrieMapSync<ZkPublicKey, rpds::HashTrieSetSync<NoteId>>,
+) {
+    let Some(utxo) = utxos.get(spent_id) else {
+        return;
+    };
+
+    let pk = utxo.note.pk;
+    *utxos = utxos.remove(spent_id);
+
+    let Some(note_set) = pk_index.get(&pk) else {
+        return;
+    };
+
+    let updated_set = note_set.remove(spent_id);
+    if updated_set.is_empty() {
+        *pk_index = pk_index.remove(&pk);
+    } else {
+        *pk_index = pk_index.insert(pk, updated_set);
     }
 }
 
@@ -514,7 +541,7 @@ mod tests {
     use lb_core::{
         crypto::{Hash, ZkDigest as _},
         mantle::{
-            Note, Op,
+            Note,
             gas::MainnetGasConstants as Gas,
             ledger::{Inputs, Outputs},
             ops::channel::{ChannelId, MsgId, inscribe::InscriptionOp},
@@ -648,6 +675,7 @@ mod tests {
             parent: genesis,
             epoch: 1.into(),
             voucher_cm: v1_cm,
+            spent_notes: vec![],
             transfers: vec![transfer1.clone()],
         };
 
@@ -665,6 +693,7 @@ mod tests {
             parent: block_1.id,
             epoch: 2.into(),
             voucher_cm: v2_cm,
+            spent_notes: vec![alice_100_nmo_utxo.id()],
             transfers: vec![TransferOp {
                 inputs: Inputs::new(vec![alice_100_nmo_utxo.id()]),
                 outputs: Outputs::new(vec![Note::new(20, bob), Note::new(80, alice)]),
@@ -696,15 +725,32 @@ mod tests {
         );
 
         // Block 3 (still, epoch 2)
+        // - alice spends the 80 NMO note through a non-transfer operation.
         // - voucher v3 is not ours -> should not be tracked
+        let alice_80_nmo_utxo = block_2.transfers[0]
+            .outputs
+            .utxo_by_index(1, &block_2.transfers[0])
+            .unwrap();
+
         let block_3 = WalletBlock {
             id: HeaderId::from([3; 32]),
             parent: block_2.id,
             epoch: 2.into(),
             voucher_cm: v3_cm,
+            spent_notes: vec![alice_80_nmo_utxo.id()],
             transfers: vec![],
         };
         wallet.apply_block(&block_3).unwrap();
+
+        assert_eq!(
+            wallet.balance(block_3.id, alice).unwrap().unwrap().balance,
+            4
+        );
+        assert_eq!(
+            wallet.balance(block_3.id, bob).unwrap().unwrap().balance,
+            20
+        );
+
         // v1 is still claimable
         assert_snapshotted_voucher(&wallet, block_3.id, &v1_cm);
         // v2 is still not snapshotted


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes a few channel deposit issues.

After channel deposits started carrying explicit input notes, some wallet and funding paths still only accounted for transfer inputs.

This PR fixes that in three places:

- `MantleTxBuilder::input_notes()` is used as the funding exclusion set. It now includes `ChannelDeposit` inputs, so deposit notes are not selected again when the wallet chooses fee inputs.
- Channel deposit signing used `tx_builder.ledger_inputs()` to find signer public keys, but `ledger_inputs` only contains UTXOs selected for the builder-created transfer. It now resolves deposit input keys from the ledger UTXO set.
- Wallet sync now treats `ChannelDeposit` inputs as spent notes, so deposited notes are removed from wallet balance once the deposit lands on chain.

Fixed e2e tests:

- `channel_deposit`
- `test_subscribe_to_finalized_deposit`
- `test_subscribe_to_finalized_withdraw`
- `test_atomic_deposit_inscription`


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
