### PR TITLE
fix(mantle): include `pk` when encoding `LeaderClaimOp`

### DIFF
--- a/core/src/mantle/encoding.rs
+++ b/core/src/mantle/encoding.rs
@@ -713,6 +713,7 @@ pub fn encode_leader_claim(op: &LeaderClaimOp) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend(encode_field_element(&op.rewards_root.into()));
     bytes.extend(encode_field_element(&op.voucher_nullifier.into()));
+    bytes.extend(encode_field_element(op.pk.as_fr()));
     bytes
 }
 
@@ -1697,6 +1698,21 @@ mod tests {
                 voucher_nf,
             ))
         );
+    }
+
+    #[test]
+    fn test_encode_decode_leader_claim_op() {
+        let leader_claim_op = LeaderClaimOp {
+            rewards_root: RewardsRoot::default(),
+            voucher_nullifier: VoucherNullifier::default(),
+            pk: ZkPublicKey::from(BigUint::from(0u64)),
+        };
+        let op = Op::LeaderClaim(leader_claim_op);
+
+        let encoded = encode_op(&op);
+        let (remaining, decoded_op) = decode_op(&encoded).unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(decoded_op, op);
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

This fixes a bug introduced by #2579. When encoding `LeaderClaimOp`, we were omitting `LeaderClaimOp::pk` which was added by #2579. Because of that, a tx including `LeaderClaimOp`s was successfully added to the mempool storage, but was not able to be fetched from the mempool storage because of `nom::ParsingError` when proposing new blocks. It was causing that the tx is never be included in new block proposals.

## 2. Does the code have enough context to be clearly understood?

Yes

This is up to the latest spec. Recently, the `public key` has been added to the `ClaimRequest` in the [spec](https://www.notion.so/nomos-tech/1-4-0-Mantle-335261aa09df8065a38acff4b25aee82?source=copy_link#335261aa09df81cbae23c6145649c37e) (updated by [RFC](https://www.notion.so/nomos-tech/RFC-Enforce-NoteId-uniqueness-335261aa09df807b9fe3c9bb9bd2c6db?source=copy_link#335261aa09df803bb3d2c361e7129fe9)). But, the encoding logic wasn't updated.

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
