### PR TITLE
fix(tx-builder): exclude locked notes from auto-funding

### DIFF
--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -215,16 +215,18 @@ mod tests {
     use lb_key_management_system_keys::keys::Ed25519Key;
 
     use super::*;
-    use crate::mantle::{
-        gas::MainnetGasConstants,
-        ops::{
-            channel::{ChannelId, deposit::DepositOp, inscribe::InscriptionOp},
-            leader_claim::LeaderClaimOp,
-            sdp::{SDPDeclareOp, SDPWithdrawOp},
+    use crate::{
+        mantle::{
+            gas::MainnetGasConstants,
+            ops::{
+                channel::{ChannelId, deposit::DepositOp, inscribe::InscriptionOp},
+                leader_claim::LeaderClaimOp,
+                sdp::{SDPDeclareOp, SDPWithdrawOp},
+            },
+            tx::MantleTxGasContext,
         },
-        tx::MantleTxGasContext,
+        sdp::{DeclarationId, ProviderId, ServiceType},
     };
-    use crate::sdp::{DeclarationId, ProviderId, ServiceType};
 
     #[test]
     fn inscription_op() {
@@ -434,24 +436,23 @@ mod tests {
             }))
             .add_ledger_input(transfer_input);
 
-        let notes: Vec<_> = builder.consumed_or_locked_notes().collect();
-
+        let consumed_or_locked: Vec<_> = builder.consumed_or_locked_notes().collect();
         assert!(
-            notes.contains(&deposit_input),
+            consumed_or_locked.contains(&deposit_input),
             "should contain deposit input"
         );
         assert!(
-            notes.contains(&declare_locked),
+            consumed_or_locked.contains(&declare_locked),
             "should contain declare locked note"
         );
         assert!(
-            notes.contains(&withdraw_locked),
+            consumed_or_locked.contains(&withdraw_locked),
             "should contain withdraw locked note"
         );
         assert!(
-            notes.contains(&transfer_input.id()),
+            consumed_or_locked.contains(&transfer_input.id()),
             "should contain transfer input"
         );
-        assert_eq!(notes.len(), 4);
+        assert_eq!(consumed_or_locked.len(), 4);
     }
 }

--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -169,9 +169,10 @@ impl MantleTxBuilder {
         Ok(self.net_balance() - i128::from(self.gas_cost::<G>()?.into_inner()))
     }
 
-    /// Returns all note IDs already consumed by this transaction, plus the
-    /// funding inputs that will be appended as a transfer during build.
-    pub fn input_notes(&self) -> impl Iterator<Item = NoteId> {
+    /// Returns all note IDs already consumed or locked by this transaction,
+    /// plus the funding inputs that will be appended as a transfer during
+    /// build.
+    pub fn consumed_or_locked_notes(&self) -> impl Iterator<Item = NoteId> {
         self.mantle_tx
             .ops
             .iter()
@@ -181,7 +182,12 @@ impl MantleTxBuilder {
                     Op::ChannelDeposit(deposit) => &deposit.inputs,
                     _ => &[],
                 };
-                inputs.iter().copied()
+                let locked = match op {
+                    Op::SDPDeclare(declare) => Some(declare.locked_note_id),
+                    Op::SDPWithdraw(withdraw) => Some(withdraw.locked_note_id),
+                    _ => None,
+                };
+                inputs.iter().copied().chain(locked)
             })
             .chain(self.ledger_inputs().iter().map(Utxo::id))
     }
@@ -214,9 +220,11 @@ mod tests {
         ops::{
             channel::{ChannelId, deposit::DepositOp, inscribe::InscriptionOp},
             leader_claim::LeaderClaimOp,
+            sdp::{SDPDeclareOp, SDPWithdrawOp},
         },
         tx::MantleTxGasContext,
     };
+    use crate::sdp::{DeclarationId, ProviderId, ServiceType};
 
     #[test]
     fn inscription_op() {
@@ -392,5 +400,58 @@ mod tests {
             builder.funding_delta::<MainnetGasConstants>().unwrap(),
             0 // zero gas price for now
         );
+    }
+
+    #[test]
+    fn consumed_or_locked_notes() {
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::default(),
+            leader_reward_amount: 30,
+        };
+
+        let deposit_input = NoteId(Fr::from(1u64));
+        let declare_locked = NoteId(Fr::from(2u64));
+        let withdraw_locked = NoteId(Fr::from(3u64));
+        let transfer_input = Utxo::new([0u8; 32], 0, Note::new(50, ZkPublicKey::zero()));
+
+        let builder = MantleTxBuilder::new(context)
+            .push_op(Op::ChannelDeposit(DepositOp {
+                channel_id: [0; 32].into(),
+                inputs: Inputs::new(vec![deposit_input]),
+                metadata: vec![],
+            }))
+            .push_op(Op::SDPDeclare(SDPDeclareOp {
+                service_type: ServiceType::BlendNetwork,
+                locators: vec![],
+                provider_id: ProviderId(Ed25519Key::from_bytes(&[0; 32]).public_key()),
+                zk_id: ZkPublicKey::zero(),
+                locked_note_id: declare_locked,
+            }))
+            .push_op(Op::SDPWithdraw(SDPWithdrawOp {
+                declaration_id: DeclarationId([0; 32]),
+                locked_note_id: withdraw_locked,
+                nonce: 1,
+            }))
+            .add_ledger_input(transfer_input);
+
+        let notes: Vec<_> = builder.consumed_or_locked_notes().collect();
+
+        assert!(
+            notes.contains(&deposit_input),
+            "should contain deposit input"
+        );
+        assert!(
+            notes.contains(&declare_locked),
+            "should contain declare locked note"
+        );
+        assert!(
+            notes.contains(&withdraw_locked),
+            "should contain withdraw locked note"
+        );
+        assert!(
+            notes.contains(&transfer_input.id()),
+            "should contain transfer input"
+        );
+        assert_eq!(notes.len(), 4);
     }
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -49,6 +49,7 @@ impl WalletBlock {
     where
         Tx: AuthenticatedMantleTx,
     {
+        // TODO: handle inputs/outputs of ALL operations: https://github.com/logos-blockchain/logos-blockchain/issues/2627
         let mut spent_notes = Vec::new();
         let mut transfers = Vec::new();
 
@@ -144,12 +145,14 @@ impl WalletState {
         pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
     ) -> Result<MantleTxBuilder, WalletError> {
         // Get all UTXOs owned by the provided PKs, excluding any that are already being
-        // used as inputs in the tx builder.
-        let inputs = tx_builder.input_notes().collect::<HashSet<_>>();
+        // consumed/locked by the tx.
+        let consumed_or_locked = tx_builder
+            .consumed_or_locked_notes()
+            .collect::<HashSet<_>>();
         let mut utxos = self
             .utxos_owned_by_pks(pks)
             .into_iter()
-            .filter(|utxo| !inputs.contains(&utxo.id()))
+            .filter(|utxo| !consumed_or_locked.contains(&utxo.id()))
             .collect::<Vec<_>>();
 
         // Consume large valued notes first to ensure we converge.


### PR DESCRIPTION
## 1. What does this PR implement?

MantleTxBuilder should exclude notes locked for SDP Declare/Withdraw operations when auto-funding txs, because those notes shouldn't/can't be spent.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
