### PR TITLE
fix(test): avoid deleting fresh port claims

### DIFF
--- a/tools/config/src/unique.rs
+++ b/tools/config/src/unique.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     sync::{Mutex, OnceLock},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use lb_utils::net::{get_available_tcp_port, get_available_udp_port};
@@ -15,6 +15,7 @@ use lb_utils::net::{get_available_tcp_port, get_available_udp_port};
 const PORT_BLOCK_SIZE: u16 = 256;
 const PORT_RANGE_START: u16 = 20_000;
 const PORT_RANGE_END: u16 = 55_000;
+const MALFORMED_CLAIM_FILE_REAP_GRACE: Duration = Duration::from_mins(1);
 
 static TEST_PORT_ALLOCATOR: OnceLock<Mutex<Option<TestPortAllocator>>> = OnceLock::new();
 static PROCESS_START_NONCE: OnceLock<String> = OnceLock::new();
@@ -179,7 +180,7 @@ fn write_port_claim_metadata(
 
 fn try_reap_stale_port_claim_file(claim_file: &Path) {
     let Ok(contents) = fs::read_to_string(claim_file) else {
-        drop(fs::remove_file(claim_file));
+        try_reap_malformed_claim_file(claim_file);
         return;
     };
 
@@ -189,13 +190,30 @@ fn try_reap_stale_port_claim_file(claim_file: &Path) {
         .and_then(|pid| pid.parse::<u32>().ok());
 
     let Some(pid) = pid else {
-        drop(fs::remove_file(claim_file));
+        try_reap_malformed_claim_file(claim_file);
         return;
     };
 
     if !process_exists(pid) {
         drop(fs::remove_file(claim_file));
     }
+}
+
+fn try_reap_malformed_claim_file(claim_file: &Path) {
+    // A claim file is visible before its metadata is fully written. Give fresh
+    // malformed files time to become valid instead of deleting a live claim.
+    if claim_file_age(claim_file).is_some_and(|age| age >= MALFORMED_CLAIM_FILE_REAP_GRACE) {
+        drop(fs::remove_file(claim_file));
+    }
+}
+
+fn claim_file_age(claim_file: &Path) -> Option<Duration> {
+    fs::metadata(claim_file)
+        .ok()?
+        .modified()
+        .ok()?
+        .elapsed()
+        .ok()
 }
 
 fn process_exists(pid: u32) -> bool {


### PR DESCRIPTION
## 1. What does this PR implement?

This fixes a race in `TestPortAllocator`.

The lock file creation itself is atomic, but there was still a small window after creating the file and before writing metadata into it. During that window another test process could see an empty/partial claim file, treat it as malformed, delete it, and then claim the same port block.

This PR makes malformed claim cleanup more conservative: fresh malformed claim files are left alone and only old malformed files are deleted. That way another process skips the block instead of accidentally stealing it while the original owner is still writing metadata.


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
