### PR TITLE
fix(test): enable reward calculation test with real income

### DIFF
--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -407,20 +407,21 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO: Re-enable when session_income is implemented (currently hardcoded to 0)"]
     fn test_rewards_calculation() {
         let provider1 = create_provider_id(1);
         let provider2 = create_provider_id(2);
         let provider3 = create_provider_id(3);
         let provider4 = create_provider_id(4);
 
-        // Create a reward tracker, and update session from 0 to 1.
+        // Create a reward tracker, accumulate session income during session 0,
+        // and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
         let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
             create_blend_rewards_params(864_000, 1),
             &epoch_state,
         )
+        .add_income(1000)
         .update_session(
             &create_test_session_state(
                 &[provider1, provider2, provider3, provider4],
@@ -431,8 +432,7 @@ mod tests {
             &config,
         );
 
-        // provider1 submits an activity proof, which has the minimum
-        // Hamming distance among all proofs.
+        // provider1 submits an activity proof
         let rewards_tracker = rewards_tracker
             .update_active(
                 provider1,
@@ -446,7 +446,8 @@ mod tests {
             )
             .unwrap();
 
-        // provider2 submits an activity proof.
+        // provider2 submits an activity proof, which has the minimum
+        // Hamming distance among all proofs.
         let rewards_tracker = rewards_tracker
             .update_active(
                 provider2,
@@ -460,8 +461,7 @@ mod tests {
             )
             .unwrap();
 
-        // provider3 submits an activity proof, which has the minimum
-        // Hamming distance among all proofs.
+        // provider3 submits an activity proof
         let rewards_tracker = rewards_tracker
             .update_active(
                 provider3,
@@ -512,14 +512,14 @@ mod tests {
             })
             .collect();
 
-        // Provider1 and provider3 should get double rewards compared to provider2.
+        // Provider2 gets double rewards compared to provider1 and provider3.
         assert_eq!(
-            *rewards.get(&provider1).unwrap(),
-            rewards.get(&provider2).unwrap() * 2
+            *rewards.get(&provider2).unwrap(),
+            rewards.get(&provider1).unwrap() * 2
         );
         assert_eq!(
-            *rewards.get(&provider3).unwrap(),
-            rewards.get(&provider2).unwrap() * 2
+            *rewards.get(&provider2).unwrap(),
+            rewards.get(&provider3).unwrap() * 2
         );
         // Provider4 should get no rewards.
         assert_eq!(rewards.get(&provider4), None);


### PR DESCRIPTION
## 1. What does this PR implement?

We were disabling the following test because the session income was not implemented at the time when I wrote the test.
https://github.com/logos-blockchain/logos-blockchain/blob/f9a1c56501e0dfb2c895c1c68ed3362340920072/ledger/src/mantle/sdp/rewards/blend/mod.rs#L410.

Now that we have the session income implemented, we can enable the test.

## 2. Does the code have enough context to be clearly understood?
yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?
yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
