### PR TITLE
fix(wallet-service): do not use locked note pk for signing activity msg

### DIFF
--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -687,15 +687,7 @@ where
                 active_op.declaration_id,
             ))?;
 
-        let locked_note = ledger
-            .mantle_ledger()
-            .locked_notes()
-            .get(&declaration.locked_note_id)
-            .ok_or(WalletServiceError::MissingLockedNote(
-                declaration.locked_note_id,
-            ))?;
-
-        let zk_sig = Self::sign_zksig(tx_hash, [locked_note.pk, declaration.zk_id], kms).await?;
+        let zk_sig = Self::sign_zksig(tx_hash, [declaration.zk_id], kms).await?;
 
         Ok(OpProof::ZkSig(zk_sig))
     }


### PR DESCRIPTION
## 1. What does this PR implement?

Wallet service has been changed by https://github.com/logos-blockchain/logos-blockchain/pull/2437 to sign activity messages using `locked_note_pk` as well as `zk_id`. But, the verification logic wasn't changed. It's still using only `zk_id`: https://github.com/logos-blockchain/logos-blockchain/blob/26464103c230547f1c8bc782e82d0066baf1d072/core/src/mantle/ops/sdp/active.rs#L50

I checked the spec to check which one is correct. The [Mantle v1.4](https://www.notion.so/nomos-tech/v1-4-Mantle-335261aa09df8065a38acff4b25aee82?source=copy_link#335261aa09df81a28f25ff8ab5164c50) and [SDP v1.0.0](https://www.notion.so/nomos-tech/1-0-0-Service-Declaration-Protocol-1fd261aa09df819ca9f8eb2bdfd4ec1d?source=copy_link#1fd261aa09df81a8aab3e6529e23189f) says that the message must be signed by `zk_id`.

So, I reverted the wallet service to sign activity messages using only `zk_id`.

There is not test yet. Also I'm not adding tests in this PR. I will refactor the `Operation` trait to have all logic in one place and to make them easy to test. https://github.com/logos-blockchain/logos-blockchain/issues/2638
Also, I have an e2e test that I'm not committing yet because there are other bugs to be fixed. I will open a separate PR for the test soon.

@thomaslavaur If we have to use `locked_note_pk` as well, let's update the spec first and change this implementation.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?
yes

## 5. Does the implementation introduce changes in the specification?

Needs opinions from @thomaslavaur 

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
