### PR TITLE
chore(ci): publish logos-blockchain-node image on pushes to master

### DIFF
--- a/.github/workflows/publish-node-image.yml
+++ b/.github/workflows/publish-node-image.yml
@@ -1,9 +1,6 @@
 name: Publish Logos Blockchain Node Docker Image
 
 on:
-  push:
-    branches:
-      - master
   release:
     types: [published, created]
 

--- a/.github/workflows/publish-node-image.yml
+++ b/.github/workflows/publish-node-image.yml
@@ -1,18 +1,16 @@
 name: Publish Logos Blockchain Node Docker Image
 
 on:
+  push:
+    branches:
+      - master
   release:
     types: [published, created]
-  workflow_dispatch:
-    inputs:
-      node_version:
-        description: 'Node version (e.g. 0.2.1)'
-        required: true
-        default: '0.2.1'
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/logos-blockchain-node
+  IMAGE_TAG: ${{ github.event.inputs.node_version || github.ref_name }}
 
 jobs:
   push_to_registries:
@@ -60,9 +58,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            LB_NODE_VERSION=${{ github.event.inputs.node_version || github.ref_name }}
+            LB_NODE_VERSION=${{ env.IMAGE_TAG }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.node_version || github.ref_name }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
             ${{ github.event_name == 'release' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
## 1. What does this PR implement?

Remove the manual dispatch that was a temporary fix, ~and add a hook for pushes to `master` that will publish the Docker image with the `master` tag. Useful if we want to pick a commit to test on DST nodes.~

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.