### PR TITLE
fix(chain): avoid panic when orphan download has no peers

### DIFF
--- a/services/chain/chain-network/src/network/adapters/libp2p.rs
+++ b/services/chain/chain-network/src/network/adapters/libp2p.rs
@@ -343,6 +343,15 @@ where
             additional_blocks.len()
         );
 
+        if peers_to_request.is_empty() {
+            return Err(format!(
+                "no candidate peers available to download orphan ancestors for target block {target_block:?} (connected={}, discovered={})",
+                connected_peers.len(),
+                discovered_peers.len()
+            )
+            .into());
+        }
+
         let requests = peers_to_request
             .into_iter()
             .map(|peer| {


### PR DESCRIPTION
## 1. What does this PR implement?

In some CI failures, a node hit ParentMissing, but at that moment there were no candidate peers available for ancestor download. We were still calling select_ok with an empty request list, which panicked and killed the node.

Now that case returns a normal error instead of crashing.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
