### PR TITLE
feat(logging): introduce log targets crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,6 +4379,7 @@ dependencies = [
  "logos-blockchain-key-management-system-service",
  "logos-blockchain-ledger",
  "logos-blockchain-libp2p",
+ "logos-blockchain-log-targets",
  "logos-blockchain-network-service",
  "logos-blockchain-poq",
  "logos-blockchain-sdp-service",
@@ -4901,6 +4902,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-blockchain-log-targets"
+version = "0.1.2"
+dependencies = [
+ "logos-blockchain-log-targets-macros",
+]
+
+[[package]]
+name = "logos-blockchain-log-targets-macros"
+version = "0.1.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "logos-blockchain-mmr"
 version = "0.1.2"
 dependencies = [
@@ -5213,6 +5230,7 @@ dependencies = [
 name = "logos-blockchain-tracing"
 version = "0.1.2"
 dependencies = [
+ "logos-blockchain-log-targets",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ members = [
   "tools/blockchain-tools",
   "tools/config",
   "tracing",
+  "tracing/targets",
+  "tracing/targets/macros",
   "utils",
   "utxotree",
   "wallet",
@@ -129,6 +131,7 @@ lb-key-management-system-operators = { default-features = false, package = "logo
 lb-key-management-system-service   = { default-features = false, package = "logos-blockchain-key-management-system-service", path = "./services/key-management-system" }
 lb-ledger                          = { default-features = false, package = "logos-blockchain-ledger", path = "./ledger" }
 lb-libp2p                          = { default-features = false, package = "logos-blockchain-libp2p", path = "./libp2p" }
+lb-log-targets                     = { default-features = false, package = "logos-blockchain-log-targets", path = "./tracing/targets" }
 lb-mmr                             = { default-features = false, package = "logos-blockchain-mmr", path = "./mmr" }
 lb-network-service                 = { default-features = false, package = "logos-blockchain-network-service", path = "./services/network" }
 lb-node                            = { default-features = false, package = "logos-blockchain-node", path = "./nodes/node/binary" }
@@ -168,6 +171,7 @@ blake2            = { default-features = false, version = "0.10" }
 bytes             = { default-features = false, version = "1.3" }
 cached            = { default-features = false, version = "0.55.1" }
 cfg-if            = { default-features = false, version = "1.0.4" }
+const-str         = { default-features = false, version = "0.4.3" }
 divan             = { default-features = false, version = "0.1" }
 ed25519-dalek     = { default-features = false, version = "2" }
 fork_stream       = { default-features = false, version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ lb-key-management-system-service   = { default-features = false, package = "logo
 lb-ledger                          = { default-features = false, package = "logos-blockchain-ledger", path = "./ledger" }
 lb-libp2p                          = { default-features = false, package = "logos-blockchain-libp2p", path = "./libp2p" }
 lb-log-targets                     = { default-features = false, package = "logos-blockchain-log-targets", path = "./tracing/targets" }
+lb-log-targets-macros              = { default-features = false, package = "logos-blockchain-log-targets-macros", path = "./tracing/targets/macros" }
 lb-mmr                             = { default-features = false, package = "logos-blockchain-mmr", path = "./mmr" }
 lb-network-service                 = { default-features = false, package = "logos-blockchain-network-service", path = "./services/network" }
 lb-node                            = { default-features = false, package = "logos-blockchain-node", path = "./nodes/node/binary" }
@@ -185,6 +186,8 @@ log               = { default-features = false, version = "0.4" }
 nutype            = { default-features = false, version = "0.6.2" }
 overwatch         = { default-features = false, git = "https://github.com/logos-co/Overwatch", rev = "448c192" }
 overwatch-derive  = { default-features = false, git = "https://github.com/logos-co/Overwatch", rev = "448c192" }
+proc-macro2       = { default-features = false, version = "1" }
+quote             = { default-features = false, version = "1" }
 rand              = { default-features = false, version = "0.8" }
 reqwest           = { default-features = false, version = "0.12" }
 serde             = { default-features = false, version = "1.0" }
@@ -194,6 +197,7 @@ serde_json        = { default-features = false, version = "1.0" }
 serde_with        = { default-features = false, version = "3.14.0" }
 serde_yaml        = { default-features = false, version = "0.9.33" }
 subtle            = { default-features = false, version = "2.6.1" }
+syn               = { features = ["full"], version = "2" }
 tempfile          = { default-features = false, version = "3" }
 thiserror         = { default-features = false, version = "2.0" }
 time              = { default-features = false, version = "0.3" }

--- a/blend/message/Cargo.toml
+++ b/blend/message/Cargo.toml
@@ -22,14 +22,13 @@ lb-blend-proofs               = { workspace = true }
 lb-core                       = { workspace = true }
 lb-groth16                    = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
-
-lb-utils        = { features = ["rng"], workspace = true }
-serde           = { workspace = true }
-serde-big-array = { workspace = true }
-serde_with      = { default-features = false, features = ["alloc"], version = "3" }
-thiserror       = { default-features = false, version = "1.0.69" }
-tracing         = { workspace = true }
-zeroize         = { workspace = true }
+lb-utils                      = { features = ["rng"], workspace = true }
+serde                         = { workspace = true }
+serde-big-array               = { workspace = true }
+serde_with                    = { default-features = false, features = ["alloc"], version = "3" }
+thiserror                     = { default-features = false, version = "1.0.69" }
+tracing                       = { workspace = true }
+zeroize                       = { workspace = true }
 
 [dev-dependencies]
 test-log = { default-features = false, features = ["trace"], version = "0.2" }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -1,6 +1,5 @@
 use core::{convert::Infallible, str::FromStr};
 use std::{
-    collections::HashMap,
     io::Read,
     net::{IpAddr, SocketAddr, ToSocketAddrs as _},
     path::{Path, PathBuf},
@@ -10,7 +9,7 @@ use ::tracing::{Level, warn};
 use clap::{Parser, Subcommand, ValueEnum, builder::OsStr};
 use color_eyre::eyre::{Result, eyre};
 use lb_libp2p::{Multiaddr, ed25519::SecretKey};
-use lb_tracing::filter::envfilter::default_envfilter_config;
+use lb_tracing::filter::envfilter::{default_envfilter_config, parse_filter_directives};
 use serde::Deserialize;
 use tracing::serde::filter::{EnvConfig, Layer};
 
@@ -473,16 +472,7 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
 
 /// Parses CLI/env filter overrides into the typed filter config form.
 fn parse_log_filter_layer(raw: &str) -> Result<Layer> {
-    let filters = raw
-        .split(',')
-        .map(str::trim)
-        .filter(|directive| !directive.is_empty())
-        .map(parse_log_filter_directive)
-        .collect::<Result<HashMap<_, _>>>()?;
-
-    if filters.is_empty() {
-        return Err(eyre!("Invalid log filter provided: {}", raw));
-    }
+    let filters = parse_filter_directives(raw).map_err(|error| eyre!(error))?;
 
     Ok(Layer::Env(EnvConfig { filters }))
 }
@@ -499,27 +489,6 @@ fn apply_default_debug_log_filter(tracing: &mut TracingConfig) {
             filters: filter.filters,
         });
     }
-}
-
-/// Parses a single filter directive of the form `target=level` or a bare
-/// global level such as `warn`.
-fn parse_log_filter_directive(directive: &str) -> Result<(String, Level)> {
-    if let Some((target, level)) = directive.split_once('=') {
-        let target = target.trim();
-        let level = level.trim();
-
-        if target.is_empty() || level.is_empty() {
-            return Err(eyre!("Invalid log filter directive: {}", directive));
-        }
-
-        return Ok((target.to_owned(), parse_log_filter_level(level)?));
-    }
-
-    Ok(("*".to_owned(), parse_log_filter_level(directive)?))
-}
-
-fn parse_log_filter_level(level: &str) -> Result<Level> {
-    Level::from_str(level.trim()).map_err(|_| eyre!("Invalid log filter level provided: {}", level))
 }
 
 pub fn update_network(network: &mut NetworkConfig, network_args: NetworkArgs) -> Result<()> {

--- a/nodes/node/binary/src/config/tests.rs
+++ b/nodes/node/binary/src/config/tests.rs
@@ -172,6 +172,18 @@ fn parse_log_filter_layer_rejects_empty_directive() {
 }
 
 #[test]
+fn parse_log_filter_layer_rejects_unknown_blend_target() {
+    let error = parse_log_filter_layer("blend::service::missing=debug")
+        .expect_err("unknown blend target should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("unknown log filter target `blend::service::missing`")
+    );
+}
+
+#[test]
 fn env_config_serializes_and_deserializes_typed_levels() {
     let config = EnvConfig {
         filters: [
@@ -195,4 +207,17 @@ fn env_config_deserialization_rejects_invalid_level() {
         .expect_err("invalid level should fail");
 
     assert!(error.to_string().contains("invalid log level"));
+}
+
+#[test]
+fn env_config_deserialization_rejects_unknown_blend_target() {
+    let error =
+        serde_json::from_str::<EnvConfig>(r#"{"filters":{"blend::service::missing":"debug"}}"#)
+            .expect_err("unknown blend target should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("unknown log filter target `blend::service::missing`")
+    );
 }

--- a/nodes/node/binary/src/config/tests.rs
+++ b/nodes/node/binary/src/config/tests.rs
@@ -206,7 +206,11 @@ fn env_config_deserialization_rejects_invalid_level() {
     let error = serde_json::from_str::<EnvConfig>(r#"{"filters":{"logos_blockchain":"debgu"}}"#)
         .expect_err("invalid level should fail");
 
-    assert!(error.to_string().contains("invalid log level"));
+    assert!(
+        error
+            .to_string()
+            .contains("Invalid log filter level provided: debgu")
+    );
 }
 
 #[test]

--- a/nodes/node/binary/src/config/tracing/serde/filter.rs
+++ b/nodes/node/binary/src/config/tracing/serde/filter.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use lb_tracing::filter::envfilter::{EnvFilterConfig, serde_filters};
+use lb_tracing::filter::envfilter::{EnvFilterConfig, serde_validated_filters};
 use lb_tracing_service::FilterLayerSettings;
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +27,6 @@ impl From<Layer> for FilterLayerSettings {
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct EnvConfig {
-    #[serde(with = "serde_filters")]
+    #[serde(with = "serde_validated_filters")]
     pub filters: HashMap<String, Level>,
 }

--- a/services/blend/Cargo.toml
+++ b/services/blend/Cargo.toml
@@ -25,7 +25,7 @@ lb-cryptarchia-engine            = { workspace = true }
 lb-groth16                       = { default-features = false, workspace = true }
 lb-key-management-system-service = { features = ["unsafe"], workspace = true }
 lb-ledger                        = { workspace = true }
-lb-libp2p                        = { optional = true, workspace = true }
+lb-libp2p                        = { workspace = true }
 lb-log-targets                   = { workspace = true }
 lb-network-service               = { workspace = true }
 lb-poq                           = { workspace = true }

--- a/services/blend/Cargo.toml
+++ b/services/blend/Cargo.toml
@@ -25,7 +25,8 @@ lb-cryptarchia-engine            = { workspace = true }
 lb-groth16                       = { default-features = false, workspace = true }
 lb-key-management-system-service = { features = ["unsafe"], workspace = true }
 lb-ledger                        = { workspace = true }
-lb-libp2p                        = { workspace = true }
+lb-libp2p                        = { optional = true, workspace = true }
+lb-log-targets                   = { workspace = true }
 lb-network-service               = { workspace = true }
 lb-poq                           = { workspace = true }
 lb-sdp-service                   = { workspace = true }

--- a/services/blend/src/epoch_info.rs
+++ b/services/blend/src/epoch_info.rs
@@ -46,7 +46,7 @@ pub trait PolInfoProvider<RuntimeServiceId> {
     ) -> Option<Self::Stream>;
 }
 
-const LOG_TARGET: &str = "blend::service::epoch";
+const LOG_TARGET: &str = lb_log_targets::blend::service::EPOCH;
 
 /// A trait that provides the needed functionalities for the epoch stream to
 /// fetch the epoch state for a given slot.

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -54,7 +54,7 @@ pub use self::service_components::ServiceComponents;
 #[cfg(test)]
 mod test_utils;
 
-const LOG_TARGET: &str = "blend::service";
+const LOG_TARGET: &str = lb_log_targets::blend::service::ROOT;
 
 pub struct BlendService<CoreService, EdgeService, RuntimeServiceId>
 where

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -20,6 +20,7 @@ ignored = [
 workspace = true
 
 [dependencies]
+lb-log-targets = { workspace = true }
 opentelemetry = { default-features = false, version = "0.31" }
 opentelemetry-appender-tracing = { default-features = false, version = "0.31" }
 opentelemetry-http = { default-features = false, features = ["reqwest"], version = "0.31" }

--- a/tracing/src/filter/envfilter.rs
+++ b/tracing/src/filter/envfilter.rs
@@ -13,6 +13,7 @@ const DEFAULT_DEBUG_TARGETS: &[&str] = &[
     "cryptarchia",
     "ledger",
 ];
+const ENVFILTER_GLOBAL_TARGET: &str = "*";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EnvFilterConfig {
@@ -20,7 +21,7 @@ pub struct EnvFilterConfig {
     ///
     /// The global default directive is represented internally with the `*`
     /// key and converted back into native `EnvFilter` syntax at the boundary.
-    #[serde(with = "serde_filters")]
+    #[serde(with = "serde_validated_filters")]
     pub filters: HashMap<String, Level>,
 }
 
@@ -42,7 +43,7 @@ pub fn default_envfilter_config(level: Level) -> Option<EnvFilterConfig> {
 #[must_use]
 /// Builds the default verbose filter policy as a typed map.
 pub fn default_debug_log_filter(level: Level) -> HashMap<String, Level> {
-    let mut filters = HashMap::from([("*".to_owned(), Level::WARN)]);
+    let mut filters = HashMap::from([(ENVFILTER_GLOBAL_TARGET.to_owned(), Level::WARN)]);
     filters.extend(
         DEFAULT_DEBUG_TARGETS
             .iter()
@@ -57,17 +58,19 @@ pub fn default_debug_log_filter(level: Level) -> HashMap<String, Level> {
 /// Targets outside the Logos catalog are currently accepted so that
 /// external targets and not-yet-catalogued internal targets continue to work.
 pub fn validate_log_filter_target(target: &str) -> Result<(), String> {
-    if target == "*" {
+    if target == ENVFILTER_GLOBAL_TARGET {
         return Ok(());
     }
 
-    if lb_log_targets::is_logos_target_root(target)
-        && !lb_log_targets::is_valid_logos_target_prefix(target)
-    {
-        return Err(format!("unknown log filter target `{target}`"));
+    if !lb_log_targets::is_logos_target_root(target) {
+        return Ok(());
     }
 
-    Ok(())
+    if lb_log_targets::is_valid_logos_target(target) {
+        return Ok(());
+    }
+
+    Err(format!("unknown log filter target `{target}`"))
 }
 
 /// Parses comma-separated filter directives into the typed filter config form.
@@ -95,7 +98,7 @@ fn envfilter_directives(filters: &HashMap<String, Level>) -> String {
     let mut directives = filters
         .iter()
         .map(|(target, level)| {
-            if target == "*" {
+            if target == ENVFILTER_GLOBAL_TARGET {
                 level.as_str().to_owned()
             } else {
                 format!("{target}={}", level.as_str())
@@ -120,7 +123,10 @@ fn parse_filter_directive(directive: &str) -> Result<(String, Level), String> {
         return Ok((target.to_owned(), parse_filter_level(level)?));
     }
 
-    Ok(("*".to_owned(), parse_filter_level(directive)?))
+    Ok((
+        ENVFILTER_GLOBAL_TARGET.to_owned(),
+        parse_filter_level(directive)?,
+    ))
 }
 
 fn parse_filter_level(level: &str) -> Result<Level, String> {
@@ -130,11 +136,13 @@ fn parse_filter_level(level: &str) -> Result<Level, String> {
         .map_err(|_| format!("Invalid log filter level provided: {level}"))
 }
 
-pub mod serde_filters {
+pub mod serde_validated_filters {
     use std::collections::HashMap;
 
     use serde::{Deserialize as _, Deserializer, Serialize as _, Serializer, de::Error as _};
     use tracing::Level;
+
+    use super::{parse_filter_level, validate_log_filter_target};
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Level>, D::Error>
     where
@@ -144,10 +152,10 @@ pub mod serde_filters {
 
         raw.into_iter()
             .map(|(target, level)| {
-                level
-                    .parse()
+                validate_log_filter_target(&target).map_err(D::Error::custom)?;
+                parse_filter_level(&level)
                     .map(|level| (target, level))
-                    .map_err(|e| D::Error::custom(format!("invalid log level {e}")))
+                    .map_err(D::Error::custom)
             })
             .collect()
     }
@@ -168,37 +176,6 @@ pub mod serde_filters {
     }
 }
 
-pub mod serde_validated_filters {
-    use std::collections::HashMap;
-
-    use serde::{Deserializer, Serializer, de::Error as _};
-    use tracing::Level;
-
-    use super::{serde_filters, validate_log_filter_target};
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Level>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let filters = serde_filters::deserialize(deserializer)?;
-        for target in filters.keys() {
-            validate_log_filter_target(target).map_err(D::Error::custom)?;
-        }
-        Ok(filters)
-    }
-
-    pub fn serialize<S, H>(
-        value: &HashMap<String, Level, H>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        H: std::hash::BuildHasher,
-    {
-        serde_filters::serialize(value, serializer)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -206,7 +183,7 @@ mod tests {
     use tracing::Level;
 
     use super::{
-        EnvFilterConfig, create_envfilter_layer, parse_filter_directives,
+        ENVFILTER_GLOBAL_TARGET, EnvFilterConfig, create_envfilter_layer, parse_filter_directives,
         validate_log_filter_target,
     };
 
@@ -214,7 +191,7 @@ mod tests {
     fn create_envfilter_layer_accepts_global_and_target_directives() {
         let config = EnvFilterConfig {
             filters: HashMap::from([
-                ("*".to_owned(), Level::WARN),
+                (ENVFILTER_GLOBAL_TARGET.to_owned(), Level::WARN),
                 ("logos_blockchain".to_owned(), Level::DEBUG),
                 ("libp2p".to_owned(), Level::INFO),
             ]),
@@ -241,7 +218,7 @@ mod tests {
         let filters = parse_filter_directives("warn,blend::service=debug,libp2p=info")
             .expect("filter directives should parse");
 
-        assert_eq!(filters.get("*"), Some(&Level::WARN));
+        assert_eq!(filters.get(ENVFILTER_GLOBAL_TARGET), Some(&Level::WARN));
         assert_eq!(filters.get("blend::service"), Some(&Level::DEBUG));
         assert_eq!(filters.get("libp2p"), Some(&Level::INFO));
     }

--- a/tracing/src/filter/envfilter.rs
+++ b/tracing/src/filter/envfilter.rs
@@ -51,6 +51,45 @@ pub fn default_debug_log_filter(level: Level) -> HashMap<String, Level> {
     filters
 }
 
+/// Validates a configured log-filter target against the known Logos target
+/// catalog.
+///
+/// Targets outside the Logos catalog are currently accepted so that
+/// external targets and not-yet-catalogued internal targets continue to work.
+pub fn validate_log_filter_target(target: &str) -> Result<(), String> {
+    if target == "*" {
+        return Ok(());
+    }
+
+    if lb_log_targets::is_logos_target_root(target)
+        && !lb_log_targets::is_valid_logos_target_prefix(target)
+    {
+        return Err(format!("unknown log filter target `{target}`"));
+    }
+
+    Ok(())
+}
+
+/// Parses comma-separated filter directives into the typed filter config form.
+///
+/// Supported syntax:
+/// - `target=level`
+/// - bare global level such as `warn`
+pub fn parse_filter_directives(raw: &str) -> Result<HashMap<String, Level>, String> {
+    let filters = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|directive| !directive.is_empty())
+        .map(parse_filter_directive)
+        .collect::<Result<HashMap<_, _>, _>>()?;
+
+    if filters.is_empty() {
+        return Err(format!("Invalid log filter provided: {raw}"));
+    }
+
+    Ok(filters)
+}
+
 /// Converts the typed filter config into native `EnvFilter` directives.
 fn envfilter_directives(filters: &HashMap<String, Level>) -> String {
     let mut directives = filters
@@ -66,6 +105,29 @@ fn envfilter_directives(filters: &HashMap<String, Level>) -> String {
 
     directives.sort();
     directives.join(",")
+}
+
+fn parse_filter_directive(directive: &str) -> Result<(String, Level), String> {
+    if let Some((target, level)) = directive.split_once('=') {
+        let target = target.trim();
+        let level = level.trim();
+
+        if target.is_empty() || level.is_empty() {
+            return Err(format!("Invalid log filter directive: {directive}"));
+        }
+
+        validate_log_filter_target(target)?;
+        return Ok((target.to_owned(), parse_filter_level(level)?));
+    }
+
+    Ok(("*".to_owned(), parse_filter_level(directive)?))
+}
+
+fn parse_filter_level(level: &str) -> Result<Level, String> {
+    level
+        .trim()
+        .parse()
+        .map_err(|_| format!("Invalid log filter level provided: {level}"))
 }
 
 pub mod serde_filters {
@@ -106,13 +168,47 @@ pub mod serde_filters {
     }
 }
 
+pub mod serde_validated_filters {
+    use std::collections::HashMap;
+
+    use serde::{Deserializer, Serializer, de::Error as _};
+    use tracing::Level;
+
+    use super::{serde_filters, validate_log_filter_target};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Level>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let filters = serde_filters::deserialize(deserializer)?;
+        for target in filters.keys() {
+            validate_log_filter_target(target).map_err(D::Error::custom)?;
+        }
+        Ok(filters)
+    }
+
+    pub fn serialize<S, H>(
+        value: &HashMap<String, Level, H>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        H: std::hash::BuildHasher,
+    {
+        serde_filters::serialize(value, serializer)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
     use tracing::Level;
 
-    use super::{EnvFilterConfig, create_envfilter_layer};
+    use super::{
+        EnvFilterConfig, create_envfilter_layer, parse_filter_directives,
+        validate_log_filter_target,
+    };
 
     #[test]
     fn create_envfilter_layer_accepts_global_and_target_directives() {
@@ -125,5 +221,28 @@ mod tests {
         };
 
         assert!(create_envfilter_layer(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_log_filter_target_rejects_unknown_blend_target() {
+        let error = validate_log_filter_target("blend::service::missing")
+            .expect_err("unknown blend target should fail");
+
+        assert_eq!(error, "unknown log filter target `blend::service::missing`");
+    }
+
+    #[test]
+    fn validate_log_filter_target_accepts_external_targets() {
+        assert!(validate_log_filter_target("libp2p").is_ok());
+    }
+
+    #[test]
+    fn parse_filter_directives_accepts_global_and_target_directives() {
+        let filters = parse_filter_directives("warn,blend::service=debug,libp2p=info")
+            .expect("filter directives should parse");
+
+        assert_eq!(filters.get("*"), Some(&Level::WARN));
+        assert_eq!(filters.get("blend::service"), Some(&Level::DEBUG));
+        assert_eq!(filters.get("libp2p"), Some(&Level::INFO));
     }
 }

--- a/tracing/targets/Cargo.toml
+++ b/tracing/targets/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+categories  = { workspace = true }
+description = { workspace = true }
+edition     = { workspace = true }
+keywords    = { workspace = true }
+license     = { workspace = true }
+name        = "logos-blockchain-log-targets"
+readme      = { workspace = true }
+repository  = { workspace = true }
+version     = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+logos-blockchain-log-targets-macros = { path = "./macros" }

--- a/tracing/targets/Cargo.toml
+++ b/tracing/targets/Cargo.toml
@@ -13,4 +13,4 @@ version     = { workspace = true }
 workspace = true
 
 [dependencies]
-logos-blockchain-log-targets-macros = { path = "./macros" }
+lb-log-targets-macros = { workspace = true }

--- a/tracing/targets/macros/Cargo.toml
+++ b/tracing/targets/macros/Cargo.toml
@@ -13,9 +13,9 @@ version     = { workspace = true }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { default-features = false, version = "1" }
-quote       = { default-features = false, version = "1" }
-syn         = { features = ["full"], version = "2" }
+proc-macro2 = { workspace = true }
+quote       = { workspace = true }
+syn         = { workspace = true }
 
 [lints]
 workspace = true

--- a/tracing/targets/macros/Cargo.toml
+++ b/tracing/targets/macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+categories  = { workspace = true }
+description = { workspace = true }
+edition     = { workspace = true }
+keywords    = { workspace = true }
+license     = { workspace = true }
+name        = "logos-blockchain-log-targets-macros"
+readme      = { workspace = true }
+repository  = { workspace = true }
+version     = { workspace = true }
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { default-features = false, version = "1" }
+quote       = { default-features = false, version = "1" }
+syn         = { features = ["full"], version = "2" }
+
+[lints]
+workspace = true

--- a/tracing/targets/macros/src/lib.rs
+++ b/tracing/targets/macros/src/lib.rs
@@ -19,11 +19,11 @@
 //! That input generates:
 //! - nested modules and `ROOT` / leaf constants
 //! - target collection helpers
-//!
+use std::path::Path;
+
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Literal, TokenStream as TokenStream2};
 use quote::quote;
-use std::path::Path;
 use syn::{
     Error, Result, Token,
     parse::{Parse, ParseStream},
@@ -224,10 +224,7 @@ fn infer_root_name_from_path(path: &Path) -> Option<String> {
         return Some(stem.to_owned());
     }
 
-    path.parent()?
-        .file_name()?
-        .to_str()
-        .map(ToOwned::to_owned)
+    path.parent()?.file_name()?.to_str().map(ToOwned::to_owned)
 }
 
 impl ModuleNode {
@@ -235,11 +232,7 @@ impl ModuleNode {
     ///
     /// This also rejects invalid declarations where a leaf conflicts with a
     /// child module or a leaf is declared more than once in the same module.
-    fn insert(
-        &mut self,
-        modules: &[Ident],
-        leaf: Ident,
-    ) -> Result<()> {
+    fn insert(&mut self, modules: &[Ident], leaf: Ident) -> Result<()> {
         let mut current = self;
         for module in modules {
             current = current.child_mut(module)?;

--- a/tracing/targets/macros/src/lib.rs
+++ b/tracing/targets/macros/src/lib.rs
@@ -6,22 +6,22 @@
 //! this too, but the declaration format and expansion logic became harder to
 //! read once nesting and collection were involved.
 //!
-//! The input we want to support is a flat list of target paths:
+//! The input is a grouped list of target paths:
 //!
 //! ```ignore
 //! log_targets! {
-//!     blend::service::CORE,
-//!     blend::service::core::KMS_POQ_GENERATOR,
-//!     blend::network::core::handler::CORE_EDGE,
+//!     blend::{
+//!         service::{CORE, core::KMS_POQ_GENERATOR},
+//!         network::core::handler::{CORE_EDGE},
+//!     }
 //! }
 //! ```
-//!
-//! From that list we need to generate:
+//! From those declarations the macro generates:
 //! - nested modules and `ROOT` / leaf constants
 //! - target collection helpers
 //!
 //! The proc macro does the following:
-//! - parse the flat path list once
+//! - parse the grouped declarations once
 //! - build a small in-memory tree
 //! - emit the nested module structure from that tree
 //! - report duplicate/conflicting definitions with direct, readable errors
@@ -37,16 +37,30 @@ use syn::{
 
 /// A parsed list of target declarations passed to `log_targets!`.
 struct TargetList {
-    /// Comma-separated target declarations such as
-    /// `blend::service::core::KMS_POQ_GENERATOR`.
-    targets: Punctuated<TargetPath, Token![,]>,
+    /// Comma-separated grouped declarations such as
+    /// `blend::{service::{CORE}}`.
+    groups: Punctuated<TargetGroup, Token![,]>,
 }
 
-/// One declared target path from the macro input.
-struct TargetPath {
-    /// Top-level namespace root, for example `blend`.
-    root: Ident,
-    /// Intermediate modules between the root and the leaf constant.
+/// One grouped declaration block such as `service::{CORE, core::LEAF}`.
+struct TargetGroup {
+    /// Path prefix shared by all items in this group.
+    prefix: Vec<Ident>,
+    /// Items declared under that prefix.
+    items: Punctuated<TargetItem, Token![,]>,
+}
+
+/// One item inside a grouped declaration block.
+enum TargetItem {
+    /// A leaf target like `CORE` or `core::KMS_POQ_GENERATOR`.
+    Leaf(TargetLeafPath),
+    /// A nested grouped block such as `service::{...}`.
+    Group(TargetGroup),
+}
+
+/// One declared leaf path relative to its surrounding group.
+struct TargetLeafPath {
+    /// Intermediate modules between the surrounding group prefix and the leaf.
     modules: Vec<Ident>,
     /// Final constant name, for example `CORE_AND_LEADER`.
     leaf: Ident,
@@ -85,26 +99,45 @@ struct TargetLeaf {
 }
 
 impl Parse for TargetList {
-    /// Parse the full macro input as a comma-separated list of target paths.
+    /// Parse the full macro input as a comma-separated list of grouped target
+    /// declarations.
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         Ok(Self {
-            targets: Punctuated::parse_terminated(input)?,
+            groups: Punctuated::parse_terminated(input)?,
         })
     }
 }
 
-impl Parse for TargetPath {
-    /// Parse a single declaration such as `blend::service::CORE`.
+impl Parse for TargetGroup {
+    /// Parse a grouped declaration such as `blend::{service::{CORE}}`.
     fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let root = input.parse()?;
+        let prefix = parse_path_segments(input)?;
         input.parse::<Token![::]>()?;
 
-        let mut parts = Vec::new();
-        parts.push(input.parse::<Ident>()?);
+        let content;
+        syn::braced!(content in input);
 
-        while input.peek(Token![::]) {
+        Ok(Self {
+            prefix,
+            items: Punctuated::parse_terminated(&content)?,
+        })
+    }
+}
+
+impl Parse for TargetItem {
+    /// Parse one item inside a grouped declaration.
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut parts = parse_path_segments(input)?;
+
+        if input.peek(Token![::]) {
             input.parse::<Token![::]>()?;
-            parts.push(input.parse::<Ident>()?);
+            let content;
+            syn::braced!(content in input);
+
+            return Ok(Self::Group(TargetGroup {
+                prefix: parts,
+                items: Punctuated::parse_terminated(&content)?,
+            }));
         }
 
         let segment_override = if input.peek(Token![=]) {
@@ -115,13 +148,29 @@ impl Parse for TargetPath {
         };
 
         let leaf = parts.pop().expect("target path must have a leaf");
-        Ok(Self {
-            root,
+        Ok(Self::Leaf(TargetLeafPath {
             modules: parts,
             leaf,
             segment_override,
-        })
+        }))
     }
+}
+
+fn parse_path_segments(input: ParseStream<'_>) -> Result<Vec<Ident>> {
+    let mut parts = vec![input.parse::<Ident>()?];
+
+    while input.peek(Token![::]) {
+        let fork = input.fork();
+        fork.parse::<Token![::]>()?;
+        if fork.peek(syn::token::Brace) {
+            break;
+        }
+
+        input.parse::<Token![::]>()?;
+        parts.push(input.parse::<Ident>()?);
+    }
+
+    Ok(parts)
 }
 
 impl ModuleNode {
@@ -197,22 +246,12 @@ pub fn log_targets(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Convert the parsed flat path list into a grouped module tree, then emit
-/// code.
+/// Convert the parsed grouped declarations into a module tree, then emit code.
 fn expand_target_list(input: TargetList) -> Result<TokenStream2> {
     let mut roots: Vec<(Ident, ModuleNode)> = Vec::new();
 
-    for target in input.targets {
-        let root_index =
-            if let Some(index) = roots.iter().position(|(name, _)| *name == target.root) {
-                index
-            } else {
-                roots.push((target.root.clone(), ModuleNode::default()));
-                roots.len() - 1
-            };
-
-        let root = &mut roots[root_index].1;
-        root.insert(&target.modules, target.leaf, target.segment_override)?;
+    for group in input.groups {
+        flatten_group(group, &mut roots)?;
     }
 
     let modules = roots
@@ -223,6 +262,59 @@ fn expand_target_list(input: TargetList) -> Result<TokenStream2> {
     Ok(quote! {
         #(#modules)*
     })
+}
+
+fn flatten_group(group: TargetGroup, roots: &mut Vec<(Ident, ModuleNode)>) -> Result<()> {
+    for item in group.items {
+        flatten_item(item, &group.prefix, roots)?;
+    }
+
+    Ok(())
+}
+
+fn flatten_item(
+    item: TargetItem,
+    parent_prefix: &[Ident],
+    roots: &mut Vec<(Ident, ModuleNode)>,
+) -> Result<()> {
+    match item {
+        TargetItem::Leaf(leaf) => insert_leaf(parent_prefix, leaf, roots),
+        TargetItem::Group(group) => {
+            let mut prefix = parent_prefix.to_vec();
+            prefix.extend(group.prefix);
+            for child in group.items {
+                flatten_item(child, &prefix, roots)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn insert_leaf(
+    parent_prefix: &[Ident],
+    leaf: TargetLeafPath,
+    roots: &mut Vec<(Ident, ModuleNode)>,
+) -> Result<()> {
+    let mut full_prefix = parent_prefix.to_vec();
+    full_prefix.extend(leaf.modules);
+
+    let Some((root_name, modules)) = full_prefix.split_first() else {
+        return Err(Error::new_spanned(
+            &leaf.leaf,
+            "target declaration must have a root prefix",
+        ));
+    };
+
+    let root_index = roots
+        .iter()
+        .position(|(name, _)| *name == *root_name)
+        .unwrap_or_else(|| {
+            roots.push((root_name.clone(), ModuleNode::default()));
+            roots.len() - 1
+        });
+
+    let root = &mut roots[root_index].1;
+    root.insert(modules, leaf.leaf, leaf.segment_override)
 }
 
 fn kebab_case_ident(ident: &Ident) -> String {

--- a/tracing/targets/macros/src/lib.rs
+++ b/tracing/targets/macros/src/lib.rs
@@ -1,43 +1,78 @@
 //! Proc-macro implementation for the log-targets crate.
 //!
-//! A proc macro is used here so target definitions only need to be written
-//! once, while still generating both the constants used by code and the
-//! collected target list used for validation. A `macro_rules!` macro could do
-//! this too, but the declaration format and expansion logic became harder to
-//! read once nesting and collection were involved.
+//! `log_targets!` defines one target namespace per file. The namespace root is
+//! inferred from the call-site path:
+//! - `blend.rs` -> `blend`
+//! - `time.rs` -> `time`
+//! - `mod.rs` -> parent directory name
 //!
-//! The input is a grouped list of target paths under an explicit root:
+//! Inside the macro, declarations are written relative to that inferred root:
 //!
 //! ```ignore
+//! // blend.rs
 //! log_targets! {
-//!     root = blend;
-//!
 //!     service::{CORE, core::KMS_POQ_GENERATOR},
 //!     network::core::handler::{CORE_EDGE},
 //! }
 //! ```
-//! From those declarations the macro generates:
+//!
+//! That input generates:
 //! - nested modules and `ROOT` / leaf constants
 //! - target collection helpers
 //!
-//! The proc macro does the following:
-//! - parse the grouped declarations once
-//! - build a small in-memory tree
-//! - emit the nested module structure from that tree
-//! - report duplicate/conflicting definitions with direct, readable errors
-
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Literal, TokenStream as TokenStream2};
 use quote::quote;
+use std::path::Path;
 use syn::{
-    Error, LitStr, Result, Token,
+    Error, Result, Token,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
 };
 
+/// Define log targets for one namespace from grouped relative declarations.
+///
+/// The namespace root is inferred from the file where the macro is invoked:
+/// - `blend.rs` -> `blend`
+/// - `time.rs` -> `time`
+/// - `mod.rs` -> parent directory name
+///
+/// Declarations inside the macro are written relative to that inferred root.
+///
+/// For example, in `blend.rs`:
+///
+/// ```ignore
+/// log_targets! {
+///     service::{CORE, core::KMS_POQ_GENERATOR},
+///     network::core::handler::{CORE_EDGE},
+/// }
+/// ```
+///
+/// This generates nested modules and constants such as:
+/// - `blend::ROOT`
+/// - `blend::service::ROOT`
+/// - `blend::service::CORE`
+/// - `blend::service::core::KMS_POQ_GENERATOR`
+/// - `blend::network::core::handler::CORE_EDGE`
+///
+/// It also generates target collection helpers under the inferred root module.
+///
+/// Naming convention:
+/// - use one file per target namespace
+/// - file name determines the root namespace
+/// - leaf identifiers are written in `SHOUTY_SNAKE_CASE`
+/// - leaf string segments are emitted in kebab-case
+#[proc_macro]
+pub fn log_targets(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as TargetList);
+    expand_target_list(input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
 /// A parsed list of target declarations passed to `log_targets!`.
 struct TargetList {
-    /// Top-level namespace root such as `blend`.
+    /// Top-level namespace root inferred from the call-site file name.
     root: Ident,
     /// Comma-separated grouped declarations such as `service::{CORE}`.
     groups: Punctuated<TargetGroup, Token![,]>,
@@ -65,10 +100,6 @@ struct TargetLeafPath {
     modules: Vec<Ident>,
     /// Final constant name, for example `CORE_AND_LEADER`.
     leaf: Ident,
-    /// Optional explicit string segment override for the leaf.
-    ///
-    /// If omitted, the leaf is converted from `SHOUTY_SNAKE` to kebab-case.
-    segment_override: Option<LitStr>,
 }
 
 /// A mutable tree node used while grouping flat target paths into nested
@@ -93,27 +124,14 @@ struct ChildModule {
 struct TargetLeaf {
     /// Rust identifier used for the generated constant.
     ident: Ident,
-    /// Optional explicit string segment override for the constant.
-    ///
-    /// If absent, the identifier is converted to kebab-case at compile time.
-    segment_override: Option<LitStr>,
 }
 
 impl Parse for TargetList {
     /// Parse the full macro input as a comma-separated list of grouped target
     /// declarations.
     fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let keyword = input.parse::<Ident>()?;
-        if keyword != "root" {
-            return Err(Error::new_spanned(keyword, "expected `root = <ident>;`"));
-        }
-
-        input.parse::<Token![=]>()?;
-        let root = input.parse::<Ident>()?;
-        input.parse::<Token![;]>()?;
-
         Ok(Self {
-            root,
+            root: infer_root_ident()?,
             groups: Punctuated::parse_terminated(input)?,
         })
     }
@@ -150,18 +168,10 @@ impl Parse for TargetItem {
             }));
         }
 
-        let segment_override = if input.peek(Token![=]) {
-            input.parse::<Token![=]>()?;
-            Some(input.parse()?)
-        } else {
-            None
-        };
-
         let leaf = parts.pop().expect("target path must have a leaf");
         Ok(Self::Leaf(TargetLeafPath {
             modules: parts,
             leaf,
-            segment_override,
         }))
     }
 }
@@ -183,6 +193,43 @@ fn parse_path_segments(input: ParseStream<'_>) -> Result<Vec<Ident>> {
     Ok(parts)
 }
 
+fn infer_root_ident() -> Result<Ident> {
+    let Some(path) = proc_macro::Span::call_site().local_file() else {
+        return Err(Error::new(
+            proc_macro2::Span::call_site(),
+            "could not infer target root; use `root = <ident>;` explicitly",
+        ));
+    };
+
+    let root = infer_root_name_from_path(&path).ok_or_else(|| {
+        Error::new(
+            proc_macro2::Span::call_site(),
+            "could not infer target root from call-site path; use `root = <ident>;` explicitly",
+        )
+    })?;
+
+    syn::parse_str::<Ident>(&root).map_err(|_| {
+        Error::new(
+            proc_macro2::Span::call_site(),
+            format!(
+                "inferred target root `{root}` is not a valid Rust identifier; use `root = <ident>;` explicitly"
+            ),
+        )
+    })
+}
+
+fn infer_root_name_from_path(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    if stem != "mod" {
+        return Some(stem.to_owned());
+    }
+
+    path.parent()?
+        .file_name()?
+        .to_str()
+        .map(ToOwned::to_owned)
+}
+
 impl ModuleNode {
     /// Insert one parsed target path into the module tree.
     ///
@@ -192,7 +239,6 @@ impl ModuleNode {
         &mut self,
         modules: &[Ident],
         leaf: Ident,
-        segment_override: Option<LitStr>,
     ) -> Result<()> {
         let mut current = self;
         for module in modules {
@@ -210,10 +256,7 @@ impl ModuleNode {
             return Err(Error::new_spanned(&leaf, "duplicate target leaf"));
         }
 
-        current.leaves.push(TargetLeaf {
-            ident: leaf,
-            segment_override,
-        });
+        current.leaves.push(TargetLeaf { ident: leaf });
         Ok(())
     }
 
@@ -244,16 +287,6 @@ impl ModuleNode {
             Ok(&mut self.children[last].node)
         }
     }
-}
-
-/// Expand the `log_targets!` macro into nested modules plus target collection
-/// helpers.
-#[proc_macro]
-pub fn log_targets(input: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(input as TargetList);
-    expand_target_list(input)
-        .unwrap_or_else(Error::into_compile_error)
-        .into()
 }
 
 /// Convert the parsed grouped declarations into a module tree, then emit code.
@@ -331,7 +364,7 @@ fn insert_leaf(
         });
 
     let root = &mut roots[root_index].1;
-    root.insert(modules, leaf.leaf, leaf.segment_override)
+    root.insert(modules, leaf.leaf)
 }
 
 fn kebab_case_ident(ident: &Ident) -> String {
@@ -349,10 +382,7 @@ fn emit_module(module_ident: &Ident, root_path: &str, node: &ModuleNode) -> Toke
     let root_literal = Literal::string(root_path);
     let leaves = node.leaves.iter().map(|leaf| {
         let ident = &leaf.ident;
-        let leaf_segment = leaf
-            .segment_override
-            .as_ref()
-            .map_or_else(|| kebab_case_ident(ident), LitStr::value);
+        let leaf_segment = kebab_case_ident(ident);
         let leaf_literal = Literal::string(&format!("{root_path}::{leaf_segment}"));
 
         quote! {

--- a/tracing/targets/macros/src/lib.rs
+++ b/tracing/targets/macros/src/lib.rs
@@ -6,14 +6,14 @@
 //! this too, but the declaration format and expansion logic became harder to
 //! read once nesting and collection were involved.
 //!
-//! The input is a grouped list of target paths:
+//! The input is a grouped list of target paths under an explicit root:
 //!
 //! ```ignore
 //! log_targets! {
-//!     blend::{
-//!         service::{CORE, core::KMS_POQ_GENERATOR},
-//!         network::core::handler::{CORE_EDGE},
-//!     }
+//!     root = blend;
+//!
+//!     service::{CORE, core::KMS_POQ_GENERATOR},
+//!     network::core::handler::{CORE_EDGE},
 //! }
 //! ```
 //! From those declarations the macro generates:
@@ -37,14 +37,15 @@ use syn::{
 
 /// A parsed list of target declarations passed to `log_targets!`.
 struct TargetList {
-    /// Comma-separated grouped declarations such as
-    /// `blend::{service::{CORE}}`.
+    /// Top-level namespace root such as `blend`.
+    root: Ident,
+    /// Comma-separated grouped declarations such as `service::{CORE}`.
     groups: Punctuated<TargetGroup, Token![,]>,
 }
 
 /// One grouped declaration block such as `service::{CORE, core::LEAF}`.
 struct TargetGroup {
-    /// Path prefix shared by all items in this group.
+    /// Path prefix shared by all items in this group, relative to the root.
     prefix: Vec<Ident>,
     /// Items declared under that prefix.
     items: Punctuated<TargetItem, Token![,]>,
@@ -102,18 +103,27 @@ impl Parse for TargetList {
     /// Parse the full macro input as a comma-separated list of grouped target
     /// declarations.
     fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let keyword = input.parse::<Ident>()?;
+        if keyword != "root" {
+            return Err(Error::new_spanned(keyword, "expected `root = <ident>;`"));
+        }
+
+        input.parse::<Token![=]>()?;
+        let root = input.parse::<Ident>()?;
+        input.parse::<Token![;]>()?;
+
         Ok(Self {
+            root,
             groups: Punctuated::parse_terminated(input)?,
         })
     }
 }
 
 impl Parse for TargetGroup {
-    /// Parse a grouped declaration such as `blend::{service::{CORE}}`.
+    /// Parse a grouped declaration such as `service::{CORE}`.
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let prefix = parse_path_segments(input)?;
         input.parse::<Token![::]>()?;
-
         let content;
         syn::braced!(content in input);
 
@@ -248,10 +258,10 @@ pub fn log_targets(input: TokenStream) -> TokenStream {
 
 /// Convert the parsed grouped declarations into a module tree, then emit code.
 fn expand_target_list(input: TargetList) -> Result<TokenStream2> {
-    let mut roots: Vec<(Ident, ModuleNode)> = Vec::new();
+    let mut roots = vec![(input.root.clone(), ModuleNode::default())];
 
     for group in input.groups {
-        flatten_group(group, &mut roots)?;
+        flatten_group(group, &input.root, &mut roots)?;
     }
 
     let modules = roots
@@ -264,9 +274,16 @@ fn expand_target_list(input: TargetList) -> Result<TokenStream2> {
     })
 }
 
-fn flatten_group(group: TargetGroup, roots: &mut Vec<(Ident, ModuleNode)>) -> Result<()> {
+fn flatten_group(
+    group: TargetGroup,
+    root: &Ident,
+    roots: &mut Vec<(Ident, ModuleNode)>,
+) -> Result<()> {
+    let mut prefix = vec![root.clone()];
+    prefix.extend(group.prefix);
+
     for item in group.items {
-        flatten_item(item, &group.prefix, roots)?;
+        flatten_item(item, &prefix, roots)?;
     }
 
     Ok(())

--- a/tracing/targets/macros/src/lib.rs
+++ b/tracing/targets/macros/src/lib.rs
@@ -1,0 +1,297 @@
+//! Proc-macro implementation for the log-targets crate.
+//!
+//! A proc macro is used here so target definitions only need to be written
+//! once, while still generating both the constants used by code and the
+//! collected target list used for validation. A `macro_rules!` macro could do
+//! this too, but the declaration format and expansion logic became harder to
+//! read once nesting and collection were involved.
+//!
+//! The input we want to support is a flat list of target paths:
+//!
+//! ```ignore
+//! log_targets! {
+//!     blend::service::CORE,
+//!     blend::service::core::KMS_POQ_GENERATOR,
+//!     blend::network::core::handler::CORE_EDGE,
+//! }
+//! ```
+//!
+//! From that list we need to generate:
+//! - nested modules and `ROOT` / leaf constants
+//! - target collection helpers
+//!
+//! The proc macro does the following:
+//! - parse the flat path list once
+//! - build a small in-memory tree
+//! - emit the nested module structure from that tree
+//! - report duplicate/conflicting definitions with direct, readable errors
+
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Literal, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{
+    Error, LitStr, Result, Token,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+};
+
+/// A parsed list of target declarations passed to `log_targets!`.
+struct TargetList {
+    /// Comma-separated target declarations such as
+    /// `blend::service::core::KMS_POQ_GENERATOR`.
+    targets: Punctuated<TargetPath, Token![,]>,
+}
+
+/// One declared target path from the macro input.
+struct TargetPath {
+    /// Top-level namespace root, for example `blend`.
+    root: Ident,
+    /// Intermediate modules between the root and the leaf constant.
+    modules: Vec<Ident>,
+    /// Final constant name, for example `CORE_AND_LEADER`.
+    leaf: Ident,
+    /// Optional explicit string segment override for the leaf.
+    ///
+    /// If omitted, the leaf is converted from `SHOUTY_SNAKE` to kebab-case.
+    segment_override: Option<LitStr>,
+}
+
+/// A mutable tree node used while grouping flat target paths into nested
+/// modules.
+#[derive(Default)]
+struct ModuleNode {
+    /// Direct child modules under this module.
+    children: Vec<ChildModule>,
+    /// Direct leaf targets under this module.
+    leaves: Vec<TargetLeaf>,
+}
+
+/// One named child module in the generated tree.
+struct ChildModule {
+    /// Rust identifier used for the generated child module.
+    ident: Ident,
+    /// Subtree rooted at that child module.
+    node: ModuleNode,
+}
+
+/// One leaf target constant in the generated tree.
+struct TargetLeaf {
+    /// Rust identifier used for the generated constant.
+    ident: Ident,
+    /// Optional explicit string segment override for the constant.
+    ///
+    /// If absent, the identifier is converted to kebab-case at compile time.
+    segment_override: Option<LitStr>,
+}
+
+impl Parse for TargetList {
+    /// Parse the full macro input as a comma-separated list of target paths.
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        Ok(Self {
+            targets: Punctuated::parse_terminated(input)?,
+        })
+    }
+}
+
+impl Parse for TargetPath {
+    /// Parse a single declaration such as `blend::service::CORE`.
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let root = input.parse()?;
+        input.parse::<Token![::]>()?;
+
+        let mut parts = Vec::new();
+        parts.push(input.parse::<Ident>()?);
+
+        while input.peek(Token![::]) {
+            input.parse::<Token![::]>()?;
+            parts.push(input.parse::<Ident>()?);
+        }
+
+        let segment_override = if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            Some(input.parse()?)
+        } else {
+            None
+        };
+
+        let leaf = parts.pop().expect("target path must have a leaf");
+        Ok(Self {
+            root,
+            modules: parts,
+            leaf,
+            segment_override,
+        })
+    }
+}
+
+impl ModuleNode {
+    /// Insert one parsed target path into the module tree.
+    ///
+    /// This also rejects invalid declarations where a leaf conflicts with a
+    /// child module or a leaf is declared more than once in the same module.
+    fn insert(
+        &mut self,
+        modules: &[Ident],
+        leaf: Ident,
+        segment_override: Option<LitStr>,
+    ) -> Result<()> {
+        let mut current = self;
+        for module in modules {
+            current = current.child_mut(module)?;
+        }
+
+        if current.children.iter().any(|child| child.ident == leaf) {
+            return Err(Error::new_spanned(
+                &leaf,
+                "target leaf conflicts with an existing child module",
+            ));
+        }
+
+        if current.leaves.iter().any(|existing| existing.ident == leaf) {
+            return Err(Error::new_spanned(&leaf, "duplicate target leaf"));
+        }
+
+        current.leaves.push(TargetLeaf {
+            ident: leaf,
+            segment_override,
+        });
+        Ok(())
+    }
+
+    /// Return a mutable child module, creating it if it does not exist yet.
+    ///
+    /// This also rejects invalid declarations where a module name would collide
+    /// with an already-declared leaf at the same level.
+    fn child_mut(&mut self, module: &Ident) -> Result<&mut Self> {
+        if self.leaves.iter().any(|leaf| leaf.ident == *module) {
+            return Err(Error::new_spanned(
+                module,
+                "child module conflicts with an existing target leaf",
+            ));
+        }
+
+        if let Some(index) = self
+            .children
+            .iter()
+            .position(|child| child.ident == *module)
+        {
+            Ok(&mut self.children[index].node)
+        } else {
+            self.children.push(ChildModule {
+                ident: module.clone(),
+                node: Self::default(),
+            });
+            let last = self.children.len() - 1;
+            Ok(&mut self.children[last].node)
+        }
+    }
+}
+
+/// Expand the `log_targets!` macro into nested modules plus target collection
+/// helpers.
+#[proc_macro]
+pub fn log_targets(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as TargetList);
+    expand_target_list(input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+/// Convert the parsed flat path list into a grouped module tree, then emit
+/// code.
+fn expand_target_list(input: TargetList) -> Result<TokenStream2> {
+    let mut roots: Vec<(Ident, ModuleNode)> = Vec::new();
+
+    for target in input.targets {
+        let root_index =
+            if let Some(index) = roots.iter().position(|(name, _)| *name == target.root) {
+                index
+            } else {
+                roots.push((target.root.clone(), ModuleNode::default()));
+                roots.len() - 1
+            };
+
+        let root = &mut roots[root_index].1;
+        root.insert(&target.modules, target.leaf, target.segment_override)?;
+    }
+
+    let modules = roots
+        .into_iter()
+        .map(|(name, node)| emit_root_module(&name, &node))
+        .collect::<Vec<_>>();
+
+    Ok(quote! {
+        #(#modules)*
+    })
+}
+
+fn kebab_case_ident(ident: &Ident) -> String {
+    ident.to_string().replace('_', "-").to_ascii_lowercase()
+}
+
+/// Emit one top-level root module such as `pub mod blend`.
+fn emit_root_module(module_ident: &Ident, node: &ModuleNode) -> TokenStream2 {
+    let root_path = module_ident.to_string();
+    emit_module(module_ident, &root_path, node)
+}
+
+/// Emit one module and recurse into its child modules.
+fn emit_module(module_ident: &Ident, root_path: &str, node: &ModuleNode) -> TokenStream2 {
+    let root_literal = Literal::string(root_path);
+    let leaves = node.leaves.iter().map(|leaf| {
+        let ident = &leaf.ident;
+        let leaf_segment = leaf
+            .segment_override
+            .as_ref()
+            .map_or_else(|| kebab_case_ident(ident), LitStr::value);
+        let leaf_literal = Literal::string(&format!("{root_path}::{leaf_segment}"));
+
+        quote! {
+            pub const #ident: &str = #leaf_literal;
+        }
+    });
+
+    let children = node.children.iter().map(|child| {
+        let child_root_path = format!("{root_path}::{}", child.ident);
+        emit_module(&child.ident, &child_root_path, &child.node)
+    });
+
+    let collect_body = emit_collect_body(node);
+    quote! {
+        pub mod #module_ident {
+            pub const ROOT: &str = #root_literal;
+
+            #(#leaves)*
+            #(#children)*
+
+            pub fn collect_targets(targets: &mut Vec<&'static str>) {
+                targets.push(ROOT);
+                #collect_body
+            }
+
+            pub fn all_targets() -> Vec<&'static str> {
+                let mut targets = Vec::new();
+                collect_targets(&mut targets);
+                targets
+            }
+
+        }
+    }
+}
+
+/// Emit the statements that collect this module's leaves and child modules.
+fn emit_collect_body(node: &ModuleNode) -> TokenStream2 {
+    let leaf_pushes = node.leaves.iter().map(|leaf| {
+        let ident = &leaf.ident;
+        quote!(targets.push(#ident);)
+    });
+    let child_pushes = node.children.iter().map(|child| {
+        let module_ident = &child.ident;
+        quote!(#module_ident::collect_targets(targets);)
+    });
+
+    quote! {
+        #(#leaf_pushes)*
+        #(#child_pushes)*
+    }
+}

--- a/tracing/targets/src/blend.rs
+++ b/tracing/targets/src/blend.rs
@@ -1,4 +1,4 @@
-use logos_blockchain_log_targets_macros::log_targets;
+use lb_log_targets_macros::log_targets;
 
 log_targets! {
     blend::{

--- a/tracing/targets/src/blend.rs
+++ b/tracing/targets/src/blend.rs
@@ -1,8 +1,6 @@
 use lb_log_targets_macros::log_targets;
 
 log_targets! {
-    root = blend;
-
     backend::{LIBP2P},
     message::{REWARD},
     network::core::{

--- a/tracing/targets/src/blend.rs
+++ b/tracing/targets/src/blend.rs
@@ -1,25 +1,33 @@
 use logos_blockchain_log_targets_macros::log_targets;
 
 log_targets! {
-    blend::backend::LIBP2P,
-    blend::message::REWARD,
-    blend::network::core::core::BEHAVIOUR,
-    blend::network::core::core::behaviour::OLD,
-    blend::network::core::core::conn::HANDLER,
-    blend::network::core::core::conn::MAINTENANCE,
-    blend::network::core::edge::BEHAVIOUR,
-    blend::network::core::handler::CORE_EDGE,
-    blend::scheduling::COVER,
-    blend::scheduling::DELAY,
-    blend::scheduling::proofs::CORE,
-    blend::scheduling::proofs::CORE_AND_LEADER,
-    blend::scheduling::proofs::LEADER,
-    blend::service::CORE,
-    blend::service::EDGE,
-    blend::service::EPOCH,
-    blend::service::MODES,
-    blend::service::core::KMS_POQ_GENERATOR,
-    blend::service::edge::backend::LIBP2P,
+    blend::{
+        backend::LIBP2P,
+        message::REWARD,
+        network::core::{
+            core::BEHAVIOUR,
+            core::behaviour::OLD,
+            core::conn::HANDLER,
+            core::conn::MAINTENANCE,
+            edge::BEHAVIOUR,
+            handler::CORE_EDGE,
+        },
+        scheduling::{
+            COVER,
+            DELAY,
+            proofs::CORE,
+            proofs::CORE_AND_LEADER,
+            proofs::LEADER,
+        },
+        service::{
+            CORE,
+            EDGE,
+            EPOCH,
+            MODES,
+            core::KMS_POQ_GENERATOR,
+            edge::backend::LIBP2P,
+        },
+    }
 }
 
 pub use self::blend::*;

--- a/tracing/targets/src/blend.rs
+++ b/tracing/targets/src/blend.rs
@@ -1,0 +1,25 @@
+use logos_blockchain_log_targets_macros::log_targets;
+
+log_targets! {
+    blend::backend::LIBP2P,
+    blend::message::REWARD,
+    blend::network::core::core::BEHAVIOUR,
+    blend::network::core::core::behaviour::OLD,
+    blend::network::core::core::conn::HANDLER,
+    blend::network::core::core::conn::MAINTENANCE,
+    blend::network::core::edge::BEHAVIOUR,
+    blend::network::core::handler::CORE_EDGE,
+    blend::scheduling::COVER,
+    blend::scheduling::DELAY,
+    blend::scheduling::proofs::CORE,
+    blend::scheduling::proofs::CORE_AND_LEADER,
+    blend::scheduling::proofs::LEADER,
+    blend::service::CORE,
+    blend::service::EDGE,
+    blend::service::EPOCH,
+    blend::service::MODES,
+    blend::service::core::KMS_POQ_GENERATOR,
+    blend::service::edge::backend::LIBP2P,
+}
+
+pub use self::blend::*;

--- a/tracing/targets/src/blend.rs
+++ b/tracing/targets/src/blend.rs
@@ -1,32 +1,32 @@
 use lb_log_targets_macros::log_targets;
 
 log_targets! {
-    blend::{
-        backend::LIBP2P,
-        message::REWARD,
-        network::core::{
-            core::BEHAVIOUR,
-            core::behaviour::OLD,
-            core::conn::HANDLER,
-            core::conn::MAINTENANCE,
-            edge::BEHAVIOUR,
-            handler::CORE_EDGE,
-        },
-        scheduling::{
-            COVER,
-            DELAY,
-            proofs::CORE,
-            proofs::CORE_AND_LEADER,
-            proofs::LEADER,
-        },
-        service::{
-            CORE,
-            EDGE,
-            EPOCH,
-            MODES,
-            core::KMS_POQ_GENERATOR,
-            edge::backend::LIBP2P,
-        },
+    root = blend;
+
+    backend::{LIBP2P},
+    message::{REWARD},
+    network::core::{
+        core::BEHAVIOUR,
+        core::behaviour::OLD,
+        core::conn::HANDLER,
+        core::conn::MAINTENANCE,
+        edge::BEHAVIOUR,
+        handler::CORE_EDGE,
+    },
+    scheduling::{
+        COVER,
+        DELAY,
+        proofs::CORE,
+        proofs::CORE_AND_LEADER,
+        proofs::LEADER,
+    },
+    service::{
+        CORE,
+        EDGE,
+        EPOCH,
+        MODES,
+        core::KMS_POQ_GENERATOR,
+        edge::backend::LIBP2P,
     }
 }
 

--- a/tracing/targets/src/lib.rs
+++ b/tracing/targets/src/lib.rs
@@ -1,0 +1,78 @@
+#![forbid(unsafe_code)]
+
+pub mod blend;
+
+#[must_use]
+pub(crate) fn matches_target_prefix(target: &str, candidate: &str) -> bool {
+    target == candidate
+        || candidate
+            .strip_prefix(target)
+            .is_some_and(|suffix| suffix.starts_with("::"))
+}
+
+#[must_use]
+fn target_root(target: &str) -> &str {
+    target.split("::").next().unwrap_or(target)
+}
+
+#[must_use]
+pub fn all_targets() -> Vec<&'static str> {
+    blend::all_targets()
+}
+
+#[must_use]
+pub fn is_valid_target(target: &str) -> bool {
+    all_targets().into_iter().any(|known| known == target)
+}
+
+#[must_use]
+pub fn is_valid_logos_target_prefix(target: &str) -> bool {
+    all_targets()
+        .into_iter()
+        .any(|known| matches_target_prefix(target, known))
+}
+
+#[must_use]
+pub fn is_logos_target_root(target: &str) -> bool {
+    let root = target_root(target);
+    all_targets()
+        .into_iter()
+        .any(|known| target_root(known) == root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{blend, is_logos_target_root, is_valid_logos_target_prefix, is_valid_target};
+
+    #[test]
+    fn blend_targets_are_registered() {
+        assert!(blend::all_targets().contains(&blend::service::CORE));
+        assert!(blend::all_targets().contains(&blend::network::core::handler::CORE_EDGE));
+    }
+
+    #[test]
+    fn exact_target_validation_accepts_known_targets() {
+        assert!(is_valid_target(blend::service::ROOT));
+        assert!(is_valid_target(blend::service::core::KMS_POQ_GENERATOR));
+        assert!(!is_valid_target("blend::service::missing"));
+    }
+
+    #[test]
+    fn prefix_validation_accepts_known_prefixes() {
+        assert!(is_valid_logos_target_prefix("blend"));
+        assert!(is_valid_logos_target_prefix("blend::service"));
+        assert!(is_valid_logos_target_prefix("blend::network::core::core"));
+        assert!(!is_valid_logos_target_prefix("blend::unknown"));
+        assert!(!is_valid_logos_target_prefix("other"));
+    }
+
+    #[test]
+    fn logos_target_root_detection_matches_known_roots() {
+        assert!(is_logos_target_root("blend"));
+        assert!(is_logos_target_root("blend::service"));
+        assert!(is_logos_target_root("blend::service::missing"));
+        assert!(!is_logos_target_root("bl"));
+        assert!(!is_logos_target_root("libp2p"));
+        assert!(!is_logos_target_root("other"));
+    }
+}

--- a/tracing/targets/src/lib.rs
+++ b/tracing/targets/src/lib.rs
@@ -1,32 +1,33 @@
-#![forbid(unsafe_code)]
+use std::collections::HashSet;
 
 pub mod blend;
 
+/// Log target namespaces follow Rust-style `module::path` segments.
+const TARGET_NAMESPACE_DELIMITER: &str = "::";
+
 #[must_use]
-pub(crate) fn matches_target_prefix(target: &str, candidate: &str) -> bool {
+fn matches_target_prefix(target: &str, candidate: &str) -> bool {
     target == candidate
         || candidate
             .strip_prefix(target)
-            .is_some_and(|suffix| suffix.starts_with("::"))
+            .is_some_and(|suffix| suffix.starts_with(TARGET_NAMESPACE_DELIMITER))
 }
 
 #[must_use]
 fn target_root(target: &str) -> &str {
-    target.split("::").next().unwrap_or(target)
+    target
+        .split(TARGET_NAMESPACE_DELIMITER)
+        .next()
+        .unwrap_or(target)
 }
 
 #[must_use]
-pub fn all_targets() -> Vec<&'static str> {
-    blend::all_targets()
+pub fn all_targets() -> HashSet<&'static str> {
+    blend::all_targets().into_iter().collect()
 }
 
 #[must_use]
-pub fn is_valid_target(target: &str) -> bool {
-    all_targets().into_iter().any(|known| known == target)
-}
-
-#[must_use]
-pub fn is_valid_logos_target_prefix(target: &str) -> bool {
+fn is_valid_logos_target_prefix(target: &str) -> bool {
     all_targets()
         .into_iter()
         .any(|known| matches_target_prefix(target, known))
@@ -40,9 +41,17 @@ pub fn is_logos_target_root(target: &str) -> bool {
         .any(|known| target_root(known) == root)
 }
 
+#[must_use]
+pub fn is_valid_logos_target(target: &str) -> bool {
+    is_logos_target_root(target) && is_valid_logos_target_prefix(target)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{blend, is_logos_target_root, is_valid_logos_target_prefix, is_valid_target};
+    use super::{
+        all_targets, blend, is_logos_target_root, is_valid_logos_target,
+        is_valid_logos_target_prefix,
+    };
 
     #[test]
     fn blend_targets_are_registered() {
@@ -52,9 +61,9 @@ mod tests {
 
     #[test]
     fn exact_target_validation_accepts_known_targets() {
-        assert!(is_valid_target(blend::service::ROOT));
-        assert!(is_valid_target(blend::service::core::KMS_POQ_GENERATOR));
-        assert!(!is_valid_target("blend::service::missing"));
+        assert!(all_targets().contains(&blend::service::ROOT));
+        assert!(all_targets().contains(&blend::service::core::KMS_POQ_GENERATOR));
+        assert!(!all_targets().contains(&"blend::service::missing"));
     }
 
     #[test]
@@ -74,5 +83,13 @@ mod tests {
         assert!(!is_logos_target_root("bl"));
         assert!(!is_logos_target_root("libp2p"));
         assert!(!is_logos_target_root("other"));
+    }
+
+    #[test]
+    fn logos_target_validation_requires_known_root_and_prefix() {
+        assert!(is_valid_logos_target("blend"));
+        assert!(is_valid_logos_target("blend::service"));
+        assert!(!is_valid_logos_target("blend::service::missing"));
+        assert!(!is_valid_logos_target("libp2p"));
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds a dedicated crate for log targets.

It follows the earlier discussion here:
- [chore: reduce and standardize node logging #2430 (comment)](https://github.com/logos-blockchain/logos-blockchain/pull/2430#discussion_r2993130299)

So far targets have mostly been plain string literals spread around the codebase. That makes them easy to drift, and it also means config cannot be checked against any known set of valid targets. This change moves target definitions into one place so the same definitions can be reused both from code and when validating configured log filters.

Target declarations look like this:

```rust
log_targets! {
    blend::{
        service::{CORE, core::KMS_POQ_GENERATOR},
        network::core::handler::{CORE_EDGE},
    }
}
```

Call sites then use the generated constants directly:

```rust
const LOG_TARGET: &str = lb_log_targets::blend::service::CORE;

tracing::debug!(target: LOG_TARGET, "...");
```

A proc macro is used here so target definitions only need to be written once, while still generating both the constants used by code and the collected target list used for validation. A normal macro could do this too, but the declaration format and expansion logic became harder to read.

This PR only switches a couple of Blend call sites as examples. The rest can be moved over in follow-up PRs.


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
