### PR TITLE
test: improve fork join preserve wallet state cucumber test for ci

### DIFF
--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -159,23 +159,27 @@ Feature: Transactions
       | 4             | 2           | 1400         |
       | 5             | 2           | 1400         |
       | 7             | 0           | 0            |
+      | 8             | 0           | 0            |
     And I have a cluster with capacity of 5 nodes
+    And no nodes are declared as blend providers
     And we use IBD peers
     And all peers must be mode online after startup in 30 seconds
     And we will have distinct node groups to query wallet balances:
-      | group_name | node_name |
-      | FORK_A     | NODE_1    |
-      | FORK_A     | NODE_2    |
-      | FORK_B     | NODE_4    |
-      | FORK_B     | NODE_5    |
-      | FORK_BURN  | NODE_BURN |
+      | group_name | node_name       |
+      | FORK_A     | NODE_1          |
+      | FORK_A     | NODE_2          |
+      | FORK_B     | NODE_4          |
+      | FORK_B     | NODE_5          |
+      | FORK_BURN  | NODE_BURN       |
+      | FORK_BURN  | NODE_BURN_BUDDY |
     And I start nodes with wallet resources:
-      | node_name | account_index | wallet_name | connected_to |
-      | NODE_1    | 1             | WALLET_1A   |              |
-      | NODE_2    | 2             | WALLET_2A   | NODE_1       |
-      | NODE_4    | 4             | WALLET_4A   |              |
-      | NODE_5    | 5             | WALLET_5A   | NODE_4       |
-      | NODE_BURN | 7             | WALLET_BURN |              |
+      | node_name       | account_index | wallet_name       | connected_to |
+      | NODE_1          | 1             | WALLET_1A         |              |
+      | NODE_2          | 2             | WALLET_2A         | NODE_1       |
+      | NODE_4          | 4             | WALLET_4A         |              |
+      | NODE_5          | 5             | WALLET_5A         | NODE_4       |
+      | NODE_BURN       | 7             | WALLET_BURN       |              |
+      | NODE_BURN_BUDDY | 8             | WALLET_BURN_BUDDY | NODE_BURN    |
     When node "NODE_1" is at height 2 in 240 seconds
     And node "NODE_4" is at height 2 in 180 seconds
     # Fork A transfer: each wallet sends half its funds

--- a/tests/src/cucumber/steps/manual_nodes/config_override.rs
+++ b/tests/src/cucumber/steps/manual_nodes/config_override.rs
@@ -627,9 +627,6 @@ mod tests {
         },
     };
 
-    const GENESIS_INSCRIPTION_OVERRIDE_PATH: &str =
-        "cryptarchia.genesis_block.transactions.0.mantle_tx.ops.1.payload.inscription";
-
     #[test]
     fn normalize_path_rejects_empty_segments() {
         let path = "network..backend";
@@ -903,52 +900,6 @@ mod tests {
             config.user.cryptarchia.leader.wallet.funding_pk,
             lb_key_management_system_service::keys::ZkPublicKey::zero(),
         );
-    }
-
-    #[test]
-    fn deployment_override_hex_inscription_round_trips_into_genesis_inscription_bytes() {
-        let (configs, genesis_block) =
-            create_general_configs(1, Some("test_override_inscription_hex"));
-        let deployment_settings = e2e_deployment_settings_with_genesis_block(&genesis_block);
-        let mut config = create_validator_config(configs[0].clone(), deployment_settings);
-        let mut world = CucumberWorld::default();
-
-        // Hex input
-        set_deployment_config_override(
-            &mut world,
-            "test-step",
-            GENESIS_INSCRIPTION_OVERRIDE_PATH,
-            "hex(70726f636573735f73746172745f6e6f6e6365)",
-        )
-        .expect("inscription hex override");
-
-        apply_deployment_config_overrides(&mut config, &world.deployment_config_overrides)
-            .expect("apply deployment overrides");
-
-        assert_genesis_inscription_bytes(&config, b"process_start_nonce");
-
-        set_deployment_config_override(
-            &mut world,
-            "test-step",
-            GENESIS_INSCRIPTION_OVERRIDE_PATH,
-            "70726f636573735f73746172745f6e6f6e6365",
-        )
-        .expect("inscription text override");
-
-        apply_deployment_config_overrides(&mut config, &world.deployment_config_overrides)
-            .expect("apply deployment overrides");
-
-        assert_genesis_inscription_bytes(&config, b"process_start_nonce");
-    }
-
-    fn assert_genesis_inscription_bytes(config: &RunConfig, expected: &[u8]) {
-        let yaml = serde_yaml::to_value(&config.deployment).expect("deployment yaml");
-        let path = split_path(GENESIS_INSCRIPTION_OVERRIDE_PATH);
-        let inscription = get_at_path(&yaml, &path).expect("inscription path");
-        let encoded = inscription.as_str().expect("inscription hex string");
-        let got = hex::decode(encoded).expect("inscription hex");
-
-        assert_eq!(got, expected);
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

Improve `Scenario: Two fork chains join later and preserve persisted state wallet balances` for cucumber CI, 
by adding a buddy node in the `FORK_BURN` group and removing all blend providers.

Two failure modes have been observed for this test that is flaky only in CI:
- **Type A:** `Step fail: Step `node "NODE_1" is at height 2 in 240 seconds` error: Node 'NODE_1' did not reach height 2 in 240 s`
- **Type B:** `Step fail: Step `node "NODE_1" is at height 5 in 180 seconds` error: NODE_BURN is not responsive anymore: error sending request for url (http://127.0.0.1:20810/cryptarchia/info) / Node `NODE_BURN` did not respond to network_info after 5`

The `Type B` failures are targeted directly with this PR, and it may possibly improve `Type A` failures as well.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
