### PR TITLE
refactor(sdp): remove dead code: `SessionState::update`

### DIFF
--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -66,9 +66,9 @@ impl Service {
     }
 
     #[cfg(test)]
-    const fn forming_session(&self) -> &SessionState {
+    const fn next_session(&self) -> &SessionState {
         match self {
-            Self::BlendNetwork(state) => &state.forming,
+            Self::BlendNetwork(state) => &state.next,
         }
     }
 
@@ -144,8 +144,8 @@ pub enum Error {
     DuplicateDeclaration(DeclarationId),
     #[error("Active session for service {0:?} not found")]
     ActiveSessionNotFound(ServiceType),
-    #[error("Forming session for service {0:?} not found")]
-    FormingSessionNotFound(ServiceType),
+    #[error("Next session for service {0:?} not found")]
+    NextSessionNotFound(ServiceType),
     #[error("Session parameters for {0:?} not found")]
     SessionParamsNotFound(ServiceType),
     #[error("Service parameters are missing for {0:?}")]
@@ -182,14 +182,14 @@ pub struct SessionState {
 struct ServiceState<R: Rewards> {
     // state of declarations at block b
     declarations: Declarations,
-    // (current) active session
+    // (current) active session.
     // snapshot of `declarations` at the start of block ((b // config.session_duration) - 1) *
     // config.session_duration
     active: SessionState,
-    // new forming session, overlaps with `declarations` until the next session boundary
+    // next session.
     // snapshot of `declarations` at the start of block (b // config.session_duration) *
     // config.session_duration
-    forming: SessionState,
+    next: SessionState,
     // rewards calculation and tracking for this service
     pub rewards: R,
 }
@@ -245,10 +245,10 @@ impl<R: Rewards> ServiceState<R> {
                 service_params,
                 rewards_params,
             );
-            self.active = self.forming.clone();
-            self.forming = SessionState {
+            self.active = self.next.clone();
+            self.next = SessionState {
                 declarations: self.declarations.clone(),
-                session_n: self.forming.session_n + 1,
+                session_n: self.next.session_n + 1,
             };
         } else {
             assert!(
@@ -322,7 +322,7 @@ impl SdpLedger {
 
         let Service::BlendNetwork(state) = blend;
         state.active.declarations = state.declarations.clone();
-        state.forming.declarations = state.declarations.clone();
+        state.next.declarations = state.declarations.clone();
 
         Ok(sdp)
     }
@@ -350,7 +350,7 @@ impl SdpLedger {
                 session_n: 0,
             },
 
-            forming: SessionState {
+            next: SessionState {
                 declarations: rpds::RedBlackTreeMapSync::new_sync(),
                 session_n: 1,
             },
@@ -599,10 +599,8 @@ impl SdpLedger {
     }
 
     #[cfg(test)]
-    fn get_forming_session(&self, service_type: ServiceType) -> Option<&SessionState> {
-        self.services
-            .get(&service_type)
-            .map(Service::forming_session)
+    fn get_next_session(&self, service_type: ServiceType) -> Option<&SessionState> {
+        self.services.get(&service_type).map(Service::next_session)
     }
 
     #[cfg(test)]
@@ -757,11 +755,11 @@ mod tests {
             (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
         }
 
-        // At block 10, declaration enters forming session 2
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 2);
-        assert!(forming_session.declarations.contains_key(&declaration_id));
-        assert_eq!(forming_session.declarations.size(), 1);
+        // At block 10, declaration enters the next session 2
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 2);
+        assert!(next_session.declarations.contains_key(&declaration_id));
+        assert_eq!(next_session.declarations.size(), 1);
     }
 
     #[test]
@@ -851,16 +849,16 @@ mod tests {
             (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
         }
 
-        // At block 10: active becomes session 1 (was empty forming), forming becomes
-        // session 2 (snapshot at block 10)
+        // At block 10: `active` becomes session 1 (was empty `next`),
+        // `next` becomes session 2 (snapshot at block 10)
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 1);
         assert!(active_session.declarations.is_empty()); // Active session 1 is empty
 
-        // Check forming session is now session 2 and contains declaration
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 2);
-        assert!(forming_session.declarations.contains_key(&declaration_id));
+        // Check next session is now session 2 and contains declaration
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 2);
+        assert!(next_session.declarations.contains_key(&declaration_id));
 
         // Continue to block 20 to see declaration become active
         for _ in 0..10 {
@@ -894,9 +892,9 @@ mod tests {
         assert_eq!(active_session.session_n, 0);
         assert!(active_session.declarations.is_empty());
 
-        // Check forming session is still session 1
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 1);
+        // Check next session is still session 1
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 1);
     }
 
     #[test]
@@ -917,8 +915,8 @@ mod tests {
         // Check BlendNetwork is promoted to session 1
         let active_session = sdp_ledger.get_active_session(service).unwrap();
         assert_eq!(active_session.session_n, 1);
-        let forming_session = sdp_ledger.get_forming_session(service).unwrap();
-        assert_eq!(forming_session.session_n, 2);
+        let next_session = sdp_ledger.get_next_session(service).unwrap();
+        assert_eq!(next_session.session_n, 2);
     }
 
     #[test]
@@ -959,28 +957,28 @@ mod tests {
         }
         assert_eq!(sdp_ledger.block_number, 9);
 
-        // Declaration is not in active or forming sessions yet
+        // Declaration is not in active or next sessions yet
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 0);
         assert!(!active_session.declarations.contains_key(&declaration_id));
 
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 1);
-        assert!(forming_session.declarations.is_empty());
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 1);
+        assert!(next_session.declarations.is_empty());
 
         // SESSION 1: Cross session boundary to block 10
         (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
         assert_eq!(sdp_ledger.block_number, 10);
 
-        // Active session 1 is empty (was the empty forming session 1)
+        // Active session 1 is empty (was the empty next session 1)
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 1);
         assert!(active_session.declarations.is_empty());
 
-        // Forming session 2 now has the declaration (snapshot from block 10)
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 2);
-        assert!(forming_session.declarations.contains_key(&declaration_id));
+        // Next session 2 now has the declaration (snapshot from block 10)
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 2);
+        assert!(next_session.declarations.contains_key(&declaration_id));
 
         // SESSION 2: Cross to block 20
         for _ in 11..20 {
@@ -1132,10 +1130,10 @@ mod tests {
         assert_eq!(active_session.session_n, 2);
         assert!(active_session.declarations.contains_key(&declaration_id));
 
-        // Forming session (session 3) should also contain the declaration
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 3);
-        assert!(forming_session.declarations.contains_key(&declaration_id));
+        // Next session (session 3) should also contain the declaration
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 3);
+        assert!(next_session.declarations.contains_key(&declaration_id));
     }
 
     #[test]
@@ -1162,9 +1160,9 @@ mod tests {
         assert_eq!(active_session.session_n, 0);
         assert!(active_session.declarations.is_empty());
 
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 1);
-        assert!(forming_session.declarations.is_empty());
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 1);
+        assert!(next_session.declarations.is_empty());
 
         // Create first declaration at block 9
         let utxo_1 = utxo();
@@ -1183,7 +1181,7 @@ mod tests {
                 .unwrap();
 
         // Cross to block 10 (session boundary - start of session 1)
-        // At this point, the snapshot for forming session 2 is taken
+        // At this point, the snapshot for next session 2 is taken
         (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
         assert_eq!(sdp_ledger.block_number, 10);
 
@@ -1191,10 +1189,10 @@ mod tests {
         assert_eq!(active_session.session_n, 1);
         assert!(active_session.declarations.is_empty());
 
-        // Forming session 2 should contain declaration_1 (made at block 9)
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 2);
-        assert!(forming_session.declarations.contains_key(&declaration_id_1));
+        // Next session 2 should contain declaration_1 (made at block 9)
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 2);
+        assert!(next_session.declarations.contains_key(&declaration_id_1));
 
         // Create second declaration at block 10 (first block of session 1)
         let zk_key_2 = create_zk_key(2);
@@ -1213,12 +1211,12 @@ mod tests {
             apply_declare_with_dummies(&utxo_tree_2, sdp_ledger, declare_op_2, &zk_key_2, &config)
                 .unwrap();
 
-        // Forming session 2 still only has declaration_1 (snapshot was already taken at
+        // Next session 2 still only has declaration_1 (snapshot was already taken at
         // block 10)
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 2);
-        assert!(forming_session.declarations.contains_key(&declaration_id_1));
-        assert!(!forming_session.declarations.contains_key(&declaration_id_2));
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 2);
+        assert!(next_session.declarations.contains_key(&declaration_id_1));
+        assert!(!next_session.declarations.contains_key(&declaration_id_2));
 
         // Jump to block 20 (start of session 2)
         for _ in 11..20 {
@@ -1233,11 +1231,11 @@ mod tests {
         assert!(active_session.declarations.contains_key(&declaration_id_1));
         assert!(!active_session.declarations.contains_key(&declaration_id_2));
 
-        // Forming session 3 has both declarations (snapshot from block 20)
-        let forming_session = sdp_ledger.get_forming_session(service_a).unwrap();
-        assert_eq!(forming_session.session_n, 3);
-        assert!(forming_session.declarations.contains_key(&declaration_id_1));
-        assert!(forming_session.declarations.contains_key(&declaration_id_2));
+        // Next session 3 has both declarations (snapshot from block 20)
+        let next_session = sdp_ledger.get_next_session(service_a).unwrap();
+        assert_eq!(next_session.session_n, 3);
+        assert!(next_session.declarations.contains_key(&declaration_id_1));
+        assert!(next_session.declarations.contains_key(&declaration_id_2));
 
         // Jump to block 30 (start of session 3)
         for _ in 21..30 {

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -194,23 +194,6 @@ struct ServiceState<R: Rewards> {
     pub rewards: R,
 }
 
-impl SessionState {
-    fn update<R: Rewards>(
-        &self,
-        service_state: &ServiceState<R>,
-        block_number: u64,
-        config: &ServiceParameters,
-    ) -> Self {
-        if self.session_n.saturating_sub(1) * config.session_duration > block_number {
-            return Self {
-                session_n: self.session_n,
-                declarations: service_state.declarations.clone(),
-            };
-        }
-        self.clone()
-    }
-}
-
 const fn is_active(
     declaration: &Declaration,
     current_block: u64,
@@ -269,11 +252,11 @@ impl<R: Rewards> ServiceState<R> {
             };
         } else {
             assert!(
-                current_session < self.active.session_n + 1,
-                "Logos blockchain isn't ready for time travel yet"
+                current_session == self.active.session_n,
+                "Logos blockchain isn't ready for time travel yet: session_of_block={current_session}, active_session={}",
+                self.active.session_n
             );
             self.rewards = self.rewards.update_epoch(epoch_state, rewards_params);
-            self.forming = self.forming.update(&self, block_number, service_params);
             reward_utxos = Vec::new();
         }
 

--- a/ledger/src/mantle/sdp/rewards/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/mod.rs
@@ -45,7 +45,7 @@ pub trait Rewards: Clone + PartialEq + Send + Sync + std::fmt::Debug {
     /// distribute.
     ///
     /// Called during session boundaries when active, `past_session`, and
-    /// forming sessions are updated. Returns a map of `ProviderId` to
+    /// next sessions are updated. Returns a map of `ProviderId` to
     /// reward amounts for providers eligible for rewards in this session
     /// transition.
     ///

--- a/services/storage/src/api/backend/rocksdb/membership.rs
+++ b/services/storage/src/api/backend/rocksdb/membership.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 pub const MEMBERSHIP_ACTIVE_SESSION_PREFIX: &str = "membership/active/";
-pub const MEMBERSHIP_FORMING_SESSION_PREFIX: &str = "membership/forming/";
+pub const MEMBERSHIP_NEXT_SESSION_PREFIX: &str = "membership/next/";
 pub const MEMBERSHIP_LATEST_BLOCK_KEY: &str = "membership/latest_block";
 
 type MembershipProviders = (SessionNumber, HashMap<ProviderId, BTreeSet<Locator>>);
@@ -128,7 +128,7 @@ impl StorageMembershipApi for RocksBackend {
         }
     }
 
-    async fn save_forming_session(
+    async fn save_next_session(
         &mut self,
         service_type: ServiceType,
         session_id: SessionNumber,
@@ -137,7 +137,7 @@ impl StorageMembershipApi for RocksBackend {
         let service_bytes = service_type
             .to_bytes()
             .expect("Serialization of ServiceType should not fail");
-        let key = key_bytes(MEMBERSHIP_FORMING_SESSION_PREFIX, service_bytes);
+        let key = key_bytes(MEMBERSHIP_NEXT_SESSION_PREFIX, service_bytes);
 
         let session_data = (session_id, providers);
         let serialized_data = session_data
@@ -147,44 +147,44 @@ impl StorageMembershipApi for RocksBackend {
         match self.store(key, serialized_data).await {
             Ok(()) => {
                 debug!(
-                    "Successfully stored forming session {} for service {:?}",
+                    "Successfully stored next session {} for service {:?}",
                     session_id, service_type
                 );
                 Ok(())
             }
             Err(e) => {
-                error!("Failed to store forming session: {:?}", e);
+                error!("Failed to store next session: {:?}", e);
                 Err(e.into())
             }
         }
     }
 
-    async fn load_forming_session(
+    async fn load_next_session(
         &mut self,
         service_type: ServiceType,
     ) -> Result<Option<MembershipProviders>, DynError> {
         let service_bytes = service_type
             .to_bytes()
             .expect("Serialization of ServiceType should not fail");
-        let key = key_bytes(MEMBERSHIP_FORMING_SESSION_PREFIX, service_bytes);
+        let key = key_bytes(MEMBERSHIP_NEXT_SESSION_PREFIX, service_bytes);
 
         let data = self.load(&key).await?;
 
         data.map_or_else(
             || {
-                debug!("No forming session found for service {:?}", service_type);
+                debug!("No next session found for service {:?}", service_type);
                 Ok(None)
             },
             |bytes| match <MembershipProviders>::from_bytes(&bytes) {
                 Ok(session_data) => {
                     debug!(
-                        "Successfully loaded forming session for service {:?}",
+                        "Successfully loaded next session for service {:?}",
                         service_type
                     );
                     Ok(Some(session_data))
                 }
                 Err(e) => {
-                    error!("Failed to deserialize forming session: {:?}", e);
+                    error!("Failed to deserialize next session: {:?}", e);
                     Ok(None)
                 }
             },

--- a/services/storage/src/api/membership/mod.rs
+++ b/services/storage/src/api/membership/mod.rs
@@ -27,14 +27,14 @@ pub trait StorageMembershipApi {
 
     async fn load_latest_block(&mut self) -> Result<Option<BlockNumber>, DynError>;
 
-    async fn save_forming_session(
+    async fn save_next_session(
         &mut self,
         service_type: ServiceType,
         session_id: SessionNumber,
         providers: &HashMap<ProviderId, BTreeSet<Locator>>,
     ) -> Result<(), DynError>;
 
-    async fn load_forming_session(
+    async fn load_next_session(
         &mut self,
         service_type: ServiceType,
     ) -> Result<Option<(SessionNumber, HashMap<ProviderId, BTreeSet<Locator>>)>, DynError>;

--- a/services/storage/src/api/membership/requests.rs
+++ b/services/storage/src/api/membership/requests.rs
@@ -30,12 +30,12 @@ pub enum MembershipApiRequest {
     LoadLatestBlock {
         response_tx: Sender<Option<BlockNumber>>,
     },
-    SaveFormingSession {
+    SaveNextSession {
         service_type: ServiceType,
         session_id: SessionNumber,
         providers: HashMap<ProviderId, BTreeSet<Locator>>,
     },
-    LoadFormingSession {
+    LoadNextSession {
         service_type: ServiceType,
         response_tx: SessionSender,
     },
@@ -62,15 +62,15 @@ where
             Self::LoadLatestBlock { response_tx } => {
                 handle_load_latest_block(backend, response_tx).await
             }
-            Self::SaveFormingSession {
+            Self::SaveNextSession {
                 service_type,
                 session_id,
                 providers,
-            } => handle_save_forming_session(backend, service_type, session_id, providers).await,
-            Self::LoadFormingSession {
+            } => handle_save_next_session(backend, service_type, session_id, providers).await,
+            Self::LoadNextSession {
                 service_type,
                 response_tx,
-            } => handle_load_forming_session(backend, service_type, response_tx).await,
+            } => handle_load_next_session(backend, service_type, response_tx).await,
         }
     }
 }
@@ -132,31 +132,31 @@ async fn handle_load_latest_block<Backend: StorageBackend + StorageMembershipApi
     Ok(())
 }
 
-async fn handle_save_forming_session<Backend: StorageBackend + StorageMembershipApi>(
+async fn handle_save_next_session<Backend: StorageBackend + StorageMembershipApi>(
     backend: &mut Backend,
     service_type: ServiceType,
     session_id: SessionNumber,
     providers: HashMap<ProviderId, BTreeSet<Locator>>,
 ) -> Result<(), StorageServiceError> {
     backend
-        .save_forming_session(service_type, session_id, &providers)
+        .save_next_session(service_type, session_id, &providers)
         .await
         .map_err(StorageServiceError::BackendError)
 }
 
-async fn handle_load_forming_session<Backend: StorageBackend + StorageMembershipApi>(
+async fn handle_load_next_session<Backend: StorageBackend + StorageMembershipApi>(
     backend: &mut Backend,
     service_type: ServiceType,
     response_tx: SessionSender,
 ) -> Result<(), StorageServiceError> {
     let result = backend
-        .load_forming_session(service_type)
+        .load_next_session(service_type)
         .await
         .map_err(StorageServiceError::BackendError)?;
 
     if response_tx.send(result).is_err() {
         return Err(StorageServiceError::ReplyError {
-            message: "Failed to send reply for load forming session request".to_owned(),
+            message: "Failed to send reply for load next session request".to_owned(),
         });
     }
     Ok(())

--- a/services/storage/src/backends/mock.rs
+++ b/services/storage/src/backends/mock.rs
@@ -6,19 +6,17 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use lb_cryptarchia_engine::Slot;
 use lb_core::{
     block::{BlockNumber, SessionNumber},
     header::HeaderId,
     sdp::{Locator, ProviderId, ServiceType},
 };
+use lb_cryptarchia_engine::Slot;
 use overwatch::DynError;
 use thiserror::Error;
 
 use super::{StorageBackend, StorageTransaction};
-use crate::api::{
-    StorageBackendApi, chain::StorageChainApi, membership::StorageMembershipApi,
-};
+use crate::api::{StorageBackendApi, chain::StorageChainApi, membership::StorageMembershipApi};
 
 #[derive(Debug, Error)]
 #[error("Errors in MockStorage should not happen")]
@@ -190,7 +188,7 @@ impl StorageMembershipApi for MockStorage {
         unimplemented!()
     }
 
-    async fn save_forming_session(
+    async fn save_next_session(
         &mut self,
         _service_type: ServiceType,
         _session_id: SessionNumber,
@@ -199,7 +197,7 @@ impl StorageMembershipApi for MockStorage {
         unimplemented!()
     }
 
-    async fn load_forming_session(
+    async fn load_next_session(
         &mut self,
         _service_type: ServiceType,
     ) -> Result<Option<(SessionNumber, HashMap<ProviderId, BTreeSet<Locator>>)>, DynError> {

--- a/services/storage/src/lib.rs
+++ b/services/storage/src/lib.rs
@@ -193,13 +193,13 @@ impl<Backend: StorageBackend> StorageMsg<Backend> {
     }
 
     #[must_use]
-    pub const fn save_forming_session_request(
+    pub const fn save_next_session_request(
         service_type: ServiceType,
         session_id: SessionNumber,
         providers: HashMap<ProviderId, BTreeSet<Locator>>,
     ) -> Self {
         Self::Api {
-            request: StorageApiRequest::Membership(MembershipApiRequest::SaveFormingSession {
+            request: StorageApiRequest::Membership(MembershipApiRequest::SaveNextSession {
                 service_type,
                 session_id,
                 providers,
@@ -208,12 +208,12 @@ impl<Backend: StorageBackend> StorageMsg<Backend> {
     }
 
     #[must_use]
-    pub const fn load_forming_session_request(
+    pub const fn load_next_session_request(
         service_type: ServiceType,
         response_tx: SessionSender,
     ) -> Self {
         Self::Api {
-            request: StorageApiRequest::Membership(MembershipApiRequest::LoadFormingSession {
+            request: StorageApiRequest::Membership(MembershipApiRequest::LoadNextSession {
                 service_type,
                 response_tx,
             }),


### PR DESCRIPTION
## 1. What does this PR implement?

We had a dead code.

`ServiceState` has two `SessionState`s:
- `active`: Declarations that are active now in the current session.
- `forming` Declarations that will become active from the next session.

We were calling `forming.update()` every new block processing, but it does its job **only** when the new block is **older** than its parent. It is impossible because we always build a new ledger state by cloning its parent ledger state.

So, in this PR, I removed the `update` function entirely, because we actually don't need to update the forming session state. It is actually a snapshot taken at the start block of the current session.
The name `forming` is misleading, ~~but this PR doesn't change it now~~. So, I renamed it to `next` because it's a snapshot that will be used from the next session.

I didn't add any new test for this change because it is quite clear that this is a dead code. I checked that the existing tests are sufficient.


## 2. Does the code have enough context to be clearly understood?

I believe so.

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
