### PR TITLE
feat(block-tracker): introduce block-tracker to be re-used to track chain state where applicable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,6 +4183,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-blockchain-block-tracker"
+version = "0.1.2"
+dependencies = [
+ "rpds",
+]
+
+[[package]]
 name = "logos-blockchain-c"
 version = "0.1.2"
 dependencies = [
@@ -5235,6 +5242,7 @@ version = "0.1.2"
 dependencies = [
  "async-trait",
  "futures",
+ "logos-blockchain-block-tracker",
  "logos-blockchain-common-http-client",
  "logos-blockchain-core",
  "logos-blockchain-groth16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ strip    = "none"    # Don't strip symbols to allow for better profiling results
 members = [
   "blend/core",
   "blend/crypto",
+  "block-tracker",
   "blend/message",
   "blend/network",
   "blend/proofs",
@@ -111,6 +112,7 @@ lb-blend-network                   = { default-features = false, package = "logo
 lb-blend-proofs                    = { default-features = false, package = "logos-blockchain-blend-proofs", path = "./blend/proofs" }
 lb-blend-scheduling                = { default-features = false, package = "logos-blockchain-blend-scheduling", path = "./blend/scheduling" }
 lb-blend-service                   = { default-features = false, package = "logos-blockchain-blend-service", path = "./services/blend" }
+lb-block-tracker                   = { default-features = false, package = "logos-blockchain-block-tracker", path = "./block-tracker" }
 lb-cfgsync                         = { default-features = false, package = "logos-blockchain-cfgsync", path = "./testnet/cfgsync" }
 lb-chain-broadcast-service         = { default-features = false, package = "logos-blockchain-chain-broadcast-service", path = "./services/chain/broadcast-service" }
 lb-chain-leader-service            = { default-features = false, package = "logos-blockchain-chain-leader-service", path = "./services/chain/chain-leader" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ strip    = "none"    # Don't strip symbols to allow for better profiling results
 members = [
   "blend/core",
   "blend/crypto",
-  "block-tracker",
   "blend/message",
   "blend/network",
   "blend/proofs",
   "blend/scheduling",
+  "block-tracker",
   "c-bindings",
   "consensus/cryptarchia-engine",
   "consensus/cryptarchia-sync",

--- a/block-tracker/Cargo.toml
+++ b/block-tracker/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+categories  = { workspace = true }
+description = "Generic per-branch state tracker over a block tree, with reorg and LIB support."
+edition     = { workspace = true }
+keywords    = { workspace = true }
+license     = { workspace = true }
+name        = "logos-blockchain-block-tracker"
+publish     = false
+readme      = { workspace = true }
+repository  = { workspace = true }
+version     = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+rpds = { workspace = true }

--- a/block-tracker/src/lib.rs
+++ b/block-tracker/src/lib.rs
@@ -1,0 +1,46 @@
+//! Generic per-branch state tracker over a block tree.
+//!
+//! A [`BlockView`] is a strategy that describes how to derive per-block
+//! state from an input. A [`BlockTree`] maintains those states across the
+//! chain's branching structure, supports reorgs via lowest-common-ancestor
+//! lookup, and prunes finalized history as LIB advances.
+//!
+//! The `Input` type is generic so consumers can feed not just blocks but
+//! richer per-position data (e.g. `(Block, Payouts)`) — useful when the
+//! domain-of-interest depends on data that the protocol computes alongside
+//! a block but that doesn't appear in transactions.
+//!
+//! By convention, the driver is responsible for summarizing raw chain data
+//! into the lens's `Input` type before calling [`BlockTree::process`]. The
+//! lens's `apply` method is itself a pure derivation `(parent, input) ->
+//! child`, but the tree exposes mutation primitives (e.g.
+//! [`BlockTree::iter_states_mut`]) for cross-branch maintenance that
+//! doesn't fit a per-block fold.
+
+mod tree;
+
+pub use tree::{BlockTree, PrunedBlock};
+
+/// View into a chain: how to fold per-block input into accumulated branch
+/// state.
+///
+/// Implementations are pure functions of their arguments. The driver feeds
+/// `Input` for each block; the tracker takes care of branching and reorgs.
+pub trait BlockView {
+    /// Per-position input. May be a block summary, or a tuple bundling a
+    /// block with additional protocol-derived data the lens needs.
+    type Input;
+
+    /// Accumulated state along a branch (e.g. UTXO set, safe-tx set).
+    ///
+    /// Required to be `Clone` because the tree stores one state per block;
+    /// implementations should use a persistent data structure (e.g. `rpds`)
+    /// to keep cloning cheap across deep histories.
+    type State: Clone;
+
+    /// Derive child state from parent state plus this block's input.
+    fn apply(&self, parent: &Self::State, input: &Self::Input) -> Self::State;
+
+    /// Initial state at genesis (before any block has been applied).
+    fn default_state() -> Self::State;
+}

--- a/block-tracker/src/tree.rs
+++ b/block-tracker/src/tree.rs
@@ -1,0 +1,406 @@
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+};
+
+use crate::BlockView;
+
+/// A block reported by [`BlockTree::advance_lib`] as newly finalized.
+///
+/// The `input` is moved out of the tree at finalization time — once a
+/// block is below LIB, the tree no longer needs its per-block data.
+/// Consumers that want to materialize "finalized" effects (e.g. mark
+/// rewards as spendable) read these.
+pub struct PrunedBlock<Id, Input> {
+    pub id: Id,
+    pub input: Input,
+}
+
+/// Per-branch state tracker over a block tree.
+///
+/// Stores per-block accumulated state and per-block input along every
+/// branch. Reorgs are handled by switching to a different tip;
+/// [`Self::find_lcm`] gives the common ancestor for diffing.
+///
+/// As LIB advances, the chain segment below the new LIB is finalized and
+/// returned to the caller; sibling branches of that segment are pruned.
+pub struct BlockTree<Id, V: BlockView> {
+    states: HashMap<Id, V::State>,
+    inputs: HashMap<Id, V::Input>,
+    parent_map: HashMap<Id, Id>,
+    lib: Id,
+}
+
+impl<Id, V> BlockTree<Id, V>
+where
+    Id: Clone + Eq + Hash,
+    V: BlockView,
+{
+    /// Create a new tree rooted at `genesis` with default state.
+    ///
+    /// `genesis` becomes the initial LIB. It has no parent in `parent_map`
+    /// and no input in `inputs` (it's the base case for the fold).
+    pub fn new(genesis: Id) -> Self {
+        let mut states = HashMap::new();
+        states.insert(genesis.clone(), V::default_state());
+        Self {
+            states,
+            inputs: HashMap::new(),
+            parent_map: HashMap::new(),
+            lib: genesis,
+        }
+    }
+
+    /// Process a block.
+    ///
+    /// Derives the branch state from the parent's state via the lens, and
+    /// stores both the state and the input keyed by `id`. If the block has
+    /// already been processed, its state and input are overwritten —
+    /// reprocessing is safe in a chain context because block ids are
+    /// content-addressed (same id ⇒ same content).
+    ///
+    /// If `parent` is not known to the tree (e.g. after backfill where LIB
+    /// advanced between batches and the parent was pruned), the lens is
+    /// applied against `V::default_state()` and the parent relationship is
+    /// still recorded — so a future descendant can still walk the lineage.
+    pub fn process(&mut self, id: Id, parent: Id, input: V::Input, view: &V) {
+        let parent_state = self
+            .states
+            .get(&parent)
+            .cloned()
+            .unwrap_or_else(V::default_state);
+        let state = view.apply(&parent_state, &input);
+        self.states.insert(id.clone(), state);
+        self.inputs.insert(id.clone(), input);
+        self.parent_map.insert(id, parent);
+    }
+
+    /// Accumulated state at `id`, if known.
+    pub fn state_at(&self, id: &Id) -> Option<&V::State> {
+        self.states.get(id)
+    }
+
+    /// Per-block input at `id`, if known and not yet finalized.
+    pub fn input_at(&self, id: &Id) -> Option<&V::Input> {
+        self.inputs.get(id)
+    }
+
+    /// Mutable iterator over all branch states in the tree.
+    ///
+    /// Useful for tree-wide mutations that aren't expressible as a per-block
+    /// fold — e.g. shrinking states in response to information learned
+    /// outside the lens (such as which entries became finalized in an
+    /// external system). The lens itself remains a pure function; this
+    /// escape hatch lets the driver perform cross-branch maintenance.
+    pub fn iter_states_mut(&mut self) -> impl Iterator<Item = &mut V::State> + '_ {
+        self.states.values_mut()
+    }
+
+    /// Current LIB.
+    pub const fn lib(&self) -> &Id {
+        &self.lib
+    }
+
+    /// Lowest common ancestor of `a` and `b`, walking the parent chain.
+    ///
+    /// Returns `None` if the two ids are not in the same tree.
+    pub fn find_lcm(&self, a: &Id, b: &Id) -> Option<Id> {
+        let mut a_chain: HashSet<Id> = HashSet::new();
+        let mut cur = a.clone();
+        loop {
+            a_chain.insert(cur.clone());
+            match self.parent_map.get(&cur) {
+                Some(p) => cur = p.clone(),
+                None => break,
+            }
+        }
+        let mut cur = b.clone();
+        loop {
+            if a_chain.contains(&cur) {
+                return Some(cur);
+            }
+            match self.parent_map.get(&cur) {
+                Some(p) => cur = p.clone(),
+                None => return None,
+            }
+        }
+    }
+
+    /// Inputs along the path from `from` (exclusive) up to `to` (inclusive),
+    /// in oldest-first order.
+    ///
+    /// Returns an empty vec if `from` is not an ancestor of `to`, or if
+    /// any input on the path has been finalized (and therefore moved out).
+    pub fn inputs_between(&self, from: &Id, to: &Id) -> Vec<&V::Input> {
+        let mut chain = Vec::new();
+        let mut cur = to.clone();
+        while &cur != from {
+            let Some(input) = self.inputs.get(&cur) else {
+                return Vec::new();
+            };
+            chain.push(input);
+            match self.parent_map.get(&cur) {
+                Some(p) => cur = p.clone(),
+                None => return Vec::new(),
+            }
+        }
+        chain.reverse();
+        chain
+    }
+
+    /// Advance LIB to `new_lib`.
+    ///
+    /// Returns the chain segment from old LIB (exclusive) up to `new_lib`
+    /// (inclusive) in oldest-first order — these are the newly finalized
+    /// blocks. Their inputs are moved out of the tree (no longer needed
+    /// for branch computation).
+    ///
+    /// All branches that are not descendants of `new_lib` are pruned —
+    /// they've been definitively orphaned by finalization.
+    ///
+    /// # Panics
+    /// Panics if `new_lib` is not a descendant of the current LIB.
+    pub fn advance_lib(&mut self, new_lib: Id) -> Vec<PrunedBlock<Id, V::Input>> {
+        if new_lib == self.lib {
+            return Vec::new();
+        }
+        let path = self.path_from_lib_to(&new_lib);
+        let keep = self.subtree_of(&new_lib);
+
+        let mut finalized = Vec::with_capacity(path.len());
+        for id in path {
+            let input = self
+                .inputs
+                .remove(&id)
+                .expect("block on finalized path must have an input");
+            self.parent_map.remove(&id);
+            // Keep state at the new LIB — it's the new root for future
+            // branch computation. Drop everything strictly below it.
+            if id != new_lib {
+                self.states.remove(&id);
+            }
+            finalized.push(PrunedBlock { id, input });
+        }
+
+        let to_drop: Vec<Id> = self
+            .states
+            .keys()
+            .filter(|id| !keep.contains(id))
+            .cloned()
+            .collect();
+        for id in to_drop {
+            self.states.remove(&id);
+            self.inputs.remove(&id);
+            self.parent_map.remove(&id);
+        }
+
+        self.lib = new_lib;
+        finalized
+    }
+
+    /// Walk `parent_map` from `target` back to current LIB; oldest-first.
+    fn path_from_lib_to(&self, target: &Id) -> Vec<Id> {
+        let mut path = Vec::new();
+        let mut cur = target.clone();
+        while cur != self.lib {
+            path.push(cur.clone());
+            match self.parent_map.get(&cur) {
+                Some(p) => cur = p.clone(),
+                None => panic!("target is not a descendant of current LIB"),
+            }
+        }
+        path.reverse();
+        path
+    }
+
+    /// Set of `root` and all its known descendants.
+    fn subtree_of(&self, root: &Id) -> HashSet<Id> {
+        let mut children: HashMap<&Id, Vec<&Id>> = HashMap::new();
+        for (child, parent) in &self.parent_map {
+            children.entry(parent).or_default().push(child);
+        }
+        let mut keep: HashSet<Id> = HashSet::new();
+        keep.insert(root.clone());
+        let mut frontier = vec![root.clone()];
+        while let Some(node) = frontier.pop() {
+            if let Some(kids) = children.get(&node) {
+                for k in kids {
+                    if keep.insert((*k).clone()) {
+                        frontier.push((*k).clone());
+                    }
+                }
+            }
+        }
+        keep
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    /// Toy lens: each input is a `&str` tag; state is the accumulated set
+    /// of tags along a branch. Sufficient to exercise tree mechanics
+    /// without dragging in any chain types.
+    struct TagLens;
+
+    impl BlockView for TagLens {
+        type Input = &'static str;
+        type State = BTreeSet<&'static str>;
+
+        fn apply(&self, parent: &Self::State, input: &Self::Input) -> Self::State {
+            let mut s = parent.clone();
+            s.insert(*input);
+            s
+        }
+
+        fn default_state() -> Self::State {
+            BTreeSet::new()
+        }
+    }
+
+    fn linear() -> BlockTree<u64, TagLens> {
+        // 0 (genesis) -> 1 -> 2 -> 3
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "a", &TagLens);
+        tree.process(2, 1, "b", &TagLens);
+        tree.process(3, 2, "c", &TagLens);
+        tree
+    }
+
+    #[test]
+    fn linear_apply_accumulates() {
+        let tree = linear();
+        assert_eq!(tree.state_at(&3).unwrap(), &BTreeSet::from(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn inputs_between_returns_oldest_first() {
+        let tree = linear();
+        let path = tree.inputs_between(&0, &3);
+        assert_eq!(path, vec![&"a", &"b", &"c"]);
+    }
+
+    #[test]
+    fn fork_diverges_state() {
+        // 0 -> 1 -> 2a
+        //        \-> 2b
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "shared", &TagLens);
+        tree.process(20, 1, "a-only", &TagLens);
+        tree.process(21, 1, "b-only", &TagLens);
+
+        assert_eq!(
+            tree.state_at(&20).unwrap(),
+            &BTreeSet::from(["shared", "a-only"])
+        );
+        assert_eq!(
+            tree.state_at(&21).unwrap(),
+            &BTreeSet::from(["shared", "b-only"])
+        );
+    }
+
+    #[test]
+    fn lcm_finds_fork_point() {
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "x", &TagLens);
+        tree.process(2, 1, "y", &TagLens);
+        tree.process(20, 1, "a", &TagLens);
+        tree.process(21, 20, "a2", &TagLens);
+
+        assert_eq!(tree.find_lcm(&2, &21), Some(1));
+        assert_eq!(tree.find_lcm(&2, &2), Some(2));
+        assert_eq!(tree.find_lcm(&21, &0), Some(0));
+    }
+
+    #[test]
+    fn lcm_unrelated_returns_none() {
+        let tree = BlockTree::<u64, TagLens>::new(0);
+        assert_eq!(tree.find_lcm(&999, &0), None);
+    }
+
+    #[test]
+    fn advance_lib_returns_finalized_segment_oldest_first() {
+        let mut tree = linear();
+        let pruned = tree.advance_lib(3);
+        let ids: Vec<u64> = pruned.iter().map(|p| p.id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+        assert_eq!(*tree.lib(), 3);
+        assert_eq!(tree.state_at(&3).unwrap(), &BTreeSet::from(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn advance_lib_prunes_orphan_branches() {
+        // 0 -> 1 -> 2a (becomes new LIB)
+        //        \-> 2b (should be pruned)
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "x", &TagLens);
+        tree.process(20, 1, "a", &TagLens);
+        tree.process(21, 1, "b", &TagLens);
+
+        drop(tree.advance_lib(20));
+        assert!(tree.state_at(&20).is_some(), "new LIB kept");
+        assert!(tree.state_at(&21).is_none(), "orphan branch pruned");
+    }
+
+    #[test]
+    fn advance_lib_keeps_descendants_of_new_lib() {
+        // 0 -> 1 -> 2 -> 3a
+        //               \-> 3b
+        // advance to 2 — 3a and 3b are descendants of new LIB, both kept.
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "a", &TagLens);
+        tree.process(2, 1, "b", &TagLens);
+        tree.process(30, 2, "c1", &TagLens);
+        tree.process(31, 2, "c2", &TagLens);
+
+        drop(tree.advance_lib(2));
+        assert!(tree.state_at(&30).is_some());
+        assert!(tree.state_at(&31).is_some());
+        assert!(tree.state_at(&1).is_none(), "below new LIB pruned");
+    }
+
+    #[test]
+    fn advance_lib_no_op_when_unchanged() {
+        let mut tree = linear();
+        let pruned = tree.advance_lib(0);
+        assert!(pruned.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "not a descendant")]
+    fn advance_lib_to_unrelated_panics() {
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "a", &TagLens);
+        tree.process(20, 1, "b", &TagLens);
+        // 999 is not in the tree — should panic.
+        drop(tree.advance_lib(999));
+    }
+
+    #[test]
+    fn reorg_workflow_produces_correct_diffs() {
+        // Simulate the multi-sequencer reorg pattern:
+        // 0 -> 1 -> 2a -> 3a   (old canonical)
+        //        \-> 2b -> 3b  (new canonical after reorg)
+        //
+        // From a switch from 3a to 3b:
+        //   orphaned = inputs on 1..3a = ["2a", "3a"] (oldest first)
+        //   adopted  = inputs on 1..3b = ["2b", "3b"] (oldest first)
+        let mut tree = BlockTree::<u64, TagLens>::new(0);
+        tree.process(1, 0, "x", &TagLens);
+        tree.process(20, 1, "2a", &TagLens);
+        tree.process(30, 20, "3a", &TagLens);
+        tree.process(21, 1, "2b", &TagLens);
+        tree.process(31, 21, "3b", &TagLens);
+
+        let lcm = tree.find_lcm(&30, &31).unwrap();
+        assert_eq!(lcm, 1);
+
+        let orphaned: Vec<&&str> = tree.inputs_between(&lcm, &30);
+        let adopted: Vec<&&str> = tree.inputs_between(&lcm, &31);
+        assert_eq!(orphaned, vec![&"2a", &"3a"]);
+        assert_eq!(adopted, vec![&"2b", &"3b"]);
+    }
+}

--- a/block-tracker/tests/channel_lens.rs
+++ b/block-tracker/tests/channel_lens.rs
@@ -1,0 +1,189 @@
+//! End-to-end test of `BlockView` / `BlockTree` modeling zone-sdk's
+//! channel inscription tracking.
+//!
+//! Mirrors the data shapes used by `zone-sdk/src/state.rs::TxState`:
+//!   - state: `HashTrieSetSync<TxHash>` — cumulative safe-tx set per branch
+//!   - per-block input: `Vec<InscriptionInfo>` — inscriptions in this block
+//!   - id: `HeaderId` (modeled here as `[u8; 32]` to avoid an `lb-core`
+//!     dev-dep; the real type is just a newtype around a 32-byte array)
+//!
+//! The test exercises the multi-sequencer reorg pattern:
+//!   - two competing branches publish inscriptions
+//!   - reorg switches from one tip to the other
+//!   - `inputs_between(lcm, tip)` produces the orphaned/adopted lists that
+//!     drive `Event::ChannelUpdate` in zone-sdk
+
+use logos_blockchain_block_tracker::{BlockTree, BlockView};
+use rpds::HashTrieSetSync;
+
+type HeaderId = [u8; 32];
+type TxHash = [u8; 32];
+type MsgId = [u8; 32];
+
+const fn id(b: u8) -> [u8; 32] {
+    let mut a = [0u8; 32];
+    a[0] = b;
+    a
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct InscriptionInfo {
+    tx_hash: TxHash,
+    parent_msg: MsgId,
+    this_msg: MsgId,
+    payload: Vec<u8>,
+}
+
+struct ChannelLens;
+
+impl BlockView for ChannelLens {
+    type Input = Vec<InscriptionInfo>;
+    type State = HashTrieSetSync<TxHash>;
+
+    fn apply(&self, parent: &Self::State, input: &Self::Input) -> Self::State {
+        let mut state = parent.clone();
+        for ins in input {
+            state.insert_mut(ins.tx_hash);
+        }
+        state
+    }
+
+    fn default_state() -> Self::State {
+        HashTrieSetSync::new_sync()
+    }
+}
+
+fn ins(tx: u8, this: u8, parent: u8) -> InscriptionInfo {
+    InscriptionInfo {
+        tx_hash: id(tx),
+        parent_msg: id(parent),
+        this_msg: id(this),
+        payload: vec![tx],
+    }
+}
+
+#[test]
+fn linear_safe_set_grows() {
+    let genesis = id(0);
+    let mut tree = BlockTree::<HeaderId, ChannelLens>::new(genesis);
+    tree.process(id(1), genesis, vec![ins(0xa1, 1, 0)], &ChannelLens);
+    tree.process(id(2), id(1), vec![ins(0xa2, 2, 1)], &ChannelLens);
+    tree.process(id(3), id(2), vec![ins(0xa3, 3, 2)], &ChannelLens);
+
+    let safe_set = tree.state_at(&id(3)).unwrap();
+    assert_eq!(safe_set.size(), 3);
+    assert!(safe_set.contains(&id(0xa1)));
+    assert!(safe_set.contains(&id(0xa2)));
+    assert!(safe_set.contains(&id(0xa3)));
+}
+
+#[test]
+fn competing_sequencers_reorg_produces_orphaned_and_adopted() {
+    // Two sequencers publish on a fork:
+    //   genesis -> 1 -> 2a -> 3a   (sequencer A's branch)
+    //                \-> 2b -> 3b  (sequencer B's branch wins)
+    //
+    // After a reorg from 3a to 3b, zone-sdk should emit:
+    //   orphaned = [inscriptions in 2a, inscriptions in 3a]
+    //   adopted  = [inscriptions in 2b, inscriptions in 3b]
+    let genesis = id(0);
+    let mut tree = BlockTree::<HeaderId, ChannelLens>::new(genesis);
+
+    tree.process(id(1), genesis, vec![ins(0x10, 1, 0)], &ChannelLens);
+
+    // Sequencer A's branch
+    tree.process(id(0x2a), id(1), vec![ins(0xa2, 0x2a, 1)], &ChannelLens);
+    tree.process(
+        id(0x3a),
+        id(0x2a),
+        vec![ins(0xa3, 0x3a, 0x2a)],
+        &ChannelLens,
+    );
+
+    // Sequencer B's branch (becomes canonical)
+    tree.process(id(0x2b), id(1), vec![ins(0xb2, 0x2b, 1)], &ChannelLens);
+    tree.process(
+        id(0x3b),
+        id(0x2b),
+        vec![ins(0xb3, 0x3b, 0x2b)],
+        &ChannelLens,
+    );
+
+    // Reorg: lcm gives us the fork point; inputs_between gives orphaned/adopted.
+    let lcm = tree.find_lcm(&id(0x3a), &id(0x3b)).expect("lcm exists");
+    assert_eq!(lcm, id(1), "fork point is block 1");
+
+    let orphaned: Vec<_> = tree
+        .inputs_between(&lcm, &id(0x3a))
+        .into_iter()
+        .flatten()
+        .collect();
+    let adopted: Vec<_> = tree
+        .inputs_between(&lcm, &id(0x3b))
+        .into_iter()
+        .flatten()
+        .collect();
+
+    assert_eq!(orphaned.len(), 2);
+    assert_eq!(orphaned[0].tx_hash, id(0xa2));
+    assert_eq!(orphaned[1].tx_hash, id(0xa3));
+
+    assert_eq!(adopted.len(), 2);
+    assert_eq!(adopted[0].tx_hash, id(0xb2));
+    assert_eq!(adopted[1].tx_hash, id(0xb3));
+}
+
+#[test]
+fn safe_set_diverges_per_branch() {
+    // Each branch should only see its own inscriptions in the safe set.
+    let genesis = id(0);
+    let mut tree = BlockTree::<HeaderId, ChannelLens>::new(genesis);
+
+    tree.process(id(1), genesis, vec![ins(0x10, 1, 0)], &ChannelLens);
+    tree.process(id(0x2a), id(1), vec![ins(0xa2, 0x2a, 1)], &ChannelLens);
+    tree.process(id(0x2b), id(1), vec![ins(0xb2, 0x2b, 1)], &ChannelLens);
+
+    let a_set = tree.state_at(&id(0x2a)).unwrap();
+    let b_set = tree.state_at(&id(0x2b)).unwrap();
+
+    assert!(a_set.contains(&id(0x10)), "shared block visible on A");
+    assert!(a_set.contains(&id(0xa2)), "A's own inscription visible");
+    assert!(!a_set.contains(&id(0xb2)), "B's inscription not on A");
+
+    assert!(b_set.contains(&id(0x10)));
+    assert!(b_set.contains(&id(0xb2)));
+    assert!(!b_set.contains(&id(0xa2)));
+}
+
+#[test]
+fn lib_advance_finalizes_segment_and_prunes_competing_branch() {
+    // genesis -> 1 -> 2a (canonical, becomes new LIB)
+    //              \-> 2b (competing branch — pruned at finalization)
+    let genesis = id(0);
+    let mut tree = BlockTree::<HeaderId, ChannelLens>::new(genesis);
+    tree.process(id(1), genesis, vec![ins(0x10, 1, 0)], &ChannelLens);
+    tree.process(id(0x2a), id(1), vec![ins(0xa2, 0x2a, 1)], &ChannelLens);
+    tree.process(id(0x2b), id(1), vec![ins(0xb2, 0x2b, 1)], &ChannelLens);
+
+    let pruned = tree.advance_lib(id(0x2a));
+
+    // Finalized segment is [block 1, block 2a] in oldest-first order.
+    let finalized_ids: Vec<_> = pruned.iter().map(|p| p.id).collect();
+    assert_eq!(finalized_ids, vec![id(1), id(0x2a)]);
+
+    // The pruned blocks carry their per-block inscriptions for the
+    // consumer to materialize as "finalized" effects.
+    assert_eq!(pruned[0].input.len(), 1);
+    assert_eq!(pruned[0].input[0].tx_hash, id(0x10));
+    assert_eq!(pruned[1].input[0].tx_hash, id(0xa2));
+
+    // State at the new LIB is preserved; competing branch is gone.
+    assert!(tree.state_at(&id(0x2a)).is_some(), "new LIB state kept");
+    assert!(
+        tree.state_at(&id(0x2b)).is_none(),
+        "competing branch pruned"
+    );
+
+    let safe_set = tree.state_at(&id(0x2a)).unwrap();
+    assert_eq!(safe_set.size(), 2, "safe set unchanged by finalization");
+}

--- a/zone-sdk/Cargo.toml
+++ b/zone-sdk/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 async-trait                      = { workspace = true }
 futures                          = { workspace = true }
+lb-block-tracker                 = { workspace = true }
 lb-common-http-client            = { workspace = true }
 lb-core                          = { workspace = true }
 lb-groth16                       = { workspace = true }

--- a/zone-sdk/src/state.rs
+++ b/zone-sdk/src/state.rs
@@ -1,5 +1,6 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
+use lb_block_tracker::{BlockTree, BlockView};
 use lb_core::{
     header::HeaderId,
     mantle::{SignedMantleTx, Transaction as _, ops::channel::MsgId, tx::TxHash},
@@ -56,7 +57,50 @@ pub struct PendingInscription {
     pub payload: Vec<u8>,
 }
 
+/// Per-block channel data fed to [`ChannelLens`].
+///
+/// The driver pre-summarizes a raw L1 block into this shape:
+/// - `safe_txs`: tx hashes in this block that match our local pending set (txs
+///   we care about that landed on chain).
+/// - `inscriptions`: channel inscriptions in this block, in observed order.
+#[derive(Debug, Clone)]
+pub struct ChannelBlock {
+    pub safe_txs: Vec<TxHash>,
+    pub inscriptions: Vec<InscriptionInfo>,
+}
+
+/// Strategy for accumulating per-branch channel state.
+///
+/// State is a `HashTrieSetSync<TxHash>` of "safe" txs — those of ours
+/// that have been seen on this branch. `apply` extends the parent's set
+/// with the txs in this block.
+#[derive(Debug)]
+pub struct ChannelLens;
+
+impl BlockView for ChannelLens {
+    type Input = ChannelBlock;
+    type State = HashTrieSetSync<TxHash>;
+
+    fn apply(&self, parent: &Self::State, input: &Self::Input) -> Self::State {
+        let mut state = parent.clone();
+        for tx in &input.safe_txs {
+            state.insert_mut(*tx);
+        }
+        state
+    }
+
+    fn default_state() -> Self::State {
+        HashTrieSetSync::new_sync()
+    }
+}
+
 /// Transaction state tracker.
+///
+/// Splits responsibility cleanly:
+/// - Chain-derived state (per-branch safe-tx set, per-block inscriptions,
+///   parent lineage, LIB) lives in `tree`, driven by [`ChannelLens`].
+/// - Locally-driven mempool state (pending inscriptions, lineage indices, the
+///   finalized-msg cursor) lives in this struct directly.
 pub struct TxState {
     /// Local pending inscriptions indexed by tx hash.
     pending: HashMap<TxHash, PendingInscription>,
@@ -64,32 +108,21 @@ pub struct TxState {
     pending_by_parent: HashMap<MsgId, Vec<TxHash>>,
     /// Non-inscription pending txs (e.g. `set_keys`).
     pending_other: HashMap<TxHash, SignedMantleTx>,
-    /// Per-block cumulative safe sets.
-    block_states: BTreeMap<HeaderId, HashTrieSetSync<TxHash>>,
-    /// Block parent relationships for pruning.
-    parent_map: HashMap<HeaderId, HeaderId>,
-    /// Current LIB for pruning.
-    current_lib: HeaderId,
-    /// Channel inscriptions per L1 block (unfinalized window only).
-    block_inscriptions: HashMap<HeaderId, Vec<InscriptionInfo>>,
     /// Last finalized channel tip — used as parent when pending is empty.
     finalized_msg: MsgId,
+    /// Per-branch chain-derived state (safe-tx set + per-block inscriptions).
+    tree: BlockTree<HeaderId, ChannelLens>,
 }
 
 impl TxState {
     #[must_use]
     pub fn new(lib: HeaderId, finalized_msg: MsgId) -> Self {
-        let mut block_states = BTreeMap::new();
-        block_states.insert(lib, HashTrieSetSync::new_sync());
         Self {
             pending: HashMap::new(),
             pending_by_parent: HashMap::new(),
             pending_other: HashMap::new(),
-            block_states,
-            parent_map: HashMap::new(),
-            current_lib: lib,
-            block_inscriptions: HashMap::new(),
             finalized_msg,
+            tree: BlockTree::new(lib),
         }
     }
 
@@ -145,56 +178,41 @@ impl TxState {
         our_txs: impl IntoIterator<Item = TxHash>,
         inscriptions: Vec<InscriptionInfo>,
     ) {
-        // Store parent relationship for pruning
-        self.parent_map.insert(block_id, parent_id);
+        // Pre-filter our_txs to the ones we know about. Same semantics as
+        // before: only txs in our pending sets contribute to the safe set.
+        // BlockTree handles missing parent (uses default state) — needed
+        // for slot-range backfill where LIB advanced between batches.
+        let safe_txs: Vec<TxHash> = our_txs
+            .into_iter()
+            .filter(|tx| self.pending.contains_key(tx) || self.pending_other.contains_key(tx))
+            .collect();
+        self.tree.process(
+            block_id,
+            parent_id,
+            ChannelBlock {
+                safe_txs,
+                inscriptions,
+            },
+            &ChannelLens,
+        );
 
-        // Build cumulative safe set from parent. Parent may be missing
-        // when blocks are processed from slot-range backfill and LIB has
-        // advanced between batches (pruning the parent). Starting with an
-        // empty set is conservative: txs show as "pending" until seen in
-        // a subsequent block with a known parent.
-        let mut safe_set = self
-            .block_states
-            .get(&parent_id)
-            .cloned()
-            .unwrap_or_default();
-
-        for tx in our_txs {
-            if self.pending.contains_key(&tx) || self.pending_other.contains_key(&tx) {
-                safe_set = safe_set.insert(tx);
-            }
-        }
-        self.block_states.insert(block_id, safe_set);
-
-        // Store channel inscriptions for this block
-        if !inscriptions.is_empty() {
-            self.block_inscriptions.insert(block_id, inscriptions);
-        }
-
-        // When lib advances: update finalized_msg and prune.
-        // NOTE: we do NOT remove pending txs here. Pending txs are only
-        // removed when confirmed by backfill ground truth (canonical
-        // finalized blocks from the node). The safe set is used for
-        // branch-relative status (pending_txs resubmission) but not
-        // as proof of canonical finalization — it can include blocks
-        // from orphaned branches in concurrent scenarios.
-        if lib != self.current_lib {
-            // Compute finalized_msg BEFORE pruning — walk from new LIB
-            // backwards to find the latest inscription in the finalized range.
+        // When lib advances: update finalized_msg, advance the tree (which
+        // prunes blocks below the new LIB and any sibling branches).
+        // NOTE: pending txs are NOT removed here — that's done by backfill
+        // ground truth.
+        if lib != *self.tree.lib() {
+            // Compute finalized_msg BEFORE advancing — the walk needs the
+            // pre-advance lineage.
             self.finalized_msg = self.channel_tip_at(lib);
+            let _pruned = self.tree.advance_lib(lib);
 
-            // Prune ancestors of new lib (but not lib itself)
-            let mut prune_cursor = self.parent_map.get(&lib).copied();
-            while let Some(b) = prune_cursor {
-                self.block_states.remove(&b);
-                self.block_inscriptions.remove(&b);
-                prune_cursor = self.parent_map.remove(&b);
-            }
-
-            // Remove finalized tx hashes from all safe sets. Using remove
-            // (rather than rebuild) preserves rpds memory sharing between
-            // block states for non-finalized txs.
-            if let Some(lib_safe_set) = self.block_states.get(&lib) {
+            // Optimization: shrink remaining safe sets by removing tx
+            // hashes that are no longer in our pending sets (i.e. were
+            // confirmed finalized externally). Without this, descendant
+            // safe sets grow without bound — correctness is unaffected
+            // (pending_txs filters by current pending set), but memory
+            // would leak.
+            if let Some(lib_safe_set) = self.tree.state_at(&lib) {
                 let finalized_hashes: Vec<TxHash> = lib_safe_set
                     .iter()
                     .filter(|hash| {
@@ -202,42 +220,13 @@ impl TxState {
                     })
                     .copied()
                     .collect();
-                for safe_set in self.block_states.values_mut() {
-                    for tx_hash in &finalized_hashes {
-                        *safe_set = safe_set.remove(tx_hash);
+                if !finalized_hashes.is_empty() {
+                    for safe_set in self.tree.iter_states_mut() {
+                        for tx_hash in &finalized_hashes {
+                            *safe_set = safe_set.remove(tx_hash);
+                        }
                     }
                 }
-            }
-
-            self.prune_orphans(lib);
-            self.current_lib = lib;
-        }
-    }
-
-    /// Remove orphaned blocks whose parent was pruned.
-    fn prune_orphans(&mut self, lib: HeaderId) {
-        loop {
-            let orphans: Vec<_> = self
-                .parent_map
-                .iter()
-                .filter_map(|(id, parent)| {
-                    if *id == lib {
-                        return None; // lib is root
-                    }
-                    let parent_is_lib = *parent == lib;
-                    let parent_exists = self.parent_map.contains_key(parent);
-                    (!parent_is_lib && !parent_exists).then_some(*id)
-                })
-                .collect();
-
-            if orphans.is_empty() {
-                break;
-            }
-
-            for orphan in orphans {
-                self.block_states.remove(&orphan);
-                self.block_inscriptions.remove(&orphan);
-                self.parent_map.remove(&orphan);
             }
         }
     }
@@ -251,8 +240,8 @@ impl TxState {
     /// iteration order is arbitrary.
     pub fn pending_txs(&self, tip: HeaderId) -> Vec<(TxHash, SignedMantleTx)> {
         let safe = self
-            .block_states
-            .get(&tip)
+            .tree
+            .state_at(&tip)
             .cloned()
             .unwrap_or_else(HashTrieSetSync::new_sync);
 
@@ -314,8 +303,8 @@ impl TxState {
             .map(|i| i.tx_hash)
             .collect();
         let safe: std::collections::HashSet<TxHash> = self
-            .block_states
-            .get(&tip)
+            .tree
+            .state_at(&tip)
             .map(|s| s.iter().copied().collect())
             .unwrap_or_default();
 
@@ -371,13 +360,13 @@ impl TxState {
     /// Check if we have state for a block.
     #[must_use]
     pub fn has_block(&self, block_id: &HeaderId) -> bool {
-        self.block_states.contains_key(block_id)
+        self.tree.state_at(block_id).is_some()
     }
 
     /// Current LIB.
     #[must_use]
     pub const fn lib(&self) -> HeaderId {
-        self.current_lib
+        *self.tree.lib()
     }
 
     /// All pending transactions (for checkpoint serialization).
@@ -443,29 +432,23 @@ impl TxState {
         }
     }
 
-    /// Derive the channel tip `MsgId` at a given L1 block by walking backwards
-    /// through the block tree and finding the most recent inscription.
-    /// Returns `finalized_msg` if no inscriptions are found in the
-    /// unfinalized window.
+    /// Derive the channel tip `MsgId` at a given L1 block by walking the
+    /// inputs from current LIB up to `block_id` and finding the latest
+    /// inscription. Returns `finalized_msg` if no inscriptions are found
+    /// in the unfinalized window or the block is unknown.
     #[must_use]
     pub fn channel_tip_at(&self, block_id: HeaderId) -> MsgId {
-        let mut current = block_id;
-        loop {
-            if let Some(inscs) = self.block_inscriptions.get(&current)
-                && let Some(last) = inscs.last()
-            {
+        let lib = *self.tree.lib();
+        if block_id == lib {
+            return self.finalized_msg;
+        }
+        let inputs = self.tree.inputs_between(&lib, &block_id);
+        for input in inputs.iter().rev() {
+            if let Some(last) = input.inscriptions.last() {
                 return last.this_msg;
             }
-
-            if current == self.current_lib {
-                return self.finalized_msg;
-            }
-
-            match self.parent_map.get(&current) {
-                Some(&parent) => current = parent,
-                None => return self.finalized_msg,
-            }
         }
+        self.finalized_msg
     }
 
     /// Detect a channel update between old and new L1 tips.
@@ -490,9 +473,24 @@ impl TxState {
             return None;
         }
 
-        let new_branch = self.collect_inscriptions_on_branch(new_tip);
-        let old_branch = self.collect_inscriptions_on_branch(old_tip);
+        // Find the divergence point. Anything strictly above LCM on either
+        // branch is the linear delta between the two chains.
+        let lcm = self.tree.find_lcm(&old_tip, &new_tip)?;
+        let old_branch: Vec<InscriptionInfo> = self
+            .tree
+            .inputs_between(&lcm, &old_tip)
+            .into_iter()
+            .flat_map(|i| i.inscriptions.iter().cloned())
+            .collect();
+        let new_branch: Vec<InscriptionInfo> = self
+            .tree
+            .inputs_between(&lcm, &new_tip)
+            .into_iter()
+            .flat_map(|i| i.inscriptions.iter().cloned())
+            .collect();
 
+        // Same MsgId can appear on both branches (e.g. a competitor block
+        // re-included our inscription); filter those out as no-op moves.
         let new_chain: std::collections::HashSet<MsgId> =
             new_branch.iter().map(|i| i.this_msg).collect();
         let old_chain: std::collections::HashSet<MsgId> =
@@ -554,29 +552,11 @@ impl TxState {
     /// in oldest-first order.
     #[must_use]
     pub fn collect_inscriptions_on_branch(&self, tip: HeaderId) -> Vec<InscriptionInfo> {
-        let mut blocks = Vec::new();
-        let mut current = tip;
-
-        loop {
-            blocks.push(current);
-            if current == self.current_lib {
-                break;
-            }
-            match self.parent_map.get(&current) {
-                Some(&parent) => current = parent,
-                None => break,
-            }
-        }
-
-        blocks.reverse();
-        blocks
+        let lib = *self.tree.lib();
+        self.tree
+            .inputs_between(&lib, &tip)
             .into_iter()
-            .flat_map(|block_id| {
-                self.block_inscriptions
-                    .get(&block_id)
-                    .cloned()
-                    .unwrap_or_default()
-            })
+            .flat_map(|i| i.inscriptions.iter().cloned())
             .collect()
     }
 }
@@ -738,8 +718,8 @@ mod tests {
         state.process_block(b2, b1, genesis, vec![], vec![]);
 
         // Verify fork blocks exist before lib advances
-        assert!(state.block_states.contains_key(&b1));
-        assert!(state.block_states.contains_key(&b2));
+        assert!(state.has_block(&b1));
+        assert!(state.has_block(&b2));
 
         // Continue main chain, lib advances to a3
         state.process_block(a2, a1, genesis, vec![], vec![]);
@@ -751,34 +731,25 @@ mod tests {
         // - a3 (new lib) should exist
 
         assert!(
-            !state.block_states.contains_key(&genesis),
+            !state.has_block(&genesis),
             "genesis (old lib) should be pruned"
         );
-        assert!(!state.block_states.contains_key(&a1), "a1 should be pruned");
-        assert!(!state.block_states.contains_key(&a2), "a2 should be pruned");
-        assert!(
-            !state.block_states.contains_key(&b1),
-            "orphan b1 should be pruned"
-        );
-        assert!(
-            !state.block_states.contains_key(&b2),
-            "orphan b2 should be pruned"
-        );
+        assert!(!state.has_block(&a1), "a1 should be pruned");
+        assert!(!state.has_block(&a2), "a2 should be pruned");
+        assert!(!state.has_block(&b1), "orphan b1 should be pruned");
+        assert!(!state.has_block(&b2), "orphan b2 should be pruned");
 
-        assert!(state.block_states.contains_key(&a3), "lib should exist");
+        assert!(state.has_block(&a3), "lib should exist");
 
         // Continue and verify pruning continues working
         state.process_block(a4, a3, a3, vec![], vec![]);
         state.process_block(a5, a4, a5, vec![], vec![]); // lib advances to a5
         state.process_block(a6, a5, a5, vec![], vec![]);
 
-        assert!(
-            !state.block_states.contains_key(&a3),
-            "old lib should be pruned"
-        );
-        assert!(!state.block_states.contains_key(&a4), "a4 should be pruned");
-        assert!(state.block_states.contains_key(&a5), "new lib should exist");
-        assert!(state.block_states.contains_key(&a6), "tip should exist");
+        assert!(!state.has_block(&a3), "old lib should be pruned");
+        assert!(!state.has_block(&a4), "a4 should be pruned");
+        assert!(state.has_block(&a5), "new lib should exist");
+        assert!(state.has_block(&a6), "tip should exist");
     }
 
     fn msg_id(n: u8) -> MsgId {


### PR DESCRIPTION
## 1. What does this PR implement?

Adds a new `block-tracker` crate that provides a generic per-branch state tracker (`BlockView` strategy + `BlockTree<Id, V>`), and
  refactors zone-sdk's `state.rs` to use it.

**Not for merge yet** — please review the trait shape and flag anything that wouldn't fit the use case. I have tried to integrate it to zone-sdk right away to show the usage. Let's see if it makes sense for other consumers as well.

 ## The abstraction

  ```rust
  trait BlockView {
      type Input;          // generic — Block, (Block, Payouts), or anything
      type State: Clone;
      fn apply(&self, parent: &Self::State, input: &Self::Input) -> Self::State;
      fn default_state() -> Self::State;
  }

  struct BlockTree<Id, V: BlockView> { ... }
  // process, state_at, find_lcm, inputs_between, advance_lib, iter_states_mut
  
  ```
`BlockView` is closer to a strategy than a pure FP lens. — apply is functional, but the tree exposes `iter_states_mut` for cross-branch maintenance that doesn't fit a per-block fold (e.g. shrinking states when finalized externally).

@danielSanchezQ, @youngjoon-lee  — I also took a look at the wallet side to sanity check the fit.

My understanding is that wallet currently handles reorgs implicitly — it relies on chain-service to feed the canonical view and signal pruned blocks, rather than computing branch diffs itself.

Adopting BlockTree wouldn’t change that model, but it would expose primitives like find_lcm / inputs_between in case wallet ever wants to reason about reorgs locally. And the block aware state is shared.

For rewards specifically, it seems the current approach could be extended without BlockTree (e.g. passing additional data alongside blocks). The generic Input shape might still be useful for structuring that (e.g. Input = (Block, Payouts)), but it doesn’t look strictly required.

So from my side it looks like:

* zone-sdk: clear fit 
* wallet: optional — current model works, this would mainly add structure / optional capabilities
* mempool: likely similar to wallet (chain-service-driven), but unclear if the abstraction adds value there without more reorg-aware logic

**Bottom line**: the shared piece is the multi-branch state-map pattern. The reorg-detection primitives (find_lcm, inputs_between) are external-consumer-only — they exist because the public API doesn't expose what chain-service gives internally. If a future event-stream-style public API ever ships, those primitives become vestigial; until then, zone-sdk needs them.

Curious to hear your thoughts.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic @danielSanchezQ @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes
## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
