### PR TITLE
fix(logging): reduce noisy node logs

### DIFF
--- a/services/chain/broadcast-service/src/lib.rs
+++ b/services/chain/broadcast-service/src/lib.rs
@@ -18,7 +18,7 @@ use overwatch::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, oneshot};
 use tokio_stream::wrappers::BroadcastStream;
-use tracing::{debug, error, info};
+use tracing::{error, info, trace};
 
 const BROADCAST_CHANNEL_SIZE: usize = 128;
 
@@ -96,13 +96,13 @@ where
             match msg {
                 BlockBroadcastMsg::BroadcastFinalizedBlock(block) => {
                     if self.finalized_blocks.send(block).is_err() {
-                        debug!("No listener for finalized blocks. Not broadcasting. ");
+                        trace!("No listener for finalized blocks. Not broadcasting. ");
                     }
                 }
                 BlockBroadcastMsg::BroadcastBlendSession(session) => {
                     self.last_blend_session = Some(session.clone());
                     if self.blend_session.send(session).is_err() {
-                        debug!("No listener for blend sessions. Not broadcasting. ");
+                        trace!("No listener for blend sessions. Not broadcasting. ");
                     }
                 }
                 BlockBroadcastMsg::SubscribeToFinalizedBlocks { result_sender } => {

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -42,7 +42,7 @@ use overwatch::{
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use tokio::{sync::oneshot, time::sleep};
-use tracing::{Level, debug, error, info, instrument, span, trace};
+use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 use tracing_futures::Instrument as _;
 
 pub use crate::{
@@ -467,6 +467,10 @@ where
             .await;
     }
 
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "Keep proposal error handling in one match."
+    )]
     fn handle_proposal_processing_error(
         err: Error,
         block_id: HeaderId,
@@ -486,6 +490,15 @@ where
                         "Failed to enqueue block for orphan processing",
                     );
                 }
+            }
+            Error::Cryptarchia(lb_chain_service::api::ApiError::FutureBlock {
+                block_slot,
+                current_slot,
+            }) => {
+                warn!(
+                    target: LOG_TARGET, ?block_id, ?block_slot, ?current_slot,
+                    "Block is still from a future slot after apply retries",
+                );
             }
             err => {
                 error!(
@@ -699,7 +712,7 @@ where
                 block_slot,
                 current_slot,
             })) if attempt < max_retries => {
-                info!(
+                debug!(
                     target: LOG_TARGET,
                     ?block_id,
                     ?block_slot,
@@ -725,7 +738,11 @@ where
 /// Try to add a [`Block`] to [`Cryptarchia`].
 /// A [`Block`] is only added if it's valid
 #[expect(clippy::allow_attributes_without_reason)]
-#[instrument(level = "debug", skip(cryptarchia, mempool_adapter))]
+#[instrument(
+    level = "debug",
+    skip(block, cryptarchia, mempool_adapter),
+    fields(block_id = %block.header().id(), tx_count = block.transactions().len())
+)]
 async fn apply_block_and_reconcile_mempool<Cryptarchia, Mempool, RuntimeServiceId>(
     block: Block<Cryptarchia::Tx>,
     cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
@@ -738,7 +755,7 @@ where
         RecoverableMempool<BlockId = HeaderId, Key = TxHash, Item = Cryptarchia::Tx> + Send + Sync,
     RuntimeServiceId: Send + Sync,
 {
-    debug!("Received proposal with ID: {:?}", block.header().id());
+    trace!("Received proposal with ID: {:?}", block.header().id());
 
     let (tip, reorged_txs) = cryptarchia.apply_block(block.clone()).await?;
     let reorged_tx_count = reorged_txs.len();

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -240,6 +240,43 @@ impl PrunedBlocksInfo {
     }
 }
 
+fn log_pruned_ledger_states(pruned_states_count: usize) {
+    if pruned_states_count <= 1 {
+        tracing::trace!(target: LOG_TARGET, "Pruned {pruned_states_count} old forks and their ledger states.");
+    } else {
+        tracing::debug!(target: LOG_TARGET, "Pruned {pruned_states_count} old forks and their ledger states.");
+    }
+}
+
+fn log_process_block_error(error: &Error) {
+    let error_msg = format!("Failed to process block: {error:?}");
+    if matches!(error, Error::FutureBlock { .. }) {
+        trace!(target: LOG_TARGET, "{}", error_msg);
+    } else {
+        error!(target: LOG_TARGET, "{}", error_msg);
+    }
+}
+
+fn log_lib_advanced(
+    prev_lib: &HeaderId,
+    new_lib: &HeaderId,
+    stale_blocks_count: usize,
+    immutable_blocks_count: usize,
+    reorged_blocks_count: usize,
+) {
+    if stale_blocks_count == 0 && immutable_blocks_count == 1 && reorged_blocks_count == 0 {
+        trace!(
+            target: LOG_TARGET,
+            "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={stale_blocks_count}, immutable_blocks={immutable_blocks_count}, reorged_blocks={reorged_blocks_count}",
+        );
+    } else {
+        debug!(
+            target: LOG_TARGET,
+            "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={stale_blocks_count}, immutable_blocks={immutable_blocks_count}, reorged_blocks={reorged_blocks_count}",
+        );
+    }
+}
+
 #[derive(Clone)]
 pub struct Cryptarchia {
     pub ledger: lb_ledger::Ledger<HeaderId>,
@@ -391,7 +428,7 @@ impl Cryptarchia {
                 );
             }
         }
-        tracing::debug!(target: LOG_TARGET, "Pruned {pruned_states_count} old forks and their ledger states.");
+        log_pruned_ledger_states(pruned_states_count);
     }
 
     /// Shrinks the memory held by the ledger states.
@@ -716,8 +753,7 @@ where
                                         });
                                     }
                                     Err(e) => {
-                                        let error_msg = format!("Failed to process block: {e:?}");
-                                        error!(target: LOG_TARGET, "{}", error_msg);
+                                        log_process_block_error(&e);
                                         reply_channel.send(Err(e)).unwrap_or_else(|_| {
                                             error!("Could not send process block error through channel");
                                         });
@@ -1018,7 +1054,7 @@ where
         new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
         lib_broadcaster: &broadcast::Sender<LibUpdate>,
     ) -> Result<(PrunedBlocks<HeaderId>, Vec<Tx>), Error> {
-        debug!("Received proposal with ID: {:?}", block.header().id());
+        trace!("Received proposal with ID: {:?}", block.header().id());
         let header = block.header();
         let prev_lib = cryptarchia.lib();
 
@@ -1067,13 +1103,14 @@ where
         }
 
         if prev_lib != new_lib {
-            debug!(
-                target: LOG_TARGET,
-                "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={}, immutable_blocks={}, reorged_blocks={}",
+            log_lib_advanced(
+                &prev_lib,
+                &new_lib,
                 pruned_blocks.stale_blocks().count(),
                 pruned_blocks.immutable_blocks().len(),
-                reorged_blocks.len()
+                reorged_blocks.len(),
             );
+
             let height = cryptarchia
                 .consensus
                 .branches()

--- a/services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -119,6 +119,9 @@ impl<R: Clone + Send + RngCore + 'static> SwarmHandler<R> {
                         .unwrap_or_else(|_| tracing::error!("could not schedule retry"));
                 });
             }
+            Err(gossipsub::PublishError::Duplicate) => {
+                tracing::trace!("not publishing duplicate message to topic: {topic}");
+            }
             Err(e) => {
                 tracing::error!("failed to broadcast message to topic: {topic} {e:?}");
             }

--- a/services/time/src/backends/ntp/mod.rs
+++ b/services/time/src/backends/ntp/mod.rs
@@ -173,7 +173,7 @@ impl NtpStream {
             );
             return;
         }
-        tracing::debug!(
+        tracing::trace!(
             "Applying NTP clock update for slot {current_slot:?} with roundtrip {}us",
             roundtrip.as_micros()
         );

--- a/services/tx-service/src/backend/pool.rs
+++ b/services/tx-service/src/backend/pool.rs
@@ -150,10 +150,7 @@ where
             self.pending_items.remove(key);
             self.removed_items.insert(key.clone(), removed_at);
         }
-        tracing::debug!(
-            "Removed {removed_count} items from mempool; pending_items={}",
-            self.pending_items.len()
-        );
+        log_removed_items(removed_count, self.pending_items.len());
 
         metrics::mempool_transactions_removed(removed_count);
         metrics::mempool_transactions_pending(self.pending_items.len());
@@ -259,4 +256,16 @@ fn current_timestamp_millis() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64
+}
+
+fn log_removed_items(removed_count: usize, pending_items: usize) {
+    if removed_count == 0 {
+        tracing::trace!(
+            "Removed {removed_count} items from mempool; pending_items={pending_items}"
+        );
+    } else {
+        tracing::debug!(
+            "Removed {removed_count} items from mempool; pending_items={pending_items}"
+        );
+    }
 }

--- a/services/tx-service/src/tx/service.rs
+++ b/services/tx-service/src/tx/service.rs
@@ -509,7 +509,14 @@ where
         NetworkAdapter::Settings: Send + Sync,
     {
         if let Err(e) = pool.add_item(key, item).await {
-            tracing::debug!("could not add item to the pool due to: {e}");
+            match e {
+                MempoolError::ExistingItem => {
+                    tracing::trace!("network item already exists in the mempool");
+                }
+                err => {
+                    tracing::debug!("could not add item to the pool due to: {err}");
+                }
+            }
             return;
         }
 

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -1124,12 +1124,7 @@ where
         storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
         state: &mut ServiceState<'_>,
     ) {
-        debug!(
-            new_lib = ?lib_update.new_lib,
-            stale_blocks_count = lib_update.pruned_blocks.stale_blocks.len(),
-            immutable_blocks_count = lib_update.pruned_blocks.immutable_blocks.len(),
-            "Received LIB update"
-        );
+        log_lib_update(lib_update);
 
         state.advance_lib(
             lib_update.new_lib,
@@ -1271,6 +1266,26 @@ where
         if let Err(e) = resp_tx.send(Ok(ledger_state.tx_context())) {
             error!(err = ?e, "Failed to send gas context response");
         }
+    }
+}
+
+fn log_lib_update(lib_update: &LibUpdate) {
+    let stale_blocks_count = lib_update.pruned_blocks.stale_blocks.len();
+    let immutable_blocks_count = lib_update.pruned_blocks.immutable_blocks.len();
+    if stale_blocks_count == 0 && immutable_blocks_count == 1 {
+        trace!(
+            new_lib = ?lib_update.new_lib,
+            stale_blocks_count,
+            immutable_blocks_count,
+            "Received LIB update"
+        );
+    } else {
+        debug!(
+            new_lib = ?lib_update.new_lib,
+            stale_blocks_count,
+            immutable_blocks_count,
+            "Received LIB update"
+        );
     }
 }
 

--- a/tracing/src/filter/envfilter.rs
+++ b/tracing/src/filter/envfilter.rs
@@ -13,6 +13,7 @@ const DEFAULT_DEBUG_TARGETS: &[&str] = &[
     "cryptarchia",
     "ledger",
 ];
+const DEFAULT_QUIET_TARGETS: &[(&str, Level)] = &[("libp2p_gossipsub", Level::ERROR)];
 const ENVFILTER_GLOBAL_TARGET: &str = "*";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -48,6 +49,11 @@ pub fn default_debug_log_filter(level: Level) -> HashMap<String, Level> {
         DEFAULT_DEBUG_TARGETS
             .iter()
             .map(|target| ((*target).to_owned(), level)),
+    );
+    filters.extend(
+        DEFAULT_QUIET_TARGETS
+            .iter()
+            .map(|(target, level)| ((*target).to_owned(), *level)),
     );
     filters
 }
@@ -183,8 +189,8 @@ mod tests {
     use tracing::Level;
 
     use super::{
-        ENVFILTER_GLOBAL_TARGET, EnvFilterConfig, create_envfilter_layer, parse_filter_directives,
-        validate_log_filter_target,
+        ENVFILTER_GLOBAL_TARGET, EnvFilterConfig, create_envfilter_layer, default_debug_log_filter,
+        parse_filter_directives, validate_log_filter_target,
     };
 
     #[test]
@@ -198,6 +204,13 @@ mod tests {
         };
 
         assert!(create_envfilter_layer(&config).is_ok());
+    }
+
+    #[test]
+    fn default_debug_log_filter_quiets_noisy_gossipsub_internals() {
+        let filters = default_debug_log_filter(Level::DEBUG);
+
+        assert_eq!(filters.get("libp2p_gossipsub"), Some(&Level::ERROR));
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adjusts several noisy logging paths to keep routine node activity out of higher log levels.

This mainly quiets repeated block-processing logs, routine LIB updates, NTP update ticks, no-op mempool removals, and duplicate gossipsub publish noise. 

The gossipsub part is specifically for the duplicate publish loop reported in #2662

Closes #2662


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
