### PR TITLE
fix(sdp): do not store Blend reward parameters in recovery state

### DIFF
--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -66,10 +66,8 @@ impl LedgerState {
     pub fn new(config: &Config, epoch_state: &EpochState) -> Self {
         Self {
             channels: channel::Channels::new(),
-            sdp: sdp::SdpLedger::new().with_blend_service(
-                config.sdp_config.service_rewards_params.blend.clone(),
-                epoch_state,
-            ),
+            sdp: sdp::SdpLedger::new()
+                .with_blend_service(&config.sdp_config.service_rewards_params.blend, epoch_state),
             leaders: leader::LeaderState::new(),
         }
     }

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -38,10 +38,16 @@ impl Service {
         block_number: BlockNumber,
         epoch_state: &EpochState,
         config: &ServiceParameters,
+        rewards_params: &ServiceRewardsParameters,
     ) -> (Self, Vec<Utxo>) {
         match self {
             Self::BlendNetwork(state) => {
-                let (new_state, utxos) = state.try_apply_header(block_number, epoch_state, config);
+                let (new_state, utxos) = state.try_apply_header(
+                    block_number,
+                    epoch_state,
+                    config,
+                    &rewards_params.blend,
+                );
                 (Self::BlendNetwork(new_state), utxos)
             }
         }
@@ -89,12 +95,16 @@ impl Service {
         provider_id: ProviderId,
         metadata: &ActivityMetadata,
         block_number: BlockNumber,
+        rewards_params: &ServiceRewardsParameters,
     ) -> Result<(), Error> {
         match self {
             Self::BlendNetwork(state) => {
-                state.rewards = state
-                    .rewards
-                    .update_active(provider_id, metadata, block_number)?;
+                state.rewards = state.rewards.update_active(
+                    provider_id,
+                    metadata,
+                    block_number,
+                    &rewards_params.blend,
+                )?;
                 Ok(())
             }
         }
@@ -216,9 +226,10 @@ impl<R: Rewards> ServiceState<R> {
         mut self,
         block_number: u64,
         epoch_state: &EpochState,
-        config: &ServiceParameters,
+        service_params: &ServiceParameters,
+        rewards_params: &R::Params,
     ) -> (Self, Vec<Utxo>) {
-        let current_session = config.session_for_block(block_number);
+        let current_session = service_params.session_for_block(block_number);
         let reward_utxos;
 
         // shift all session!
@@ -230,7 +241,7 @@ impl<R: Rewards> ServiceState<R> {
                 .declarations
                 .iter()
                 .filter(|(_id, declaration)| {
-                    let active = is_active(declaration, block_number, config);
+                    let active = is_active(declaration, block_number, service_params);
                     if !active {
                         warn!(
                             provider_id = ?declaration.provider_id,
@@ -245,9 +256,12 @@ impl<R: Rewards> ServiceState<R> {
                 .collect();
 
             // Update rewards with current session state and distribute rewards
-            (self.rewards, reward_utxos) =
-                self.rewards
-                    .update_session(&self.active, epoch_state, config);
+            (self.rewards, reward_utxos) = self.rewards.update_session(
+                &self.active,
+                epoch_state,
+                service_params,
+                rewards_params,
+            );
             self.active = self.forming.clone();
             self.forming = SessionState {
                 declarations: self.declarations.clone(),
@@ -258,8 +272,8 @@ impl<R: Rewards> ServiceState<R> {
                 current_session < self.active.session_n + 1,
                 "Logos blockchain isn't ready for time travel yet"
             );
-            self.rewards = self.rewards.update_epoch(epoch_state);
-            self.forming = self.forming.update(&self, block_number, config);
+            self.rewards = self.rewards.update_epoch(epoch_state, rewards_params);
+            self.forming = self.forming.update(&self, block_number, service_params);
             reward_utxos = Vec::new();
         }
 
@@ -303,8 +317,8 @@ impl SdpLedger {
         tx_hash: TxHash,
         ops: impl Iterator<Item = (&'a SDPDeclareOp, &'a OpProof)> + 'a,
     ) -> Result<Self, Error> {
-        let mut sdp = Self::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), epoch_state);
+        let mut sdp =
+            Self::new().with_blend_service(&config.service_rewards_params.blend, epoch_state);
 
         for (op, proof) in ops {
             let OpProof::ZkAndEd25519Sigs {
@@ -333,7 +347,7 @@ impl SdpLedger {
     #[must_use]
     pub fn with_blend_service(
         mut self,
-        rewards_settings: blend::RewardsParameters,
+        rewards_settings: &blend::RewardsParameters,
         epoch_state: &EpochState,
     ) -> Self {
         let service = Service::BlendNetwork(Self::new_service_state(blend::Rewards::new(
@@ -373,14 +387,16 @@ impl SdpLedger {
             .services
             .iter()
             .map(|(service, service_state)| {
-                let config = config
+                let service_params = config
                     .service_params
                     .get(service)
                     .ok_or(Error::SessionParamsNotFound(*service))?;
-                let (new_state, reward_utxos) =
-                    service_state
-                        .clone()
-                        .try_apply_header(block_number, epoch_state, config);
+                let (new_state, reward_utxos) = service_state.clone().try_apply_header(
+                    block_number,
+                    epoch_state,
+                    service_params,
+                    &config.service_rewards_params,
+                );
                 all_reward_utxos.extend(reward_utxos);
                 Ok::<_, Error>((*service, new_state))
             })
@@ -466,7 +482,12 @@ impl SdpLedger {
             .provider_id;
 
         service_state.update_declarations(result.declarations);
-        service_state.update_rewards(provider_id, &op.metadata, self.block_number)?;
+        service_state.update_rewards(
+            provider_id,
+            &op.metadata,
+            self.block_number,
+            &config.service_rewards_params,
+        )?;
 
         Ok(self)
     }
@@ -735,8 +756,8 @@ mod tests {
 
         // Initialize ledger with service config
         let epoch_state = dummy_epoch_state();
-        let sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Apply declare at block 0
         let utxo_tree = utxo_tree(vec![utxo]);
@@ -780,8 +801,8 @@ mod tests {
 
         // Initialize ledger with service config and declare
         let epoch_state = dummy_epoch_state();
-        let sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         let utxo_tree = utxo_tree(vec![utxo]);
         let sdp_ledger =
@@ -833,8 +854,8 @@ mod tests {
 
         // Initialize ledger with service config
         let epoch_state = dummy_epoch_state();
-        let sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Declare at block 0
         let utxo_tree = utxo_tree(vec![utxo]);
@@ -876,8 +897,8 @@ mod tests {
 
         // Initialize ledger with service config
         let epoch_state = dummy_epoch_state();
-        let mut sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let mut sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Apply headers to reach block 9 (still in session 0, promotion happens at
         // block 10)
@@ -902,8 +923,8 @@ mod tests {
 
         // Initialize ledger with Blend service
         let epoch_state = dummy_epoch_state();
-        let mut sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let mut sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Apply headers to reach block 10 (session boundary for BlendNetwork)
         for _ in 0..10 {
@@ -926,8 +947,8 @@ mod tests {
 
         // Initialize ledger
         let epoch_state = dummy_epoch_state();
-        let mut sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let mut sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // SESSION 0: Add a declaration at block 5
         for _ in 0..5 {
@@ -999,8 +1020,8 @@ mod tests {
         let zk_key_1 = create_zk_key(1);
 
         let epoch_state = dummy_epoch_state();
-        let mut sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let mut sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Add declaration at block 0
         let utxo_1 = utxo();
@@ -1091,8 +1112,8 @@ mod tests {
         let zk_key = create_zk_key(0);
 
         let epoch_state = dummy_epoch_state();
-        let mut sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let mut sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Add declaration at block 3
         for _ in 0..3 {
@@ -1145,8 +1166,8 @@ mod tests {
         let zk_key_1 = create_zk_key(1);
 
         let epoch_state = dummy_epoch_state();
-        let mut sdp_ledger = SdpLedger::new()
-            .with_blend_service(config.service_rewards_params.blend.clone(), &epoch_state);
+        let mut sdp_ledger =
+            SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Move to block 9 (last block of session 0)
         for _ in 0..9 {

--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -35,7 +35,7 @@ const LOG_TARGET: &str = "ledger::mantle::rewards::blend";
 
 /// Tracks Blend rewards based on activity proofs submitted by providers.
 /// Activity proofs for the session `s-1` must be submitted during session `s`.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Rewards<ProofsVerifier> {
     /// State before the first target session is finalized, or if the target
     /// session has less than the minimum required number of declarations.

--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -41,7 +41,6 @@ pub enum Rewards<ProofsVerifier> {
     /// session has less than the minimum required number of declarations.
     /// No activity messages are accepted in this state.
     WithoutTargetSession {
-        settings: RewardsParameters,
         current_session_tracker: CurrentSessionTracker,
     },
     /// State after a new target session `s-1` is finalized.
@@ -52,7 +51,6 @@ pub enum Rewards<ProofsVerifier> {
         target_session_tracker: Box<TargetSessionTracker>,
         current_session_state: CurrentSessionState,
         current_session_tracker: CurrentSessionTracker,
-        settings: RewardsParameters,
     },
 }
 
@@ -60,11 +58,14 @@ impl<ProofsVerifier> super::Rewards for Rewards<ProofsVerifier>
 where
     ProofsVerifier: ProofsVerifierTrait + Clone + Debug + PartialEq + Send + Sync,
 {
+    type Params = RewardsParameters;
+
     fn update_active(
         &self,
         provider_id: ProviderId,
         metadata: &ActivityMetadata,
         _block_number: BlockNumber,
+        params: &Self::Params,
     ) -> Result<Self, Error> {
         match self {
             Self::WithoutTargetSession { .. } => {
@@ -76,7 +77,6 @@ where
                 target_session_tracker,
                 current_session_state,
                 current_session_tracker,
-                settings,
             } => {
                 let ActivityMetadata::Blend(proof) = metadata;
 
@@ -84,7 +84,7 @@ where
                     &provider_id,
                     proof,
                     current_session_state,
-                    settings,
+                    params,
                 )?;
 
                 let target_session_tracker = target_session_tracker.insert(
@@ -99,7 +99,6 @@ where
                     target_session_tracker: Box::new(target_session_tracker),
                     current_session_state: current_session_state.clone(),
                     current_session_tracker: current_session_tracker.clone(),
-                    settings: settings.clone(),
                 })
             }
         }
@@ -110,20 +109,19 @@ where
         last_active: &SessionState,
         next_session_first_epoch_state: &EpochState,
         _config: &ServiceParameters,
+        params: &Self::Params,
     ) -> (Self, Vec<Utxo>) {
         match self {
             Self::WithoutTargetSession {
-                settings,
                 current_session_tracker,
             } => (
                 Self::from_current_session_tracker_output(
                     current_session_tracker.finalize(
                         last_active,
                         next_session_first_epoch_state,
-                        settings,
+                        params,
                     ),
                     TargetSessionTracker::new(),
-                    settings.clone(),
                 ),
                 Vec::new(),
             ),
@@ -131,7 +129,6 @@ where
                 target_session_state,
                 target_session_tracker,
                 current_session_tracker,
-                settings,
                 ..
             } => {
                 let (target_session_tracker, rewards) = target_session_tracker.finalize(
@@ -143,10 +140,9 @@ where
                     current_session_tracker.finalize(
                         last_active,
                         next_session_first_epoch_state,
-                        settings,
+                        params,
                     ),
                     target_session_tracker,
-                    settings.clone(),
                 );
 
                 (new_state, rewards)
@@ -154,29 +150,23 @@ where
         }
     }
 
-    fn update_epoch(&self, epoch_state: &EpochState) -> Self {
+    fn update_epoch(&self, epoch_state: &EpochState, params: &Self::Params) -> Self {
         match self {
             Self::WithoutTargetSession {
-                settings,
                 current_session_tracker,
             } => Self::WithoutTargetSession {
-                settings: settings.clone(),
-                current_session_tracker: current_session_tracker
-                    .collect_epoch(epoch_state, settings),
+                current_session_tracker: current_session_tracker.collect_epoch(epoch_state, params),
             },
             Self::WithTargetSession {
                 target_session_state,
                 target_session_tracker,
                 current_session_state,
                 current_session_tracker,
-                settings,
             } => Self::WithTargetSession {
                 target_session_state: target_session_state.clone(),
                 target_session_tracker: target_session_tracker.clone(),
                 current_session_state: current_session_state.clone(),
-                current_session_tracker: current_session_tracker
-                    .collect_epoch(epoch_state, settings),
-                settings: settings.clone(),
+                current_session_tracker: current_session_tracker.collect_epoch(epoch_state, params),
             },
         }
     }
@@ -184,10 +174,8 @@ where
     fn add_income(&self, income: Value) -> Self {
         match self {
             Self::WithoutTargetSession {
-                settings,
                 current_session_tracker,
             } => Self::WithoutTargetSession {
-                settings: settings.clone(),
                 current_session_tracker: current_session_tracker.add_block_rewards(income),
             },
             Self::WithTargetSession {
@@ -195,13 +183,11 @@ where
                 target_session_tracker,
                 current_session_state,
                 current_session_tracker,
-                settings,
             } => Self::WithTargetSession {
                 target_session_state: target_session_state.clone(),
                 target_session_tracker: target_session_tracker.clone(),
                 current_session_state: current_session_state.clone(),
                 current_session_tracker: current_session_tracker.add_block_rewards(income),
-                settings: settings.clone(),
             },
         }
     }
@@ -211,10 +197,9 @@ impl<ProofsVerifier> Rewards<ProofsVerifier> {
     /// Create a new uninitialized [`Rewards`] that doesn't accept activity
     /// messages until the first session update.
     #[must_use]
-    pub fn new(settings: RewardsParameters, epoch_state: &EpochState) -> Self {
-        let current_session_tracker = CurrentSessionTracker::new(epoch_state, &settings);
+    pub fn new(settings: &RewardsParameters, epoch_state: &EpochState) -> Self {
+        let current_session_tracker = CurrentSessionTracker::new(epoch_state, settings);
         Self::WithoutTargetSession {
-            settings,
             current_session_tracker,
         }
     }
@@ -227,7 +212,6 @@ where
     fn from_current_session_tracker_output(
         current_session_output: CurrentSessionTrackerOutput<ProofsVerifier>,
         target_session_tracker: TargetSessionTracker,
-        settings: RewardsParameters,
     ) -> Self {
         match current_session_output {
             CurrentSessionTrackerOutput::WithTargetSession {
@@ -239,11 +223,9 @@ where
                 target_session_tracker: Box::new(target_session_tracker),
                 current_session_state,
                 current_session_tracker,
-                settings,
             },
             CurrentSessionTrackerOutput::WithoutTargetSession(current_session_tracker) => {
                 Self::WithoutTargetSession {
-                    settings,
                     current_session_tracker,
                 }
             }
@@ -350,10 +332,8 @@ mod tests {
     fn test_blend_no_reward_calculated_after_session_0() {
         // Create a reward tracker
         let epoch_state = dummy_epoch_state();
-        let rewards_tracker = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            create_blend_rewards_params(864_000, 1),
-            &epoch_state,
-        );
+        let params = create_blend_rewards_params(864_000, 1);
+        let rewards_tracker = Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state);
 
         // Create session_0 with providers
         let session_0 = create_test_session_state(
@@ -367,6 +347,7 @@ mod tests {
             &session_0,
             &dummy_epoch_state(),
             &create_service_parameters(),
+            &params,
         );
 
         // No rewards should be returned yet because session0 just ended,
@@ -379,19 +360,18 @@ mod tests {
         // Create a reward tracker, and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            create_blend_rewards_params(864_000, 1),
-            &epoch_state,
-        )
-        .update_session(
-            &create_test_session_state(
-                &[create_provider_id(1), create_provider_id(2)],
-                ServiceType::BlendNetwork,
-                0,
-            ),
-            &epoch_state,
-            &config,
-        );
+        let params = create_blend_rewards_params(864_000, 1);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state).update_session(
+                &create_test_session_state(
+                    &[create_provider_id(1), create_provider_id(2)],
+                    ServiceType::BlendNetwork,
+                    0,
+                ),
+                &epoch_state,
+                &config,
+                &params,
+            );
 
         // Update session from 1 to 2 without any activity proofs submitted.
         let (_, rewards) = rewards_tracker.update_session(
@@ -402,6 +382,7 @@ mod tests {
             ),
             &epoch_state,
             &config,
+            &params,
         );
         assert_eq!(rewards.len(), 0);
     }
@@ -417,20 +398,20 @@ mod tests {
         // and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            create_blend_rewards_params(864_000, 1),
-            &epoch_state,
-        )
-        .add_income(1000)
-        .update_session(
-            &create_test_session_state(
-                &[provider1, provider2, provider3, provider4],
-                ServiceType::BlendNetwork,
-                0,
-            ),
-            &epoch_state,
-            &config,
-        );
+        let params = create_blend_rewards_params(864_000, 1);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state)
+                .add_income(1000)
+                .update_session(
+                    &create_test_session_state(
+                        &[provider1, provider2, provider3, provider4],
+                        ServiceType::BlendNetwork,
+                        0,
+                    ),
+                    &epoch_state,
+                    &config,
+                    &params,
+                );
 
         // provider1 submits an activity proof
         let rewards_tracker = rewards_tracker
@@ -443,6 +424,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap();
 
@@ -458,6 +440,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(2),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap();
 
@@ -473,6 +456,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap();
 
@@ -487,6 +471,7 @@ mod tests {
             ),
             &epoch_state,
             &config,
+            &params,
         );
 
         assert_eq!(reward_utxos.len(), 3); // except provider4
@@ -532,15 +517,14 @@ mod tests {
         // Create a reward tracker, and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            create_blend_rewards_params(864_000, 1),
-            &epoch_state,
-        )
-        .update_session(
-            &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
-            &epoch_state,
-            &config,
-        );
+        let params = create_blend_rewards_params(864_000, 1);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state).update_session(
+                &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
+                &epoch_state,
+                &config,
+                &params,
+            );
 
         // provider1 submits an activity proof.
         let rewards_tracker = rewards_tracker
@@ -553,6 +537,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap();
 
@@ -568,6 +553,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(2),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap_err();
         assert_eq!(
@@ -586,15 +572,14 @@ mod tests {
         // Create a reward tracker, and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            create_blend_rewards_params(864_000, 1),
-            &epoch_state,
-        )
-        .update_session(
-            &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
-            &epoch_state,
-            &config,
-        );
+        let params = create_blend_rewards_params(864_000, 1);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state).update_session(
+                &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
+                &epoch_state,
+                &config,
+                &params,
+            );
 
         // provider1 submits an activity proof with invalid session.
         let err = rewards_tracker
@@ -607,6 +592,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap_err();
         assert_eq!(
@@ -622,6 +608,7 @@ mod tests {
             &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 1),
             &epoch_state,
             &config,
+            &params,
         );
         assert_eq!(rewards.len(), 0);
     }
@@ -633,16 +620,15 @@ mod tests {
         // Create a reward tracker, and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            // Set minimum network size to 2
-            create_blend_rewards_params(864_000, 2),
-            &epoch_state,
-        )
-        .update_session(
-            &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
-            &epoch_state,
-            &config,
-        );
+        // Set minimum network size to 2
+        let params = create_blend_rewards_params(864_000, 2);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state).update_session(
+                &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
+                &epoch_state,
+                &config,
+                &params,
+            );
 
         // provider1 submits an activity proof, but it should be rejected
         // since the network is too small.
@@ -656,6 +642,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap_err();
         assert_eq!(err, Error::TargetSessionNotSet);
@@ -665,6 +652,7 @@ mod tests {
             &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 1),
             &epoch_state,
             &config,
+            &params,
         );
         assert_eq!(rewards.len(), 0);
     }
@@ -676,15 +664,14 @@ mod tests {
         // Create a reward tracker, and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state_with(0, 9999);
-        let (rewards_tracker, _) = Rewards::<AlwaysSuccessProofsVerifier>::new(
-            create_blend_rewards_params(10, 1),
-            &epoch_state,
-        )
-        .update_session(
-            &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
-            &epoch_state,
-            &config,
-        );
+        let params = create_blend_rewards_params(10, 1);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysSuccessProofsVerifier>::new(&params, &epoch_state).update_session(
+                &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
+                &epoch_state,
+                &config,
+                &params,
+            );
 
         // provider1 submits an activity proof that is larger than activity threshold.
         let err = rewards_tracker
@@ -697,6 +684,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(2),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap_err();
         assert_eq!(err, Error::InvalidProof);
@@ -706,6 +694,7 @@ mod tests {
             &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 1),
             &epoch_state,
             &config,
+            &params,
         );
         assert_eq!(rewards.len(), 0);
     }
@@ -717,15 +706,14 @@ mod tests {
         // Create a reward tracker, and update session from 0 to 1.
         let config = create_service_parameters();
         let epoch_state = dummy_epoch_state();
-        let (rewards_tracker, _) = Rewards::<AlwaysFailureProofsVerifier>::new(
-            create_blend_rewards_params(1000, 1),
-            &epoch_state,
-        )
-        .update_session(
-            &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 1),
-            &epoch_state,
-            &config,
-        );
+        let params = create_blend_rewards_params(1000, 1);
+        let (rewards_tracker, _) =
+            Rewards::<AlwaysFailureProofsVerifier>::new(&params, &epoch_state).update_session(
+                &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 1),
+                &epoch_state,
+                &config,
+                &params,
+            );
 
         // provider1 submits an activity proof, but PoQ/PoSel verification fails.
         let err = rewards_tracker
@@ -738,6 +726,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .unwrap_err();
         assert_eq!(err, Error::InvalidProof);
@@ -747,6 +736,7 @@ mod tests {
             &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 2),
             &dummy_epoch_state(),
             &config,
+            &params,
         );
         assert_eq!(rewards.len(), 0);
     }
@@ -754,8 +744,9 @@ mod tests {
     #[test]
     fn test_blend_epoch_updates() {
         // Create a reward tracker, and update session from 0 to 1.
+        let params = create_blend_rewards_params(1000, 1);
         let rewards_tracker = Rewards::<ZeroNonceFailureProofsVerifier>::new(
-            create_blend_rewards_params(1000, 1),
+            &params,
             // Set 0 to epoch nonce, to make a proof verifier that always fails.
             &dummy_epoch_state_with(0, 0),
         );
@@ -772,7 +763,7 @@ mod tests {
         // A new epoch received before a new session starts.
         // Set non-zero to epoch nonce, to make a proof verifier that always succeed.
         let new_epoch = dummy_epoch_state_with(1, 1);
-        let rewards_tracker = rewards_tracker.update_epoch(&new_epoch);
+        let rewards_tracker = rewards_tracker.update_epoch(&new_epoch, &params);
         if let Rewards::WithoutTargetSession {
             current_session_tracker,
             ..
@@ -790,6 +781,7 @@ mod tests {
             &create_test_session_state(&[provider1], ServiceType::BlendNetwork, 0),
             &new_epoch,
             &config,
+            &params,
         );
         if let Rewards::WithTargetSession {
             current_session_tracker,
@@ -811,6 +803,7 @@ mod tests {
                     proof_of_selection: new_proof_of_selection_unchecked(1),
                 })),
                 config.session_duration,
+                &params,
             )
             .expect("Proofs must be successfully verified");
     }

--- a/ledger/src/mantle/sdp/rewards/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/mod.rs
@@ -26,6 +26,9 @@ pub type RewardAmount = u64;
 /// and can calculate expected rewards for each provider based on the service's
 /// internal logic.
 pub trait Rewards: Clone + PartialEq + Send + Sync + std::fmt::Debug {
+    /// Service-specific reward parameters.
+    type Params;
+
     /// Update rewards state when an active message is received.
     ///
     /// Called when a provider submits an active message with metadata
@@ -35,6 +38,7 @@ pub trait Rewards: Clone + PartialEq + Send + Sync + std::fmt::Debug {
         declaration_id: ProviderId,
         metadata: &ActivityMetadata,
         block_number: BlockNumber,
+        params: &Self::Params,
     ) -> Result<Self, Error>;
 
     /// Update rewards state when sessions transition and calculate rewards to
@@ -57,6 +61,7 @@ pub trait Rewards: Clone + PartialEq + Send + Sync + std::fmt::Debug {
         last_active: &SessionState,
         next_session_first_epoch_state: &EpochState,
         config: &ServiceParameters,
+        params: &Self::Params,
     ) -> (Self, Vec<Utxo>);
 
     /// Update rewards state when a new epoch begins while the session remains
@@ -65,7 +70,7 @@ pub trait Rewards: Clone + PartialEq + Send + Sync + std::fmt::Debug {
     /// If the epoch has already been processed previously, this method performs
     /// no update and returns the current state unchanged.
     #[must_use]
-    fn update_epoch(&self, epoch_state: &EpochState) -> Self;
+    fn update_epoch(&self, epoch_state: &EpochState, params: &Self::Params) -> Self;
     #[must_use]
     fn add_income(&self, income: Value) -> Self;
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #2673 

I removed `RewardsParameters` from the SDP ledger state, so that it is not stored in the recovery state.
It is part of the deployment config. It should be loaded from the deployment config whenever the node is (re-)started. It shouldn't be loaded from the recovery state.
For example, if users agreed to change some values in the deployment config, rebuild the binary, and restart the node, the reward module should run with the new deployment config, not with something recovered from the state. 

One important thing is that, the SDP Ledger has 2 modes for blend rewards.
- `WithoutTargetSession`: Reject all activity proofs because network is small or because we're still in session 0 or 1.
- `WithTargetSession`: Accept activity proofs because network is large enough.

SDP Ledger stores this mode and related data into the recovery state. When the node is restarted, it loads the previous mode from the state, regardless of the new deployment config. 
Therefore, the new deployment config becomes effective from the next session, when it comes to Blend rewards.
Also, 
- If activity proofs are generated/received due to the decreased minimum network size in the new deployment config, and if the loaded mode is `WithoutTargetSession`, the SDP ledger will return `Error::TargetSessionNotSet` to reject activity proofs, resulting that the block that contains the activity message is rejected. 
- If activity proofs are no longer generated due to the increased minimum network size in the new deployment config, and if the loaded mode is `WithTargetSession`, the SDP ledger won't see any new activity proofs until the next session transition.
These behaviors are correct, and have no issue in terms of consensus.

This PR doesn't have any new tests because the existing tests cover all cases.


## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
