### PR TITLE
fix(cryptarchia): add panics to `Branches::walk_back_*` to avoid infinite loop

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -268,6 +268,10 @@ where
     fn walk_back_before(&self, branch: &Branch<Id>, slot: Slot) -> Branch<Id> {
         let mut current = branch;
         while current.slot > slot {
+            assert!(
+                current.id != current.parent,
+                "shouldn't meet genesis block before reaching target slot: {slot:?}"
+            );
             current = &self.branches[&current.parent];
         }
         *current
@@ -286,6 +290,10 @@ where
                 None
             } else {
                 let branch = &self.branches[&current];
+                assert!(
+                    current != branch.parent,
+                    "shouldn't meet genesis block before reaching target"
+                );
                 current = branch.parent;
                 Some(branch.id)
             }


### PR DESCRIPTION
## 1. What does this PR implement?

`Branches::walk_back_before` and `Branches::walk_back_to_block` never end if they meet the genesis block before reaching the target. It's better to panic in that case.

I chose to panic instead of returning an error because all functions of `Branches` are already panicking if they cannot finish their job with the provided arguments. I think it's reasonable because `Branches` is a sub-component of `Cryptarchia` and is not used anywhere else. 

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @davidrusu 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
