### PR TITLE
test: fix large transaction input handling in cucumber

### DIFF
--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -41,7 +41,7 @@ Feature: Transactions
     And I send 2 transactions of 250 LGO each from wallet "WALLET_2A" to wallet "WALLET_1A"
     When wallet "WALLET_2A" has all submitted transactions settled in 120 seconds
     And tracked wallet fees equal sponsored fee account spent fees
-    And wallet "WALLET_1A" has exact settled balance of 1500 LGO in 120 seconds
+    And wallet "WALLET_1A" has exactly 1500 LGO in 120 seconds
     Then I stop all nodes
 
   @transactions_ci
@@ -63,7 +63,7 @@ Feature: Transactions
     When wallet "WALLET_2A" has 2 or more outputs in 120 seconds
     And I send 2 transactions of 250 LGO each from wallet "WALLET_2A" to wallet "WALLET_1A"
     When wallet "WALLET_2A" has all submitted transactions settled in 120 seconds
-    And wallet "WALLET_1A" has exact settled balance of 1500 LGO in 120 seconds
+    And wallet "WALLET_1A" has exactly 1500 LGO in 120 seconds
     Then I stop all nodes
 
   @transactions_ci
@@ -81,8 +81,6 @@ Feature: Transactions
       | 9             | 0           | 0            |
       | 10            | 0           | 0            |
     And I have a cluster with capacity of 10 nodes
-#    And we use IBD peers
-#    And all peers must be mode online after startup in 30 seconds
     And I start nodes with wallet resources:
       | node_name | account_index | wallet_name | connected_to |
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
@@ -129,8 +127,6 @@ Feature: Transactions
       | 1             | 4           | 26000        |
       | 2             | 0           | 0            |
     And I have a cluster with capacity of 2 nodes
-#    And we use IBD peers
-#    And all peers must be mode online after startup in 30 seconds
     And I start nodes with wallet resources:
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
@@ -216,80 +212,56 @@ Feature: Transactions
     And wallet "WALLET_5A" has 2100 or less LGO in 10 seconds
     Then I stop all nodes
 
-  @transactions_ci @undefined_behaviour
-  Scenario: Coin join transaction never mined
+  @transactions_ci
+  Scenario: Large coin split followed by large coin join transaction succeed
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |
-      | 1             | 4           | 26000        |
+      | 1             | 10          | 25000        |
       | 2             | 0           | 0            |
-    And we have a sponsored genesis fee account with 20 tokens of 997 value each
+    And we have a sponsored genesis fee account with 200 tokens of 100 value each
     And I have a cluster with capacity of 2 nodes
-#    And we use IBD peers
-#    And all peers must be mode online after startup in 30 seconds
     And I start nodes with wallet resources:
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
     When node "NODE_1" is at height 2 in 240 seconds
-    # Coin split
-    And I do a coin split for "WALLET_1A" of 25 UTXOs valued at 1000 LGO tokens each
-    And I do a coin split for "WALLET_1A" of 25 UTXOs valued at 1000 LGO tokens each
-    And I do a coin split for "WALLET_1A" of 25 UTXOs valued at 1000 LGO tokens each
-    And I do a coin split for "WALLET_1A" of 25 UTXOs valued at 1000 LGO tokens each
-    # Do a transfers to other wallet
-    When wallet "WALLET_1A" has 100 or more outputs in 180 seconds
+    # Coin split (This will use multiple inputs to create many outputs)
+    # Maximum number of outputs per transaction is 255 (as per encoding limits)
+    And I do a coin split for "WALLET_1A" of 250 UTXOs valued at 1000 LGO tokens each
+    # Do a transfer to the other wallet
+    When wallet "WALLET_1A" has 250 or more outputs in 180 seconds
     And I send 1 transactions of 1000 LGO each from wallet "WALLET_1A" to wallet "WALLET_2A"
     When wallet "WALLET_2A" has 1 or more outputs in 180 seconds
-    # Coin join
-    # Breaks here - the transaction that includes more than one outputs is never mined
-    And I send 1 transactions of 2000 LGO each from wallet "WALLET_1A" to wallet "WALLET_1A"
+    # Coin join all outputs back to one output
+    # Maximum number of inputs per transaction is 255 (as per encoding limits)
+    And I send 1 transactions of 249000 LGO each from wallet "WALLET_1A" to wallet "WALLET_1A"
     When wallet "WALLET_1A" has 0 or less encumbered outputs in 60 seconds
-    And I send 1 transactions of 47000 LGO each from wallet "WALLET_1A" to wallet "WALLET_1A"
-    When wallet "WALLET_1A" has 0 or less encumbered outputs in 60 seconds
+    And I update all user wallets balances
+    When wallet "WALLET_1A" has exactly 1 outputs and 249000 LGO in 20 seconds
+    And tracked wallet fees equal sponsored fee account spent fees
     Then I stop all nodes
 
   @transactions_ci
-  Scenario: Large coin split transactions are mined
+  Scenario: Transaction with multiple inputs and multiple outputs
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |
       | 1             | 3           | 100000       |
       | 2             | 0           | 0            |
+    And we have a sponsored genesis fee account with 5 tokens of 100 value each
     And I have a cluster with capacity of 2 nodes
-#    And we use IBD peers
-#    And all peers must be mode online after startup in 30 seconds
     And I start nodes with wallet resources:
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
     When node "NODE_1" is at height 2 in 240 seconds
-    And I do a coin split for "WALLET_1A" of 100 UTXOs valued at 100 LGO tokens each
-    When wallet "WALLET_1A" has 100 or more outputs in 180 seconds
-    And I do a coin split for "WALLET_1A" of 200 UTXOs valued at 100 LGO tokens each
-    When wallet "WALLET_1A" has 300 or more outputs in 180 seconds
     # Maximum number of outputs per transaction is 255 (as per encoding limits)
-    And I do a coin split for "WALLET_1A" of 250 UTXOs valued at 100 LGO tokens each
-    When wallet "WALLET_1A" has 550 or more outputs in 180 seconds
-
-    Then I stop all nodes
-
-  @transactions_ci @undefined_behaviour
-  Scenario: Multi output transaction not mined
-    Given the genesis block has the following wallet resources:
-      | account_index | token_count | token_amount |
-      | 1             | 2           | 100000       |
-      | 2             | 0           | 0            |
-    And I have a cluster with capacity of 2 nodes
-#    And we use IBD peers
-#    And all peers must be mode online after startup in 30 seconds
-    And I start nodes with wallet resources:
-      | node_name | account_index | wallet_name | connected_to |
-      | NODE_1    | 1             | WALLET_1A   |              |
-      | NODE_2    | 2             | WALLET_2A   | NODE_1       |
-    When node "NODE_1" is at height 2 in 240 seconds
-    # Breaks here - 300 seems to be too many outputs (259 are still fine) for the node to handle in a single
-    # transaction, causing the transaction to not be mined and the test to fail
-    And I send one transaction with 300 outputs of 100 LGO each from wallet "WALLET_1A" to wallet "WALLET_2A"
-    When wallet "WALLET_2A" has 100 or more outputs in 60 seconds
+    # The wallet has 3 x 100000 = 300000 LGO outputs, so this transaction is valid and should be mined; it
+    # should use all 3x its outputs and create 250 new outputs of 1000 LGO each.
+    And I send one transaction with 250 outputs of 1000 LGO each from wallet "WALLET_1A" to wallet "WALLET_2A"
+    When wallet "WALLET_2A" has 250 or more outputs in 60 seconds
+    And I update all user wallets balances
+    And wallet "WALLET_1A" has exactly 50000 LGO in 20 seconds
+    And tracked wallet fees equal sponsored fee account spent fees
     Then I stop all nodes
 
   @transactions_ci

--- a/tests/src/cucumber/steps/manual_transactions/chunked_transfers.rs
+++ b/tests/src/cucumber/steps/manual_transactions/chunked_transfers.rs
@@ -1,0 +1,174 @@
+use std::cmp::{Ordering, Reverse};
+
+use lb_core::mantle::{
+    Note, Utxo,
+    gas::MainnetGasConstants,
+    ledger::{Inputs, Outputs},
+    ops::{Op, transfer::TransferOp},
+    tx_builder::MantleTxBuilder,
+};
+use lb_key_management_system_service::keys::ZkPublicKey;
+use lb_wallet::WalletError;
+
+const ZKSIGN_MAX_INPUTS: usize = 32;
+
+/// Selects the sender-funded portion of a sponsored transaction without yet
+/// populating the builder's pending transfer.
+///
+/// The sponsored path may need to combine sender inputs with fee inputs into
+/// multiple transfer chunks, so it cannot eagerly push sender inputs into the
+/// builder the way the legacy single-transfer path did.
+pub(super) fn select_sender_inputs_and_change(
+    tx_builder: MantleTxBuilder,
+    output_total: u64,
+    mut sender_utxos: Vec<Utxo>,
+    sender_change_pk: ZkPublicKey,
+) -> Result<(MantleTxBuilder, Vec<Utxo>), WalletError> {
+    sender_utxos.sort_by_key(|utxo| Reverse(utxo.note.value));
+
+    let mut sender_input_sum = 0u64;
+    let mut sender_inputs = Vec::new();
+
+    for utxo in sender_utxos.iter().copied() {
+        sender_input_sum = sender_input_sum.saturating_add(utxo.note.value);
+        sender_inputs.push(utxo);
+        if sender_input_sum >= output_total {
+            break;
+        }
+    }
+
+    if sender_input_sum < output_total {
+        return Err(WalletError::InsufficientFunds {
+            available: sender_utxos.iter().map(|utxo| utxo.note.value).sum(),
+        });
+    }
+
+    let sender_change = sender_input_sum - output_total;
+    let builder = if sender_change > 0 {
+        tx_builder.add_ledger_output(Note::new(sender_change, sender_change_pk))
+    } else {
+        tx_builder
+    };
+
+    Ok((builder, sender_inputs))
+}
+
+/// Builds caller-side transfer chunks for manual wallet-built cucumber
+/// transactions.
+///
+/// This helper exists because `MantleTxBuilder` still exposes only one pending
+/// funding transfer, while this scenario needs to build multiple transfer ops
+/// once the input count exceeds the `ZkSign` limit.
+pub(super) fn build_chunked_funded_tx(
+    tx_builder: &MantleTxBuilder,
+    funding_utxos: &[Utxo],
+    change_pk: ZkPublicKey,
+) -> Result<Option<MantleTxBuilder>, WalletError> {
+    if funding_utxos.len() <= ZKSIGN_MAX_INPUTS || !tx_builder.ledger_inputs().is_empty() {
+        return Ok(None);
+    }
+
+    let input_sum = funding_utxos
+        .iter()
+        .map(|utxo| u128::from(utxo.note.value))
+        .sum::<u128>();
+    let output_sum = pending_transfer_output_sum(tx_builder);
+
+    let chunked_builder = with_transfer_input_chunks(tx_builder, funding_utxos);
+    let funding_delta = funding_delta_for_chunked_builder(&chunked_builder, input_sum, output_sum)?;
+
+    match funding_delta.cmp(&0) {
+        Ordering::Less => Ok(None),
+        Ordering::Equal => Ok(Some(chunked_builder)),
+        Ordering::Greater => {
+            let builder_with_dummy_change = chunked_builder
+                .clone()
+                .add_ledger_output(Note::new(0, change_pk));
+            let delta_with_change = funding_delta_for_chunked_builder(
+                &builder_with_dummy_change,
+                input_sum,
+                output_sum,
+            )?;
+
+            if delta_with_change <= 0 {
+                return Ok(None);
+            }
+
+            let change = u64::try_from(delta_with_change).expect("Positive delta must fit in u64");
+            let tx_with_change = chunked_builder.add_ledger_output(Note::new(change, change_pk));
+
+            assert_eq!(
+                funding_delta_for_chunked_builder(
+                    &tx_with_change,
+                    input_sum,
+                    output_sum + u128::from(change),
+                )?,
+                0
+            );
+
+            Ok(Some(tx_with_change))
+        }
+    }
+}
+
+/// Appends transfer chunks with at most 32 inputs, leaving the final chunk in
+/// the builder's pending transfer so user outputs and change remain on the last
+/// transfer.
+///
+/// Intermediate chunks intentionally emit no outputs; they only split the
+/// funding inputs into proof-sized pieces while preserving deterministic op
+/// order.
+fn with_transfer_input_chunks(
+    tx_builder: &MantleTxBuilder,
+    funding_utxos: &[Utxo],
+) -> MantleTxBuilder {
+    let final_chunk_len = match funding_utxos.len() % ZKSIGN_MAX_INPUTS {
+        0 => ZKSIGN_MAX_INPUTS,
+        remainder => remainder,
+    };
+    let split_index = funding_utxos.len() - final_chunk_len;
+
+    let mut builder = tx_builder.clone();
+    for chunk in funding_utxos[..split_index].chunks(ZKSIGN_MAX_INPUTS) {
+        builder = builder.push_op(Op::Transfer(TransferOp::new(
+            Inputs::new(chunk.iter().map(Utxo::id).collect()),
+            // Intermediate chunks intentionally emit no outputs so the final
+            // transfer can carry the user-visible outputs and any change.
+            Outputs::new(vec![]),
+        )));
+    }
+
+    builder.extend_ledger_inputs(funding_utxos[split_index..].iter().copied())
+}
+
+/// Reads the builder-authored pending transfer outputs so caller-side chunking
+/// can preserve them on the final transfer chunk.
+fn pending_transfer_output_sum(tx_builder: &MantleTxBuilder) -> u128 {
+    match tx_builder.clone().build().ops.pop() {
+        Some(Op::Transfer(transfer)) => transfer
+            .outputs
+            .iter()
+            .map(|note| u128::from(note.value))
+            .sum(),
+        _ => 0,
+    }
+}
+
+/// Recomputes the funding delta for the manual chunked path.
+///
+/// This intentionally duplicates the builder's balance math because the
+/// builder cannot currently express multiple funding transfers. Keep this logic
+/// aligned with the wallet crate until the builder has first-class
+/// multi-transfer funding support.
+fn funding_delta_for_chunked_builder(
+    tx_builder: &MantleTxBuilder,
+    input_sum: u128,
+    output_sum: u128,
+) -> Result<i128, WalletError> {
+    let gas_cost = u128::from(tx_builder.gas_cost::<MainnetGasConstants>()?.into_inner());
+    Ok(i128::try_from(input_sum)
+        .expect("Input sum must fit in i128")
+        .checked_sub(i128::try_from(output_sum).expect("Output sum must fit in i128"))
+        .and_then(|delta| delta.checked_sub(i128::try_from(gas_cost).expect("Gas fits in i128")))
+        .expect("Chunked funding delta must fit in i128"))
+}

--- a/tests/src/cucumber/steps/manual_transactions/chunked_transfers.rs
+++ b/tests/src/cucumber/steps/manual_transactions/chunked_transfers.rs
@@ -64,6 +64,9 @@ pub(super) fn build_chunked_funded_tx(
     funding_utxos: &[Utxo],
     change_pk: ZkPublicKey,
 ) -> Result<Option<MantleTxBuilder>, WalletError> {
+    // This helper expects all funding inputs to arrive through `funding_utxos`.
+    // Preloaded builder inputs would be folded into the final pending transfer
+    // and break the deterministic <=32-input chunking contract.
     if funding_utxos.len() <= ZKSIGN_MAX_INPUTS || !tx_builder.ledger_inputs().is_empty() {
         return Ok(None);
     }

--- a/tests/src/cucumber/steps/manual_transactions/mod.rs
+++ b/tests/src/cucumber/steps/manual_transactions/mod.rs
@@ -1,4 +1,5 @@
 mod best_node;
+mod chunked_transfers;
 pub mod command_file_parsing;
 pub mod command_file_utils;
 mod faucet;

--- a/tests/src/cucumber/steps/manual_transactions/steps.rs
+++ b/tests/src/cucumber/steps/manual_transactions/steps.rs
@@ -18,8 +18,8 @@ use crate::{
                 utils,
                 utils::{
                     WalletStateType, assert_tracked_wallet_fees_equal_sponsored_fee_account_spend,
-                    create_and_submit_transaction, wait_for_exact_settled_wallet_balance,
-                    wait_for_transactions_inclusion, wait_for_wallet_or_encumbered_state,
+                    create_and_submit_transaction, wait_for_transactions_inclusion,
+                    wait_for_wallet_or_encumbered_state,
                 },
             },
         },
@@ -108,6 +108,29 @@ async fn step_wallet_has_at_most_coins(
     .await
 }
 
+#[when(expr = "wallet {string} has exactly {int} outputs in {int} seconds")]
+#[then(expr = "wallet {string} has exactly {int} outputs in {int} seconds")]
+async fn step_wallet_has_exact_coins(
+    world: &mut CucumberWorld,
+    step: &Step,
+    wallet_name: String,
+    coin_count: usize,
+    time_out_seconds: u64,
+) -> StepResult {
+    wait_for_wallet_or_encumbered_state(
+        world,
+        &step.value,
+        wallet_name,
+        Some(&coin_count),
+        Some(&coin_count),
+        None,
+        None,
+        time_out_seconds,
+        WalletStateType::OnChain,
+    )
+    .await
+}
+
 #[when(expr = "wallet {string} has {int} or less encumbered outputs in {int} seconds")]
 #[then(expr = "wallet {string} has {int} or less encumbered outputs in {int} seconds")]
 async fn step_wallet_has_at_most_encumbered_coins(
@@ -148,6 +171,29 @@ async fn step_wallet_has_at_least_value(
         None,
         Some(&min_token_value),
         None,
+        time_out_seconds,
+        WalletStateType::OnChain,
+    )
+    .await
+}
+
+#[when(expr = "wallet {string} has exactly {int} LGO in {int} seconds")]
+#[then(expr = "wallet {string} has exactly {int} LGO in {int} seconds")]
+async fn step_wallet_has_exact_value(
+    world: &mut CucumberWorld,
+    step: &Step,
+    wallet_name: String,
+    token_value: u64,
+    time_out_seconds: u64,
+) -> StepResult {
+    wait_for_wallet_or_encumbered_state(
+        world,
+        &step.value,
+        wallet_name,
+        None,
+        None,
+        Some(&token_value),
+        Some(&token_value),
         time_out_seconds,
         WalletStateType::OnChain,
     )
@@ -225,21 +271,26 @@ async fn step_wallet_has_at_most_coins_and_value(
     .await
 }
 
-#[when(expr = "wallet {string} has exact settled balance of {int} LGO in {int} seconds")]
-#[then(expr = "wallet {string} has exact settled balance of {int} LGO in {int} seconds")]
-async fn step_wallet_has_exact_settled_balance(
+#[when(expr = "wallet {string} has exactly {int} outputs and {int} LGO in {int} seconds")]
+#[then(expr = "wallet {string} has exactly {int} outputs and {int} LGO in {int} seconds")]
+async fn step_wallet_has_exact_coins_and_value(
     world: &mut CucumberWorld,
     step: &Step,
     wallet_name: String,
-    nominal_token_value: u64,
+    coin_count: usize,
+    token_value: u64,
     time_out_seconds: u64,
 ) -> StepResult {
-    wait_for_exact_settled_wallet_balance(
+    wait_for_wallet_or_encumbered_state(
         world,
         &step.value,
-        &wallet_name,
-        nominal_token_value,
+        wallet_name,
+        Some(&coin_count),
+        Some(&coin_count),
+        Some(&token_value),
+        Some(&token_value),
         time_out_seconds,
+        WalletStateType::OnChain,
     )
     .await
 }

--- a/tests/src/cucumber/steps/manual_transactions/utils.rs
+++ b/tests/src/cucumber/steps/manual_transactions/utils.rs
@@ -14,6 +14,7 @@ use lb_core::{
         AuthenticatedMantleTx as _, Note, NoteId, OpProof, SignedMantleTx, Transaction as _,
         TxHash, Utxo,
         gas::MainnetGasConstants,
+        ops::Op,
         tx::{MantleTxContext, MantleTxGasContext},
         tx_builder::MantleTxBuilder,
     },
@@ -32,7 +33,11 @@ use crate::cucumber::{
     fee_reserve::{DEFAULT_STORAGE_GAS_PRICE, SCENARIO_FEE_ACCOUNT_NAME},
     steps::{
         TARGET,
-        manual_transactions::{best_node::sanitize_best_node_info, faucet::FaucetTask},
+        manual_transactions::{
+            best_node::sanitize_best_node_info,
+            chunked_transfers::{build_chunked_funded_tx, select_sender_inputs_and_change},
+            faucet::FaucetTask,
+        },
     },
     world::{CucumberWorld, WalletInfo, WalletTokenMap, WalletType},
 };
@@ -79,37 +84,16 @@ struct PreparedUserWalletTransaction {
     funded_builder: MantleTxBuilder,
     newly_encumbered: Vec<Utxo>,
     newly_encumbered_fee: Vec<Utxo>,
-    signing_keys: Vec<ZkKey>,
+    transfer_signers: HashMap<NoteId, ZkKey>,
 }
 
 pub(crate) struct PreparedUserWalletSubmission {
     wallet: WalletInfo,
     funded_builder: MantleTxBuilder,
     pub(crate) tx_hash: TxHash,
-    transfer_proof: OpProof,
+    transfer_proofs: Vec<OpProof>,
     newly_encumbered: Vec<Utxo>,
     newly_encumbered_fee: Vec<Utxo>,
-}
-
-pub async fn submit_user_wallet_built_transaction(
-    world: &mut CucumberWorld,
-    step: &str,
-    sender_wallet_name: &str,
-    tx_builder: MantleTxBuilder,
-    sender_output_total: u64,
-    best_node_info: Option<&BestNodeInfo>,
-) -> Result<TxHash, StepError> {
-    let prepared = prepare_user_wallet_built_transaction_submission(
-        world,
-        step,
-        sender_wallet_name,
-        tx_builder,
-        sender_output_total,
-        best_node_info,
-    )
-    .await?;
-
-    submit_prepared_user_wallet_transaction(world, step, prepared, Vec::new(), best_node_info).await
 }
 
 pub async fn create_and_submit_transaction(
@@ -241,7 +225,7 @@ pub(crate) async fn prepare_user_wallet_built_transaction_submission(
         funded_builder,
         newly_encumbered,
         newly_encumbered_fee,
-        signing_keys,
+        transfer_signers,
     } = prepare_built_user_wallet_transaction(
         step,
         tx_builder,
@@ -253,15 +237,43 @@ pub(crate) async fn prepare_user_wallet_built_transaction_submission(
 
     let mantle_tx = funded_builder.clone().build();
     let tx_hash = mantle_tx.hash();
-    let transfer_proof = ZkKey::multi_sign(&signing_keys, tx_hash.as_ref()).inspect_err(|e| {
-        warn!(target: TARGET, "Step `{}` error: {e}", step);
-    })?;
+    let transfer_proofs = mantle_tx
+        .ops
+        .iter()
+        .filter_map(|op| match op {
+            Op::Transfer(transfer_op) => Some(transfer_op),
+            _ => None,
+        })
+        .map(|transfer_op| {
+            let signing_keys = transfer_op
+                .inputs
+                .iter()
+                .map(|note_id| {
+                    transfer_signers
+                        .get(note_id)
+                        .cloned()
+                        .ok_or_else(|| StepError::LogicalError {
+                            message: format!(
+                                "Step `{step}` error: missing signing key for transfer input {note_id:?}"
+                            ),
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let transfer_proof =
+                ZkKey::multi_sign(&signing_keys, tx_hash.as_ref()).inspect_err(|e| {
+                    warn!(target: TARGET, "Step `{}` error: {e}", step);
+                })?;
+
+            Ok(OpProof::ZkSig(transfer_proof))
+        })
+        .collect::<Result<Vec<_>, StepError>>()?;
 
     Ok(PreparedUserWalletSubmission {
         wallet,
         funded_builder,
         tx_hash,
-        transfer_proof: OpProof::ZkSig(transfer_proof),
+        transfer_proofs,
         newly_encumbered,
         newly_encumbered_fee,
     })
@@ -278,14 +290,14 @@ pub(crate) async fn submit_prepared_user_wallet_transaction(
         wallet,
         funded_builder,
         tx_hash,
-        transfer_proof,
+        transfer_proofs,
         newly_encumbered,
         newly_encumbered_fee,
     } = prepared;
     let sender_wallet_name = wallet.wallet_name.as_str();
 
     let mantle_tx = funded_builder.build();
-    extra_op_proofs.push(transfer_proof);
+    extra_op_proofs.extend(transfer_proofs);
 
     let signed_tx = SignedMantleTx::new(mantle_tx, extra_op_proofs).inspect_err(|e| {
         warn!(target: TARGET, "Step `{}` error: {e}", step);
@@ -339,49 +351,88 @@ fn prepare_built_user_wallet_transaction(
     wallet_account: &WalletAccount,
 ) -> Result<PreparedUserWalletTransaction, StepError> {
     let sender_pk = wallet_account.public_key();
-    let (funded_builder_result, fee_pk, fee_signing_key) = match scenario_fee_state {
-        Some((fee_wallet_account, fee_utxos)) => (
-            fund_sponsored_user_wallet_transaction(
-                tx_builder,
-                sender_output_total,
-                fee_utxos,
-                sender_utxos,
-                wallet_account,
-                &fee_wallet_account,
-            ),
-            Some(fee_wallet_account.public_key()),
-            Some(fee_wallet_account.secret_key.clone()),
+    let mut transfer_signers = HashMap::new();
+    for utxo in &sender_utxos {
+        transfer_signers.insert(utxo.id(), wallet_account.secret_key.clone());
+    }
+
+    let fee_pk = scenario_fee_state
+        .as_ref()
+        .map(|(fee_wallet_account, _)| fee_wallet_account.public_key());
+    if let Some((fee_wallet_account, fee_utxos)) = scenario_fee_state.as_ref() {
+        for utxo in fee_utxos {
+            transfer_signers.insert(utxo.id(), fee_wallet_account.secret_key.clone());
+        }
+    }
+
+    let input_utxos_by_note_id: HashMap<_, _> = sender_utxos
+        .iter()
+        .copied()
+        .chain(
+            scenario_fee_state
+                .as_ref()
+                .into_iter()
+                .flat_map(|(_, fee_utxos)| fee_utxos.iter().copied()),
+        )
+        .map(|utxo| (utxo.id(), utxo))
+        .collect();
+
+    let funded_builder_result = match scenario_fee_state {
+        Some((fee_wallet_account, fee_utxos)) => fund_sponsored_user_wallet_transaction(
+            tx_builder,
+            sender_output_total,
+            fee_utxos,
+            sender_utxos,
+            wallet_account,
+            &fee_wallet_account,
         ),
-        None => (
-            fund_unsponsored_user_wallet_transaction(&tx_builder, sender_utxos, wallet_account),
-            None,
-            None,
-        ),
+        None => fund_unsponsored_user_wallet_transaction(&tx_builder, sender_utxos, wallet_account),
     };
 
     let funded_builder = funded_builder_result.inspect_err(|e| {
         warn!(target: TARGET, "Step `{}` error: {e}", step);
     })?;
 
-    let (newly_encumbered, newly_encumbered_fee) = partition_transaction_inputs(
-        funded_builder.ledger_inputs(),
-        sender_pk,
-        fee_pk.unwrap_or(sender_pk),
-    );
-
-    let mut signing_keys = vec![wallet_account.secret_key.clone()];
-    if !newly_encumbered_fee.is_empty()
-        && let Some(fee_signing_key) = fee_signing_key
-    {
-        signing_keys.push(fee_signing_key);
-    }
+    let funding_inputs = funding_inputs_from_transfers(
+        &funded_builder.clone().build(),
+        &input_utxos_by_note_id,
+        step,
+    )?;
+    let (newly_encumbered, newly_encumbered_fee) =
+        partition_transaction_inputs(&funding_inputs, sender_pk, fee_pk.unwrap_or(sender_pk));
 
     Ok(PreparedUserWalletTransaction {
         funded_builder,
         newly_encumbered,
         newly_encumbered_fee,
-        signing_keys,
+        transfer_signers,
     })
+}
+
+fn funding_inputs_from_transfers(
+    mantle_tx: &lb_core::mantle::MantleTx,
+    input_utxos_by_note_id: &HashMap<NoteId, Utxo>,
+    step: &str,
+) -> Result<Vec<Utxo>, StepError> {
+    mantle_tx
+        .ops
+        .iter()
+        .filter_map(|op| match op {
+            Op::Transfer(transfer_op) => Some(transfer_op),
+            _ => None,
+        })
+        .flat_map(|transfer_op| transfer_op.inputs.iter())
+        .map(|note_id| {
+            input_utxos_by_note_id
+                .get(note_id)
+                .copied()
+                .ok_or_else(|| StepError::LogicalError {
+                    message: format!(
+                        "Step `{step}` error: missing funding UTXO for transfer input {note_id:?}"
+                    ),
+                })
+        })
+        .collect()
 }
 
 fn partition_transaction_inputs(
@@ -543,36 +594,6 @@ pub async fn wait_for_transactions_inclusion(
         }
 
         sleep(Duration::from_millis(500)).await;
-    }
-}
-
-pub async fn wait_for_exact_settled_wallet_balance(
-    world: &mut CucumberWorld,
-    step_value: &str,
-    wallet_name: &str,
-    nominal_token_value: u64,
-    time_out_seconds: u64,
-) -> StepResult {
-    let start = Instant::now();
-    let timeout = Duration::from_secs(time_out_seconds);
-
-    loop {
-        let (_, value) =
-            get_wallet_balances(world, step_value, wallet_name, WalletStateType::OnChain).await?;
-
-        if value == nominal_token_value {
-            return Ok(());
-        }
-
-        if start.elapsed() >= timeout {
-            return Err(StepError::StepFail {
-                message: format!(
-                    "Step `{step_value}` error: wallet '{wallet_name}' has settled LGO = {value}, expected exactly {nominal_token_value}"
-                ),
-            });
-        }
-
-        sleep(Duration::from_millis(100)).await;
     }
 }
 
@@ -787,109 +808,77 @@ fn fund_unsponsored_user_wallet_transaction(
     wallet_account: &WalletAccount,
 ) -> Result<MantleTxBuilder, WalletError> {
     sender_utxos.sort_by_key(|utxo| Reverse(utxo.note.value));
-    fund_builder_from_ordered_utxos(tx_builder, &sender_utxos, wallet_account.public_key())
+    fund_builder_from_ordered_utxos(tx_builder, &sender_utxos, &[], wallet_account.public_key())
 }
 
 fn fund_sponsored_user_wallet_transaction(
     tx_builder: MantleTxBuilder,
     output_total: u64,
-    fee_utxos: Vec<Utxo>,
+    mut fee_utxos: Vec<Utxo>,
     sender_utxos: Vec<Utxo>,
     wallet_account: &WalletAccount,
     fee_wallet_account: &WalletAccount,
 ) -> Result<MantleTxBuilder, WalletError> {
-    let builder_with_sender = add_sender_inputs_and_change(
+    let (builder_with_sender_outputs, sender_inputs) = select_sender_inputs_and_change(
         tx_builder,
         output_total,
         sender_utxos,
         wallet_account.public_key(),
     )?;
-
-    fund_with_fee_inputs(
-        builder_with_sender,
-        fee_utxos,
+    fee_utxos.sort_by_key(|utxo| utxo.note.value);
+    fund_builder_from_ordered_utxos(
+        &builder_with_sender_outputs,
+        &fee_utxos,
+        &sender_inputs,
         fee_wallet_account.public_key(),
     )
-}
-
-fn add_sender_inputs_and_change(
-    tx_builder: MantleTxBuilder,
-    output_total: u64,
-    mut sender_utxos: Vec<Utxo>,
-    sender_change_pk: ZkPublicKey,
-) -> Result<MantleTxBuilder, WalletError> {
-    sender_utxos.sort_by_key(|utxo| Reverse(utxo.note.value));
-
-    let mut sender_input_sum = 0u64;
-    let mut builder = tx_builder;
-
-    for utxo in sender_utxos.iter().copied() {
-        builder = builder.add_ledger_input(utxo);
-        sender_input_sum = sender_input_sum.saturating_add(utxo.note.value);
-        if sender_input_sum >= output_total {
-            break;
-        }
-    }
-
-    if sender_input_sum < output_total {
-        return Err(WalletError::InsufficientFunds {
-            available: sender_utxos.iter().map(|utxo| utxo.note.value).sum(),
-        });
-    }
-
-    let sender_change = sender_input_sum - output_total;
-    if sender_change > 0 {
-        builder = builder.add_ledger_output(Note::new(sender_change, sender_change_pk));
-    }
-
-    Ok(builder)
-}
-
-fn fund_with_fee_inputs(
-    builder: MantleTxBuilder,
-    mut fee_utxos: Vec<Utxo>,
-    fee_change_pk: ZkPublicKey,
-) -> Result<MantleTxBuilder, WalletError> {
-    if fee_utxos.is_empty() {
-        return if builder.funding_delta::<MainnetGasConstants>()? == 0 {
-            Ok(builder)
-        } else {
-            Err(WalletError::InsufficientFunds { available: 0 })
-        };
-    }
-
-    fee_utxos.sort_by_key(|utxo| utxo.note.value);
-    fund_builder_from_ordered_utxos(&builder, &fee_utxos, fee_change_pk)
 }
 
 fn fund_builder_from_ordered_utxos(
     builder: &MantleTxBuilder,
     ordered_utxos: &[Utxo],
+    base_inputs: &[Utxo],
     change_pk: ZkPublicKey,
 ) -> Result<MantleTxBuilder, WalletError> {
     for i in 0..ordered_utxos.len() {
-        let funded_builder = builder
-            .clone()
-            .extend_ledger_inputs(ordered_utxos[..=i].iter().copied());
+        let mut selected_inputs = base_inputs.to_vec();
+        selected_inputs.extend_from_slice(&ordered_utxos[..=i]);
 
-        match funded_builder
-            .funding_delta::<MainnetGasConstants>()?
-            .cmp(&0)
-        {
-            Ordering::Less => {}
-            Ordering::Equal => return Ok(funded_builder),
-            Ordering::Greater => {
-                if let Some(tx_with_change) =
-                    funded_builder.return_change::<MainnetGasConstants>(change_pk)?
-                {
-                    return Ok(tx_with_change);
+        if selected_inputs.len() <= 32 {
+            let funded_builder = builder
+                .clone()
+                .extend_ledger_inputs(selected_inputs.iter().copied());
+
+            match funded_builder
+                .funding_delta::<MainnetGasConstants>()?
+                .cmp(&0)
+            {
+                Ordering::Less => {}
+                Ordering::Equal => return Ok(funded_builder),
+                Ordering::Greater => {
+                    if let Some(tx_with_change) =
+                        funded_builder.return_change::<MainnetGasConstants>(change_pk)?
+                    {
+                        return Ok(tx_with_change);
+                    }
                 }
             }
+            continue;
+        }
+
+        if let Some(chunked_builder) =
+            build_chunked_funded_tx(builder, &selected_inputs, change_pk)?
+        {
+            return Ok(chunked_builder);
         }
     }
 
     Err(WalletError::InsufficientFunds {
-        available: ordered_utxos.iter().map(|utxo| utxo.note.value).sum(),
+        available: base_inputs
+            .iter()
+            .chain(ordered_utxos.iter())
+            .map(|utxo| utxo.note.value)
+            .sum(),
     })
 }
 
@@ -1072,19 +1061,16 @@ fn validate_wait_conditions(
             ),
         });
     }
-    if min_coin_count.is_some() && max_coin_count.is_some() {
+    if u8::from(min_coin_count.is_some())
+        + u8::from(max_coin_count.is_some())
+        + u8::from(min_token_value.is_some())
+        + u8::from(max_token_value.is_some())
+        == 3
+    {
         return Err(StepError::LogicalError {
             message: format!(
-                "Step `{step}` error: 'min_coin_count' and 'max_coin_count' cannot be used \
-                together"
-            ),
-        });
-    }
-    if min_token_value.is_some() && max_token_value.is_some() {
-        return Err(StepError::LogicalError {
-            message: format!(
-                "Step `{step}` error: 'min_token_value' and 'max_token_value' cannot be used \
-                together"
+                "Step `{step}` error: missing one of 'min_coin_count', 'max_coin_count', \
+                'min_token_value' or 'max_token_value'"
             ),
         });
     }
@@ -1176,6 +1162,7 @@ pub async fn wait_for_wallet_or_encumbered_state(
     clippy::cognitive_complexity,
     reason = "Singular fn with multiple branches to handle different events and futures."
 )]
+#[expect(clippy::too_many_lines, reason = "Test function")]
 fn conditions_met(
     wallet_name: &str,
     wallet_node_name: &str,
@@ -1193,73 +1180,101 @@ fn conditions_met(
         max_coin_count,
         max_token_value,
     ) {
-        (Some(min_count), Some(min_value), _, _) => {
+        (Some(min_count), None, Some(max_count), None) => {
+            if coin_count == *min_count && coin_count == *max_count {
+                info!(
+                    target: TARGET,
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+                    {coin_count}",
+                );
+                return true;
+            }
+        }
+        (None, Some(min_value), None, Some(max_value)) => {
+            if value == *min_value && value == *max_value {
+                info!(
+                    target: TARGET,
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
+                    {value}",
+                );
+                return true;
+            }
+        }
+        (Some(min_count), Some(min_value), Some(max_count), Some(max_value)) => {
+            if coin_count == *min_count
+                && coin_count == *max_count
+                && value == *min_value
+                && value == *max_value
+            {
+                info!(
+                    target: TARGET,
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+                    {coin_count} and token value: {value}",
+                );
+                return true;
+            }
+        }
+        (Some(min_count), Some(min_value), None, None) => {
             if coin_count >= *min_count && value >= *min_value {
                 info!(
                     target: TARGET,
-                    "Wallet '{wallet_name}/{}' has required '{wallet_state_type}' coin count: {coin_count} >= \
-                    {min_count}, token value: {value} >= {min_value}",
-                    wallet_node_name
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+                    {coin_count} >= {min_count}, token value: {value} >= {min_value}",
                 );
                 return true;
             }
         }
-        (Some(min_count), None, _, _) => {
+        (Some(min_count), None, None, None) => {
             if coin_count >= *min_count {
                 info!(
                     target: TARGET,
-                    "Wallet '{wallet_name}/{}' has required '{wallet_state_type}' coin count: {coin_count} >= \
-                    {min_count}",
-                    wallet_node_name
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+                    {coin_count} >= {min_count}",
                 );
                 return true;
             }
         }
-        (None, Some(min_value), _, _) => {
+        (None, Some(min_value), None, None) => {
             if value >= *min_value {
                 info!(
                     target: TARGET,
-                    "Wallet '{wallet_name}/{}' has required '{wallet_state_type}' token value: {value} >= \
-                    {min_value}",
-                    wallet_node_name
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
+                    {value} >= {min_value}",
                 );
                 return true;
             }
         }
-        (_, _, Some(max_count), Some(max_value)) => {
+        (None, None, Some(max_count), Some(max_value)) => {
             if coin_count <= *max_count && value <= *max_value {
                 info!(
                     target: TARGET,
-                    "Wallet '{wallet_name}/{}' has required '{wallet_state_type}' coin count: {coin_count} <= \
-                    {max_count}, token value: {value} <= {max_value}",
-                    wallet_node_name
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+                    {coin_count} <= {max_count}, token value: {value} <= {max_value}",
                 );
                 return true;
             }
         }
-        (_, _, Some(max_count), None) => {
+        (None, None, Some(max_count), None) => {
             if coin_count <= *max_count {
                 info!(
                     target: TARGET,
-                    "Wallet '{wallet_name}/{}' has required '{wallet_state_type}' coin count: {coin_count} <= \
-                    {max_count}",
-                    wallet_node_name
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+                    {coin_count} <= {max_count}",
                 );
                 return true;
             }
         }
-        (_, _, None, Some(max_value)) => {
+        (None, None, None, Some(max_value)) => {
             if value <= *max_value {
                 info!(
                     target: TARGET,
-                    "Wallet '{wallet_name}/{}' has required '{wallet_state_type}' token value: {value} <= \
-                    {max_value}",
-                    wallet_node_name
+                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
+                    {value} <= {max_value}",
                 );
                 return true;
             }
         }
-        (None, None, None, None) => unreachable!(),
+        (_, _, _, _) => unreachable!(),
     }
 
     false

--- a/tests/src/cucumber/steps/manual_transactions/utils.rs
+++ b/tests/src/cucumber/steps/manual_transactions/utils.rs
@@ -237,9 +237,25 @@ pub(crate) async fn prepare_user_wallet_built_transaction_submission(
 
     let mantle_tx = funded_builder.clone().build();
     let tx_hash = mantle_tx.hash();
-    let transfer_proofs = mantle_tx
-        .ops
-        .iter()
+    let transfer_proofs = build_transfer_proofs(step, &mantle_tx.ops, &tx_hash, &transfer_signers)?;
+
+    Ok(PreparedUserWalletSubmission {
+        wallet,
+        funded_builder,
+        tx_hash,
+        transfer_proofs,
+        newly_encumbered,
+        newly_encumbered_fee,
+    })
+}
+
+fn build_transfer_proofs(
+    step: &str,
+    ops: &[Op],
+    tx_hash: &TxHash,
+    transfer_signers: &HashMap<NoteId, ZkKey>,
+) -> Result<Vec<OpProof>, StepError> {
+    ops.iter()
         .filter_map(|op| match op {
             Op::Transfer(transfer_op) => Some(transfer_op),
             _ => None,
@@ -260,23 +276,14 @@ pub(crate) async fn prepare_user_wallet_built_transaction_submission(
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            let transfer_proof =
-                ZkKey::multi_sign(&signing_keys, tx_hash.as_ref()).inspect_err(|e| {
+            let transfer_proof = ZkKey::multi_sign(&signing_keys, tx_hash.as_ref())
+                .inspect_err(|e| {
                     warn!(target: TARGET, "Step `{}` error: {e}", step);
                 })?;
 
             Ok(OpProof::ZkSig(transfer_proof))
         })
-        .collect::<Result<Vec<_>, StepError>>()?;
-
-    Ok(PreparedUserWalletSubmission {
-        wallet,
-        funded_builder,
-        tx_hash,
-        transfer_proofs,
-        newly_encumbered,
-        newly_encumbered_fee,
-    })
+        .collect()
 }
 
 pub(crate) async fn submit_prepared_user_wallet_transaction(
@@ -1049,6 +1056,9 @@ fn validate_wait_conditions(
     min_token_value: Option<&u64>,
     max_token_value: Option<&u64>,
 ) -> StepResult {
+    // Supported shapes are: one bound, matching min/max pairs for exact checks,
+    // or all four bounds for exact count plus exact value. Exactly three bounds
+    // leaves one dimension half-specified and is ambiguous.
     if min_coin_count.is_none()
         && min_token_value.is_none()
         && max_coin_count.is_none()
@@ -1116,15 +1126,19 @@ pub async fn wait_for_wallet_or_encumbered_state(
         let (coin_count, value) =
             get_output_balances(world, step, &wallet, &wallet_name, wallet_state_type).await?;
 
-        if conditions_met(
-            &wallet_name,
-            &wallet.node_name,
-            coin_count,
-            value,
+        let observed_state = ObservedWalletState { coin_count, value };
+        let expected_bounds = WalletStateBounds {
             min_coin_count,
             max_coin_count,
             min_token_value,
             max_token_value,
+        };
+
+        if conditions_met(
+            &wallet_name,
+            &wallet.node_name,
+            observed_state,
+            expected_bounds,
             wallet_state_type,
         ) {
             return Ok(());
@@ -1154,130 +1168,167 @@ pub async fn wait_for_wallet_or_encumbered_state(
     }
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "This function is more readable with explicit arguments rather than packing them into structs or tuples."
-)]
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "Singular fn with multiple branches to handle different events and futures."
-)]
-#[expect(clippy::too_many_lines, reason = "Test function")]
+#[derive(Copy, Clone)]
+struct ObservedWalletState {
+    coin_count: usize,
+    value: u64,
+}
+
+#[derive(Copy, Clone)]
+struct WalletStateBounds<'a> {
+    min_coin_count: Option<&'a usize>,
+    max_coin_count: Option<&'a usize>,
+    min_token_value: Option<&'a u64>,
+    max_token_value: Option<&'a u64>,
+}
+
 fn conditions_met(
     wallet_name: &str,
     wallet_node_name: &str,
-    coin_count: usize,
-    value: u64,
-    min_coin_count: Option<&usize>,
-    max_coin_count: Option<&usize>,
-    min_token_value: Option<&u64>,
-    max_token_value: Option<&u64>,
+    observed_state: ObservedWalletState,
+    expected_bounds: WalletStateBounds<'_>,
     wallet_state_type: WalletStateType,
 ) -> bool {
-    match (
-        min_coin_count,
-        min_token_value,
-        max_coin_count,
-        max_token_value,
+    if !bounds_match(
+        &observed_state.coin_count,
+        expected_bounds.min_coin_count,
+        expected_bounds.max_coin_count,
+    ) || !bounds_match(
+        &observed_state.value,
+        expected_bounds.min_token_value,
+        expected_bounds.max_token_value,
     ) {
-        (Some(min_count), None, Some(max_count), None) => {
-            if coin_count == *min_count && coin_count == *max_count {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
-                    {coin_count}",
-                );
-                return true;
-            }
-        }
-        (None, Some(min_value), None, Some(max_value)) => {
-            if value == *min_value && value == *max_value {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
-                    {value}",
-                );
-                return true;
-            }
-        }
-        (Some(min_count), Some(min_value), Some(max_count), Some(max_value)) => {
-            if coin_count == *min_count
-                && coin_count == *max_count
-                && value == *min_value
-                && value == *max_value
-            {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
-                    {coin_count} and token value: {value}",
-                );
-                return true;
-            }
-        }
-        (Some(min_count), Some(min_value), None, None) => {
-            if coin_count >= *min_count && value >= *min_value {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
-                    {coin_count} >= {min_count}, token value: {value} >= {min_value}",
-                );
-                return true;
-            }
-        }
-        (Some(min_count), None, None, None) => {
-            if coin_count >= *min_count {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
-                    {coin_count} >= {min_count}",
-                );
-                return true;
-            }
-        }
-        (None, Some(min_value), None, None) => {
-            if value >= *min_value {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
-                    {value} >= {min_value}",
-                );
-                return true;
-            }
-        }
-        (None, None, Some(max_count), Some(max_value)) => {
-            if coin_count <= *max_count && value <= *max_value {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
-                    {coin_count} <= {max_count}, token value: {value} <= {max_value}",
-                );
-                return true;
-            }
-        }
-        (None, None, Some(max_count), None) => {
-            if coin_count <= *max_count {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
-                    {coin_count} <= {max_count}",
-                );
-                return true;
-            }
-        }
-        (None, None, None, Some(max_value)) => {
-            if value <= *max_value {
-                info!(
-                    target: TARGET,
-                    "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
-                    {value} <= {max_value}",
-                );
-                return true;
-            }
-        }
-        (_, _, _, _) => unreachable!(),
+        return false;
     }
 
-    false
+    log_condition_match(
+        wallet_name,
+        wallet_node_name,
+        observed_state,
+        expected_bounds,
+        wallet_state_type,
+    );
+
+    true
+}
+
+fn log_condition_match(
+    wallet_name: &str,
+    wallet_node_name: &str,
+    observed_state: ObservedWalletState,
+    expected_bounds: WalletStateBounds<'_>,
+    wallet_state_type: WalletStateType,
+) {
+    let exact_coin_count = expected_bounds
+        .min_coin_count
+        .zip(expected_bounds.max_coin_count)
+        .is_some_and(|(min, max)| min == max);
+    let exact_value = expected_bounds
+        .min_token_value
+        .zip(expected_bounds.max_token_value)
+        .is_some_and(|(min, max)| min == max);
+
+    if exact_coin_count || exact_value {
+        log_exact_condition_match(
+            wallet_name,
+            wallet_node_name,
+            observed_state,
+            wallet_state_type,
+            exact_coin_count,
+            exact_value,
+        );
+    } else {
+        log_ranged_condition_match(
+            wallet_name,
+            wallet_node_name,
+            observed_state,
+            expected_bounds,
+            wallet_state_type,
+        );
+    }
+}
+
+fn log_exact_condition_match(
+    wallet_name: &str,
+    wallet_node_name: &str,
+    observed_state: ObservedWalletState,
+    wallet_state_type: WalletStateType,
+    exact_coin_count: bool,
+    exact_value: bool,
+) {
+    match (exact_coin_count, exact_value) {
+        (true, true) => info!(
+            target: TARGET,
+            "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+            {} and token value: {}",
+            observed_state.coin_count,
+            observed_state.value,
+        ),
+        (true, false) => info!(
+            target: TARGET,
+            "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+            {}",
+            observed_state.coin_count,
+        ),
+        (false, true) => info!(
+            target: TARGET,
+            "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
+            {}",
+            observed_state.value,
+        ),
+        (false, false) => unreachable!(),
+    }
+}
+
+fn log_ranged_condition_match(
+    wallet_name: &str,
+    wallet_node_name: &str,
+    observed_state: ObservedWalletState,
+    expected_bounds: WalletStateBounds<'_>,
+    wallet_state_type: WalletStateType,
+) {
+    let coin_count_message = bound_message(
+        &observed_state.coin_count,
+        expected_bounds.min_coin_count,
+        expected_bounds.max_coin_count,
+    );
+    let value_message = bound_message(
+        &observed_state.value,
+        expected_bounds.min_token_value,
+        expected_bounds.max_token_value,
+    );
+
+    match (coin_count_message, value_message) {
+        (Some(coin_count_message), Some(value_message)) => info!(
+            target: TARGET,
+            "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+            {coin_count_message}, token value: {value_message}",
+        ),
+        (Some(coin_count_message), None) => info!(
+            target: TARGET,
+            "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' coin count: \
+            {coin_count_message}",
+        ),
+        (None, Some(value_message)) => info!(
+            target: TARGET,
+            "Wallet '{wallet_name}/{wallet_node_name}' has required '{wallet_state_type}' token value: \
+            {value_message}",
+        ),
+        (None, None) => unreachable!(),
+    }
+}
+
+fn bounds_match<T: Ord>(actual: &T, min: Option<&T>, max: Option<&T>) -> bool {
+    min.is_none_or(|min| actual >= min) && max.is_none_or(|max| actual <= max)
+}
+
+fn bound_message<T: Display>(actual: &T, min: Option<&T>, max: Option<&T>) -> Option<String> {
+    match (min, max) {
+        (Some(min), Some(max)) => Some(format!("{actual} >= {min} and <= {max}")),
+        (Some(min), None) => Some(format!("{actual} >= {min}")),
+        (None, Some(max)) => Some(format!("{actual} <= {max}")),
+        (None, None) => None,
+    }
 }
 
 fn record_header_height(


### PR DESCRIPTION
## 1. What does this PR implement?

Previously the test code prepared a single `transfer_proof`. This PR changes that to collect one proof per `Op::Transfer`, using the exact signing keys for that transfer’s inputs.

Summary of changes:
- Fixed cucumber/manual transaction handling for:
  - transactions with multiple funding inputs;
  - transactions that need to be split into multiple transfer ops when signer/input limits (`32`) are exceeded.
- Reworked proof generation so proofs are created per transfer op instead of once for the whole transaction.
- Updated cucumber step definitions to support exact wallet/output assertions.
- Refreshed transaction scenarios to validate the previously broken cases.

The following scenarios that were previously tagged with `@undefined_behaviour` now succeed:
- `Scenario: Coin join transaction never mined` 
   (new name `Scenario: Large coin split followed by large coin join transaction succeed`)
- `Scenario: Multi output transaction not mined` 
   (new name `Scenario: Transaction with multiple inputs and multiple outputs`)
   
This scenario has been dropped as it is covered by the above:
- `Scenario: Large coin split transactions are mined`

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
