### PR TITLE
fix(chain): verify immutable block id

### DIFF
--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -491,8 +491,8 @@ where
             .map_err(|(e, _)| GetBlocksError::SendError(e.to_string()))?;
 
         match rx.await.map_err(|_| GetBlocksError::ChannelDropped)? {
-            Some(_) => Ok(Some(block)),
-            None => Ok(None),
+            Some(immutable_id) if immutable_id == id => Ok(Some(block)),
+            Some(_) | None => Ok(None),
         }
     }
 
@@ -630,6 +630,29 @@ mod tests {
 
         env.retrieve_and_validate_blocks(target_block, &known_blocks, &expected)
             .await;
+    }
+
+    #[tokio::test]
+    async fn test_storage_block_at_immutable_slot_must_match_immutable_id() {
+        let env = TestEnv::new().await;
+
+        let ids = env.create_storage_only_blocks(3).await;
+        let stale_block = env
+            .build_block_with_parent(ids[0], Slot::from(2))
+            .expect("stale block should be valid");
+
+        let stale_block_id = stale_block.header().id();
+        assert_ne!(stale_block_id, ids[2]);
+
+        env.store_block_only(&stale_block, stale_block_id).await;
+
+        let known_blocks = HashSet::from([ids[0]]);
+        env.test_error_scenario(
+            stale_block_id,
+            &known_blocks,
+            BlocksUnavailableReason::BlockNotFound(stale_block_id),
+        )
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes `load_immutable_block` so a block is only treated as immutable when the immutable index for that slot points to the same block ID.

Before this, any block present in storage could be misclassified as immutable if the immutable index had some block for the same slot. That later made path computation fail with `Couldn't reach start_block`.

Added a regression test for that case.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
