### PR TITLE
fix(chain): ignore blocks before lib

### DIFF
--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -327,7 +327,13 @@ where
                         let header_id = block.header().id();
                         info!("Processing block from orphan downloader: {header_id:?}");
 
-                        if !should_process_block(relays.cryptarchia(), block.header().id()).await {
+                        if !should_process_block(
+                            relays.cryptarchia(),
+                            block.header().id(),
+                            block.header().slot(),
+                        )
+                        .await
+                        {
                             continue;
                         }
 
@@ -423,8 +429,9 @@ where
         RuntimeServiceId: Send + Sync + 'static,
     {
         let block_id = proposal.header().id();
+        let block_slot = proposal.header().slot();
 
-        if !should_process_block(relays.cryptarchia(), block_id).await {
+        if !should_process_block(relays.cryptarchia(), block_id, block_slot).await {
             return;
         }
 
@@ -581,12 +588,17 @@ where
 async fn should_process_block<Cryptarchia, RuntimeServiceId>(
     cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
     block_id: HeaderId,
+    block_slot: Slot,
 ) -> bool
 where
     Cryptarchia: CryptarchiaServiceData,
     Cryptarchia::Tx: AuthenticatedMantleTx + Debug + Clone + Send + Sync,
     RuntimeServiceId: Send + Sync,
 {
+    if !is_after_lib(cryptarchia, block_id, block_slot).await {
+        return false;
+    }
+
     match cryptarchia.get_ledger_state(block_id).await {
         Ok(Some(_)) => false,
         Ok(None) => {
@@ -599,6 +611,43 @@ where
             true
         }
     }
+}
+
+async fn is_after_lib<Cryptarchia, RuntimeServiceId>(
+    cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+    block_id: HeaderId,
+    block_slot: Slot,
+) -> bool
+where
+    Cryptarchia: CryptarchiaServiceData,
+    Cryptarchia::Tx: AuthenticatedMantleTx + Debug + Clone + Send + Sync,
+    RuntimeServiceId: Send + Sync,
+{
+    match cryptarchia.info().await {
+        Ok(info) => {
+            if !is_at_or_before_lib(block_slot, info.lib_slot) {
+                return true;
+            }
+
+            trace!(
+                target: LOG_TARGET,
+                ?block_id,
+                ?block_slot,
+                lib = ?info.lib,
+                lib_slot = ?info.lib_slot,
+                "Ignoring block at or before local LIB"
+            );
+            false
+        }
+        Err(err) => {
+            error!(target: LOG_TARGET, err = ?err, "Failure when checking local LIB");
+            true
+        }
+    }
+}
+
+fn is_at_or_before_lib(block_slot: Slot, lib_slot: Slot) -> bool {
+    block_slot <= lib_slot
 }
 
 /// Retry applying a block when `Cryptarchia` reports it as a `FutureBlock`.


### PR DESCRIPTION
## 1. What does this PR implement?

Drops incoming blocks whose slot is already at or before the local LIB slot before they can enter orphan recovery.

The logs showed many orphan enqueue attempts for proposals that were already older than the node’s LIB. Those blocks cannot become part of the local chain, so treating them as recoverable orphans only adds queue pressure and noise.


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
