### PR TITLE
fix(metrics): restore unwired metrics

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -3,6 +3,7 @@ mod blend;
 mod kms;
 mod leadership;
 mod mempool;
+mod metrics;
 mod relays;
 mod wallet;
 
@@ -461,6 +462,7 @@ where
                                     Self::publish_block_proposal(block, &blend_adapter).await;
                                 }
                                 Err(e) => {
+                                    metrics::consensus_proposals_create_failed();
                                     error!(target: LOG_TARGET, "{e}");
                                 }
                             }
@@ -657,6 +659,7 @@ where
         );
 
         blend_adapter.publish_proposal(block.to_proposal()).await;
+        metrics::consensus_proposals_created_local();
     }
 
     async fn handle_inbound_message(

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -7,7 +7,11 @@ mod relays;
 mod sync;
 
 use core::fmt::Debug;
-use std::{fmt::Display, hash::Hash, time::Duration};
+use std::{
+    fmt::Display,
+    hash::Hash,
+    time::{Duration, Instant},
+};
 
 use bootstrap::ibd::ChainNetworkIbdBlockProcessor;
 use futures::{StreamExt as _, future::join_all};
@@ -66,6 +70,8 @@ pub enum Error {
     Serialisation(#[from] lb_core::codec::Error),
     #[error("Invalid block: {0}")]
     InvalidBlock(String),
+    #[error("Failed to reconstruct block: {0} mempool transactions not found")]
+    MissingMempoolTransactions(usize),
     #[error("Mempool error: {0}")]
     Mempool(String),
     #[error("Block header id not found: {0}")]
@@ -430,15 +436,24 @@ where
     {
         let block_id = proposal.header().id();
         let block_slot = proposal.header().slot();
+        metrics::consensus_proposals_received_total("network");
 
         if !should_process_block(relays.cryptarchia(), block_id, block_slot).await {
+            metrics::consensus_proposals_ignored_total("already_processed", "network");
             return;
         }
 
+        let reconstruct_started_at = Instant::now();
         let block = match reconstruct_block_from_proposal(proposal, relays.mempool_adapter()).await
         {
-            Ok(block) => block,
+            Ok(block) => {
+                metrics::consensus_observe_proposal_reconstruct_ok(
+                    reconstruct_started_at.elapsed(),
+                );
+                block
+            }
             Err(e) => {
+                metrics::consensus_observe_proposal_reconstruct_err("network", &e);
                 error!(
                     target: LOG_TARGET,
                     "Failed to reconstruct block from proposal: {:?}",
@@ -498,13 +513,16 @@ where
         Self::log_received_block(&block);
 
         let block_id = block.header().id();
+        let started_at = Instant::now();
 
         match Self::apply_block_with_future_block_retry(block, relays).await {
             Ok(()) => {
+                metrics::consensus_observe_apply_block_ok(started_at.elapsed());
                 orphan_downloader.remove_orphan(&block_id);
                 trace!(counter.consensus_processed_blocks = 1);
             }
             Err(err) => {
+                metrics::consensus_observe_apply_block_err(&err);
                 Self::handle_proposal_processing_error(err, block_id, orphan_downloader);
             }
         }
@@ -785,10 +803,9 @@ where
         })?;
 
     if !mempool_response.all_found() {
-        return Err(Error::InvalidBlock(format!(
-            "Failed to reconstruct block: {:?} mempool transactions not found",
-            mempool_response.not_found()
-        )));
+        let missing_count = mempool_response.not_found().len();
+        metrics::consensus_observe_proposal_missing_txs(missing_count);
+        return Err(Error::MissingMempoolTransactions(missing_count));
     }
 
     let reconstructed_transactions = mempool_response.into_found();

--- a/services/chain/chain-network/src/metrics.rs
+++ b/services/chain/chain-network/src/metrics.rs
@@ -1,12 +1,9 @@
-#![allow(
-    dead_code,
-    reason = "metrics are defined incrementally and may be wired in follow-up changes"
-)]
-
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use lb_chain_service::api::ApiError;
 use overwatch::DynError;
+
+use crate::Error;
 
 pub fn consensus_proposals_received_total(origin: &'static str) {
     lb_tracing::increase_counter_u64!(consensus_proposals_received_total, 1, origin = origin);
@@ -29,9 +26,9 @@ pub fn consensus_observe_apply_block_ok(duration: Duration) {
     lb_tracing::metric_histogram_f64!(consensus_apply_block_seconds, duration.as_secs_f64());
 }
 
-pub fn consensus_observe_apply_block_err(err: &ApiError) {
+pub fn consensus_observe_apply_block_err(err: &Error) {
     let reason = match err {
-        ApiError::ParentMissing { .. } => "parent_missing",
+        Error::Cryptarchia(ApiError::ParentMissing { .. }) => "parent_missing",
         _ => "other",
     };
     consensus_apply_block_failed_total(reason);
@@ -44,7 +41,14 @@ pub fn consensus_observe_proposal_reconstruct_ok(duration: Duration) {
     );
 }
 
-pub fn consensus_observe_proposal_reconstruct_err(origin: &'static str, reason: &'static str) {
+pub fn consensus_observe_proposal_reconstruct_err(origin: &'static str, err: &Error) {
+    let reason = match err {
+        Error::MissingMempoolTransactions(_) => "missing_txs",
+        Error::Mempool(_) => "mempool",
+        Error::InvalidBlock(_) => "invalid_block",
+        _ => "other",
+    };
+
     lb_tracing::increase_counter_u64!(
         consensus_proposal_reconstruct_failed_total,
         1,
@@ -87,23 +91,6 @@ pub fn orphan_blocks_received_total() {
 
 pub fn orphan_blocks_fetch_failed_total() {
     lb_tracing::increase_counter_u64!(orphan_blocks_fetch_failed_total, 1);
-}
-
-pub fn consensus_block_blob_validation_failed_total(mode: &'static str, reason: &'static str) {
-    lb_tracing::increase_counter_u64!(
-        consensus_block_blob_validation_failed_total,
-        1,
-        mode = mode,
-        reason = reason
-    );
-}
-
-pub fn consensus_observe_block_blob_validation_ok(started_at: Instant, mode: &'static str) {
-    lb_tracing::metric_histogram_f64!(
-        consensus_block_blob_validation_seconds,
-        started_at.elapsed().as_secs_f64(),
-        mode = mode
-    );
 }
 
 pub fn chainsync_observe_download_blocks_ok(duration: Duration, blocks_downloaded: u64) {

--- a/services/sdp/src/metrics.rs
+++ b/services/sdp/src/metrics.rs
@@ -1,16 +1,3 @@
-#![allow(
-    dead_code,
-    reason = "metrics are defined incrementally and may be wired in follow-up changes"
-)]
-
-pub fn subscriptions_total() {
-    lb_tracing::increase_counter_u64!(sdp_subscriptions_total, 1);
-}
-
-pub fn subscription_errors_total() {
-    lb_tracing::increase_counter_u64!(sdp_subscription_errors_total, 1);
-}
-
 pub fn activity_posts_total() {
     lb_tracing::increase_counter_u64!(sdp_activity_posts_total, 1);
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR rewires metrics that we had defined previously but removed during services refactor work. Raised in the #2661

Closes #2661.

## 2. Does the code have enough context to be clearly understood?
Yes


## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
