### PR TITLE
feat: add HTTP CLI wrapper with a first command to join Blend as a core node

### DIFF
--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -187,6 +187,16 @@ jobs:
           artifact_subdir: Transactions
           verbose_console: "true"
 
+      # Feature: CLI utility binary (@cli_ci)
+      - name: Run cucumber suite - CLI utilities
+        if: ${{ !cancelled() && steps.verify_local_ntp.conclusion == 'success' }}
+        timeout-minutes: 60
+        uses: ./.github/actions/run-cucumber-suite
+        with:
+          suite_tag: "@cli_ci"
+          suite_name: CLI
+          artifact_subdir: Cli
+
       # Always upload JUnit test results for reporting, even if tests fail
       - name: Upload cucumber JUnit results
         if: ${{ !cancelled() && steps.verify_local_ntp.conclusion == 'success' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5045,14 +5045,19 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
+ "logos-blockchain-common-http-client",
  "logos-blockchain-core",
+ "logos-blockchain-http-api-common",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-libp2p",
  "logos-blockchain-node",
  "num-bigint",
  "serde",
  "serde_json",
  "serde_yml",
  "thiserror 2.0.18",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,7 +5049,6 @@ dependencies = [
  "logos-blockchain-core",
  "logos-blockchain-http-api-common",
  "logos-blockchain-key-management-system-keys",
- "logos-blockchain-libp2p",
  "logos-blockchain-node",
  "num-bigint",
  "serde",

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -14,7 +14,7 @@ use strum::EnumIter;
 use crate::{
     block::BlockNumber,
     mantle::{NoteId, ops::channel::Ed25519PublicKey},
-    utils::serde_bytes_newtype,
+    utils::{display_hex_bytes_newtype, serde_bytes_newtype},
 };
 
 pub type SessionNumber = u64;
@@ -168,6 +168,7 @@ impl Ord for ProviderId {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct DeclarationId(pub [u8; 32]);
 serde_bytes_newtype!(DeclarationId, 32);
+display_hex_bytes_newtype!(DeclarationId);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Declaration {

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -471,13 +471,13 @@ impl UserConfig {
         Ok(ProviderId(secret_key.public_key()))
     }
 
-    pub fn blend_zk_key(&self) -> Result<ZkPublicKey, &'static str> {
+    pub fn blend_zk_key(&self) -> Result<ZkPublicKey, String> {
         let key_id = &self.blend.core.zk.secret_key_kms_id;
         let Some(key) = self.kms.backend.keys.get(key_id) else {
-            return Err("Blend ZK signing key not found in KMS");
+            return Err(format!("Blend ZK signing key '{key_id}' not found in KMS"));
         };
         let Key::Zk(secret_key) = key else {
-            return Err("Blend ZK signing key must be Zk");
+            return Err("Blend ZK signing key must be Zk".to_owned());
         };
         Ok(secret_key.to_public_key())
     }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -9,6 +9,8 @@ use std::{
 use ::tracing::{Level, warn};
 use clap::{Parser, Subcommand, ValueEnum, builder::OsStr};
 use color_eyre::eyre::{Result, eyre};
+use lb_core::sdp::ProviderId;
+use lb_key_management_system_service::keys::{Key, ZkPublicKey};
 use lb_libp2p::{Multiaddr, ed25519::SecretKey};
 use lb_tracing::{
     filter::envfilter::{default_envfilter_config, parse_filter_directives},
@@ -454,6 +456,30 @@ impl UserConfig {
             time: TimeConfig::default(),
             tracing: TracingConfig::default(),
         }
+    }
+
+    pub fn blend_provider_id(&self) -> Result<ProviderId, String> {
+        let key_id = &self.blend.non_ephemeral_signing_key_id;
+        let Some(key) = self.kms.backend.keys.get(key_id) else {
+            return Err(format!(
+                "Blend non-ephemeral signing key '{key_id}' not found in KMS"
+            ));
+        };
+        let Key::Ed25519(secret_key) = key else {
+            return Err("Blend non-ephemeral signing key must be Ed25519".to_owned());
+        };
+        Ok(ProviderId(secret_key.public_key()))
+    }
+
+    pub fn blend_zk_key(&self) -> Result<ZkPublicKey, &'static str> {
+        let key_id = &self.blend.core.zk.secret_key_kms_id;
+        let Some(key) = self.kms.backend.keys.get(key_id) else {
+            return Err("Blend ZK signing key not found in KMS");
+        };
+        let Key::Zk(secret_key) = key else {
+            return Err("Blend ZK signing key must be Zk");
+        };
+        Ok(secret_key.to_public_key())
     }
 }
 

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -471,7 +471,7 @@ impl UserConfig {
         Ok(ProviderId(secret_key.public_key()))
     }
 
-    pub fn blend_zk_key(&self) -> Result<ZkPublicKey, String> {
+    pub fn blend_zk_key(&self) -> Result<(String, ZkPublicKey), String> {
         let key_id = &self.blend.core.zk.secret_key_kms_id;
         let Some(key) = self.kms.backend.keys.get(key_id) else {
             return Err(format!("Blend ZK signing key '{key_id}' not found in KMS"));
@@ -479,7 +479,7 @@ impl UserConfig {
         let Key::Zk(secret_key) = key else {
             return Err("Blend ZK signing key must be Zk".to_owned());
         };
-        Ok(secret_key.to_public_key())
+        Ok((key_id.to_owned(), secret_key.to_public_key()))
     }
 }
 

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -8,6 +8,7 @@ use lb_core::{
     header::{ContentId, HeaderId},
     mantle::SignedMantleTx,
     proofs::leader_proof::Groth16LeaderProof,
+    sdp::{DeclarationId, DeclarationMessage},
 };
 use lb_groth16::fr_to_bytes;
 use lb_http_api_common::{
@@ -18,7 +19,7 @@ use lb_http_api_common::{
     },
     paths::{
         BLOCKS, BLOCKS_DETAIL, BLOCKS_RANGE_STREAM, BLOCKS_STREAM, CRYPTARCHIA_INFO,
-        CRYPTARCHIA_LIB_STREAM, MEMPOOL_ADD_TX,
+        CRYPTARCHIA_LIB_STREAM, MEMPOOL_ADD_TX, SDP_POST_DECLARATION,
         wallet::{BALANCE, TRANSACTIONS_TRANSFER_FUNDS},
     },
     settings::default_max_body_size,
@@ -264,6 +265,18 @@ impl CommonHttpClient {
             .join(MEMPOOL_ADD_TX.trim_start_matches('/'))
             .map_err(Error::Url)?;
         self.post(request_url, &transaction).await
+    }
+
+    /// Post a service declaration to the SDP endpoint.
+    pub async fn post_declaration(
+        &self,
+        base_url: Url,
+        declaration: &DeclarationMessage,
+    ) -> Result<DeclarationId, Error> {
+        let request_url = base_url
+            .join(SDP_POST_DECLARATION.trim_start_matches('/'))
+            .map_err(Error::Url)?;
+        self.post(request_url, declaration).await
     }
 
     /// Get consensus info (tip, height, etc.)

--- a/tests/cucumber_tests/features/api-cli.feature
+++ b/tests/cucumber_tests/features/api-cli.feature
@@ -12,6 +12,6 @@ Feature: API CLI
       | NODE_1    | 1             | WALLET_1A   |              |
     When all nodes have at least 2 blocks and converged to within 1 blocks in 180 seconds
     And I send 1 transactions of 1000 LGO each from wallet "WALLET_1A" to blend core zk key of node "NODE_1"
-    Then I run blend core SDP declaration CLI for node "NODE_1"
+    Then I declare node "NODE_1" as blend core node via the CLI binary
     And blend core SDP declaration for node "NODE_1" is included on node "NODE_1"
     And I stop all nodes

--- a/tests/cucumber_tests/features/api-cli.feature
+++ b/tests/cucumber_tests/features/api-cli.feature
@@ -1,17 +1,17 @@
 Feature: API CLI
 
   @api_cli_ci
-  Scenario: Join Blend core via CLI declaration
+  Scenario: Join Blend via CLI declaration
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |
       | 1             | 1           | 2000         |
-    And I have a cluster with capacity of 2 nodes
+    And I have a cluster with capacity of 1 nodes
     And no nodes are declared as blend providers
     And I start nodes with wallet resources:
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
-    And I start peer node "NODE_2" connected to node "NODE_1"
     When all nodes have at least 2 blocks and converged to within 1 blocks in 180 seconds
-    And I send 1 transactions of 1000 LGO each from wallet "WALLET_1A" to blend core zk key of node "NODE_2"
-    Then I run blend core SDP declaration CLI for node "NODE_2" against node "NODE_2"
+    And I send 1 transactions of 1000 LGO each from wallet "WALLET_1A" to blend core zk key of node "NODE_1"
+    Then I run blend core SDP declaration CLI for node "NODE_1"
+    And blend core SDP declaration for node "NODE_1" is included on node "NODE_1"
     And I stop all nodes

--- a/tests/cucumber_tests/features/api-cli.feature
+++ b/tests/cucumber_tests/features/api-cli.feature
@@ -1,0 +1,17 @@
+Feature: API CLI
+
+  @api_cli_ci
+  Scenario: Join Blend core via CLI declaration
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 1           | 2000         |
+    And I have a cluster with capacity of 2 nodes
+    And no nodes are declared as blend providers
+    And I start nodes with wallet resources:
+      | node_name | account_index | wallet_name | connected_to |
+      | NODE_1    | 1             | WALLET_1A   |              |
+    And I start peer node "NODE_2" connected to node "NODE_1"
+    When all nodes have at least 2 blocks and converged to within 1 blocks in 180 seconds
+    And I send 1 transactions of 1000 LGO each from wallet "WALLET_1A" to blend core zk key of node "NODE_2"
+    Then I run blend core SDP declaration CLI for node "NODE_2" against node "NODE_2"
+    And I stop all nodes

--- a/tests/cucumber_tests/features/api-cli.feature
+++ b/tests/cucumber_tests/features/api-cli.feature
@@ -1,6 +1,6 @@
-Feature: API CLI
+Feature: CLI
 
-  @api_cli_ci
+  @cli_ci
   Scenario: Join Blend via CLI declaration
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |

--- a/tests/src/cucumber/error.rs
+++ b/tests/src/cucumber/error.rs
@@ -69,8 +69,8 @@ pub enum StepError {
     Error(#[from] Error),
     #[error(transparent)]
     IoError(#[from] IoError),
-    #[error("Configuration error: {0}")]
-    ConfigError(String),
+    #[error("User configuration error: {0}")]
+    UserConfigError(String),
 }
 
 pub type StepResult = Result<(), StepError>;

--- a/tests/src/cucumber/error.rs
+++ b/tests/src/cucumber/error.rs
@@ -69,6 +69,8 @@ pub enum StepError {
     Error(#[from] Error),
     #[error(transparent)]
     IoError(#[from] IoError),
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
 }
 
 pub type StepResult = Result<(), StepError>;

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use cucumber::{gherkin::Step, given, then, when};
+use lb_common_http_client::CommonHttpClient;
+use lb_core::codec::DeserializeOp as _;
+use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_libp2p::{Multiaddr, PeerId};
+use lb_testing_framework::USER_CONFIG_FILE;
 use tokio::time::{Instant, sleep};
 use tracing::{info, warn};
 
@@ -32,8 +36,11 @@ use crate::{
                     wait_for_all_nodes_to_be_synced_to_chain,
                 },
             },
+            manual_transactions::utils::{
+                create_and_submit_transaction_hashes, wait_for_transactions_inclusion,
+            },
         },
-        utils::resolve_literal_or_env,
+        utils::{blend_core_zk_pk_from_node_yaml, resolve_literal_or_env},
         world::{
             CucumberWorld, GenesisTokens, ManualClusterKind, ManualClusterSpec, NodeSnapshot,
             PublicCryptarchiaEndpointPeer,
@@ -45,6 +52,231 @@ use crate::{
 const PUBLIC_CRYPTARCHIA_ENDPOINT: &str = "public_cryptarchia_endpoint";
 const PUBLIC_CRYPTARCHIA_ENDPOINT_USERNAME: &str = "username";
 const PUBLIC_CRYPTARCHIA_ENDPOINT_PASSWORD: &str = "password";
+
+fn blend_zk_pk_for_node(world: &CucumberWorld, node_name: &str) -> Result<ZkPublicKey, StepError> {
+    let node_info = world
+        .nodes_info
+        .get(node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{node_name}' not found in world state"),
+        })?;
+
+    let user_config_path = node_info.runtime_dir.join(USER_CONFIG_FILE);
+    let blend_zk_pk_hex = blend_core_zk_pk_from_node_yaml(&user_config_path)?;
+    let blend_zk_pk = ZkPublicKey::from_bytes(&hex::decode(blend_zk_pk_hex)?)?;
+
+    Ok(blend_zk_pk)
+}
+
+fn node_user_config_path(world: &CucumberWorld, node_name: &str) -> Result<PathBuf, StepError> {
+    let node_info = world
+        .nodes_info
+        .get(node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{node_name}' not found in world state"),
+        })?;
+
+    Ok(node_info.runtime_dir.join(USER_CONFIG_FILE))
+}
+
+#[when(
+    expr = "I send {int} transactions of {int} LGO each from wallet {string} to blend core zk key of node {string}"
+)]
+async fn step_send_multiple_transactions_to_blend_core_zk_key(
+    world: &mut CucumberWorld,
+    step: &Step,
+    number_of_transactions: usize,
+    output_value: u64,
+    sender_wallet_name: String,
+    receiver_node_name: String,
+) -> StepResult {
+    let receiver_blend_zk_pk = blend_zk_pk_for_node(world, &receiver_node_name)?;
+    let sender_node_name = world.resolve_wallet(&sender_wallet_name)?.node_name;
+    let sender_node_client = world
+        .nodes_info
+        .get(&sender_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{sender_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .clone();
+
+    for _ in 0..number_of_transactions {
+        let tx_hashes = create_and_submit_transaction_hashes(
+            world,
+            &step.value,
+            &sender_wallet_name,
+            &[(receiver_blend_zk_pk, output_value)],
+            None,
+        )
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
+
+        wait_for_transactions_inclusion(&sender_node_client, &tx_hashes, Duration::from_secs(120))
+            .await
+            .inspect_err(|error| {
+                warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+            })?;
+
+        info!(
+            target: TARGET,
+            "Sent and included normal transaction from `{sender_wallet_name}` to blend zk key of {receiver_node_name}, value: {output_value}, tx count: {}",
+            tx_hashes.len(),
+        );
+    }
+
+    Ok(())
+}
+
+#[then(expr = "I run blend core SDP declaration CLI for node {string} against node {string}")]
+async fn step_run_blend_sdp_declaration_cli(
+    world: &mut CucumberWorld,
+    step: &Step,
+    declarer_node_name: String,
+    api_node_name: String,
+) -> StepResult {
+    let user_config_path = node_user_config_path(world, &declarer_node_name)?;
+    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
+
+    let declarer_api_base_url = world
+        .nodes_info
+        .get(&declarer_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{declarer_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .base_url()
+        .clone();
+
+    // Query notes from the declarer node API so wallet ownership lookups use
+    // the same node config as the key source.
+    let note_lookup_timeout = Duration::from_secs(30);
+    let note_lookup_started = Instant::now();
+    let mut last_lookup_error: Option<String> = None;
+    let locked_note_id = loop {
+        match CommonHttpClient::new(None)
+            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .await
+        {
+            Ok(wallet_balance) => {
+                if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
+                    break note_id;
+                }
+                last_lookup_error = Some("wallet has no notes yet".to_owned());
+            }
+            Err(error) => {
+                last_lookup_error = Some(error.to_string());
+                warn!(target: TARGET, "Step `{}` transient lookup error: {error}", step.value);
+            }
+        }
+
+        if note_lookup_started.elapsed() >= note_lookup_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
+                    declarer_api_base_url,
+                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    };
+
+    let locked_note_id_json =
+        serde_json::to_string(&locked_note_id).map_err(|error| StepError::LogicalError {
+            message: format!("Failed to serialize locked note ID: {error}"),
+        })?;
+    let locked_note_id_hex = locked_note_id_json.trim_matches('"').to_owned();
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+    let output = tokio::process::Command::new("cargo")
+        .current_dir(workspace_root)
+        .arg("run")
+        .arg("-p")
+        .arg("logos-blockchain-tools")
+        .arg("--bin")
+        .arg("api")
+        .arg("--")
+        .arg("sdp")
+        .arg("post-blend-declaration")
+        .arg("--user-config-path")
+        .arg(user_config_path)
+        .arg("--locked-note-id")
+        .arg(locked_note_id_hex)
+        .arg("--node-address")
+        .arg(declarer_api_base_url.to_string())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(StepError::StepFail {
+            message: format!(
+                "Blend declaration CLI failed for node '{declarer_node_name}' against '{api_node_name}'\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            ),
+        });
+    }
+
+    let step_timeout = Duration::from_secs(30);
+    let start_time = Instant::now();
+    loop {
+        let declarations_result = world
+            .nodes_info
+            .get(&api_node_name)
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Node '{api_node_name}' not found in world state"),
+            })?
+            .started_node
+            .client
+            .get_sdp_declarations()
+            .await;
+
+        let declarations = match declarations_result {
+            Ok(declarations) => declarations,
+            Err(error) => {
+                let error_message = error.to_string();
+                if error_message.contains("404 Not Found") {
+                    info!(
+                        target: TARGET,
+                        "Skipping declaration visibility assertion on '{api_node_name}' because testing SDP endpoint is unavailable: {error_message}",
+                    );
+                    return Ok(());
+                }
+
+                warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+                return Err(error.into());
+            }
+        };
+
+        if declarations.iter().any(|declaration| {
+            declaration.locked_note_id == locked_note_id && declaration.zk_id == blend_zk_pk
+        }) {
+            info!(
+                target: TARGET,
+                "Blend declaration observed for node '{declarer_node_name}'"
+            );
+            break;
+        }
+
+        if start_time.elapsed() >= step_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for declaration submitted by '{declarer_node_name}' to appear on node '{api_node_name}'"
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    Ok(())
+}
 
 #[given(expr = "I have a cluster with capacity of {int} nodes")]
 #[when(expr = "I have a cluster with capacity of {int} nodes")]

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1046,7 +1046,7 @@ async fn step_send_multiple_transactions_to_blend_core_zk_key(
             warn!(target: TARGET, "Step `{}` error: {error}", step.value);
         })?;
 
-        wait_for_transactions_inclusion(&sender_node_client, &tx_hashes, Duration::from_secs(120))
+        wait_for_transactions_inclusion(&sender_node_client, &tx_hashes, Duration::from_mins(2))
             .await
             .inspect_err(|error| {
                 warn!(target: TARGET, "Step `{}` error: {error}", step.value);
@@ -1077,6 +1077,11 @@ fn blend_zk_pk_for_node(world: &CucumberWorld, node_name: &str) -> Result<ZkPubl
     Ok(blend_zk_pk)
 }
 
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Required to be mutable by cucumber step function signature"
+)]
+#[expect(unused_variables, reason = "Cucumber step function signature")]
 #[then(expr = "I declare node {string} as blend core node via the CLI binary")]
 async fn step_run_blend_sdp_declaration_cli(
     world: &mut CucumberWorld,
@@ -1132,7 +1137,7 @@ async fn step_run_blend_sdp_declaration_cli(
         .arg("--user-config-path")
         .arg(user_config_path)
         .arg("--locked-note-id")
-        .arg(locked_note_id_hex)
+        .arg(locked_note_id)
         .arg("--node-address")
         .arg(declarer_api_base_url.to_string())
         .output()
@@ -1162,6 +1167,14 @@ fn node_user_config_path(world: &CucumberWorld, node_name: &str) -> Result<PathB
     Ok(node_info.runtime_dir.join(USER_CONFIG_FILE))
 }
 
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "TODO: Address this at some point."
+)]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Required to be mutable by cucumber step function signature"
+)]
 #[then(expr = "blend core SDP declaration for node {string} is included on node {string}")]
 async fn step_verify_blend_sdp_declaration_included(
     world: &mut CucumberWorld,

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -53,286 +53,6 @@ const PUBLIC_CRYPTARCHIA_ENDPOINT: &str = "public_cryptarchia_endpoint";
 const PUBLIC_CRYPTARCHIA_ENDPOINT_USERNAME: &str = "username";
 const PUBLIC_CRYPTARCHIA_ENDPOINT_PASSWORD: &str = "password";
 
-fn blend_zk_pk_for_node(world: &CucumberWorld, node_name: &str) -> Result<ZkPublicKey, StepError> {
-    let node_info = world
-        .nodes_info
-        .get(node_name)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Node '{node_name}' not found in world state"),
-        })?;
-
-    let user_config_path = node_info.runtime_dir.join(USER_CONFIG_FILE);
-    let blend_zk_pk_hex = blend_core_zk_pk_from_node_yaml(&user_config_path)?;
-    let blend_zk_pk = ZkPublicKey::from_bytes(&hex::decode(blend_zk_pk_hex)?)?;
-
-    Ok(blend_zk_pk)
-}
-
-fn node_user_config_path(world: &CucumberWorld, node_name: &str) -> Result<PathBuf, StepError> {
-    let node_info = world
-        .nodes_info
-        .get(node_name)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Node '{node_name}' not found in world state"),
-        })?;
-
-    Ok(node_info.runtime_dir.join(USER_CONFIG_FILE))
-}
-
-#[when(
-    expr = "I send {int} transactions of {int} LGO each from wallet {string} to blend core zk key of node {string}"
-)]
-async fn step_send_multiple_transactions_to_blend_core_zk_key(
-    world: &mut CucumberWorld,
-    step: &Step,
-    number_of_transactions: usize,
-    output_value: u64,
-    sender_wallet_name: String,
-    receiver_node_name: String,
-) -> StepResult {
-    let receiver_blend_zk_pk = blend_zk_pk_for_node(world, &receiver_node_name)?;
-    let sender_node_name = world.resolve_wallet(&sender_wallet_name)?.node_name;
-    let sender_node_client = world
-        .nodes_info
-        .get(&sender_node_name)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Node '{sender_node_name}' not found in world state"),
-        })?
-        .started_node
-        .client
-        .clone();
-
-    for _ in 0..number_of_transactions {
-        let tx_hashes = create_and_submit_transaction_hashes(
-            world,
-            &step.value,
-            &sender_wallet_name,
-            &[(receiver_blend_zk_pk, output_value)],
-            None,
-        )
-        .await
-        .inspect_err(|error| {
-            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-        })?;
-
-        wait_for_transactions_inclusion(&sender_node_client, &tx_hashes, Duration::from_secs(120))
-            .await
-            .inspect_err(|error| {
-                warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-            })?;
-
-        info!(
-            target: TARGET,
-            "Sent and included normal transaction from `{sender_wallet_name}` to blend zk key of {receiver_node_name}, value: {output_value}, tx count: {}",
-            tx_hashes.len(),
-        );
-    }
-
-    Ok(())
-}
-
-#[then(expr = "I run blend core SDP declaration CLI for node {string}")]
-async fn step_run_blend_sdp_declaration_cli(
-    world: &mut CucumberWorld,
-    step: &Step,
-    declarer_node_name: String,
-) -> StepResult {
-    let user_config_path = node_user_config_path(world, &declarer_node_name)?;
-    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
-
-    let declarer_api_base_url = world
-        .nodes_info
-        .get(&declarer_node_name)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Node '{declarer_node_name}' not found in world state"),
-        })?
-        .started_node
-        .client
-        .base_url()
-        .clone();
-
-    // Query notes from the declarer node API so wallet ownership lookups use
-    // the same node config as the key source.
-    let note_lookup_timeout = Duration::from_secs(30);
-    let note_lookup_started = Instant::now();
-    let mut last_lookup_error: Option<String> = None;
-    let locked_note_id = loop {
-        match CommonHttpClient::new(None)
-            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
-            .await
-        {
-            Ok(wallet_balance) => {
-                if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
-                    break note_id;
-                }
-                last_lookup_error = Some("wallet has no notes yet".to_owned());
-            }
-            Err(error) => {
-                last_lookup_error = Some(error.to_string());
-                warn!(target: TARGET, "Step `{}` transient lookup error: {error}", step.value);
-            }
-        }
-
-        if note_lookup_started.elapsed() >= note_lookup_timeout {
-            return Err(StepError::Timeout {
-                message: format!(
-                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
-                    declarer_api_base_url,
-                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
-                ),
-            });
-        }
-
-        sleep(Duration::from_millis(250)).await;
-    };
-
-    let locked_note_id_json =
-        serde_json::to_string(&locked_note_id).map_err(|error| StepError::LogicalError {
-            message: format!("Failed to serialize locked note ID: {error}"),
-        })?;
-    let locked_note_id_hex = locked_note_id_json.trim_matches('"').to_owned();
-
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
-    let output = tokio::process::Command::new("cargo")
-        .current_dir(workspace_root)
-        .arg("run")
-        .arg("-p")
-        .arg("logos-blockchain-tools")
-        .arg("--bin")
-        .arg("api")
-        .arg("--")
-        .arg("sdp")
-        .arg("post-blend-declaration")
-        .arg("--user-config-path")
-        .arg(user_config_path)
-        .arg("--locked-note-id")
-        .arg(locked_note_id_hex)
-        .arg("--node-address")
-        .arg(declarer_api_base_url.to_string())
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(StepError::StepFail {
-            message: format!(
-                "Blend declaration CLI failed for node '{declarer_node_name}'\nstdout:\n{stdout}\nstderr:\n{stderr}"
-            ),
-        });
-    }
-
-    Ok(())
-}
-
-#[then(expr = "blend core SDP declaration for node {string} is included on node {string}")]
-async fn step_verify_blend_sdp_declaration_included(
-    world: &mut CucumberWorld,
-    step: &Step,
-    declarer_node_name: String,
-    api_node_name: String,
-) -> StepResult {
-    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
-
-    let declarer_api_base_url = world
-        .nodes_info
-        .get(&declarer_node_name)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Node '{declarer_node_name}' not found in world state"),
-        })?
-        .started_node
-        .client
-        .base_url()
-        .clone();
-
-    let note_lookup_timeout = Duration::from_secs(30);
-    let note_lookup_started = Instant::now();
-    let mut last_lookup_error: Option<String> = None;
-    let locked_note_id = loop {
-        match CommonHttpClient::new(None)
-            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
-            .await
-        {
-            Ok(wallet_balance) => {
-                if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
-                    break note_id;
-                }
-                last_lookup_error = Some("wallet has no notes yet".to_owned());
-            }
-            Err(error) => {
-                last_lookup_error = Some(error.to_string());
-                warn!(target: TARGET, "Step `{}` transient lookup error: {error}", step.value);
-            }
-        }
-
-        if note_lookup_started.elapsed() >= note_lookup_timeout {
-            return Err(StepError::Timeout {
-                message: format!(
-                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
-                    declarer_api_base_url,
-                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
-                ),
-            });
-        }
-
-        sleep(Duration::from_millis(250)).await;
-    };
-
-    let step_timeout = Duration::from_secs(30);
-    let start_time = Instant::now();
-    loop {
-        let declarations_result = world
-            .nodes_info
-            .get(&api_node_name)
-            .ok_or_else(|| StepError::LogicalError {
-                message: format!("Node '{api_node_name}' not found in world state"),
-            })?
-            .started_node
-            .client
-            .get_sdp_declarations()
-            .await;
-
-        let declarations = match declarations_result {
-            Ok(declarations) => declarations,
-            Err(error) => {
-                let error_message = error.to_string();
-                if error_message.contains("404 Not Found") {
-                    info!(
-                        target: TARGET,
-                        "Skipping declaration visibility assertion on '{api_node_name}' because testing SDP endpoint is unavailable: {error_message}",
-                    );
-                    return Ok(());
-                }
-
-                warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-                return Err(error.into());
-            }
-        };
-
-        if declarations.iter().any(|declaration| {
-            declaration.locked_note_id == locked_note_id && declaration.zk_id == blend_zk_pk
-        }) {
-            info!(
-                target: TARGET,
-                "Blend declaration observed for node '{declarer_node_name}'"
-            );
-            break;
-        }
-
-        if start_time.elapsed() >= step_timeout {
-            return Err(StepError::Timeout {
-                message: format!(
-                    "Timed out waiting for declaration submitted by '{declarer_node_name}' to appear on node '{api_node_name}'"
-                ),
-            });
-        }
-
-        sleep(Duration::from_millis(250)).await;
-    }
-
-    Ok(())
-}
-
 #[given(expr = "I have a cluster with capacity of {int} nodes")]
 #[when(expr = "I have a cluster with capacity of {int} nodes")]
 fn step_manual_cluster(world: &mut CucumberWorld, step: &Step, nodes_count: usize) -> StepResult {
@@ -1286,6 +1006,261 @@ fn step_stop_all_nodes(world: &mut CucumberWorld) -> StepResult {
         info!(target: TARGET, "Stopping node '{node_name}'");
     }
     world.nodes_info.clear();
+
+    Ok(())
+}
+
+#[when(
+    expr = "I send {int} transactions of {int} LGO each from wallet {string} to blend core zk key of node {string}"
+)]
+async fn step_send_multiple_transactions_to_blend_core_zk_key(
+    world: &mut CucumberWorld,
+    step: &Step,
+    number_of_transactions: usize,
+    output_value: u64,
+    sender_wallet_name: String,
+    receiver_node_name: String,
+) -> StepResult {
+    let receiver_blend_zk_pk = blend_zk_pk_for_node(world, &receiver_node_name)?;
+    let sender_node_name = world.resolve_wallet(&sender_wallet_name)?.node_name;
+    let sender_node_client = world
+        .nodes_info
+        .get(&sender_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{sender_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .clone();
+
+    for _ in 0..number_of_transactions {
+        let tx_hashes = create_and_submit_transaction_hashes(
+            world,
+            &step.value,
+            &sender_wallet_name,
+            &[(receiver_blend_zk_pk, output_value)],
+            None,
+        )
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
+
+        wait_for_transactions_inclusion(&sender_node_client, &tx_hashes, Duration::from_secs(120))
+            .await
+            .inspect_err(|error| {
+                warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+            })?;
+
+        info!(
+            target: TARGET,
+            "Sent and included normal transaction from `{sender_wallet_name}` to blend zk key of {receiver_node_name}, value: {output_value}, tx count: {}",
+            tx_hashes.len(),
+        );
+    }
+
+    Ok(())
+}
+
+fn blend_zk_pk_for_node(world: &CucumberWorld, node_name: &str) -> Result<ZkPublicKey, StepError> {
+    let node_info = world
+        .nodes_info
+        .get(node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{node_name}' not found in world state"),
+        })?;
+
+    let user_config_path = node_info.runtime_dir.join(USER_CONFIG_FILE);
+    let blend_zk_pk_hex = blend_core_zk_pk_from_node_yaml(&user_config_path)?;
+    let blend_zk_pk = ZkPublicKey::from_bytes(&hex::decode(blend_zk_pk_hex)?)?;
+
+    Ok(blend_zk_pk)
+}
+
+#[then(expr = "I declare node {string} as blend core node via the CLI binary")]
+async fn step_run_blend_sdp_declaration_cli(
+    world: &mut CucumberWorld,
+    step: &Step,
+    declarer_node_name: String,
+) -> StepResult {
+    let user_config_path = node_user_config_path(world, &declarer_node_name)?;
+    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
+
+    let declarer_api_base_url = world
+        .nodes_info
+        .get(&declarer_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{declarer_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .base_url()
+        .clone();
+
+    // Query notes from the declarer node API so wallet ownership lookups use
+    // the same node config as the key source.
+    let locked_note_id = loop {
+        let Ok(wallet_balance) = CommonHttpClient::new(None)
+            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .await
+        else {
+            continue;
+        };
+        if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
+            let locked_note_id_json =
+                serde_json::to_string(&note_id).map_err(|error| StepError::LogicalError {
+                    message: format!("Failed to serialize locked note ID: {error}"),
+                })?;
+            let locked_note_id_hex = locked_note_id_json.trim_matches('"').to_owned();
+            break locked_note_id_hex;
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    };
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+    let output = tokio::process::Command::new("cargo")
+        .current_dir(workspace_root)
+        .arg("run")
+        .arg("-p")
+        .arg("logos-blockchain-tools")
+        .arg("--bin")
+        .arg("api")
+        .arg("--")
+        .arg("sdp")
+        .arg("post-blend-declaration")
+        .arg("--user-config-path")
+        .arg(user_config_path)
+        .arg("--locked-note-id")
+        .arg(locked_note_id_hex)
+        .arg("--node-address")
+        .arg(declarer_api_base_url.to_string())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(StepError::StepFail {
+            message: format!(
+                "Blend declaration CLI failed for node '{declarer_node_name}'\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn node_user_config_path(world: &CucumberWorld, node_name: &str) -> Result<PathBuf, StepError> {
+    let node_info = world
+        .nodes_info
+        .get(node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{node_name}' not found in world state"),
+        })?;
+
+    Ok(node_info.runtime_dir.join(USER_CONFIG_FILE))
+}
+
+#[then(expr = "blend core SDP declaration for node {string} is included on node {string}")]
+async fn step_verify_blend_sdp_declaration_included(
+    world: &mut CucumberWorld,
+    step: &Step,
+    declarer_node_name: String,
+    api_node_name: String,
+) -> StepResult {
+    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
+
+    let declarer_api_base_url = world
+        .nodes_info
+        .get(&declarer_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{declarer_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .base_url()
+        .clone();
+
+    let note_lookup_timeout = Duration::from_secs(30);
+    let note_lookup_started = Instant::now();
+    let mut last_lookup_error: Option<String>;
+    let locked_note_id = loop {
+        let Ok(wallet_balance) = CommonHttpClient::new(None)
+            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .await
+        else {
+            continue;
+        };
+        if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
+            break note_id;
+        }
+        last_lookup_error = Some("wallet has no notes yet".to_owned());
+
+        if note_lookup_started.elapsed() >= note_lookup_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
+                    declarer_api_base_url,
+                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    };
+
+    let step_timeout = Duration::from_secs(30);
+    let start_time = Instant::now();
+    loop {
+        let declarations_result = world
+            .nodes_info
+            .get(&api_node_name)
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Node '{api_node_name}' not found in world state"),
+            })?
+            .started_node
+            .client
+            .get_sdp_declarations()
+            .await;
+
+        let declarations = match declarations_result {
+            Ok(declarations) => declarations,
+            Err(error) => {
+                let error_message = error.to_string();
+                if error_message.contains("404 Not Found") {
+                    info!(
+                        target: TARGET,
+                        "Skipping declaration visibility assertion on '{api_node_name}' because testing SDP endpoint is unavailable: {error_message}",
+                    );
+                    return Ok(());
+                }
+
+                warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+                return Err(error.into());
+            }
+        };
+
+        if declarations.iter().any(|declaration| {
+            declaration.locked_note_id == locked_note_id && declaration.zk_id == blend_zk_pk
+        }) {
+            info!(
+                target: TARGET,
+                "Blend declaration observed for node '{declarer_node_name}'"
+            );
+            break;
+        }
+
+        if start_time.elapsed() >= step_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for declaration submitted by '{declarer_node_name}' to appear on node '{api_node_name}'"
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    }
 
     Ok(())
 }

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -131,12 +131,11 @@ async fn step_send_multiple_transactions_to_blend_core_zk_key(
     Ok(())
 }
 
-#[then(expr = "I run blend core SDP declaration CLI for node {string} against node {string}")]
+#[then(expr = "I run blend core SDP declaration CLI for node {string}")]
 async fn step_run_blend_sdp_declaration_cli(
     world: &mut CucumberWorld,
     step: &Step,
     declarer_node_name: String,
-    api_node_name: String,
 ) -> StepResult {
     let user_config_path = node_user_config_path(world, &declarer_node_name)?;
     let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
@@ -218,10 +217,66 @@ async fn step_run_blend_sdp_declaration_cli(
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(StepError::StepFail {
             message: format!(
-                "Blend declaration CLI failed for node '{declarer_node_name}' against '{api_node_name}'\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                "Blend declaration CLI failed for node '{declarer_node_name}'\nstdout:\n{stdout}\nstderr:\n{stderr}"
             ),
         });
     }
+
+    Ok(())
+}
+
+#[then(expr = "blend core SDP declaration for node {string} is included on node {string}")]
+async fn step_verify_blend_sdp_declaration_included(
+    world: &mut CucumberWorld,
+    step: &Step,
+    declarer_node_name: String,
+    api_node_name: String,
+) -> StepResult {
+    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
+
+    let declarer_api_base_url = world
+        .nodes_info
+        .get(&declarer_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{declarer_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .base_url()
+        .clone();
+
+    let note_lookup_timeout = Duration::from_secs(30);
+    let note_lookup_started = Instant::now();
+    let mut last_lookup_error: Option<String> = None;
+    let locked_note_id = loop {
+        match CommonHttpClient::new(None)
+            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .await
+        {
+            Ok(wallet_balance) => {
+                if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
+                    break note_id;
+                }
+                last_lookup_error = Some("wallet has no notes yet".to_owned());
+            }
+            Err(error) => {
+                last_lookup_error = Some(error.to_string());
+                warn!(target: TARGET, "Step `{}` transient lookup error: {error}", step.value);
+            }
+        }
+
+        if note_lookup_started.elapsed() >= note_lookup_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
+                    declarer_api_base_url,
+                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    };
 
     let step_timeout = Duration::from_secs(30);
     let start_time = Instant::now();

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1104,6 +1104,9 @@ async fn step_run_blend_sdp_declaration_cli(
 
     // Query notes from the declarer node API so wallet ownership lookups use
     // the same node config as the key source.
+    let note_lookup_timeout = Duration::from_secs(30);
+    let note_lookup_started = Instant::now();
+    let mut last_lookup_error: Option<String>;
     let locked_note_id = loop {
         let Ok(wallet_balance) = CommonHttpClient::new(None)
             .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
@@ -1118,6 +1121,17 @@ async fn step_run_blend_sdp_declaration_cli(
                 })?;
             let locked_note_id_hex = locked_note_id_json.trim_matches('"').to_owned();
             break locked_note_id_hex;
+        }
+        last_lookup_error = Some("wallet has no notes yet".to_owned());
+
+        if note_lookup_started.elapsed() >= note_lookup_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
+                    declarer_api_base_url,
+                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
+                ),
+            });
         }
 
         sleep(Duration::from_millis(250)).await;

--- a/tests/src/cucumber/utils.rs
+++ b/tests/src/cucumber/utils.rs
@@ -6,6 +6,7 @@ use std::{
 
 use hex::ToHex as _;
 use lb_core::codec::SerializeOp as _;
+use lb_key_management_system_service::keys::Key;
 use lb_libp2p::{PeerId, identity, identity::ed25519};
 use lb_node::UserConfig;
 use lb_testing_framework::{CoreBuilderExt as _, ScenarioBuilder};
@@ -182,6 +183,30 @@ fn user_config_from_node_yaml(path: &Path) -> Result<UserConfig, StepError> {
 pub fn funding_wallet_pk_from_node_yaml(path: &Path) -> Result<String, StepError> {
     let config = user_config_from_node_yaml(path)?;
     Ok(config.sdp.wallet.funding_pk.to_bytes()?.encode_hex())
+}
+
+/// Reads a node YAML user config file and extracts the configured Blend core
+/// ZK wallet public key.
+pub fn blend_core_zk_pk_from_node_yaml(path: &Path) -> Result<String, StepError> {
+    let config = user_config_from_node_yaml(path)?;
+
+    let key_id = &config.blend.core.zk.secret_key_kms_id;
+    let key = config
+        .kms
+        .backend
+        .keys
+        .get(key_id)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Blend ZK signing key '{key_id}' not found in KMS"),
+        })?;
+
+    let Key::Zk(secret_key) = key else {
+        return Err(StepError::LogicalError {
+            message: "Blend ZK signing key must be Zk".to_owned(),
+        });
+    };
+
+    Ok(secret_key.to_public_key().to_bytes()?.encode_hex())
 }
 
 /// Extracts the child directory name that starts with a known prefix,

--- a/tests/src/cucumber/utils.rs
+++ b/tests/src/cucumber/utils.rs
@@ -6,7 +6,6 @@ use std::{
 
 use hex::ToHex as _;
 use lb_core::codec::SerializeOp as _;
-use lb_key_management_system_service::keys::Key;
 use lb_libp2p::{PeerId, identity, identity::ed25519};
 use lb_node::UserConfig;
 use lb_testing_framework::{CoreBuilderExt as _, ScenarioBuilder};
@@ -189,24 +188,8 @@ pub fn funding_wallet_pk_from_node_yaml(path: &Path) -> Result<String, StepError
 /// ZK wallet public key.
 pub fn blend_core_zk_pk_from_node_yaml(path: &Path) -> Result<String, StepError> {
     let config = user_config_from_node_yaml(path)?;
-
-    let key_id = &config.blend.core.zk.secret_key_kms_id;
-    let key = config
-        .kms
-        .backend
-        .keys
-        .get(key_id)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Blend ZK signing key '{key_id}' not found in KMS"),
-        })?;
-
-    let Key::Zk(secret_key) = key else {
-        return Err(StepError::LogicalError {
-            message: "Blend ZK signing key must be Zk".to_owned(),
-        });
-    };
-
-    Ok(secret_key.to_public_key().to_bytes()?.encode_hex())
+    let zk_key = config.blend_zk_key().map_err(StepError::ConfigError)?;
+    Ok(zk_key.to_bytes()?.encode_hex())
 }
 
 /// Extracts the child directory name that starts with a known prefix,

--- a/tests/src/cucumber/utils.rs
+++ b/tests/src/cucumber/utils.rs
@@ -188,8 +188,8 @@ pub fn funding_wallet_pk_from_node_yaml(path: &Path) -> Result<String, StepError
 /// ZK wallet public key.
 pub fn blend_core_zk_pk_from_node_yaml(path: &Path) -> Result<String, StepError> {
     let config = user_config_from_node_yaml(path)?;
-    let zk_key = config.blend_zk_key().map_err(StepError::UserConfigError)?;
-    Ok(zk_key.to_bytes()?.encode_hex())
+    let (zk_key_id, _) = config.blend_zk_key().map_err(StepError::UserConfigError)?;
+    Ok(zk_key_id)
 }
 
 /// Extracts the child directory name that starts with a known prefix,

--- a/tests/src/cucumber/utils.rs
+++ b/tests/src/cucumber/utils.rs
@@ -188,7 +188,7 @@ pub fn funding_wallet_pk_from_node_yaml(path: &Path) -> Result<String, StepError
 /// ZK wallet public key.
 pub fn blend_core_zk_pk_from_node_yaml(path: &Path) -> Result<String, StepError> {
     let config = user_config_from_node_yaml(path)?;
-    let zk_key = config.blend_zk_key().map_err(StepError::ConfigError)?;
+    let zk_key = config.blend_zk_key().map_err(StepError::UserConfigError)?;
     Ok(zk_key.to_bytes()?.encode_hex())
 }
 

--- a/tools/blockchain-tools/Cargo.toml
+++ b/tools/blockchain-tools/Cargo.toml
@@ -16,7 +16,6 @@ lb-common-http-client         = { workspace = true }
 lb-core                       = { workspace = true }
 lb-http-api-common            = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
-lb-libp2p                     = { workspace = true }
 lb-node                       = { workspace = true }
 serde                         = { features = ["derive"], workspace = true }
 serde_json                    = { workspace = true }

--- a/tools/blockchain-tools/Cargo.toml
+++ b/tools/blockchain-tools/Cargo.toml
@@ -12,13 +12,18 @@ version.workspace     = true
 [dependencies]
 anyhow                        = { workspace = true }
 clap                          = { features = ["derive", "help", "std", "string"], workspace = true }
+lb-common-http-client         = { workspace = true }
 lb-core                       = { workspace = true }
+lb-http-api-common            = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
+lb-libp2p                     = { workspace = true }
 lb-node                       = { workspace = true }
 serde                         = { features = ["derive"], workspace = true }
 serde_json                    = { workspace = true }
 serde_yml                     = { workspace = true }
 thiserror                     = { workspace = true }
+tokio                         = { features = ["macros", "rt-multi-thread"], workspace = true }
+url                           = { workspace = true }
 
 [dev-dependencies]
 num-bigint = { workspace = true }

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -130,7 +130,7 @@ async fn post_blend_declaration(
     }: PostBlendDeclarationArgs,
 ) -> Result<()> {
     let user_config =
-        deserialize_config_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Fail)
+        deserialize_config_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Warn)
             .with_context(|| {
                 format!(
                     "Failed to read user config at '{}'",

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -62,7 +62,8 @@ enum SdpSubCommand {
     /// The command derives the following from `--user-config-path`:
     /// - `provider_id` (from Blend non-ephemeral signing key)
     /// - `zk_id` (from Blend core ZK key)
-    /// - `locator` (from Blend core listening address)
+    /// - `locator` (from Blend core listening address, unless overridden by
+    ///   `--blend-addr`)
     ///
     /// It then validates that `--locked-note-id` exists for that ZK key before
     /// submitting the declaration.
@@ -209,8 +210,7 @@ async fn extract_values(
     })
 }
 
-// Validate and return the overridden address, if provided, or else validates
-// and returns the address in the provided config file.
+// Validate and return the Blend listening address from the provided config.
 fn extract_blend_locator(config: &UserConfig) -> Result<Locator> {
     config
         .blend

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -202,10 +202,7 @@ async fn extract_values(
         .map_err(|e| anyhow!(e))
         .with_context(|| "Failed to extract provider ID from provided config.")?;
 
-    let zk_id = config
-        .blend_zk_key()
-        .map_err(|e| anyhow!(e))
-        .with_context(|| "Failed to extract zk ID from provided config.")?;
+    let zk_id = extract_blend_zk_key(config)?;
 
     verify_locked_note_id_value(client, node_address, zk_id, locked_note_id).await?;
 
@@ -232,6 +229,24 @@ fn extract_blend_locator(config: &UserConfig) -> Result<Locator> {
                 config.blend.core.backend.listening_address
             )
         })
+}
+
+fn extract_blend_zk_key(config: &UserConfig) -> Result<ZkPublicKey> {
+    let (zk_public_key_id, zk_public_key) = config
+        .blend_zk_key()
+        .map_err(|e| anyhow!(e))
+        .with_context(|| "Failed to extract zk ID from provided config.")?;
+    let Some(wallet_key) = config.wallet.known_keys.get(&zk_public_key_id) else {
+        bail!(
+            "ZK ID '{zk_public_key_id}' extracted from config was not found in wallet known keys"
+        );
+    };
+    if wallet_key != &zk_public_key {
+        bail!(
+            "ZK ID '{zk_public_key_id}' extracted from config does not match the corresponding public key in wallet known keys"
+        );
+    }
+    Ok(zk_public_key)
 }
 
 async fn verify_locked_note_id_value(

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -97,7 +97,7 @@ struct PostBlendDeclarationArgs {
     locked_note_id: NoteId,
 
     /// Base node URL, for example `http://localhost:8080`.
-    #[arg(long, value_name = "NODE_URL")]
+    #[arg(long, value_name = "NODE_URL", default_value = "http://localhost:8080")]
     node_address: Url,
 
     /// Optional basic auth username for the API.

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -199,10 +199,12 @@ async fn extract_values(
 
     let provider_id = config
         .blend_provider_id()
+        .map_err(|e| anyhow!(e))
         .with_context(|| "Failed to extract provider ID from provided config.")?;
 
     let zk_id = config
         .blend_zk_key()
+        .map_err(|e| anyhow!(e))
         .with_context(|| "Failed to extract zk ID from provided config.")?;
 
     verify_locked_note_id_value(client, node_address, zk_id, locked_note_id).await?;

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -8,7 +8,7 @@ use lb_core::{
     sdp::{DeclarationMessage, Locator, ProviderId, ServiceType},
 };
 use lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody;
-use lb_key_management_system_keys::keys::{Key, ZkPublicKey};
+use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_node::config::{OnUnknownKeys, UserConfig, deserialize_config_at_path};
 use serde::{Deserialize, de::IntoDeserializer as _};
 use url::Url;
@@ -197,10 +197,12 @@ async fn extract_values(
         extract_blend_locator(config)?
     };
 
-    let provider_id = extract_blend_provider_id(config)
+    let provider_id = config
+        .blend_provider_id()
         .with_context(|| "Failed to extract provider ID from provided config.")?;
 
-    let zk_id = extract_blend_zk_id(config)
+    let zk_id = config
+        .blend_zk_key()
         .with_context(|| "Failed to extract zk ID from provided config.")?;
 
     verify_locked_note_id_value(client, node_address, zk_id, locked_note_id).await?;
@@ -228,32 +230,6 @@ fn extract_blend_locator(config: &UserConfig) -> Result<Locator> {
                 config.blend.core.backend.listening_address
             )
         })
-}
-
-fn extract_blend_provider_id(config: &UserConfig) -> Result<ProviderId> {
-    let key_id = &config.blend.non_ephemeral_signing_key_id;
-    let key =
-        config.kms.backend.keys.get(key_id).with_context(|| {
-            format!("Blend non-ephemeral signing key '{key_id}' not found in KMS")
-        })?;
-    let Key::Ed25519(secret_key) = key else {
-        bail!("Blend non-ephemeral signing key must be Ed25519");
-    };
-    Ok(ProviderId(secret_key.public_key()))
-}
-
-fn extract_blend_zk_id(config: &UserConfig) -> Result<ZkPublicKey> {
-    let key_id = &config.blend.core.zk.secret_key_kms_id;
-    let key = config
-        .kms
-        .backend
-        .keys
-        .get(key_id)
-        .with_context(|| format!("Blend ZK signing key '{key_id}' not found in KMS"))?;
-    let Key::Zk(secret_key) = key else {
-        bail!("Blend ZK signing key must be Zk");
-    };
-    Ok(secret_key.to_public_key())
 }
 
 async fn verify_locked_note_id_value(

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -1,0 +1,276 @@
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, anyhow, bail};
+use clap::{Parser, Subcommand};
+use lb_common_http_client::{BasicAuthCredentials, CommonHttpClient};
+use lb_core::{
+    mantle::NoteId,
+    sdp::{DeclarationMessage, Locator, ProviderId, ServiceType},
+};
+use lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody;
+use lb_key_management_system_keys::keys::{Key, ZkPublicKey};
+use lb_node::config::{OnUnknownKeys, UserConfig, deserialize_config_at_path};
+use serde::{Deserialize, de::IntoDeserializer as _};
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    cli.run().await
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Logos blockchain HTTP API utility",
+    long_about = "Utilities for interacting with node HTTP APIs from the command line."
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: CliCommand,
+}
+
+impl Cli {
+    async fn run(self) -> Result<()> {
+        self.command.run().await
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum CliCommand {
+    /// Service Declaration Protocol (SDP) operations.
+    Sdp {
+        #[command(subcommand)]
+        command: SdpSubCommand,
+    },
+}
+
+impl CliCommand {
+    async fn run(self) -> Result<()> {
+        match self {
+            Self::Sdp { command } => command.run().await,
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum SdpSubCommand {
+    /// Post a Blend SDP declaration using values extracted from the user
+    /// config.
+    ///
+    /// The command derives the following from `--user-config-path`:
+    /// - `provider_id` (from Blend non-ephemeral signing key)
+    /// - `zk_id` (from Blend core ZK key)
+    /// - `locator` (from Blend core listening address)
+    ///
+    /// It then validates that `--locked-note-id` exists for that ZK key before
+    /// submitting the declaration.
+    PostBlendDeclaration(PostBlendDeclarationArgs),
+}
+
+impl SdpSubCommand {
+    async fn run(self) -> Result<()> {
+        match self {
+            Self::PostBlendDeclaration(args) => post_blend_declaration(args).await,
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+struct PostBlendDeclarationArgs {
+    /// Path to the node user config YAML file.
+    #[arg(long, value_name = "USER_CONFIG_YAML")]
+    user_config_path: PathBuf,
+
+    /// Address of the Blend service to use in the declaration that overrides
+    /// the one present in the config file.
+    #[arg(long, value_name = "BLEND_ADDR")]
+    blend_addr: Option<Locator>,
+
+    /// Note ID to lock for the Blend declaration (HEX-encoded field element).
+    #[arg(long, value_name = "NOTE_ID_HEX", value_parser = parse_hex_serde::<NoteId>)]
+    locked_note_id: NoteId,
+
+    /// Base node URL, for example `http://localhost:8080`.
+    #[arg(long, value_name = "NODE_URL")]
+    node_address: Url,
+
+    /// Optional basic auth username for the API.
+    #[arg(long, value_name = "USERNAME")]
+    username: Option<String>,
+
+    /// Optional basic auth password for the API.
+    #[arg(long, value_name = "PASSWORD")]
+    password: Option<String>,
+}
+
+fn parse_hex_serde<T>(input: &str) -> Result<T, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    use serde::de::value::Error;
+
+    T::deserialize(input.into_deserializer())
+        .map_err(|e: Error| format!("Failed to parse input HEX string: {e}"))
+}
+
+async fn post_blend_declaration(
+    PostBlendDeclarationArgs {
+        locked_note_id,
+        blend_addr,
+        node_address,
+        user_config_path,
+        username,
+        password,
+    }: PostBlendDeclarationArgs,
+) -> Result<()> {
+    let user_config =
+        deserialize_config_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Fail)
+            .with_context(|| {
+                format!(
+                    "Failed to read user config at '{}'",
+                    user_config_path.display()
+                )
+            })?;
+
+    let client = {
+        let credentials = username.map(|u| BasicAuthCredentials::new(u, password));
+        CommonHttpClient::new(credentials)
+    };
+
+    let ExtractedUserConfigValues {
+        provider_id,
+        zk_id,
+        locked_note_id,
+        locator,
+    } = extract_values(
+        &client,
+        node_address.clone(),
+        &user_config,
+        locked_note_id,
+        blend_addr,
+    )
+    .await
+    .with_context(|| "Failed to extract necessary values from user config")?;
+
+    let declaration = DeclarationMessage {
+        locators: vec![locator],
+        locked_note_id,
+        provider_id,
+        service_type: ServiceType::BlendNetwork,
+        zk_id,
+    };
+
+    let declaration_id = client
+        .post_declaration(node_address, &declaration)
+        .await
+        .context("Failed to post declaration")?;
+
+    println!("Declaration posted successfully: {declaration_id}");
+    Ok(())
+}
+
+struct ExtractedUserConfigValues {
+    provider_id: ProviderId,
+    zk_id: ZkPublicKey,
+    locked_note_id: NoteId,
+    locator: Locator,
+}
+
+async fn extract_values(
+    client: &CommonHttpClient,
+    node_address: Url,
+    config: &UserConfig,
+    locked_note_id: NoteId,
+    blend_address: Option<Locator>,
+) -> Result<ExtractedUserConfigValues> {
+    // Keep all config-derived declaration fields in one place so the CLI and
+    // node service remain aligned on identity/key source semantics.
+    let locator = if let Some(blend_address) = blend_address {
+        blend_address
+    } else {
+        extract_blend_locator(config)?
+    };
+
+    let provider_id = extract_blend_provider_id(config)
+        .with_context(|| "Failed to extract provider ID from provided config.")?;
+
+    let zk_id = extract_blend_zk_id(config)
+        .with_context(|| "Failed to extract zk ID from provided config.")?;
+
+    verify_locked_note_id_value(client, node_address, zk_id, locked_note_id).await?;
+
+    Ok(ExtractedUserConfigValues {
+        provider_id,
+        zk_id,
+        locked_note_id,
+        locator,
+    })
+}
+
+// Validate and return the overridden address, if provided, or else validates
+// and returns the address in the provided config file.
+fn extract_blend_locator(config: &UserConfig) -> Result<Locator> {
+    config
+        .blend
+        .core
+        .backend
+        .listening_address
+        .clone()
+        .try_into()
+        .map_err(|_| {
+            anyhow!(
+                "Blend listening address '{:?}' from config is not a valid locator",
+                config.blend.core.backend.listening_address
+            )
+        })
+}
+
+fn extract_blend_provider_id(config: &UserConfig) -> Result<ProviderId> {
+    let key_id = &config.blend.non_ephemeral_signing_key_id;
+    let key =
+        config.kms.backend.keys.get(key_id).with_context(|| {
+            format!("Blend non-ephemeral signing key '{key_id}' not found in KMS")
+        })?;
+    let Key::Ed25519(secret_key) = key else {
+        bail!("Blend non-ephemeral signing key must be Ed25519");
+    };
+    Ok(ProviderId(secret_key.public_key()))
+}
+
+fn extract_blend_zk_id(config: &UserConfig) -> Result<ZkPublicKey> {
+    let key_id = &config.blend.core.zk.secret_key_kms_id;
+    let key = config
+        .kms
+        .backend
+        .keys
+        .get(key_id)
+        .with_context(|| format!("Blend ZK signing key '{key_id}' not found in KMS"))?;
+    let Key::Zk(secret_key) = key else {
+        bail!("Blend ZK signing key must be Zk");
+    };
+    Ok(secret_key.to_public_key())
+}
+
+async fn verify_locked_note_id_value(
+    client: &CommonHttpClient,
+    node_address: Url,
+    zk_id: ZkPublicKey,
+    locked_note_id: NoteId,
+) -> Result<()> {
+    let WalletBalanceResponseBody { notes, .. } = client
+        .get_wallet_balance(node_address, zk_id, None)
+        .await
+        .context("Failed to fetch wallet balance for Blend ZK ID")?;
+
+    // Preflight guard: fail early when the provided note does not belong to the
+    // declaration ZK key according to the wallet view at `node_address`.
+    // TODO: Also verify minimum stake amount once that threshold is exposed here.
+    if !notes.contains_key(&locked_note_id) {
+        bail!(
+            "Locked note ID '{locked_note_id:?}' was not found in wallet notes for provided Blend ZK ID",
+        );
+    }
+    Ok(())
+}

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -85,7 +85,10 @@ struct PostBlendDeclarationArgs {
     user_config_path: PathBuf,
 
     /// Address of the Blend service to use in the declaration that overrides
-    /// the one present in the config file.
+    /// the one present in the config file. This is useful for the case in which
+    /// a node is listening on the `0.0.0.0` address, and the declaration needs
+    /// to be posted with the externally reachable address, since `0.0.0.0` is
+    /// not a valid `Locator` value.
     #[arg(long, value_name = "BLEND_ADDR")]
     blend_addr: Option<Locator>,
 


### PR DESCRIPTION
## 1. What does this PR implement?

Based on top of the locator validation PR as the new binary uses the locator validation function: https://github.com/logos-blockchain/logos-blockchain/pull/2712.

Add a new `api` utility binary that will introduce QoL improvements without having to touch the node binary. In this PR, we introduce a subcommand to post a Blend SDP declaration starting from the user config file and a bunch of other info.

We can start bundling this binary in our releases, and it would be the only other binary we would probably release for now.

I tested the feature with an e2e test that uses cucumber and the TF.

## 2. Does the code have enough context to be clearly understood?

The actual code, yes. The testing code might be a bit messy, but I am open to feedback on how to improve it.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.