### PR TITLE
feat(chainsync): make MAX_INCOMING_REQUESTS user-configurable

### DIFF
--- a/consensus/cryptarchia-sync/src/config.rs
+++ b/consensus/cryptarchia-sync/src/config.rs
@@ -3,18 +3,15 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationMilliSeconds, serde_as};
 
-const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// The maximum duration to wait for a peer to respond
     /// with a message.
     #[serde_as(as = "DurationMilliSeconds<u64>")]
-    #[serde(default = "default_response_timeout")]
     pub peer_response_timeout: Duration,
-}
-
-const fn default_response_timeout() -> Duration {
-    DEFAULT_RESPONSE_TIMEOUT
+    /// The maximum number of inbound requests that can be handled concurrently,
+    /// including requests waiting to be processed and requests currently being
+    /// processed.
+    pub max_inbound_requests: usize,
 }

--- a/consensus/cryptarchia-sync/src/config.rs
+++ b/consensus/cryptarchia-sync/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationMilliSeconds, serde_as};
@@ -13,5 +13,5 @@ pub struct Config {
     /// The maximum number of inbound requests that can be handled concurrently,
     /// including requests waiting to be processed and requests currently being
     /// processed.
-    pub max_inbound_requests: usize,
+    pub max_inbound_requests: NonZeroUsize,
 }

--- a/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
@@ -284,7 +284,7 @@ impl Behaviour {
             + self.sending_block_responses.len()
             + self.sending_tip_responses.len();
 
-        if concurrent_requests >= self.config.max_inbound_requests {
+        if concurrent_requests >= self.config.max_inbound_requests.into() {
             self.incoming_streams_to_close.push(
                 async move {
                     drop(stream.close().await);
@@ -550,7 +550,7 @@ mod tests {
     async fn test_block_sync_between_two_swarms() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) =
             start_provider_and_downloader(200, config).await;
@@ -577,14 +577,14 @@ mod tests {
     async fn test_reject_excess_download_requests() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) =
             start_provider_and_downloader(1, config.clone()).await;
 
         let streams = request_download(
             &mut downloader_swarm,
-            config.max_inbound_requests + 1,
+            config.max_inbound_requests.get() + 1,
             HeaderId::from([0; 32]),
             HeaderId::from([0; 32]),
             HeaderId::from([0; 32]),
@@ -596,7 +596,7 @@ mod tests {
 
         let (blocks, errors) = wait_block_messages(streams).await;
 
-        assert_eq!(blocks.len(), config.max_inbound_requests);
+        assert_eq!(blocks.len(), config.max_inbound_requests.get());
         assert_eq!(errors.len(), 1);
     }
 
@@ -604,7 +604,7 @@ mod tests {
     async fn test_reject_protocol_violation_too_many_additional_blocks() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) =
             start_provider_and_downloader(1, config).await;
@@ -631,7 +631,7 @@ mod tests {
     async fn test_get_tip() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) =
             start_provider_and_downloader(0, config).await;
@@ -653,7 +653,7 @@ mod tests {
     async fn test_timeout() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let mut provider_swarm = new_swarm_with_quic(config.clone());
         let provider_swarm_peer_id = *provider_swarm.local_peer_id();
@@ -699,7 +699,7 @@ mod tests {
     async fn test_tip_request_rejection() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) = start_rejecting_provider(config).await;
 
@@ -716,7 +716,7 @@ mod tests {
     async fn test_block_request_rejection() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) = start_rejecting_provider(config).await;
 
@@ -742,7 +742,7 @@ mod tests {
     async fn test_block_stream_error_during_transmission() {
         let config = Config {
             peer_response_timeout: Duration::from_secs(1),
-            max_inbound_requests: 4,
+            max_inbound_requests: 4.try_into().unwrap(),
         };
         let (mut downloader_swarm, provider_peer_id) =
             start_provider_with_stream_error(config).await;

--- a/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/behaviour.rs
@@ -31,8 +31,6 @@ use crate::{
     messages::{GetTipResponse, SerialisedBlock},
 };
 
-const MAX_INCOMING_REQUESTS: usize = 4;
-
 type SendingBlocksRequestsFuture = BoxFuture<'static, Result<BlocksRequestStream, ChainSyncError>>;
 
 type SendingTipRequestFuture = BoxFuture<'static, Result<TipRequestStream, ChainSyncError>>;
@@ -286,7 +284,7 @@ impl Behaviour {
             + self.sending_block_responses.len()
             + self.sending_tip_responses.len();
 
-        if concurrent_requests >= MAX_INCOMING_REQUESTS {
+        if concurrent_requests >= self.config.max_inbound_requests {
             self.incoming_streams_to_close.push(
                 async move {
                     drop(stream.close().await);
@@ -541,7 +539,7 @@ mod tests {
         ProviderResponse, TipResponse,
         config::Config,
         libp2p::{
-            behaviour::{Behaviour, BoxedStream, Event, MAX_INCOMING_REQUESTS},
+            behaviour::{Behaviour, BoxedStream, Event},
             errors::{ChainSyncError, ChainSyncErrorKind},
             provider::MAX_ADDITIONAL_BLOCKS,
         },
@@ -550,7 +548,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_sync_between_two_swarms() {
-        let (mut downloader_swarm, provider_peer_id) = start_provider_and_downloader(200).await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) =
+            start_provider_and_downloader(200, config).await;
 
         let streams = request_download(
             &mut downloader_swarm,
@@ -572,11 +575,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_reject_excess_download_requests() {
-        let (mut downloader_swarm, provider_peer_id) = start_provider_and_downloader(1).await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) =
+            start_provider_and_downloader(1, config.clone()).await;
 
         let streams = request_download(
             &mut downloader_swarm,
-            MAX_INCOMING_REQUESTS + 1,
+            config.max_inbound_requests + 1,
             HeaderId::from([0; 32]),
             HeaderId::from([0; 32]),
             HeaderId::from([0; 32]),
@@ -588,13 +596,18 @@ mod tests {
 
         let (blocks, errors) = wait_block_messages(streams).await;
 
-        assert_eq!(blocks.len(), MAX_INCOMING_REQUESTS);
+        assert_eq!(blocks.len(), config.max_inbound_requests);
         assert_eq!(errors.len(), 1);
     }
 
     #[tokio::test]
     async fn test_reject_protocol_violation_too_many_additional_blocks() {
-        let (mut downloader_swarm, provider_peer_id) = start_provider_and_downloader(1).await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) =
+            start_provider_and_downloader(1, config).await;
 
         let streams = request_download(
             &mut downloader_swarm,
@@ -616,7 +629,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_tip() {
-        let (mut downloader_swarm, provider_peer_id) = start_provider_and_downloader(0).await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) =
+            start_provider_and_downloader(0, config).await;
 
         let receiver = request_tip(&mut downloader_swarm, provider_peer_id);
 
@@ -633,7 +651,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout() {
-        let mut provider_swarm = new_swarm_with_quic();
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let mut provider_swarm = new_swarm_with_quic(config.clone());
         let provider_swarm_peer_id = *provider_swarm.local_peer_id();
 
         let provider_addr: Multiaddr = format!(
@@ -653,7 +675,7 @@ mod tests {
             }
         });
 
-        let mut downloader_swarm = new_swarm_with_quic();
+        let mut downloader_swarm = new_swarm_with_quic(config);
         downloader_swarm.dial_and_wait(provider_addr).await;
 
         let streams = request_download(
@@ -675,7 +697,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_tip_request_rejection() {
-        let (mut downloader_swarm, provider_peer_id) = start_rejecting_provider().await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) = start_rejecting_provider(config).await;
 
         let receiver = request_tip(&mut downloader_swarm, provider_peer_id);
 
@@ -688,7 +714,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_request_rejection() {
-        let (mut downloader_swarm, provider_peer_id) = start_rejecting_provider().await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) = start_rejecting_provider(config).await;
 
         let streams = request_download(
             &mut downloader_swarm,
@@ -710,7 +740,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_stream_error_during_transmission() {
-        let (mut downloader_swarm, provider_peer_id) = start_provider_with_stream_error().await;
+        let config = Config {
+            peer_response_timeout: Duration::from_secs(1),
+            max_inbound_requests: 4,
+        };
+        let (mut downloader_swarm, provider_peer_id) =
+            start_provider_with_stream_error(config).await;
 
         let streams = request_download(
             &mut downloader_swarm,
@@ -730,24 +765,11 @@ mod tests {
         assert_eq!(errors.len(), 1);
     }
 
-    fn setup_provider_swarm() -> (Swarm<Behaviour>, PeerId, Multiaddr) {
-        let mut provider_swarm = new_swarm_with_quic();
-        let provider_peer_id = *provider_swarm.local_peer_id();
-
-        let provider_addr: Multiaddr = format!(
-            "/ip4/127.0.0.1/udp/{}/quic-v1",
-            thread_rng().gen_range(10000..60000)
-        )
-        .parse()
-        .unwrap();
-
-        provider_swarm.listen_on(provider_addr.clone()).unwrap();
-
-        (provider_swarm, provider_peer_id, provider_addr)
-    }
-
-    async fn setup_downloader_and_connect(provider_addr: Multiaddr) -> Swarm<Behaviour> {
-        let mut downloader_swarm = new_swarm_with_quic();
+    async fn setup_downloader_and_connect(
+        provider_addr: Multiaddr,
+        config: Config,
+    ) -> Swarm<Behaviour> {
+        let mut downloader_swarm = new_swarm_with_quic(config);
         downloader_swarm.dial_and_wait(provider_addr).await;
         downloader_swarm
     }
@@ -848,37 +870,60 @@ mod tests {
         }
     }
 
-    async fn start_provider_and_downloader(blocks_count: usize) -> (Swarm<Behaviour>, PeerId) {
-        let (provider_swarm, provider_peer_id, provider_addr) = setup_provider_swarm();
+    async fn start_provider_and_downloader(
+        blocks_count: usize,
+        config: Config,
+    ) -> (Swarm<Behaviour>, PeerId) {
+        let (provider_swarm, provider_peer_id, provider_addr) =
+            setup_provider_swarm(config.clone());
 
         tokio::spawn(run_provider(
             provider_swarm,
             StandardProvider { blocks_count },
         ));
 
-        let downloader_swarm = setup_downloader_and_connect(provider_addr).await;
+        let downloader_swarm = setup_downloader_and_connect(provider_addr, config).await;
         (downloader_swarm, provider_peer_id)
     }
 
-    async fn start_rejecting_provider() -> (Swarm<Behaviour>, PeerId) {
-        let (provider_swarm, provider_peer_id, provider_addr) = setup_provider_swarm();
+    async fn start_rejecting_provider(config: Config) -> (Swarm<Behaviour>, PeerId) {
+        let (provider_swarm, provider_peer_id, provider_addr) =
+            setup_provider_swarm(config.clone());
 
         tokio::spawn(run_provider(provider_swarm, RejectingProvider));
 
-        let downloader_swarm = setup_downloader_and_connect(provider_addr).await;
+        let downloader_swarm = setup_downloader_and_connect(provider_addr, config).await;
         (downloader_swarm, provider_peer_id)
     }
 
-    async fn start_provider_with_stream_error() -> (Swarm<Behaviour>, PeerId) {
-        let (provider_swarm, provider_peer_id, provider_addr) = setup_provider_swarm();
+    async fn start_provider_with_stream_error(config: Config) -> (Swarm<Behaviour>, PeerId) {
+        let (provider_swarm, provider_peer_id, provider_addr) =
+            setup_provider_swarm(config.clone());
 
         tokio::spawn(run_provider(
             provider_swarm,
             ErrorStreamProvider { success_count: 1 },
         ));
 
-        let downloader_swarm = setup_downloader_and_connect(provider_addr).await;
+        let downloader_swarm = setup_downloader_and_connect(provider_addr, config).await;
         (downloader_swarm, provider_peer_id)
+    }
+
+    #[cfg(test)]
+    fn setup_provider_swarm(config: Config) -> (Swarm<Behaviour>, PeerId, Multiaddr) {
+        let mut provider_swarm = new_swarm_with_quic(config);
+        let provider_peer_id = *provider_swarm.local_peer_id();
+
+        let provider_addr: Multiaddr = format!(
+            "/ip4/127.0.0.1/udp/{}/quic-v1",
+            thread_rng().gen_range(10000..60000)
+        )
+        .parse()
+        .unwrap();
+
+        provider_swarm.listen_on(provider_addr.clone()).unwrap();
+
+        (provider_swarm, provider_peer_id, provider_addr)
     }
 
     fn request_download(
@@ -952,10 +997,7 @@ mod tests {
         (blocks, errors)
     }
 
-    fn new_swarm_with_quic() -> Swarm<Behaviour> {
-        let config = Config {
-            peer_response_timeout: Duration::from_secs(1),
-        };
+    fn new_swarm_with_quic(config: Config) -> Swarm<Behaviour> {
         let keypair = libp2p::identity::Keypair::generate_ed25519();
         libp2p::SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()

--- a/libp2p/src/config/mod.rs
+++ b/libp2p/src/config/mod.rs
@@ -95,7 +95,7 @@ mod tests {
                 identify_config: identify::Settings::default(),
                 chain_sync_config: ChainSyncSettings {
                     peer_response_timeout: Duration::from_secs(5),
-                    max_inbound_requests: 10,
+                    max_inbound_requests: 10.try_into().unwrap(),
                 },
                 nat_config: nat::Settings::default(),
             }

--- a/libp2p/src/config/mod.rs
+++ b/libp2p/src/config/mod.rs
@@ -45,7 +45,6 @@ pub struct SwarmConfig {
     pub identify_config: identify::Settings,
 
     /// Chain sync config
-    #[serde(default)]
     pub chain_sync_config: ChainSyncSettings,
 
     /// Nat config
@@ -78,6 +77,8 @@ pub mod secret_key_serde {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     impl Default for SwarmConfig {
@@ -92,7 +93,10 @@ mod tests {
                 chain_sync_protocol_name: StreamProtocol::new("/chainsync/test"),
                 kademlia_config: kademlia::Settings::default(),
                 identify_config: identify::Settings::default(),
-                chain_sync_config: ChainSyncSettings::default(),
+                chain_sync_config: ChainSyncSettings {
+                    peer_response_timeout: Duration::from_secs(5),
+                    max_inbound_requests: 10,
+                },
                 nat_config: nat::Settings::default(),
             }
         }

--- a/nodes/node/binary/src/config/network/mod.rs
+++ b/nodes/node/binary/src/config/network/mod.rs
@@ -74,6 +74,12 @@ impl From<ServiceConfig> for NetworkConfig<Libp2pConfig> {
                             .swarm
                             .chain_sync
                             .peer_response_timeout,
+                        max_inbound_requests: value
+                            .user
+                            .backend
+                            .swarm
+                            .chain_sync
+                            .max_inbound_requests,
                     },
                     nat_config: value.user.backend.swarm.nat.into(),
                 },

--- a/nodes/node/binary/src/config/network/serde/chainsync.rs
+++ b/nodes/node/binary/src/config/network/serde/chainsync.rs
@@ -11,12 +11,17 @@ pub struct Config {
     /// with a message.
     #[serde_as(as = "DurationMilliSeconds<u64>")]
     pub peer_response_timeout: Duration,
+    /// The maximum number of inbound requests that can be handled concurrently,
+    /// including requests waiting to be processed and requests currently being
+    /// processed.
+    pub max_inbound_requests: usize,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             peer_response_timeout: Duration::from_secs(5),
+            max_inbound_requests: 10,
         }
     }
 }

--- a/nodes/node/binary/src/config/network/serde/chainsync.rs
+++ b/nodes/node/binary/src/config/network/serde/chainsync.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+use std::num::NonZeroUsize;
 
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationMilliSeconds, serde_as};
@@ -14,14 +15,14 @@ pub struct Config {
     /// The maximum number of inbound requests that can be handled concurrently,
     /// including requests waiting to be processed and requests currently being
     /// processed.
-    pub max_inbound_requests: usize,
+    pub max_inbound_requests: NonZeroUsize,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             peer_response_timeout: Duration::from_secs(5),
-            max_inbound_requests: 10,
+            max_inbound_requests: 10.try_into().unwrap(),
         }
     }
 }

--- a/services/network/src/backends/libp2p/swarm/mod.rs
+++ b/services/network/src/backends/libp2p/swarm/mod.rs
@@ -351,7 +351,7 @@ mod tests {
             identify_config: lb_libp2p::IdentifySettings::default(),
             chain_sync_config: lb_cryptarchia_sync::Config {
                 peer_response_timeout: Duration::from_secs(5),
-                max_inbound_requests: 10,
+                max_inbound_requests: 10.try_into().unwrap(),
             },
             nat_config: lb_libp2p::NatSettings::Traversal(lb_libp2p::TraversalSettings {
                 autonat: lb_libp2p::AutonatClientSettings {

--- a/services/network/src/backends/libp2p/swarm/mod.rs
+++ b/services/network/src/backends/libp2p/swarm/mod.rs
@@ -349,7 +349,10 @@ mod tests {
             identify_protocol_name: StreamProtocol::new("/identify/test"),
             chain_sync_protocol_name: StreamProtocol::new("/chainsync/test"),
             identify_config: lb_libp2p::IdentifySettings::default(),
-            chain_sync_config: lb_cryptarchia_sync::Config::default(),
+            chain_sync_config: lb_cryptarchia_sync::Config {
+                peer_response_timeout: Duration::from_secs(5),
+                max_inbound_requests: 10,
+            },
             nat_config: lb_libp2p::NatSettings::Traversal(lb_libp2p::TraversalSettings {
                 autonat: lb_libp2p::AutonatClientSettings {
                     probe_interval_millisecs: Some(1000),

--- a/tools/config/src/network.rs
+++ b/tools/config/src/network.rs
@@ -43,6 +43,7 @@ pub fn create_network_configs(
                 port: get_reserved_available_udp_port().unwrap(),
                 chain_sync: network::chainsync::Config {
                     peer_response_timeout: CHAIN_SYNC_PEER_RESPONSE_TIMEOUT,
+                    ..Default::default()
                 },
                 ..default_swarm_config()
             }


### PR DESCRIPTION
## 1. What does this PR implement?

We had `MAX_INCOMING_REQUESTS = 4` which is too small. It accepts at most 4 inbound chainsync requests, including tip requests. 

This PR factors it out as a user config. 
Also, I removed `Default` impl for it. Only the binary implementation defines a default value (I chose 10 for it).

Now, `user_config.yaml` has:
```yaml
      chain_sync:
        peer_response_timeout: 5000
        max_inbound_requests: 10
```


## 2. Does the code have enough context to be clearly understood?
yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 
spec: @youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes. Actually this is not what should be defined in the spec. It's just a config.

## 5. Does the implementation introduce changes in the specification?

no.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
