### PR TITLE
feat(init): add `--no-ibd` and increase default PBP to 1h

### DIFF
--- a/nodes/node/binary/src/config/cryptarchia/serde/service.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/service.rs
@@ -23,7 +23,7 @@ pub struct BootstrapConfig {
 impl Default for BootstrapConfig {
     fn default() -> Self {
         Self {
-            prolonged_bootstrap_period: Duration::from_mins(5),
+            prolonged_bootstrap_period: Duration::from_hours(1),
             force_bootstrap: bool::default(),
             offline_grace_period: OfflineGracePeriodConfig::default(),
         }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -122,7 +122,9 @@ pub enum Command {
 #[cfg(feature = "config-gen")]
 #[derive(Parser, Debug)]
 pub struct InitArgs {
-    /// Trusted peers to bootstrap from (multiaddr format)
+    /// Trusted peers to bootstrap from (multiaddr format).
+    /// If `--no-ibd` is not set, peers whose multiaddrs include a `PeerId`
+    /// are also used as IBD peers.
     #[clap(long = "initial-peers", short = 'p', num_args = 1.., value_delimiter = ',')]
     pub initial_peers: Vec<Multiaddr>,
 
@@ -149,6 +151,11 @@ pub struct InitArgs {
 
     #[clap(long = "state-path")]
     pub state_path: Option<PathBuf>,
+
+    /// Disable Initial Block Download (IBD) by leaving the IBD peer list
+    /// empty, regardless of any peers passed via `--initial-peers`/`-p`.
+    #[clap(long = "no-ibd", default_value_t = false)]
+    pub no_ibd: bool,
 }
 
 #[cfg(feature = "config-gen")]

--- a/nodes/node/binary/src/init.rs
+++ b/nodes/node/binary/src/init.rs
@@ -1,5 +1,5 @@
 use core::str::FromStr as _;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use color_eyre::eyre::{Result, eyre};
 use lb_groth16::fr_to_bytes;
@@ -160,14 +160,19 @@ fn build_user_config(
     let cryptarchia_config = {
         let mut base_config =
             CryptarchiaConfig::with_required_values(CryptarchiaConfigRequiredValues { funding_pk });
-        base_config.network.bootstrap.ibd.peers = args
-            .initial_peers
-            .iter()
-            .filter_map(|addr| match addr.iter().last() {
-                Some(lb_libp2p::Protocol::P2p(bytes)) => PeerId::from_multihash(bytes.into()).ok(),
-                _ => None,
-            })
-            .collect();
+        base_config.network.bootstrap.ibd.peers = if args.no_ibd {
+            HashSet::new()
+        } else {
+            args.initial_peers
+                .iter()
+                .filter_map(|addr| match addr.iter().last() {
+                    Some(lb_libp2p::Protocol::P2p(bytes)) => {
+                        PeerId::from_multihash(bytes.into()).ok()
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
         base_config
     };
 
@@ -228,6 +233,10 @@ mod tests {
     use super::*;
 
     fn build_config_from_peers(initial_peers: Vec<Multiaddr>) -> UserConfig {
+        build_config(initial_peers, false)
+    }
+
+    fn build_config(initial_peers: Vec<Multiaddr>, no_ibd: bool) -> UserConfig {
         let args = InitArgs {
             initial_peers,
             output: "test_output.yaml".into(),
@@ -236,6 +245,7 @@ mod tests {
             http_addr: SocketAddr::from(([0, 0, 0, 0], 8080)),
             external_address: None,
             state_path: None,
+            no_ibd,
         };
         let network_key = lb_libp2p::ed25519::SecretKey::generate();
         let keys = generate_keys();
@@ -270,6 +280,18 @@ mod tests {
         let addr: Multiaddr = "/ip4/1.2.3.4/udp/3000/quic-v1".parse().unwrap();
 
         let config = build_config_from_peers(vec![addr]);
+
+        assert!(config.cryptarchia.network.bootstrap.ibd.peers.is_empty());
+    }
+
+    #[test]
+    fn no_ibd_flag_clears_ibd_peers_even_with_initial_peers() {
+        let peer = PeerId::random();
+        let addr_with_p2p: Multiaddr = format!("/ip4/1.2.3.4/udp/3000/quic-v1/p2p/{peer}")
+            .parse()
+            .unwrap();
+
+        let config = build_config(vec![addr_with_p2p], true);
 
         assert!(config.cryptarchia.network.bootstrap.ibd.peers.is_empty());
     }


### PR DESCRIPTION
## 1. What does this PR implement?

Closes #2704

Now, the `init` subcommand generates a `user_config.yaml`:
- with the default value `1h` for PBP.
- with setting `ibd.peers` to `[]` if a new `--no-ibd` flag is set, even if initial p2p peer addresses are specified by `-p` flags.

```bash
target/debug/logos-blockchain-node init \
    --no-ibd \
    -p /ip4/65.109.51.37/udp/3000/quic-v1/p2p/12D3KooWFrouXfmrR4nsLMtE7wu15DoMJ6VtoUtHinREZCvbWHar 
```
```yaml
network:
  backend:
    initial_peers:
      -- /ip4/65.109.51.37/udp/3000/quic-v1/p2p/12D3KooWFrouXfmrR4nsLMtE7wu15DoMJ6VtoUtHinREZCvbWHa
cryptarchia:
  service:
    bootstrap:
      prolonged_bootstrap_period: '3600.000000000'
      ...
  network:
    bootstrap:
      ibd:
        peers: []
```

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?
n/a
Not directly related to specs

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
