### PR TITLE
feat(chain-network): add retry with exponential backoff for IBD peer failures

### DIFF
--- a/nodes/node/binary/src/config/cryptarchia/mod.rs
+++ b/nodes/node/binary/src/config/cryptarchia/mod.rs
@@ -117,6 +117,8 @@ impl ServiceConfig {
                         .ibd
                         .delay_before_new_download,
                     peers: self.user.network.bootstrap.ibd.peers,
+                    max_retries: self.user.network.bootstrap.ibd.max_retries,
+                    initial_retry_delay: self.user.network.bootstrap.ibd.initial_retry_delay,
                 },
             },
             network: LibP2pAdapterSettings {

--- a/nodes/node/binary/src/config/cryptarchia/serde/network.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/network.rs
@@ -28,6 +28,12 @@ pub struct IbdConfig {
     /// Delay before attempting the next download
     /// when no download is needed at the moment from a peer.
     pub delay_before_new_download: Duration,
+    /// Maximum number of retry attempts when all peers fail during IBD.
+    /// Set to 0 to disable retries (immediate shutdown on failure).
+    pub max_retries: usize,
+    /// Initial delay before the first retry attempt.
+    /// Subsequent retries use exponential backoff (delay doubles each attempt).
+    pub initial_retry_delay: Duration,
 }
 
 impl Default for IbdConfig {
@@ -35,6 +41,8 @@ impl Default for IbdConfig {
         Self {
             peers: HashSet::default(),
             delay_before_new_download: Duration::from_secs(10),
+            max_retries: 10,
+            initial_retry_delay: Duration::from_secs(5),
         }
     }
 }

--- a/services/chain/chain-network/src/bootstrap/config.rs
+++ b/services/chain/chain-network/src/bootstrap/config.rs
@@ -23,8 +23,24 @@ where
     /// when no download is needed at the moment from a peer.
     #[serde(default = "default_delay_before_new_download")]
     pub delay_before_new_download: Duration,
+    /// Maximum number of retry attempts when all peers fail during IBD.
+    /// Set to 0 to disable retries (previous behaviour: immediate shutdown).
+    #[serde(default = "default_max_retries")]
+    pub max_retries: usize,
+    /// Initial delay before the first retry attempt.
+    /// Subsequent retries use exponential backoff (delay doubles each attempt).
+    #[serde(default = "default_initial_retry_delay")]
+    pub initial_retry_delay: Duration,
 }
 
 const fn default_delay_before_new_download() -> Duration {
     Duration::from_secs(10)
+}
+
+const fn default_max_retries() -> usize {
+    10
+}
+
+const fn default_initial_retry_delay() -> Duration {
+    Duration::from_secs(5)
 }

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -901,6 +901,8 @@ mod tests {
         IbdConfig {
             peers,
             delay_before_new_download: std::time::Duration::from_millis(1),
+            max_retries: 0, // no retries in unit tests
+            initial_retry_delay: std::time::Duration::from_millis(1),
         }
     }
 

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -38,7 +38,7 @@ use overwatch::{
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use tokio::{sync::oneshot, time::sleep};
-use tracing::{Level, debug, error, info, instrument, span, trace};
+use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 use tracing_futures::Instrument as _;
 
 pub use crate::{
@@ -258,39 +258,69 @@ where
 
         let network_adapter = NetAdapter::new(network_config, relays.network_relay().clone()).await;
 
-        let initial_block_download = InitialBlockDownload::new(
-            ChainNetworkIbdBlockProcessor::<_, Mempool, _> {
-                cryptarchia: relays.cryptarchia().clone(),
-                mempool_adapter: relays.mempool_adapter().clone(),
-            },
-            network_adapter.clone(),
-        );
+        let ibd_config = &bootstrap_config.ibd;
+        let mut attempts: usize = 0;
+        let mut retry_delay = ibd_config.initial_retry_delay;
+        let max_attempts = ibd_config.max_retries.saturating_add(1); // initial + retries
 
-        match initial_block_download.run(bootstrap_config.ibd).await {
-            Ok(_) => {
-                info!("Initial Block Download completed successfully");
-                // Notify chain-service that IBD is complete so it can start the prolonged
-                // bootstrap timer
-                if let Err(e) = relays.cryptarchia().notify_ibd_completed().await {
-                    error!("Failed to notify chain-service of IBD completion: {e:?}");
-                }
-            }
-            Err(e) => {
-                error!(
-                    "Initial Block Download failed: {e:?}. Initiating graceful shutdown. Retry with different bootstrap peers"
-                );
-                if let Err(shutdown_err) = self
-                    .service_resources_handle
-                    .overwatch_handle
-                    .shutdown()
-                    .await
-                {
-                    error!("Failed to shutdown overwatch: {shutdown_err:?}");
-                }
+        loop {
+            // Rebuild the IBD processor on each attempt since it consumes self
+            let initial_block_download = InitialBlockDownload::new(
+                ChainNetworkIbdBlockProcessor::<_, Mempool, _> {
+                    cryptarchia: relays.cryptarchia().clone(),
+                    mempool_adapter: relays.mempool_adapter().clone(),
+                },
+                network_adapter.clone(),
+            );
 
-                return Err(DynError::from(format!(
-                    "Initial Block Download failed: {e:?}"
-                )));
+            match initial_block_download.run(ibd_config.clone()).await {
+                Ok(_) => {
+                    info!("Initial Block Download completed successfully");
+                    if attempts > 0 {
+                        metrics::ibd_completed_after_retries(attempts as u64);
+                    }
+                    // Notify chain-service that IBD is complete so it can start the prolonged
+                    // bootstrap timer
+                    if let Err(e) = relays.cryptarchia().notify_ibd_completed().await {
+                        error!(target: LOG_TARGET, "Failed to notify chain-service of IBD completion: {e:?}");
+                    }
+                    break;
+                }
+                Err(e) if attempts < ibd_config.max_retries => {
+                    metrics::ibd_retry_attempt(
+                        (attempts + 1) as u64,
+                        ibd_config.max_retries as u64,
+                    );
+                    warn!(
+                        target: LOG_TARGET,
+                        attempt = attempts + 1,
+                        max_retries = ibd_config.max_retries,
+                        delay_secs = retry_delay.as_secs(),
+                        "Initial Block Download failed, retrying after delay: {e:?}"
+                    );
+                    sleep(retry_delay).await;
+                    attempts += 1;
+                    retry_delay *= 2; // exponential backoff
+                }
+                Err(e) => {
+                    error!(
+                        target: LOG_TARGET,
+                        total_attempts = max_attempts,
+                        "Initial Block Download failed after {max_attempts} attempt(s): {e:?}. Initiating shutdown."
+                    );
+                    if let Err(shutdown_err) = self
+                        .service_resources_handle
+                        .overwatch_handle
+                        .shutdown()
+                        .await
+                    {
+                        error!(target: LOG_TARGET, "Failed to shutdown overwatch: {shutdown_err:?}");
+                    }
+
+                    return Err(DynError::from(format!(
+                        "Initial Block Download failed after {max_attempts} attempt(s): {e:?}"
+                    )));
+                }
             }
         }
 

--- a/services/chain/chain-network/src/metrics.rs
+++ b/services/chain/chain-network/src/metrics.rs
@@ -136,3 +136,13 @@ pub fn chainsync_observe_request_tip<T>(
     }
     result
 }
+
+pub fn ibd_retry_attempt(attempt: u64, max_retries: u64) {
+    lb_tracing::increase_counter_u64!(ibd_retries_total, 1);
+    lb_tracing::metric_gauge_u64!(ibd_retry_attempt_current, attempt);
+    lb_tracing::metric_gauge_u64!(ibd_retry_max, max_retries);
+}
+
+pub fn ibd_completed_after_retries(attempts: u64) {
+    lb_tracing::metric_histogram_u64!(ibd_total_attempts, attempts);
+}

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -605,6 +605,8 @@ fn build_cryptarchia_user_config(
                 ibd: network::IbdConfig {
                     delay_before_new_download: Duration::from_secs(10),
                     peers: HashSet::new(),
+                    max_retries: 0,
+                    initial_retry_delay: Duration::from_secs(5),
                 },
             },
             network: network::NetworkConfig {


### PR DESCRIPTION
## 1. What does this PR implement?

Adds configurable retry logic with exponential backoff when all bootstrap peers fail during Initial Block Download (IBD).

**Problem:** When network connectivity drops during IBD, the node errors out with `AllPeersFailed` and immediately shuts down via `overwatch_handle.shutdown()`. On spotty internet connections, this forces a full manual restart — including an expensive cold-start reload of all chain state from disk.

**Solution:** Instead of immediate shutdown, the node now retries IBD up to a configurable number of times with exponential backoff (5s → 10s → 20s → ...). With defaults (10 retries), total wait time before final shutdown is ~35 minutes, giving transient network issues plenty of time to heal.

### Changes

| File | Change |
|------|--------|
| `services/chain/chain-network/src/bootstrap/config.rs` | Added `max_retries` (default: 10) and `initial_retry_delay` (default: 5s) to `IbdConfig` |
| `services/chain/chain-network/src/lib.rs` | Replaced immediate-shutdown match with retry loop using exponential backoff |
| `services/chain/chain-network/src/metrics.rs` | Added metrics: `ibd_retries_total`, `ibd_retry_attempt_current`, `ibd_retry_max`, `ibd_total_attempts` |
| `nodes/node/binary/src/config/cryptarchia/serde/network.rs` | Added same fields to user-facing config with matching defaults |
| `nodes/node/binary/src/config/cryptarchia/mod.rs` | Wired new config fields through conversion |
| `services/chain/chain-network/src/bootstrap/ibd.rs` | Updated test helper (set `max_retries: 0` to preserve existing test behavior) |

### Backward Compatibility

Existing configs get the new defaults automatically — no config changes required. Set `max_retries: 0` in your node config to restore the previous immediate-shutdown behavior.

## 2. Does the code have enough context to be clearly understood?

This is a bug fix / resilience improvement, not specification-driven. The implementation follows existing patterns in the codebase:

- Retry pattern mirrors `retry_future_block_apply_with_delay()` already in this crate
- Config defaults follow the same `const fn default_*()` convention used throughout
- Logging levels follow CONTRIBUTING.md guidelines (`warn` for retry attempts, `error` for final failure)
- Metrics follow existing `lb_tracing::increase_counter_u64!` / `metric_histogram_u64!` patterns

## 3. Who are the specification authors and who is accountable for this PR?

@vpavlin (accountable for this PR)

## 4. Is the specification accurate and complete?

N/A — this is a bug fix / resilience improvement, not spec-driven.

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

- [x] 1. The PR title follows the Conventional Commits specification.
- [x] 2. Description added.
- [ ] 3. Context and links to Specification document(s) added. (N/A — bug fix)
- [ ] 4. Main contact(s) (developers and specification authors) added
- [ ] 5. Implementation and Specification are 100% in sync including changes. (N/A — bug fix)
- [ ] 6. Link PR to a specific milestone.
- [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines). (`warn` for retry, `error` for final failure + shutdown)