### PR TITLE
chore: clarify poseidon and add test values from the specs

### DIFF
--- a/zk/poseidon2/src/hasher.rs
+++ b/zk/poseidon2/src/hasher.rs
@@ -29,14 +29,14 @@ impl Poseidon2Hasher {
     }
 
     fn update(&mut self, input: &[Fr]) {
-        assert!(!input.is_empty());
         for fr in input {
             self.update_one(fr);
         }
         self.update_one(&Fr::ONE);
     }
 
-    /// Only use `compress` before `finalize` for poseidon2 without SAFE padding
+    /// Only use `compress` before `finalize` for poseidon2 compression without
+    /// padding
     fn compress(&mut self, inputs: &[Fr; 2]) {
         self.state[0] += inputs[0];
         self.state[1] += inputs[1];
@@ -91,6 +91,14 @@ mod tests {
         let result = hasher.finalize();
         assert_eq!(result, expected);
     }
+
+    fn test_compresser(inputs: &[Fr; 2], expected: Fr) {
+        let mut hasher = Poseidon2Hasher::new();
+        hasher.compress(inputs);
+        let result = hasher.finalize();
+        assert_eq!(result, expected);
+    }
+
     #[test]
     fn test_hashes() {
         // 0
@@ -105,20 +113,69 @@ mod tests {
         )
         .unwrap();
         test_hasher(&[Fr::ONE], expected_one);
-        // 2
-        let expected_two = Fr::from_str(
-            "9632004710537414903275898870712812796867229507472840228295932832943785232633",
+        // 0, 0
+        let expected = Fr::from_str(
+            "14628790903668924121747280216643356178740756932733894594323650293252618457042",
         )
         .unwrap();
-        test_hasher(&[Fr::from(BigUint::from(2u8))], expected_two);
-        // 0, 1, 2
-        let expected_two = Fr::from_str(
-            "21739021971472524335152491270920095773040444510968189350907442466992269802900",
+        test_hasher(&[Fr::ZERO, Fr::ZERO], expected);
+        // 1, 2
+        let expected = Fr::from_str(
+            "14118544982895877636855211757199904519359053761360294109973292038354361461611",
         )
         .unwrap();
-        test_hasher(
-            &[Fr::ZERO, Fr::ONE, Fr::from(BigUint::from(2u8))],
-            expected_two,
-        );
+        test_hasher(&[Fr::ONE, Fr::from(BigUint::from(2u8))], expected);
+        // 2, 1
+        let expected = Fr::from_str(
+            "17303708087492456923876794017773991179968227132845592592623864164460458364283",
+        )
+        .unwrap();
+        test_hasher(&[Fr::from(BigUint::from(2u8)), Fr::ONE], expected);
+        // 1, 0, 0
+        let expected = Fr::from_str(
+            "8421738025868928791358153716794664271727148606331557350959968139012924692418",
+        )
+        .unwrap();
+        test_hasher(&[Fr::ONE, Fr::ZERO, Fr::ZERO], expected);
+        // 0, 0, 1
+        let expected = Fr::from_str(
+            "19071010037288550145243369517116292645821506141834920037435390558790324604368",
+        )
+        .unwrap();
+        test_hasher(&[Fr::ZERO, Fr::ZERO, Fr::ONE], expected);
+        // 0, 1, 0, 1
+        let expected = Fr::from_str(
+            "3427143977204509234202184342982950793741509606314919897018772479233527131453",
+        )
+        .unwrap();
+        test_hasher(&[Fr::ZERO, Fr::ONE, Fr::ZERO, Fr::ONE], expected);
+    }
+
+    #[test]
+    fn test_compression() {
+        // 0, 0
+        let expected = Fr::from_str(
+            "21177166670744647784289648293577786481357446166129397094207318338605633126018",
+        )
+        .unwrap();
+        test_compresser(&[Fr::ZERO, Fr::ZERO], expected);
+        // 1, 0
+        let expected = Fr::from_str(
+            "2820430044171165092709918704747590965614342875549110429217681435604321658469",
+        )
+        .unwrap();
+        test_compresser(&[Fr::ONE, Fr::ZERO], expected);
+        // 0, 1
+        let expected = Fr::from_str(
+            "15449469107951025862283679587511638593643295575495923463032662929748907033596",
+        )
+        .unwrap();
+        test_compresser(&[Fr::ZERO, Fr::ONE], expected);
+        // 1, 1
+        let expected = Fr::from_str(
+            "17847258390462923071212518425927834238796435801505415407318169918090986946609",
+        )
+        .unwrap();
+        test_compresser(&[Fr::ONE, Fr::ONE], expected);
     }
 }

--- a/zk/poseidon2/src/lib.rs
+++ b/zk/poseidon2/src/lib.rs
@@ -7,19 +7,19 @@ pub type Poseidon2Bn254Hasher = hasher::Poseidon2Hasher;
 pub type ZkHash = Fr;
 
 pub trait Digest {
-    /// Digest takes `inputs` data and 1st apply the SAFE padding protocol and
+    /// Digest takes `inputs` data and 1st apply the 10* padding protocol and
     /// apply Poseidon2 hash function.
     ///
     /// This can be used for anything.
     fn digest(inputs: &[Fr]) -> ZkHash;
 
-    /// Compress takes exactly 2 elements as `inputs`. It doesn't apply the SAFE
+    /// Compress takes exactly 2 elements as `inputs`. It doesn't apply the
     /// padding and apply the Poseidon2 hash function.
     ///
-    /// This can only be used for protocols where the inputs is always of size
-    /// 2. In Logos blockchain it's reserved for Merkle tree computations
-    ///    including
-    /// Merkle roots and Merkle proofs.
+    /// This can only be used for protocols where the inputs are always of size
+    /// 2. In Logos blockchain it's reserved for Merkle proofs, public key
+    ///    derivation,
+    /// nullifier derivation and reward voucher derivation.
     fn compress(inputs: &[Fr; 2]) -> ZkHash;
 
     fn new() -> Self;


### PR DESCRIPTION
## 1. What does this PR implement?

It clarifies the comments from the poseidon2 hasher / compresser and solve the issue #2664. It also implements the test vectors added in the specs.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@megonen @thomaslavaur 

## 4. Is the specification accurate and complete?

No that's why we updated them to clarify how Poseidon2 is instantiated and test values.

## 5. Does the implementation introduce changes in the specification?

Yes: [see here](<https://www.notion.so/nomos-tech/1-0-1-Common-Cryptographic-Components-1fd261aa09df81ac8ebbe0111e2c2d84?source=copy_link#1fd261aa09df81f48afcd5bbe86c4a18>)

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
