### PR TITLE
feat(config): Use include! tag to detach kms configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,6 +5120,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
  "time",
  "tokio",
 ]

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -156,6 +156,11 @@ pub struct InitArgs {
     /// empty, regardless of any peers passed via `--initial-peers`/`-p`.
     #[clap(long = "no-ibd", default_value_t = false)]
     pub no_ibd: bool,
+
+    /// Path for the generated KMS keys YAML file.
+    /// Defaults to 'kms.yaml' in the same directory as --output.
+    #[clap(long = "kms-file")]
+    pub kms_file: Option<PathBuf>,
 }
 
 #[cfg(feature = "config-gen")]
@@ -607,11 +612,24 @@ pub enum ConfigDeserializationError<Config> {
     IoError(#[from] std::io::Error),
     #[error(transparent)]
     SerdeError(#[from] serde_yaml::Error),
+    #[error("YAML include error: {0}")]
+    IncludeError(String),
 }
 
 pub enum OnUnknownKeys {
     Fail,
     Warn,
+}
+
+impl<C> From<lb_utils::yaml::YamlIncludeError> for ConfigDeserializationError<C> {
+    fn from(e: lb_utils::yaml::YamlIncludeError) -> Self {
+        use lb_utils::yaml::YamlIncludeError as E;
+        match e {
+            E::Io(e) => Self::IoError(e),
+            E::Serde(e) => Self::SerdeError(e),
+            E::InvalidInclude(msg) => Self::IncludeError(msg),
+        }
+    }
 }
 
 pub fn deserialize_config_at_path<Config>(
@@ -621,8 +639,30 @@ pub fn deserialize_config_at_path<Config>(
 where
     Config: for<'de> Deserialize<'de>,
 {
+    let base_dir = config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
     let file = std::fs::File::open(config_path)?;
-    deserialize_config_from_reader(file, unknown_keys_strategy)
+    let raw: serde_yaml::Value = serde_yaml::from_reader(file)?;
+    let resolved = lb_utils::yaml::resolve_includes(raw, &base_dir)
+        .map_err(ConfigDeserializationError::from)?;
+    deserialize_from_value(resolved, unknown_keys_strategy)
+}
+
+fn deserialize_from_value<Config>(
+    value: serde_yaml::Value,
+    unknown_keys_strategy: OnUnknownKeys,
+) -> Result<Config, ConfigDeserializationError<Config>>
+where
+    Config: for<'de> Deserialize<'de>,
+{
+    use serde::de::IntoDeserializer as _;
+    let mut ignored_fields = Vec::new();
+    let config = serde_ignored::deserialize::<_, _, Config>(value.into_deserializer(), |path| {
+        ignored_fields.push(path.to_string());
+    })?;
+    apply_unknown_keys_strategy(config, ignored_fields, unknown_keys_strategy)
 }
 
 pub fn deserialize_config_from_reader<Config, Reader>(
@@ -640,8 +680,15 @@ where
             ignored_fields.push(path.to_string());
         },
     )?;
+    apply_unknown_keys_strategy(config, ignored_fields, unknown_keys_strategy)
+}
 
-    match (ignored_fields, unknown_keys_strategy) {
+fn apply_unknown_keys_strategy<Config>(
+    config: Config,
+    ignored_fields: Vec<String>,
+    strategy: OnUnknownKeys,
+) -> Result<Config, ConfigDeserializationError<Config>> {
+    match (ignored_fields, strategy) {
         (ignored_fields, _) if ignored_fields.is_empty() => Ok(config),
         (ignored_fields, OnUnknownKeys::Warn) => {
             warn!(

--- a/nodes/node/binary/src/init.rs
+++ b/nodes/node/binary/src/init.rs
@@ -1,5 +1,8 @@
 use core::str::FromStr as _;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 
 use color_eyre::eyre::{Result, eyre};
 use lb_groth16::fr_to_bytes;
@@ -98,11 +101,56 @@ pub fn run(args: &InitArgs) -> Result<()> {
 
     let user_config = build_user_config(args, network_key, keys, blend_listening_address);
 
-    let yaml = serde_yaml::to_string(&user_config)?;
+    let kms_path = kms_output_path(args);
+    let kms_yaml = serde_yaml::to_string(&user_config.kms)?;
+    std::fs::write(&kms_path, &kms_yaml)?;
+
+    let kms_include = kms_include_str(args, &kms_path);
+    let yaml = serialize_with_kms_include(&user_config, &kms_include)?;
     std::fs::write(&args.output, &yaml)?;
 
     println!("Config written to {}", args.output.display());
+    println!("KMS config written to {}", kms_path.display());
     Ok(())
+}
+
+fn kms_output_path(args: &InitArgs) -> PathBuf {
+    args.kms_file.clone().unwrap_or_else(|| {
+        args.output
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("kms.yaml")
+    })
+}
+
+/// Returns the path string to use in `!include <path>` inside the main config.
+///
+/// If the KMS file is in the same directory as the main config, only the
+/// filename is used so the include stays portable when the directory is moved.
+fn kms_include_str(args: &InitArgs, kms_path: &Path) -> String {
+    if let Some(ref kms_file) = args.kms_file {
+        return kms_file.to_string_lossy().into_owned();
+    }
+    // Default: same directory as the output file → reference by filename only.
+    kms_path.file_name().map_or_else(
+        || kms_path.to_string_lossy().into_owned(),
+        |n| n.to_string_lossy().into_owned(),
+    )
+}
+
+fn serialize_with_kms_include(config: &UserConfig, kms_include: &str) -> Result<String> {
+    use serde_yaml::value::{Tag, TaggedValue};
+    let mut value = serde_yaml::to_value(config)?;
+    if let serde_yaml::Value::Mapping(ref mut map) = value {
+        map.insert(
+            serde_yaml::Value::String("kms".into()),
+            serde_yaml::Value::Tagged(Box::new(TaggedValue {
+                tag: Tag::new("include"),
+                value: serde_yaml::Value::String(kms_include.into()),
+            })),
+        );
+    }
+    Ok(serde_yaml::to_string(&value)?)
 }
 
 fn build_user_config(
@@ -245,6 +293,7 @@ mod tests {
             http_addr: SocketAddr::from(([0, 0, 0, 0], 8080)),
             external_address: None,
             state_path: None,
+            kms_file: None,
             no_ibd,
         };
         let network_key = lb_libp2p::ed25519::SecretKey::generate();

--- a/nodes/node/binary/src/init.rs
+++ b/nodes/node/binary/src/init.rs
@@ -93,25 +93,102 @@ pub fn run(args: &InitArgs) -> Result<()> {
     }
 
     let network_key = lb_libp2p::ed25519::SecretKey::generate();
-    let keys = generate_keys();
 
     let blend_listening_address =
         Multiaddr::from_str(&format!("/ip4/0.0.0.0/udp/{}/quic-v1", args.blend_port))
             .map_err(|e| eyre!("Invalid blend listening address: {e}"))?;
 
+    // If --kms-file points to an existing file, reuse its keys instead of
+    // generating new ones.
+    let (keys, kms_path, write_kms) = match &args.kms_file {
+        Some(path) if path.exists() => {
+            let contents = std::fs::read_to_string(path)?;
+            let kms_config: KmsConfig = serde_yaml::from_str(&contents)?;
+            let keys = keys_from_kms_config(&kms_config)?;
+            (keys, path.clone(), false)
+        }
+        _ => {
+            let keys = generate_keys();
+            let path = kms_output_path(args);
+            (keys, path, true)
+        }
+    };
+
     let user_config = build_user_config(args, network_key, keys, blend_listening_address);
 
-    let kms_path = kms_output_path(args);
-    let kms_yaml = serde_yaml::to_string(&user_config.kms)?;
-    std::fs::write(&kms_path, &kms_yaml)?;
+    if write_kms {
+        let kms_yaml = serde_yaml::to_string(&user_config.kms)?;
+        std::fs::write(&kms_path, &kms_yaml)?;
+        println!("KMS config written to {}", kms_path.display());
+    }
 
     let kms_include = kms_include_str(args, &kms_path);
     let yaml = serialize_with_kms_include(&user_config, &kms_include)?;
     std::fs::write(&args.output, &yaml)?;
 
     println!("Config written to {}", args.output.display());
-    println!("KMS config written to {}", kms_path.display());
     Ok(())
+}
+
+/// Extracts key material from a parsed KMS config so it can be used to
+/// populate the rest of the node config without generating new keys.
+///
+/// Assumes the KMS config was produced by `init` and follows the layout:
+/// - exactly one Ed25519 key  → blend signing key
+/// - one Zk key derived from the Ed25519 public bytes → blend Zk key
+/// - remaining Zk keys sorted by ID: first → leader, second → funding
+fn keys_from_kms_config(kms_config: &KmsConfig) -> Result<GeneratedKeys> {
+    let (blend_signing_key_id, blend_signing_key) = kms_config
+        .backend
+        .keys
+        .iter()
+        .find_map(|(id, key)| match key {
+            Key::Ed25519(k) => Some((id.clone(), k.clone())),
+            Key::Zk(_) => None,
+        })
+        .ok_or_else(|| eyre!("KMS file contains no Ed25519 key"))?;
+
+    let blend_zk_key = ZkKey::from(BigUint::from_bytes_le(
+        blend_signing_key.public_key().as_bytes(),
+    ));
+    let blend_zk_key_id = key_id(&Key::Zk(blend_zk_key.clone()));
+
+    let mut other_zk: Vec<(KeyId, ZkKey)> = kms_config
+        .backend
+        .keys
+        .iter()
+        .filter_map(|(id, key)| match key {
+            Key::Zk(k) if *id != blend_zk_key_id => Some((id.clone(), k.clone())),
+            _ => None,
+        })
+        .collect();
+
+    other_zk.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    if other_zk.len() < 2 {
+        return Err(eyre!(
+            "KMS file must contain at least 3 Zk keys (blend, leader, funding), found {}",
+            other_zk.len() + 1
+        ));
+    }
+
+    let (leader_key_id, leader_key) = other_zk.remove(0);
+    let (funding_key_id, funding_key) = other_zk.remove(0);
+    let leader_pk = leader_key.as_public_key();
+    let funding_pk = funding_key.as_public_key();
+
+    Ok(GeneratedKeys {
+        blend_signing_key,
+        blend_zk_key,
+        leader_key,
+        funding_key,
+        blend_signing_key_id,
+        blend_zk_key_id,
+        leader_key_id,
+        funding_key_id,
+        leader_pk,
+        funding_pk,
+    })
 }
 
 fn kms_output_path(args: &InitArgs) -> PathBuf {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -23,6 +23,8 @@ overwatch   = { workspace = true }
 rand        = { features = ["getrandom"], workspace = true }
 serde       = { features = ["alloc", "derive"], workspace = true }
 serde_with  = { optional = true, workspace = true }
+serde_yaml  = { workspace = true }
+thiserror   = { workspace = true }
 time        = { features = ["serde-human-readable"], optional = true, workspace = true }
 tokio       = { optional = true, workspace = true }
 
@@ -37,3 +39,4 @@ nistrs      = { workspace = true }
 rand_chacha = { workspace = true }
 serde_json  = { features = ["alloc"], workspace = true }
 serde_with  = { features = ["macros"], workspace = true }
+tempfile    = { workspace = true }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,6 +3,7 @@ pub mod math;
 pub mod net;
 pub mod noop_service;
 pub mod types;
+pub mod yaml;
 
 #[cfg(feature = "rng")]
 pub mod blake_rng;

--- a/utils/src/yaml.rs
+++ b/utils/src/yaml.rs
@@ -145,7 +145,7 @@ mod tests {
     fn include_resolves_relative_to_included_file_directory() {
         let dir = TempDir::new().unwrap();
         let sub_dir = dir.path().join("sub");
-        fs::create_dir(&sub_dir).unwrap();
+        fs::create_dir_all(&sub_dir).unwrap();
 
         fs::write(sub_dir.join("leaf.yaml"), "x: 1\n").unwrap();
         fs::write(sub_dir.join("inner.yaml"), "data: !include leaf.yaml\n").unwrap();

--- a/utils/src/yaml.rs
+++ b/utils/src/yaml.rs
@@ -1,0 +1,192 @@
+use std::path::{Path, PathBuf};
+
+use serde_yaml::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum YamlIncludeError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_yaml::Error),
+    #[error("!include error: {0}")]
+    InvalidInclude(String),
+}
+
+/// Recursively resolves `!include <path>` tags in a YAML value.
+///
+/// Paths are resolved relative to `base_dir`. Nested includes are supported
+/// (each included file's own includes resolve relative to that file's
+/// directory).
+pub fn resolve_includes(value: Value, base_dir: &Path) -> Result<Value, YamlIncludeError> {
+    match value {
+        Value::Tagged(tagged) if tagged.tag == "include" => {
+            let path_str = match &tagged.value {
+                Value::String(s) => s.clone(),
+                other => {
+                    return Err(YamlIncludeError::InvalidInclude(format!(
+                        "!include requires a string path, got: {other:?}"
+                    )));
+                }
+            };
+            let resolved_path = if Path::new(&path_str).is_absolute() {
+                PathBuf::from(&path_str)
+            } else {
+                base_dir.join(&path_str)
+            };
+            let contents = std::fs::read_to_string(&resolved_path)?;
+            let included: Value = serde_yaml::from_str(&contents)?;
+            let new_base = resolved_path.parent().unwrap_or(base_dir).to_path_buf();
+            resolve_includes(included, &new_base)
+        }
+        Value::Mapping(map) => {
+            let resolved = map
+                .into_iter()
+                .map(|(k, v)| Ok((k, resolve_includes(v, base_dir)?)))
+                .collect::<Result<serde_yaml::Mapping, YamlIncludeError>>()?;
+            Ok(Value::Mapping(resolved))
+        }
+        Value::Sequence(seq) => {
+            let resolved = seq
+                .into_iter()
+                .map(|v| resolve_includes(v, base_dir))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Value::Sequence(resolved))
+        }
+        other => Ok(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use serde_yaml::{
+        Value,
+        value::{Tag, TaggedValue},
+    };
+    use tempfile::TempDir;
+
+    use super::{YamlIncludeError, resolve_includes};
+
+    fn include_tag(path: &str) -> Value {
+        Value::Tagged(Box::new(TaggedValue {
+            tag: Tag::new("include"),
+            value: Value::String(path.into()),
+        }))
+    }
+
+    fn mapping(pairs: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
+        let m = pairs
+            .into_iter()
+            .map(|(k, v)| (Value::String(k.into()), v))
+            .collect();
+        Value::Mapping(m)
+    }
+
+    #[test]
+    fn passthrough_when_no_includes() {
+        let input = mapping([
+            ("a", Value::Number(1.into())),
+            ("b", Value::Bool(true)),
+            ("c", Value::String("hello".into())),
+        ]);
+        let result = resolve_includes(input.clone(), Path::new(".")).unwrap();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn include_substitutes_file_contents() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("sub.yaml"), "value: 42\n").unwrap();
+
+        let input = mapping([("key", include_tag("sub.yaml"))]);
+        let result = resolve_includes(input, dir.path()).unwrap();
+
+        let expected = mapping([("key", mapping([("value", Value::Number(42.into()))]))]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn include_in_sequence() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("a.yaml"), "1\n").unwrap();
+        fs::write(dir.path().join("b.yaml"), "2\n").unwrap();
+
+        let input = Value::Sequence(vec![include_tag("a.yaml"), include_tag("b.yaml")]);
+        let result = resolve_includes(input, dir.path()).unwrap();
+
+        assert_eq!(
+            result,
+            Value::Sequence(vec![Value::Number(1.into()), Value::Number(2.into())])
+        );
+    }
+
+    #[test]
+    fn nested_include() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("c.yaml"), "leaf: true\n").unwrap();
+        fs::write(dir.path().join("b.yaml"), "nested: !include c.yaml\n").unwrap();
+        fs::write(dir.path().join("a.yaml"), "top: !include b.yaml\n").unwrap();
+
+        let input: Value = serde_yaml::from_str("root: !include a.yaml\n").unwrap();
+        let result = resolve_includes(input, dir.path()).unwrap();
+
+        let expected = mapping([(
+            "root",
+            mapping([(
+                "top",
+                mapping([("nested", mapping([("leaf", Value::Bool(true))]))]),
+            )]),
+        )]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn include_resolves_relative_to_included_file_directory() {
+        let dir = TempDir::new().unwrap();
+        let sub_dir = dir.path().join("sub");
+        fs::create_dir(&sub_dir).unwrap();
+
+        fs::write(sub_dir.join("leaf.yaml"), "x: 1\n").unwrap();
+        fs::write(sub_dir.join("inner.yaml"), "data: !include leaf.yaml\n").unwrap();
+
+        let input = mapping([("result", include_tag("sub/inner.yaml"))]);
+        let result = resolve_includes(input, dir.path()).unwrap();
+
+        let expected = mapping([(
+            "result",
+            mapping([("data", mapping([("x", Value::Number(1.into()))]))]),
+        )]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn absolute_path_include() {
+        let dir = TempDir::new().unwrap();
+        let abs_path = dir.path().join("abs.yaml");
+        fs::write(&abs_path, "absolute: true\n").unwrap();
+
+        let input = mapping([("k", include_tag(abs_path.to_str().unwrap()))]);
+        let result = resolve_includes(input, Path::new("/nonexistent")).unwrap();
+
+        let expected = mapping([("k", mapping([("absolute", Value::Bool(true))]))]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let input = mapping([("k", include_tag("does_not_exist.yaml"))]);
+        let err = resolve_includes(input, Path::new(".")).unwrap_err();
+        assert!(matches!(err, YamlIncludeError::Io(_)));
+    }
+
+    #[test]
+    fn non_string_include_value_returns_invalid_include_error() {
+        let input = Value::Tagged(Box::new(TaggedValue {
+            tag: Tag::new("include"),
+            value: Value::Number(42.into()),
+        }));
+        let err = resolve_includes(input, Path::new(".")).unwrap_err();
+        assert!(matches!(err, YamlIncludeError::InvalidInclude(_)));
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?

Detach kms configuration into a different file. Use an `include!` yaml tag to point to an external file. It also automates the creation or loading from the  `init` command in the binary.

Example:

```bash
cargo run --bin logos-blockchain-node -- init --kms-file ./kms.yaml
```

* If kms doesnt exist it generates new keys
* If it does exist it fills the user_config with the keys (Its just compatible with our cli created keys)

## 2. Does the code have enough context to be clearly understood?

It's a bit tricky on the yaml side of things. But overall is really simple and does not touch any core part.

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
