### PR TITLE
feat(blend): expose provider ID as part of blend API endpoint

### DIFF
--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -528,7 +528,7 @@ where
     get,
     path = paths::BLEND_NETWORK_INFO,
     responses(
-        (status = 200, description = "Query the blend network information", body = Option<lb_blend_service::message::BlendNetworkInfo>),
+        (status = 200, description = "Query the blend network information", body = Option<lb_blend_service::message::NetworkInfo<PeerId>>),
         (status = 500, description = "Internal server error", body = String),
     )
 )]

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -42,7 +42,7 @@ use crate::{
         },
         settings::RunningBlendConfig as BlendConfig,
     },
-    message::NetworkInfo,
+    message::{CoreInfo, NetworkInfo},
     metrics,
 };
 
@@ -261,9 +261,13 @@ where
         let old_session_peers = core_behaviour
             .old_session_peer_ids()
             .map(|peers| peers.copied().collect());
-        NetworkInfo {
+        let core_info = CoreInfo {
             current_session_peers,
             old_session_peers,
+        };
+        NetworkInfo {
+            node_id: *self.swarm.local_peer_id(),
+            core_info: Some(core_info),
         }
     }
 

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -55,8 +55,8 @@ use crate::{
         ChainApi, EpochEvent, EpochHandler, PolEpochInfo, PolInfoProvider as PolInfoProviderTrait,
     },
     kms::PreloadKmsService,
-    membership::{self, MembershipInfo},
-    message::{NetworkMessage, ServiceMessage},
+    membership::{self, MembershipInfo, node_id},
+    message::{NetworkInfo, NetworkMessage, ServiceMessage},
     settings::FIRST_STREAM_ITEM_READY_TIMEOUT,
 };
 
@@ -152,7 +152,7 @@ impl<
     >
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Send + Sync,
-    NodeId: Clone + Debug + Eq + Hash + Send + Sync + 'static,
+    NodeId: Clone + Debug + Eq + Hash + Send + Sync + node_id::TryFrom + 'static,
     BroadcastSettings: Serialize + DeserializeOwned + Send,
     MembershipAdapter: membership::Adapter<NodeId = NodeId, Error: Send + Sync + 'static> + Send,
     membership::ServiceMessage<MembershipAdapter>: Send + Sync + 'static,
@@ -225,6 +225,9 @@ where
                 .await
                 .expect("Failed to retrieve non-ephemeral signing key from KMS.")
         };
+        let local_node_id =
+            NodeId::try_from_provider_id(&non_ephemeral_signing_key.public_key().to_bytes())
+                .expect("non-ephemeral signing key should decode into a valid node id");
 
         // Initialize membership stream for session and core-related public PoQ inputs.
         let session_stream = MembershipAdapter::new(
@@ -265,8 +268,10 @@ where
                         .to_vec(),
                 ),
                 ServiceMessage::GetNetworkInfo { reply } => {
-                    // Edge nodes don't return any Blend peer info.
-                    drop(reply.send(None));
+                    drop(reply.send(Some(NetworkInfo {
+                        node_id: local_node_id.clone(),
+                        core_info: None,
+                    })));
                     None
                 }
             }

--- a/services/blend/src/instance.rs
+++ b/services/blend/src/instance.rs
@@ -63,7 +63,7 @@ where
             > + Send
                                 + Sync
                                 + 'static,
-            NodeId: Eq + Hash + Send + Sync,
+            NodeId: Clone + Eq + Hash + Send + Sync,
         > + 'static,
     EdgeService: ServiceData<Message = CoreService::Message> + 'static,
     RuntimeServiceId: AsServiceId<CoreService>
@@ -83,13 +83,14 @@ where
     /// Initializes a new instance in the specified mode.
     pub async fn new(
         mode: Mode,
+        local_node_id: CoreService::NodeId,
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
     ) -> Result<Self, modes::Error> {
         match mode {
             Mode::Core => Ok(Self::Core(Self::new_core_mode(overwatch_handle).await?)),
             Mode::Edge => Ok(Self::Edge(Self::new_edge_mode(overwatch_handle).await?)),
             Mode::Broadcast => Ok(Self::Broadcast(
-                Self::new_broadcast_mode(overwatch_handle).await?,
+                Self::new_broadcast_mode(overwatch_handle, local_node_id).await?,
             )),
         }
     }
@@ -108,6 +109,7 @@ where
 
     async fn new_broadcast_mode(
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+        local_node_id: CoreService::NodeId,
     ) -> Result<
         BroadcastMode<CoreService::NetworkAdapter, CoreService::NodeId, RuntimeServiceId>,
         modes::Error,
@@ -117,7 +119,7 @@ where
                 NetworkBackendOfService<CoreService, RuntimeServiceId>,
                 RuntimeServiceId,
             >,
-        >(overwatch_handle)
+        >(overwatch_handle, local_node_id)
         .await
     }
 
@@ -143,12 +145,14 @@ where
         event: SessionEvent<MembershipInfo<CoreService::NodeId>>,
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
         minimal_network_size: usize,
+        local_node_id: CoreService::NodeId,
     ) -> Result<Self, modes::Error> {
         match event {
             SessionEvent::NewSession(MembershipInfo { membership, .. }) => {
                 self.transition(
                     Mode::choose(&membership, minimal_network_size),
                     overwatch_handle,
+                    local_node_id,
                 )
                 .await
             }
@@ -163,11 +167,15 @@ where
         self,
         to_mode: Mode,
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+        local_node_id: CoreService::NodeId,
     ) -> Result<Self, modes::Error> {
         match to_mode {
             Mode::Core => self.transition_to_core(overwatch_handle).await,
             Mode::Edge => self.transition_to_edge(overwatch_handle).await,
-            Mode::Broadcast => self.transition_to_broadcast(overwatch_handle).await,
+            Mode::Broadcast => {
+                self.transition_to_broadcast(overwatch_handle, local_node_id)
+                    .await
+            }
         }
     }
 
@@ -221,10 +229,11 @@ where
     async fn transition_to_broadcast(
         self,
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+        local_node_id: CoreService::NodeId,
     ) -> Result<Self, modes::Error> {
         match self {
             Self::Core(mode) => Ok(Self::BroadcastAfterCore {
-                mode: Self::new_broadcast_mode(overwatch_handle).await?,
+                mode: Self::new_broadcast_mode(overwatch_handle, local_node_id).await?,
                 prev: mode,
             }),
             Self::Broadcast(mode) => Ok(Self::Broadcast(mode)),
@@ -235,7 +244,7 @@ where
             mode => {
                 mode.wait_until_stopped_or_kill().await;
                 Ok(Self::Broadcast(
-                    Self::new_broadcast_mode(overwatch_handle).await?,
+                    Self::new_broadcast_mode(overwatch_handle, local_node_id).await?,
                 ))
             }
         }
@@ -323,6 +332,8 @@ mod tests {
     use super::*;
     use crate::modes::broadcast_tests::{TestMessage, TestNetworkAdapter, TestNetworkBackend};
 
+    const LOCAL_NODE_ID: u8 = 99;
+
     /// Check if the instance is initialized successfully for each mode.
     #[test]
     fn test_new() {
@@ -335,17 +346,23 @@ mod tests {
             start_network_service(handle).await;
 
             // Check if the Core instance is created successfully.
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Core(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // Check if the Edge instance is created successfully.
-            let instance = TestInstance::new(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Edge, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Edge(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // Check if the Broadcast instance is created successfully.
-            let instance = TestInstance::new(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Broadcast, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Broadcast(_)));
             instance.wait_until_stopped_or_kill().await;
         });
@@ -364,36 +381,67 @@ mod tests {
             start_network_service(handle).await;
 
             // Core -> Core
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Core, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Core, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Core(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // Edge -> Core
-            let instance = TestInstance::new(Mode::Edge, handle).await.unwrap();
-            let instance = instance.transition(Mode::Core, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Edge, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Core, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Core(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // EdgeAfterCore -> Core
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::EdgeAfterCore { .. }));
-            let instance = instance.transition(Mode::Core, handle).await.unwrap();
+            let instance = instance
+                .transition(Mode::Core, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Core(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // Broadcast -> Core
-            let instance = TestInstance::new(Mode::Broadcast, handle).await.unwrap();
-            let instance = instance.transition(Mode::Core, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Broadcast, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Core, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Core(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // BroadcastAfterCore -> Core
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::BroadcastAfterCore { .. }));
-            let instance = instance.transition(Mode::Core, handle).await.unwrap();
+            let instance = instance
+                .transition(Mode::Core, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Core(_)));
             instance.wait_until_stopped_or_kill().await;
         });
@@ -412,36 +460,67 @@ mod tests {
             start_network_service(handle).await;
 
             // Core -> EdgeAfterCore
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::EdgeAfterCore { .. }));
             instance.wait_until_stopped_or_kill().await;
 
             // Edge -> Edge
-            let instance = TestInstance::new(Mode::Edge, handle).await.unwrap();
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Edge, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Edge(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // EdgeAfterCore -> Edge
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::EdgeAfterCore { .. }));
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Edge(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // Broadcast -> Edge
-            let instance = TestInstance::new(Mode::Broadcast, handle).await.unwrap();
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Broadcast, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Edge(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // BroadcastAfterCore -> Edge
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::BroadcastAfterCore { .. }));
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Edge(_)));
             instance.wait_until_stopped_or_kill().await;
         });
@@ -460,36 +539,67 @@ mod tests {
             start_network_service(handle).await;
 
             // Core -> BroadcastAfterCore
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::BroadcastAfterCore { .. }));
             instance.wait_until_stopped_or_kill().await;
 
             // Edge -> Broadcast
-            let instance = TestInstance::new(Mode::Edge, handle).await.unwrap();
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Edge, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Broadcast(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // EdgeAfterCore -> Broadcast
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Edge, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Edge, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::EdgeAfterCore { .. }));
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Broadcast(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // Broadcast -> Broadcast
-            let instance = TestInstance::new(Mode::Broadcast, handle).await.unwrap();
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Broadcast, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Broadcast(_)));
             instance.wait_until_stopped_or_kill().await;
 
             // BroadcastAfterCore -> Broadcast
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::BroadcastAfterCore { .. }));
-            let instance = instance.transition(Mode::Broadcast, handle).await.unwrap();
+            let instance = instance
+                .transition(Mode::Broadcast, handle, LOCAL_NODE_ID)
+                .await
+                .unwrap();
             assert!(matches!(instance, Instance::Broadcast(_)));
             instance.wait_until_stopped_or_kill().await;
         });
@@ -507,10 +617,12 @@ mod tests {
             start_network_service(handle).await;
 
             // Start with the Core instance.
-            let instance = TestInstance::new(Mode::Core, handle).await.unwrap();
+            let instance = TestInstance::new(Mode::Core, LOCAL_NODE_ID, handle)
+                .await
+                .unwrap();
 
             // Core -> BroadcastAfterCore
-            let local_node = 99;
+            let local_node = LOCAL_NODE_ID;
             let minimal_network_size = 1;
             let instance = instance
                 .handle_session_event(
@@ -521,6 +633,7 @@ mod tests {
                     )),
                     handle,
                     minimal_network_size,
+                    LOCAL_NODE_ID,
                 )
                 .await
                 .unwrap();
@@ -532,6 +645,7 @@ mod tests {
                     SessionEvent::TransitionPeriodExpired,
                     handle,
                     minimal_network_size,
+                    LOCAL_NODE_ID,
                 )
                 .await
                 .unwrap();
@@ -546,6 +660,7 @@ mod tests {
                     )),
                     handle,
                     minimal_network_size,
+                    LOCAL_NODE_ID,
                 )
                 .await
                 .unwrap();
@@ -560,6 +675,7 @@ mod tests {
                     )),
                     handle,
                     minimal_network_size,
+                    LOCAL_NODE_ID,
                 )
                 .await
                 .unwrap();
@@ -574,6 +690,7 @@ mod tests {
                     )),
                     handle,
                     minimal_network_size,
+                    LOCAL_NODE_ID,
                 )
                 .await
                 .unwrap();

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -33,7 +33,10 @@ use crate::{
     edge::service_components::ServiceComponents as EdgeServiceComponents,
     instance::{Instance, Mode},
     kms::PreloadKmsService,
-    membership::{Adapter as _, MembershipInfo},
+    membership::{
+        Adapter as _, MembershipInfo,
+        node_id::{self, TryFrom as _},
+    },
     settings::{FIRST_STREAM_ITEM_READY_TIMEOUT, Settings},
 };
 
@@ -98,7 +101,7 @@ where
             > + Send
                                 + Sync
                                 + 'static,
-            NodeId: Clone + Debug + Hash + Eq + Send + Sync + 'static,
+            NodeId: Clone + Debug + Hash + Eq + Send + Sync + node_id::TryFrom + 'static,
             BackendSettings: Clone + Send + Sync,
         > + Send
         + 'static,
@@ -173,6 +176,9 @@ where
         else {
             panic!("Non-ephemeral signing key must be an Ed25519 key");
         };
+        let local_node_id =
+            CoreService::NodeId::try_from_provider_id(non_ephemeral_signing_key_public.as_bytes())
+                .expect("non-ephemeral signing public key should decode into a valid node id");
 
         let membership_stream = <MembershipAdapter<EdgeService> as membership::Adapter>::new(
             overwatch_handle
@@ -204,6 +210,7 @@ where
 
         let mut instance = Instance::<CoreService, EdgeService, RuntimeServiceId>::new(
             Mode::choose(&membership, minimal_network_size),
+            local_node_id.clone(),
             overwatch_handle,
         )
         .await?;
@@ -219,7 +226,14 @@ where
             tokio::select! {
                 Some(session_event) = remaining_session_stream.next() => {
                     debug!(target: LOG_TARGET, ?session_event, "received session event");
-                    instance = instance.handle_session_event(session_event, overwatch_handle, minimal_network_size).await?;
+                    instance = instance
+                        .handle_session_event(
+                            session_event,
+                            overwatch_handle,
+                            minimal_network_size,
+                            local_node_id.clone(),
+                        )
+                        .await?;
                 },
                 Some(message) = inbound_relay.next() => {
                     if let Err(e) = instance.handle_inbound_message(message).await {

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -7,6 +7,12 @@ use tokio::sync::oneshot;
 /// Information about the current Blend network peers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkInfo<NodeId> {
+    pub node_id: NodeId,
+    pub core_info: Option<CoreInfo<NodeId>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoreInfo<NodeId> {
     /// Negotiated peers for the current session, with a flag indicating whether
     /// they are healthy (`true`) or not (`false`).
     pub current_session_peers: Vec<(NodeId, bool)>,
@@ -21,7 +27,6 @@ pub enum ServiceMessage<BroadcastSettings, NodeId> {
     /// the [`NetworkService`].
     Blend(NetworkMessage<BroadcastSettings>),
     /// Request the current blend network info (connected peers).
-    /// The reply will be `None` if the node is not in core mode.
     GetNetworkInfo {
         reply: oneshot::Sender<Option<NetworkInfo<NodeId>>>,
     },

--- a/services/blend/src/modes/broadcast.rs
+++ b/services/blend/src/modes/broadcast.rs
@@ -13,11 +13,13 @@ use overwatch::{
 
 use crate::{
     core::{network::NetworkAdapter, service_components::MessageComponents},
+    message::NetworkInfo,
     modes::Error,
 };
 
 pub struct BroadcastMode<Adapter, NodeId, RuntimeServiceId> {
     adapter: Adapter,
+    node_id: NodeId,
     _phantom: PhantomData<(NodeId, RuntimeServiceId)>,
 }
 
@@ -27,6 +29,7 @@ where
 {
     pub async fn new<NetworkService>(
         overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+        node_id: NodeId,
     ) -> Result<Self, Error>
     where
         NetworkService:
@@ -43,6 +46,7 @@ where
         let adapter = Adapter::new(relay);
         Ok(Self {
             adapter,
+            node_id,
             _phantom: PhantomData,
         })
     }
@@ -51,7 +55,7 @@ where
 impl<Adapter, NodeId, RuntimeServiceId> BroadcastMode<Adapter, NodeId, RuntimeServiceId>
 where
     Adapter: NetworkAdapter<RuntimeServiceId> + Send + Sync + 'static,
-    NodeId: Send + Sync,
+    NodeId: Clone + Send + Sync,
     RuntimeServiceId: Send + Sync + 'static,
 {
     pub async fn handle_inbound_message<Message>(&self, message: Message) -> Result<(), Error>
@@ -64,11 +68,12 @@ where
             + Sync
             + 'static,
     {
-        // If this is a network info request, respond with None (broadcast mode
-        // has no blend peers).
         match message.try_into_network_info_request() {
             Ok(reply) => {
-                drop(reply.send(None));
+                drop(reply.send(Some(NetworkInfo {
+                    node_id: self.node_id.clone(),
+                    core_info: None,
+                })));
                 Ok(())
             }
             Err(message) => {
@@ -100,7 +105,6 @@ pub mod tests {
     use tracing::{debug, info};
 
     use super::*;
-    use crate::message::NetworkInfo;
 
     #[test_log::test(test)]
     fn broadcast_mode() {
@@ -119,7 +123,7 @@ pub mod tests {
             // Create the BroadcastMode
             let mut mode = BroadcastMode::<TestNetworkAdapter, (), RuntimeServiceId>::new::<
                 TestNetworkService,
-            >(app.handle())
+            >(app.handle(), ())
             .await
             .unwrap();
 
@@ -139,7 +143,7 @@ pub mod tests {
             // Check if the mode can be created again.
             let mut mode = BroadcastMode::<TestNetworkAdapter, (), RuntimeServiceId>::new::<
                 TestNetworkService,
-            >(app.handle())
+            >(app.handle(), ())
             .await
             .unwrap();
             mode.handle_inbound_message(TestMessage(b"world".to_vec()))

--- a/tests/testing_framework/src/diagnostics.rs
+++ b/tests/testing_framework/src/diagnostics.rs
@@ -373,37 +373,42 @@ impl NodeDiagnostic {
 
     fn format_blend(&self, peer_labels: &BTreeMap<String, String>) -> String {
         match &self.blend {
-            Ok(Some(info)) => {
-                let current = info
-                    .current_session_peers
-                    .iter()
-                    .map(|(peer, healthy)| {
-                        let suffix = if *healthy { "healthy" } else { "unhealthy" };
-                        format!("{}:{suffix}", resolve_peer_label(peer_labels, peer))
-                    })
-                    .collect::<Vec<_>>();
-                let old = info.old_session_peers.as_ref().map_or_else(
-                    || "none".to_owned(),
-                    |peers| {
-                        peers
-                            .iter()
-                            .map(|peer| resolve_peer_label(peer_labels, peer))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    },
-                );
-
-                format!(
-                    "ok session_peers={} unhealthy={} old_session=[{}] current_session=[{}]",
-                    info.current_session_peers.len(),
-                    info.current_session_peers
+            Ok(Some(info)) => info.core_info.as_ref().map_or_else(|| format!(
+                    "ok node_id={} mode=edge",
+                    resolve_peer_label(peer_labels, &info.node_id)
+                ), |core_info| {
+                    let current = core_info
+                        .current_session_peers
                         .iter()
-                        .filter(|(_, healthy)| !healthy)
-                        .count(),
-                    old,
-                    current.join(", ")
-                )
-            }
+                        .map(|(peer, healthy)| {
+                            let suffix = if *healthy { "healthy" } else { "unhealthy" };
+                            format!("{}:{suffix}", resolve_peer_label(peer_labels, peer))
+                        })
+                        .collect::<Vec<_>>();
+                    let old = core_info.old_session_peers.as_ref().map_or_else(
+                        || "none".to_owned(),
+                        |peers| {
+                            peers
+                                .iter()
+                                .map(|peer| resolve_peer_label(peer_labels, peer))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        },
+                    );
+
+                    format!(
+                        "ok node_id={} mode=core session_peers={} unhealthy={} old_session=[{}] current_session=[{}]",
+                        resolve_peer_label(peer_labels, &info.node_id),
+                        core_info.current_session_peers.len(),
+                        core_info
+                            .current_session_peers
+                            .iter()
+                            .filter(|(_, healthy)| !healthy)
+                            .count(),
+                        old,
+                        current.join(", ")
+                    )
+                }),
             Ok(None) => "unavailable".to_owned(),
             Err(error) => format!("error={error}"),
         }
@@ -469,31 +474,44 @@ impl From<lb_network_service::backends::libp2p::Libp2pInfo> for NetworkSnapshot 
 
 #[derive(Clone)]
 struct BlendSnapshot {
+    node_id: String,
+    core_info: Option<BlendCoreSnapshot>,
+}
+
+#[derive(Clone)]
+struct BlendCoreSnapshot {
     current_session_peers: Vec<(String, bool)>,
     old_session_peers: Option<Vec<String>>,
 }
 
 impl From<BlendNetworkInfo<lb_network_service::backends::libp2p::PeerId>> for BlendSnapshot {
     fn from(value: BlendNetworkInfo<lb_network_service::backends::libp2p::PeerId>) -> Self {
-        let mut current_session_peers = value
-            .current_session_peers
-            .into_iter()
-            .map(|(peer, healthy)| (peer.to_string(), healthy))
-            .collect::<Vec<_>>();
-        current_session_peers.sort_by(|left, right| left.0.cmp(&right.0));
-
-        let old_session_peers = value.old_session_peers.map(|peers| {
-            let mut peers = peers
+        let core_info = value.core_info.map(|core_info| {
+            let mut current_session_peers = core_info
+                .current_session_peers
                 .into_iter()
-                .map(|peer| peer.to_string())
+                .map(|(peer, healthy)| (peer.to_string(), healthy))
                 .collect::<Vec<_>>();
-            peers.sort();
-            peers
+            current_session_peers.sort_by(|left, right| left.0.cmp(&right.0));
+
+            let old_session_peers = core_info.old_session_peers.map(|peers| {
+                let mut peers = peers
+                    .into_iter()
+                    .map(|peer| peer.to_string())
+                    .collect::<Vec<_>>();
+                peers.sort();
+                peers
+            });
+
+            BlendCoreSnapshot {
+                current_session_peers,
+                old_session_peers,
+            }
         });
 
         Self {
-            current_session_peers,
-            old_session_peers,
+            node_id: value.node_id.to_string(),
+            core_info,
         }
     }
 }
@@ -536,6 +554,7 @@ struct ClusterSummary {
 }
 
 impl ClusterSummary {
+    #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
     fn build(
         cluster_control_profile: &str,
         node_count: usize,
@@ -572,6 +591,12 @@ impl ClusterSummary {
             .filter_map(|node| match &node.blend {
                 Ok(Some(info)) => Some((&node.label, info)),
                 _ => None,
+            })
+            .collect::<Vec<_>>();
+        let blend_core_snapshots = blend_snapshots
+            .iter()
+            .filter_map(|(label, info)| {
+                info.core_info.as_ref().map(|core_info| (*label, core_info))
             })
             .collect::<Vec<_>>();
 
@@ -613,12 +638,12 @@ impl ClusterSummary {
                 .map(|snapshot| u64::from(snapshot.n_pending_connections))
                 .sum(),
             blend_session_peer_range: format_range_usize(
-                &blend_snapshots
+                &blend_core_snapshots
                     .iter()
                     .map(|(_, info)| info.current_session_peers.len())
                     .collect::<Vec<_>>(),
             ),
-            blend_unhealthy_total: blend_snapshots
+            blend_unhealthy_total: blend_core_snapshots
                 .iter()
                 .map(|(_, info)| {
                     info.current_session_peers
@@ -627,7 +652,7 @@ impl ClusterSummary {
                         .count()
                 })
                 .sum(),
-            blend_transitioning_nodes: blend_snapshots
+            blend_transitioning_nodes: blend_core_snapshots
                 .iter()
                 .filter(|(_, info)| info.old_session_peers.is_some())
                 .map(|(label, _)| (*label).clone())


### PR DESCRIPTION
## 1. What does this PR implement?

Regardless of the state (i.e. no Blend, edge, or core), the blend endpoint would always return the peer ID configured for the node, so that it can be used to construct and SDP declare transaction and submit it using the provided HTTP endpoint.

## 2. Does the code have enough context to be clearly understood?

Yes. The structure of Blend is currently very complicated to touch, so I tried to keep the changes to the minimum. This will change after we implement session removal.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.