### PR TITLE
chore(sdp-service): Sdp http set declaration id endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4873,6 +4873,7 @@ dependencies = [
  "logos-blockchain-chain-service",
  "logos-blockchain-core",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-services-utils",
  "logos-blockchain-tracing",
  "overwatch",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,6 +4878,7 @@ dependencies = [
  "overwatch",
  "serde",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
 ]

--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -12,6 +12,7 @@ pub const CHANNEL_DEPOSIT: &str = "/channel/deposit";
 pub const SDP_POST_DECLARATION: &str = "/sdp/declaration";
 pub const SDP_POST_ACTIVITY: &str = "/sdp/activity";
 pub const SDP_POST_WITHDRAWAL: &str = "/sdp/withdrawal";
+pub const SDP_POST_SET_DECLARATION_ID: &str = "/sdp/set-declaration-id";
 pub const LEADER_CLAIM: &str = "/leader/claim";
 
 pub const BLOCKS: &str = "/cryptarchia/blocks";

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -50,7 +50,7 @@ use crate::{
     api::{
         handlers::{
             channel, channel_deposit, leader_claim, post_activity, post_declaration,
-            post_withdrawal,
+            post_set_declaration_id, post_withdrawal,
         },
         openapi::ApiDoc,
     },
@@ -262,6 +262,18 @@ where
                 paths::SDP_POST_WITHDRAWAL,
                 routing::post(
                     post_withdrawal::<
+                        SdpMempool,
+                        SdpWallet,
+                        Cryptarchia<RuntimeServiceId>,
+                        SdpStateStorage,
+                        RuntimeServiceId,
+                    >,
+                ),
+            )
+            .route(
+                paths::SDP_POST_SET_DECLARATION_ID,
+                routing::post(
+                    post_set_declaration_id::<
                         SdpMempool,
                         SdpWallet,
                         Cryptarchia<RuntimeServiceId>,

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -24,6 +24,7 @@ use lb_core::{
 };
 pub use lb_http_api_common::settings::AxumBackendSettings;
 use lb_http_api_common::{metrics::http_metrics_middleware, paths};
+use lb_sdp_service::state::SdpStateStorage as SdpStateStorageTrait;
 use lb_sdp_service::{mempool::SdpMempoolAdapter, wallet::SdpWalletAdapter};
 use lb_storage_service::{StorageService, backends::rocksdb::RocksBackend};
 use lb_tx_service::{TxMempoolService, backend::Mempool};
@@ -64,6 +65,7 @@ pub struct AxumBackend<
     MempoolStorageAdapter,
     SdpMempool,
     SdpWallet,
+    SdpStateStorage,
     ChainLeader,
 > {
     settings: AxumBackendSettings,
@@ -73,6 +75,7 @@ pub struct AxumBackend<
         MempoolStorageAdapter,
         SdpMempool,
         SdpWallet,
+        SdpStateStorage,
         ChainLeader,
     )>,
 }
@@ -84,6 +87,7 @@ impl<
     MempoolStorageAdapter,
     SdpMempool,
     SdpWallet,
+    SdpStateStorage,
     ChainLeader,
     RuntimeServiceId,
 > Backend<RuntimeServiceId>
@@ -93,6 +97,7 @@ impl<
         MempoolStorageAdapter,
         SdpMempool,
         SdpWallet,
+        SdpStateStorage,
         ChainLeader,
     >
 where
@@ -112,6 +117,7 @@ where
     SdpMempool: SdpMempoolAdapter + Send + Sync + 'static,
     SdpWallet: SdpWalletAdapter + Send + Sync + 'static,
     ChainLeader: ChainLeaderServiceData,
+    SdpStateStorage: SdpStateStorageTrait + Send + 'static,
     RuntimeServiceId: Debug
         + Sync
         + Send
@@ -150,6 +156,7 @@ where
                 SdpMempool,
                 SdpWallet,
                 Cryptarchia<RuntimeServiceId>,
+                SdpStateStorage,
                 RuntimeServiceId,
             >,
         >
@@ -234,6 +241,7 @@ where
                         SdpMempool,
                         SdpWallet,
                         Cryptarchia<RuntimeServiceId>,
+                        SdpStateStorage,
                         RuntimeServiceId,
                     >,
                 ),
@@ -245,6 +253,7 @@ where
                         SdpMempool,
                         SdpWallet,
                         Cryptarchia<RuntimeServiceId>,
+                        SdpStateStorage,
                         RuntimeServiceId,
                     >,
                 ),
@@ -256,6 +265,7 @@ where
                         SdpMempool,
                         SdpWallet,
                         Cryptarchia<RuntimeServiceId>,
+                        SdpStateStorage,
                         RuntimeServiceId,
                     >,
                 ),

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -24,8 +24,10 @@ use lb_core::{
 };
 pub use lb_http_api_common::settings::AxumBackendSettings;
 use lb_http_api_common::{metrics::http_metrics_middleware, paths};
-use lb_sdp_service::state::SdpStateStorage as SdpStateStorageTrait;
-use lb_sdp_service::{mempool::SdpMempoolAdapter, wallet::SdpWalletAdapter};
+use lb_sdp_service::{
+    mempool::SdpMempoolAdapter, state::SdpStateStorage as SdpStateStorageTrait,
+    wallet::SdpWalletAdapter,
+};
 use lb_storage_service::{StorageService, backends::rocksdb::RocksBackend};
 use lb_tx_service::{TxMempoolService, backend::Mempool};
 use overwatch::{overwatch::handle::OverwatchHandle, services::AsServiceId};

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -37,7 +37,9 @@ use lb_http_api_common::{
 };
 use lb_libp2p::libp2p::bytes::Bytes;
 use lb_network_service::backends::libp2p::Libp2p as Libp2pNetworkBackend;
-use lb_sdp_service::{mempool::SdpMempoolAdapter, wallet::SdpWalletAdapter};
+use lb_sdp_service::{
+    mempool::SdpMempoolAdapter, state::SdpStateStorage, wallet::SdpWalletAdapter,
+};
 use lb_storage_service::{
     StorageService, api::chain::StorageChainApi, backends::rocksdb::RocksBackend,
 };
@@ -483,7 +485,13 @@ where
         (status = 500, description = "Internal server error", body = String),
     )
 )]
-pub async fn post_declaration<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>(
+pub async fn post_declaration<
+    MempoolAdapter,
+    WalletAdapter,
+    ChainService,
+    StateStorage,
+    RuntimeServiceId,
+>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
     Json(declaration): Json<lb_core::sdp::DeclarationMessage>,
 ) -> Response
@@ -491,6 +499,7 @@ where
     MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
     ChainService: lb_chain_service::api::CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
     RuntimeServiceId: Debug
         + Sync
         + Send
@@ -502,6 +511,7 @@ where
                 MempoolAdapter,
                 WalletAdapter,
                 ChainService,
+                StateStorage,
                 RuntimeServiceId,
             >,
         >,
@@ -510,6 +520,7 @@ where
         MempoolAdapter,
         WalletAdapter,
         ChainService,
+        StateStorage,
         RuntimeServiceId,
     >(handle, declaration))
 }
@@ -522,7 +533,13 @@ where
         (status = 500, description = "Internal server error", body = String),
     )
 )]
-pub async fn post_activity<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>(
+pub async fn post_activity<
+    MempoolAdapter,
+    WalletAdapter,
+    ChainService,
+    StateStorage,
+    RuntimeServiceId,
+>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
     Json(metadata): Json<lb_core::sdp::ActivityMetadata>,
 ) -> Response
@@ -530,6 +547,7 @@ where
     MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
     ChainService: lb_chain_service::api::CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
     RuntimeServiceId: Debug
         + Sync
         + Send
@@ -541,6 +559,7 @@ where
                 MempoolAdapter,
                 WalletAdapter,
                 ChainService,
+                StateStorage,
                 RuntimeServiceId,
             >,
         >,
@@ -549,6 +568,7 @@ where
         MempoolAdapter,
         WalletAdapter,
         ChainService,
+        StateStorage,
         RuntimeServiceId,
     >(handle, metadata))
 }
@@ -561,7 +581,13 @@ where
         (status = 500, description = "Internal server error", body = String),
     )
 )]
-pub async fn post_withdrawal<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>(
+pub async fn post_withdrawal<
+    MempoolAdapter,
+    WalletAdapter,
+    ChainService,
+    StateStorage,
+    RuntimeServiceId,
+>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
     Json(declaration_id): Json<lb_core::sdp::DeclarationId>,
 ) -> Response
@@ -569,6 +595,7 @@ where
     MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
     ChainService: lb_chain_service::api::CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
     RuntimeServiceId: Debug
         + Sync
         + Send
@@ -580,6 +607,7 @@ where
                 MempoolAdapter,
                 WalletAdapter,
                 ChainService,
+                StateStorage,
                 RuntimeServiceId,
             >,
         >,
@@ -588,6 +616,7 @@ where
         MempoolAdapter,
         WalletAdapter,
         ChainService,
+        StateStorage,
         RuntimeServiceId,
     >(handle, declaration_id))
 }

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -623,6 +623,56 @@ where
 
 #[utoipa::path(
     post,
+    path = paths::SDP_POST_SET_DECLARATION_ID,
+    responses(
+        (status = 200, description = "Post declaration to SDP service to be set as current", body = lb_core::sdp::DeclarationId),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
+pub async fn post_set_declaration_id<
+    MempoolAdapter,
+    WalletAdapter,
+    ChainService,
+    StateStorage,
+    RuntimeServiceId,
+>(
+    State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+    Json(declaration): Json<Option<lb_core::sdp::DeclarationId>>,
+) -> Response
+where
+    MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
+    WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
+    ChainService: lb_chain_service::api::CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
+    RuntimeServiceId: Debug
+        + Sync
+        + Send
+        + Display
+        + 'static
+        + AsServiceId<ChainService>
+        + AsServiceId<
+            lb_sdp_service::SdpService<
+                MempoolAdapter,
+                WalletAdapter,
+                ChainService,
+                StateStorage,
+                RuntimeServiceId,
+            >,
+        >,
+{
+    make_request_and_return_response!(
+        lb_api_service::http::sdp::post_set_declaration_id_handler::<
+            MempoolAdapter,
+            WalletAdapter,
+            ChainService,
+            StateStorage,
+            RuntimeServiceId,
+        >(handle, declaration)
+    )
+}
+
+#[utoipa::path(
+    post,
     path = paths::LEADER_CLAIM,
     responses(
         (status = 200, description = "Leader claim transaction submitted", body = lb_api_service::http::consensus::leader::LeaderClaimResponseBody),

--- a/nodes/node/binary/src/config/sdp/mod.rs
+++ b/nodes/node/binary/src/config/sdp/mod.rs
@@ -1,6 +1,8 @@
+use std::path::PathBuf;
+
 use lb_sdp_service::{SdpSettings, wallet::SdpWalletConfig};
 
-use crate::config::sdp::serde::Config;
+use crate::config::{StateConfig, sdp::serde::Config};
 
 pub mod serde;
 
@@ -8,14 +10,24 @@ pub struct ServiceConfig {
     pub user: Config,
 }
 
-impl From<ServiceConfig> for SdpSettings {
-    fn from(value: ServiceConfig) -> Self {
-        Self {
-            declaration_id: value.user.declaration_id,
+impl ServiceConfig {
+    #[must_use]
+    pub fn into_sdp_service_settings(self, state_config: &StateConfig) -> SdpSettings {
+        let recovery_path = state_config.get_path_for_recovery_state(
+            PathBuf::new()
+                .join("mempool")
+                .join("recovery")
+                .with_extension("json")
+                .as_path(),
+        );
+
+        SdpSettings {
+            declaration_id: self.user.declaration_id,
             wallet_config: SdpWalletConfig {
-                funding_pk: value.user.wallet.funding_pk,
-                max_tx_fee: value.user.wallet.max_tx_fee,
+                funding_pk: self.user.wallet.funding_pk,
+                max_tx_fee: self.user.wallet.max_tx_fee,
             },
+            recovery_path,
         }
     }
 }

--- a/nodes/node/binary/src/generic_services/mod.rs
+++ b/nodes/node/binary/src/generic_services/mod.rs
@@ -6,6 +6,8 @@ use lb_core::{
     mantle::{SignedMantleTx, Transaction, TxHash},
 };
 use lb_key_management_system_service::backend::preload::PreloadKMSBackend;
+use lb_sdp_service::{SdpSettings, state::SdpState};
+use lb_services_utils::overwatch::JsonFileBackend;
 use lb_storage_service::backends::rocksdb::RocksBackend;
 use lb_time_service::backends::NtpTimeBackend;
 use lb_tx_service::{backend::pool::Mempool, storage::adapters::rocksdb::RocksStorageAdapter};
@@ -106,9 +108,12 @@ pub type SdpWalletAdapter<RuntimeServiceId> = sdp::wallet::SdpWalletAdapter<
     RuntimeServiceId,
 >;
 
+pub type SdpRecoveryBackend = JsonFileBackend<SdpState, SdpSettings>;
+
 pub type SdpService<RuntimeServiceId> = lb_sdp_service::SdpService<
     SdpMempoolAdapter<RuntimeServiceId>,
     SdpWalletAdapter<RuntimeServiceId>,
     CryptarchiaService<RuntimeServiceId>,
+    SdpRecoveryBackend,
     RuntimeServiceId,
 >;

--- a/nodes/node/binary/src/lib.rs
+++ b/nodes/node/binary/src/lib.rs
@@ -57,7 +57,7 @@ use crate::{
         sdp::ServiceConfig as SdpConfig, storage::ServiceConfig as StorageConfig,
         time::ServiceConfig as TimeConfig, wallet::ServiceConfig as WalletConfig,
     },
-    generic_services::{SdpMempoolAdapter, SdpService, SdpWalletAdapter},
+    generic_services::{SdpMempoolAdapter, SdpRecoveryBackend, SdpService, SdpWalletAdapter},
     panic::log_and_exit_hook,
 };
 
@@ -108,6 +108,7 @@ pub type ApiService = lb_api_service::ApiService<
         RocksStorageAdapter<SignedMantleTx, TxHash>,
         SdpMempoolAdapter<RuntimeServiceId>,
         SdpWalletAdapter<RuntimeServiceId>,
+        SdpRecoveryBackend,
         CryptarchiaLeaderService,
     >,
     RuntimeServiceId,
@@ -204,7 +205,7 @@ pub fn run_node_from_config(
     let sdp_config = SdpConfig {
         user: config.user.sdp,
     }
-    .into();
+    .into_sdp_service_settings(&config.user.state);
 
     #[cfg(feature = "tracing")]
     let tracing_config = config::tracing::ServiceConfig {

--- a/services/api/src/http/sdp.rs
+++ b/services/api/src/http/sdp.rs
@@ -2,13 +2,14 @@ use std::fmt::{Debug, Display};
 
 use lb_chain_service::api::CryptarchiaServiceData;
 use lb_core::sdp::{ActivityMetadata, DeclarationId, DeclarationMessage};
-use lb_sdp_service::{SdpService, mempool::SdpMempoolAdapter};
+use lb_sdp_service::{SdpService, mempool::SdpMempoolAdapter, state::SdpStateStorage};
 use overwatch::{DynError, overwatch::OverwatchHandle};
 
 pub async fn post_declaration_handler<
     MempoolAdapter,
     WalletAdapter,
     ChainService,
+    StateStorage,
     RuntimeServiceId,
 >(
     handle: OverwatchHandle<RuntimeServiceId>,
@@ -17,13 +18,14 @@ pub async fn post_declaration_handler<
 where
     MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
     ChainService: CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
     RuntimeServiceId: Send
         + Sync
         + Debug
         + Display
         + 'static
         + overwatch::services::AsServiceId<
-            SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>,
+            SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>,
         >,
 {
     let relay = handle.relay().await?;
@@ -40,20 +42,27 @@ where
     reply_rx.await?
 }
 
-pub async fn post_activity_handler<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>(
+pub async fn post_activity_handler<
+    MempoolAdapter,
+    WalletAdapter,
+    ChainService,
+    StateStorage,
+    RuntimeServiceId,
+>(
     handle: OverwatchHandle<RuntimeServiceId>,
     metadata: ActivityMetadata,
 ) -> Result<(), DynError>
 where
     MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
     ChainService: CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
     RuntimeServiceId: Send
         + Sync
         + Debug
         + Display
         + 'static
         + overwatch::services::AsServiceId<
-            SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>,
+            SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>,
         >,
 {
     let relay = handle.relay().await?;
@@ -70,6 +79,7 @@ pub async fn post_withdrawal_handler<
     MempoolAdapter,
     WalletAdapter,
     ChainService,
+    StateStorage,
     RuntimeServiceId,
 >(
     handle: OverwatchHandle<RuntimeServiceId>,
@@ -78,13 +88,14 @@ pub async fn post_withdrawal_handler<
 where
     MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
     ChainService: CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
     RuntimeServiceId: Send
         + Sync
         + Debug
         + Display
         + 'static
         + overwatch::services::AsServiceId<
-            SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>,
+            SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>,
         >,
 {
     let relay = handle.relay().await?;

--- a/services/api/src/http/sdp.rs
+++ b/services/api/src/http/sdp.rs
@@ -29,12 +29,12 @@ where
         >,
 {
     let relay = handle.relay().await?;
-    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let (reply_channel, reply_rx) = tokio::sync::oneshot::channel();
 
     relay
         .send(lb_sdp_service::SdpMessage::PostDeclaration {
             declaration: Box::new(declaration),
-            reply_channel: reply_tx,
+            reply_channel,
         })
         .await
         .map_err(|(e, _)| e)?;
@@ -104,6 +104,45 @@ where
         .send(lb_sdp_service::SdpMessage::PostWithdrawal { declaration_id })
         .await
         .map_err(|(e, _)| e)?;
+
+    Ok(())
+}
+
+pub async fn post_set_declaration_id_handler<
+    MempoolAdapter,
+    WalletAdapter,
+    ChainService,
+    StateStorage,
+    RuntimeServiceId,
+>(
+    handle: OverwatchHandle<RuntimeServiceId>,
+    declaration_id: Option<DeclarationId>,
+) -> Result<(), DynError>
+where
+    MempoolAdapter: SdpMempoolAdapter + Send + Sync + 'static,
+    ChainService: CryptarchiaServiceData + Send + Sync + 'static,
+    StateStorage: SdpStateStorage,
+    RuntimeServiceId: Send
+        + Sync
+        + Debug
+        + Display
+        + 'static
+        + overwatch::services::AsServiceId<
+            SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>,
+        >,
+{
+    let relay = handle.relay().await?;
+    let (reply_channel, reply_rx) = tokio::sync::oneshot::channel();
+
+    relay
+        .send(lb_sdp_service::SdpMessage::SetCurrentDeclarationId {
+            declaration_id,
+            reply_channel,
+        })
+        .await
+        .map_err(|(e, _)| Box::new(e) as DynError)?;
+
+    reply_rx.await?.map_err(|e| Box::new(e) as DynError)?;
 
     Ok(())
 }

--- a/services/sdp/Cargo.toml
+++ b/services/sdp/Cargo.toml
@@ -18,6 +18,7 @@ futures                       = { workspace = true }
 lb-chain-service              = { workspace = true }
 lb-core                       = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
+lb-services-utils             = { workspace = true }
 lb-tracing                    = { workspace = true }
 overwatch                     = { workspace = true }
 serde                         = { features = ["derive"], workspace = true }

--- a/services/sdp/Cargo.toml
+++ b/services/sdp/Cargo.toml
@@ -23,5 +23,6 @@ lb-tracing                    = { workspace = true }
 overwatch                     = { workspace = true }
 serde                         = { features = ["derive"], workspace = true }
 thiserror                     = { workspace = true }
+time                          = { workspace = true }
 tokio                         = { workspace = true }
 tracing                       = { workspace = true }

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -257,8 +257,6 @@ where
                     declaration_id,
                     reply_channel,
                 } => {
-                    metrics::set_declaration_id_total();
-
                     self.handle_set_current_declaration_id(
                         declaration_id,
                         reply_channel,
@@ -562,8 +560,6 @@ where
         reply_channel: oneshot::Sender<Result<(), SdpError>>,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
     ) {
-        metrics::set_declaration_id_total();
-
         let result = self
             .validate_declaration_id(declaration_id, chain_api)
             .await;

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -508,11 +508,13 @@ where
             .await
         else {
             tracing::error!("Can't find declaration. Cannot post activity without declaration.");
+            metrics::withdrawal_validation_failures_total();
             return;
         };
 
         let Some(nonce) = declaration.nonce.checked_add(1) else {
             tracing::error!("Can't bump nonce");
+            metrics::withdrawal_validation_failures_total();
             return;
         };
 

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -33,6 +33,7 @@ use overwatch::{
     services::{AsServiceId, ServiceCore, ServiceData},
 };
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::sync::oneshot;
 
 pub use crate::api::SdpServiceApi;
@@ -65,6 +66,18 @@ pub struct BlockEvent {
 
 pub type BlockUpdateStream = Pin<Box<dyn Stream<Item = BlockEvent> + Send + Sync + Unpin>>;
 
+#[derive(Debug, Error)]
+pub enum SdpError {
+    #[error("Declaration {0:?} not found in ledger")]
+    DeclarationNotFound(DeclarationId),
+
+    #[error("Ledger state not found for block {0:?}")]
+    LedgerStateNotFound(HeaderId),
+
+    #[error("Chain API error: {0}")]
+    ChainApi(#[from] DynError),
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SdpSettings {
     /// Declaration ID for this node (set after posting declaration).
@@ -87,6 +100,7 @@ pub struct RuntimeDeclaration {
     pub id: DeclarationId,
     pub zk_id: ZkPublicKey,
     pub locked_note_id: NoteId,
+    pub nonce: u64,
 }
 
 pub enum SdpMessage {
@@ -100,6 +114,10 @@ pub enum SdpMessage {
     PostWithdrawal {
         declaration_id: DeclarationId,
     },
+    SetCurrentDeclarationId {
+        declaration_id: Option<DeclarationId>,
+        reply_channel: oneshot::Sender<Result<(), SdpError>>,
+    },
 }
 
 pub struct SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
@@ -107,12 +125,7 @@ where
     StateStorage: SdpStateStorage,
 {
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-    /// Declaration ID from settings - will be resolved to full declaration on
-    /// `run()`.
     declaration_id: Option<DeclarationId>,
-    /// Runtime declaration info fetched from ledger (populated in `run()`).
-    current_declaration: Option<RuntimeDeclaration>,
-    nonce: u64,
     wallet_config: SdpWalletConfig,
     _phantom: std::marker::PhantomData<(ChainService, StateStorage)>,
 }
@@ -150,18 +163,21 @@ where
 {
     fn init(
         service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-        _initial_state: Self::State,
+        initial_state: Self::State,
     ) -> Result<Self, DynError> {
         let settings = service_resources_handle
             .settings_handle
             .notifier()
             .get_updated_settings();
 
+        let declaration_id = initial_state
+            .updated
+            .and(initial_state.declaration_id)
+            .or(settings.declaration_id);
+
         Ok(Self {
-            declaration_id: settings.declaration_id,
-            current_declaration: None, // Will be fetched from ledger in run()
+            declaration_id,
             service_resources_handle,
-            nonce: 0, // Will be fetched from ledger in run()
             wallet_config: settings.wallet_config,
             _phantom: std::marker::PhantomData,
         })
@@ -190,7 +206,7 @@ where
         let chain_api: CryptarchiaServiceApi<ChainService, RuntimeServiceId> =
             CryptarchiaServiceApi::new(chain_relay);
 
-        self.try_restore_declaration_state(&chain_api).await;
+        self.resolve_declaration_status(&chain_api).await?;
 
         self.service_resources_handle.status_updater.notify_ready();
         tracing::info!(
@@ -237,6 +253,19 @@ where
                     )
                     .await;
                 }
+                SdpMessage::SetCurrentDeclarationId {
+                    declaration_id,
+                    reply_channel,
+                } => {
+                    metrics::set_declaration_id_total();
+
+                    self.handle_set_current_declaration_id(
+                        declaration_id,
+                        reply_channel,
+                        &chain_api,
+                    )
+                    .await;
+                }
             }
         }
 
@@ -266,41 +295,27 @@ where
     /// If a `declaration_id` is configured, fetches the full declaration info
     /// (including current nonce) from the ledger. This ensures the service
     /// continues with the correct nonce after a restart.
-    async fn try_restore_declaration_state(
-        &mut self,
+    async fn try_fetch_runtime_declaration(
+        &self,
+        declaration_id: DeclarationId,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
-    ) {
-        let Some(declaration_id) = self.declaration_id else {
-            return;
-        };
-
-        match self
-            .fetch_declaration_from_ledger(chain_api, declaration_id)
-            .await
-        {
-            Ok(Some((declaration, nonce))) => {
-                tracing::info!(
-                    declaration_id = ?declaration_id,
-                    nonce = nonce,
-                    "Loaded declaration from ledger"
-                );
-                self.current_declaration = Some(declaration);
-                self.nonce = nonce;
-            }
-            Ok(None) => {
-                tracing::warn!(
-                    declaration_id = ?declaration_id,
-                    "Declaration not found in ledger - may have been withdrawn or not yet confirmed"
-                );
-            }
-            Err(e) => {
-                tracing::error!(
-                    declaration_id = ?declaration_id,
-                    error = ?e,
-                    "Failed to fetch declaration from ledger"
-                );
-            }
-        }
+    ) -> Result<RuntimeDeclaration, SdpError> {
+        self.fetch_declaration_from_ledger(chain_api, declaration_id)
+            .await?
+            .map_or_else(
+                || {
+                    tracing::warn!(?declaration_id, "Declaration not found in ledger");
+                    Err(SdpError::DeclarationNotFound(declaration_id))
+                },
+                |declaration| {
+                    tracing::info!(
+                        ?declaration.id,
+                        declaration.nonce,
+                        "Loaded declaration from ledger"
+                    );
+                    Ok(declaration)
+                },
+            )
     }
 
     /// Fetch declaration info from the ledger via chain service.
@@ -308,7 +323,7 @@ where
         &self,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
         declaration_id: DeclarationId,
-    ) -> Result<Option<(RuntimeDeclaration, u64)>, DynError> {
+    ) -> Result<Option<RuntimeDeclaration>, DynError> {
         // Get current chain info to find the tip
         let ChainServiceInfo {
             cryptarchia_info, ..
@@ -329,14 +344,42 @@ where
             return Ok(None);
         };
 
-        Ok(Some((
-            RuntimeDeclaration {
-                id: declaration_id,
-                zk_id: declaration.zk_id,
-                locked_note_id: declaration.locked_note_id,
+        Ok(Some(RuntimeDeclaration {
+            id: declaration_id,
+            zk_id: declaration.zk_id,
+            locked_note_id: declaration.locked_note_id,
+            nonce: declaration.nonce,
+        }))
+    }
+
+    async fn resolve_declaration_status(
+        &self,
+        chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
+    ) -> Result<(), DynError> {
+        let Some(id) = self.declaration_id else {
+            return Ok(());
+        };
+
+        match self.try_fetch_runtime_declaration(id, chain_api).await {
+            Ok(_) => Ok(()),
+            Err(e) => match e {
+                SdpError::ChainApi(err) => {
+                    tracing::error!("Chain API error during declaration resolution: {err}");
+                    Err(err)
+                }
+                SdpError::DeclarationNotFound(id) => {
+                    tracing::warn!(
+                        declaration_id = ?id,
+                        "Declaration not found in ledger"
+                    );
+                    Ok(())
+                }
+                SdpError::LedgerStateNotFound(tip) => {
+                    tracing::error!("Could not find ledger state for tip {tip:?}");
+                    Err(format!("Missing ledger state at {tip:?}").into())
+                }
             },
-            declaration.nonce,
-        )))
+        }
     }
 
     #[expect(
@@ -381,6 +424,10 @@ where
         } else {
             metrics::declaration_success_total();
         }
+
+        self.service_resources_handle
+            .state_updater
+            .update(Some(SdpState::from(Some(declaration_id))));
     }
 
     #[expect(
@@ -388,21 +435,33 @@ where
         reason = "TODO: address this in a dedicated refactor"
     )]
     async fn handle_post_activity(
-        &mut self,
+        &self,
         metadata: ActivityMetadata,
         wallet_adapter: &WalletAdapter,
         mempool_adapter: &MempoolAdapter,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
     ) {
-        // Check if we have a declaration_id
-        let Some(ref declaration) = self.current_declaration else {
+        let Some(declaration_id) = self.declaration_id else {
             tracing::error!("No declaration_id set. Cannot post activity without declaration.");
+            return;
+        };
+
+        let Ok(ref declaration) = self
+            .try_fetch_runtime_declaration(declaration_id, chain_api)
+            .await
+        else {
+            tracing::error!("Can't find declaration. Cannot post activity without declaration.");
+            return;
+        };
+
+        let Some(nonce) = declaration.nonce.checked_add(1) else {
+            tracing::error!("Can't bump nonce");
             return;
         };
 
         let active_message = ActiveMessage {
             declaration_id: declaration.id,
-            nonce: self.bump_nonce(),
+            nonce,
             metadata,
         };
 
@@ -437,23 +496,29 @@ where
         reason = "TODO: address this in a dedicated refactor"
     )]
     async fn handle_post_withdrawal(
-        &mut self,
+        &self,
         declaration_id: DeclarationId,
         wallet_adapter: &WalletAdapter,
         mempool_adapter: &MempoolAdapter,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
     ) {
-        if let Err(e) = self.validate_withdrawal(&declaration_id) {
-            tracing::error!("{}", e);
-            metrics::withdrawal_validation_failures_total();
+        let Ok(ref declaration) = self
+            .try_fetch_runtime_declaration(declaration_id, chain_api)
+            .await
+        else {
+            tracing::error!("Can't find declaration. Cannot post activity without declaration.");
             return;
-        }
+        };
 
-        let declaration = self.current_declaration.as_ref().unwrap(); //unwrap is ok as it is validated above
+        let Some(nonce) = declaration.nonce.checked_add(1) else {
+            tracing::error!("Can't bump nonce");
+            return;
+        };
+
         let withdraw_message = WithdrawMessage {
             declaration_id,
             locked_note_id: declaration.locked_note_id,
-            nonce: self.bump_nonce(),
+            nonce,
         };
 
         let Ok(tx_context) = self.get_tx_context(None, chain_api).await else {
@@ -482,22 +547,45 @@ where
 
         metrics::withdrawal_success_total();
 
-        self.current_declaration = None;
-        // TODO: how should we reset the nonce? shouldn't it be always with
-        // current_delcaration?
+        self.service_resources_handle
+            .state_updater
+            .update(Some(SdpState::from(None)));
     }
 
-    fn validate_withdrawal(&self, declaration_id: &DeclarationId) -> Result<(), &'static str> {
-        let declaration = self
-            .current_declaration
-            .as_ref()
-            .ok_or("No declaration_id set. Cannot post withdrawal without declaration.")?;
+    async fn handle_set_current_declaration_id(
+        &mut self,
+        declaration_id: Option<DeclarationId>,
+        reply_channel: oneshot::Sender<Result<(), SdpError>>,
+        chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
+    ) {
+        metrics::set_declaration_id_total();
 
-        if *declaration_id != declaration.id {
-            return Err(
-                "Wrong declaration_id set. Cannot post withdrawal without proper declaration id.",
-            );
+        let result = self
+            .validate_declaration_id(declaration_id, chain_api)
+            .await;
+
+        if let Err(e) = reply_channel.send(result) {
+            tracing::error!("Failed to send response for set declaration: {e:?}");
         }
+    }
+
+    async fn validate_declaration_id(
+        &mut self,
+        declaration_id: Option<DeclarationId>,
+        chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
+    ) -> Result<(), SdpError> {
+        let validated_id = match declaration_id {
+            Some(id) => self
+                .try_fetch_runtime_declaration(id, chain_api)
+                .await
+                .map(|_| Some(id))?,
+            None => None,
+        };
+
+        self.declaration_id = validated_id;
+        self.service_resources_handle
+            .state_updater
+            .update(Some(SdpState::from(self.declaration_id)));
 
         Ok(())
     }
@@ -527,16 +615,5 @@ where
             return Err(format!("Ledger state not found for block {block_id:?}").into());
         };
         Ok(ledger_state.tx_context())
-    }
-
-    /// Increments the nonce of the current declaration, and returns the
-    /// incremented nonce.
-    ///
-    /// Nonce must be incremented first because it is initialized to 0 with the
-    /// declaration, and each SDP message (activity or withdrawal) must have
-    /// nonce larger than the previous one.
-    const fn bump_nonce(&mut self) -> u64 {
-        self.nonce += 1;
-        self.nonce
     }
 }

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -206,7 +206,7 @@ where
         let chain_api: CryptarchiaServiceApi<ChainService, RuntimeServiceId> =
             CryptarchiaServiceApi::new(chain_relay);
 
-        self.resolve_declaration_status(&chain_api).await?;
+        self.validate_initial_declaration_status(&chain_api).await?;
 
         self.service_resources_handle.status_updater.notify_ready();
         tracing::info!(
@@ -352,7 +352,7 @@ where
         }))
     }
 
-    async fn resolve_declaration_status(
+    async fn validate_initial_declaration_status(
         &self,
         chain_api: &CryptarchiaServiceApi<ChainService, RuntimeServiceId>,
     ) -> Result<(), DynError> {
@@ -387,7 +387,7 @@ where
         reason = "TODO: address this in a dedicated refactor"
     )]
     async fn handle_post_declaration(
-        &self,
+        &mut self,
         declaration: Box<DeclarationMessage>,
         wallet_adapter: &WalletAdapter,
         mempool_adapter: &MempoolAdapter,
@@ -425,9 +425,10 @@ where
             metrics::declaration_success_total();
         }
 
+        self.declaration_id = Some(declaration_id);
         self.service_resources_handle
             .state_updater
-            .update(Some(SdpState::from(Some(declaration_id))));
+            .update(Some(SdpState::from(self.declaration_id)));
     }
 
     #[expect(
@@ -496,7 +497,7 @@ where
         reason = "TODO: address this in a dedicated refactor"
     )]
     async fn handle_post_withdrawal(
-        &self,
+        &mut self,
         declaration_id: DeclarationId,
         wallet_adapter: &WalletAdapter,
         mempool_adapter: &MempoolAdapter,
@@ -547,9 +548,10 @@ where
 
         metrics::withdrawal_success_total();
 
+        self.declaration_id = None;
         self.service_resources_handle
             .state_updater
-            .update(Some(SdpState::from(None)));
+            .update(Some(SdpState::from(self.declaration_id)));
     }
 
     async fn handle_set_current_declaration_id(

--- a/services/sdp/src/lib.rs
+++ b/services/sdp/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod api;
 pub mod mempool;
 mod metrics;
+pub mod state;
 pub mod wallet;
 
 use std::{
     collections::BTreeSet,
     fmt::{Debug, Display},
+    path::PathBuf,
     pin::Pin,
 };
 
@@ -25,12 +27,10 @@ use lb_core::{
     },
 };
 use lb_key_management_system_keys::keys::ZkPublicKey;
+use lb_services_utils::overwatch::{RecoveryOperator, recovery::backends::FileBackendSettings};
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
-    services::{
-        AsServiceId, ServiceCore, ServiceData,
-        state::{NoOperator, NoState},
-    },
+    services::{AsServiceId, ServiceCore, ServiceData},
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
@@ -38,6 +38,7 @@ use tokio::sync::oneshot;
 pub use crate::api::SdpServiceApi;
 use crate::{
     mempool::SdpMempoolAdapter,
+    state::{SdpState, SdpStateStorage},
     wallet::{SdpWalletAdapter, SdpWalletConfig},
 };
 
@@ -71,10 +72,17 @@ pub struct SdpSettings {
     /// will be fetched from the ledger.
     pub declaration_id: Option<DeclarationId>,
     pub wallet_config: SdpWalletConfig,
+    pub recovery_path: PathBuf,
+}
+
+impl FileBackendSettings for SdpSettings {
+    fn recovery_file(&self) -> &PathBuf {
+        &self.recovery_path
+    }
 }
 
 /// Runtime declaration info fetched from ledger on startup.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RuntimeDeclaration {
     pub id: DeclarationId,
     pub zk_id: ZkPublicKey,
@@ -94,7 +102,10 @@ pub enum SdpMessage {
     },
 }
 
-pub struct SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId> {
+pub struct SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
+where
+    StateStorage: SdpStateStorage,
+{
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
     /// Declaration ID from settings - will be resolved to full declaration on
     /// `run()`.
@@ -103,25 +114,29 @@ pub struct SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServic
     current_declaration: Option<RuntimeDeclaration>,
     nonce: u64,
     wallet_config: SdpWalletConfig,
-    _chain_service: std::marker::PhantomData<ChainService>,
+    _phantom: std::marker::PhantomData<(ChainService, StateStorage)>,
 }
 
-impl<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId> ServiceData
-    for SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>
+impl<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId> ServiceData
+    for SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
+where
+    StateStorage: SdpStateStorage,
 {
     type Settings = SdpSettings;
-    type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State>;
+    type State = SdpState;
+    type StateOperator = RecoveryOperator<StateStorage>;
     type Message = SdpMessage;
 }
 
 #[async_trait]
-impl<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId> ServiceCore<RuntimeServiceId>
-    for SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>
+impl<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
+    ServiceCore<RuntimeServiceId>
+    for SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
 where
     MempoolAdapter: SdpMempoolAdapter<Tx = SignedMantleTx> + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
     ChainService: CryptarchiaServiceData<Tx = SignedMantleTx> + Send + Sync + 'static,
+    StateStorage: SdpStateStorage + Send + Sync,
     RuntimeServiceId: Debug
         + AsServiceId<Self>
         + AsServiceId<MempoolAdapter::MempoolService>
@@ -148,7 +163,7 @@ where
             service_resources_handle,
             nonce: 0, // Will be fetched from ledger in run()
             wallet_config: settings.wallet_config,
-            _chain_service: std::marker::PhantomData,
+            _phantom: std::marker::PhantomData,
         })
     }
 
@@ -229,12 +244,13 @@ where
     }
 }
 
-impl<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>
-    SdpService<MempoolAdapter, WalletAdapter, ChainService, RuntimeServiceId>
+impl<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
+    SdpService<MempoolAdapter, WalletAdapter, ChainService, StateStorage, RuntimeServiceId>
 where
     MempoolAdapter: SdpMempoolAdapter<Tx = SignedMantleTx> + Send + Sync + 'static,
     WalletAdapter: SdpWalletAdapter + Send + Sync + 'static,
     ChainService: CryptarchiaServiceData<Tx = SignedMantleTx> + Send + Sync + 'static,
+    StateStorage: SdpStateStorage + Send + Sync,
     RuntimeServiceId: Debug
         + AsServiceId<Self>
         + AsServiceId<MempoolAdapter::MempoolService>

--- a/services/sdp/src/metrics.rs
+++ b/services/sdp/src/metrics.rs
@@ -62,7 +62,3 @@ pub fn withdrawal_mempool_failures_total() {
 pub fn withdrawal_success_total() {
     lb_tracing::increase_counter_u64!(sdp_withdrawal_success_total, 1);
 }
-
-pub fn set_declaration_id_total() {
-    lb_tracing::increase_counter_u64!(sdp_set_declaration_id_total, 1);
-}

--- a/services/sdp/src/metrics.rs
+++ b/services/sdp/src/metrics.rs
@@ -62,3 +62,7 @@ pub fn withdrawal_mempool_failures_total() {
 pub fn withdrawal_success_total() {
     lb_tracing::increase_counter_u64!(sdp_withdrawal_success_total, 1);
 }
+
+pub fn set_declaration_id_total() {
+    lb_tracing::increase_counter_u64!(sdp_set_declaration_id_total, 1);
+}

--- a/services/sdp/src/state.rs
+++ b/services/sdp/src/state.rs
@@ -3,6 +3,7 @@ use std::convert::Infallible;
 use lb_core::sdp::DeclarationId;
 use overwatch::services::state::ServiceState;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::SdpSettings;
 
@@ -11,6 +12,7 @@ pub use lb_services_utils::overwatch::recovery::operators::RecoveryBackend as Sd
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SdpState {
     pub declaration_id: Option<DeclarationId>,
+    pub updated: Option<OffsetDateTime>,
 }
 
 impl ServiceState for SdpState {
@@ -20,6 +22,16 @@ impl ServiceState for SdpState {
     fn from_settings(settings: &Self::Settings) -> Result<Self, Self::Error> {
         Ok(Self {
             declaration_id: settings.declaration_id,
+            updated: None,
         })
+    }
+}
+
+impl From<Option<DeclarationId>> for SdpState {
+    fn from(declaration: Option<DeclarationId>) -> Self {
+        Self {
+            updated: declaration.map(|_| OffsetDateTime::now_utc()),
+            declaration_id: declaration,
+        }
     }
 }

--- a/services/sdp/src/state.rs
+++ b/services/sdp/src/state.rs
@@ -1,13 +1,12 @@
 use std::convert::Infallible;
 
 use lb_core::sdp::DeclarationId;
+pub use lb_services_utils::overwatch::recovery::operators::RecoveryBackend as SdpStateStorage;
 use overwatch::services::state::ServiceState;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::SdpSettings;
-
-pub use lb_services_utils::overwatch::recovery::operators::RecoveryBackend as SdpStateStorage;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SdpState {

--- a/services/sdp/src/state.rs
+++ b/services/sdp/src/state.rs
@@ -1,0 +1,25 @@
+use std::convert::Infallible;
+
+use lb_core::sdp::DeclarationId;
+use overwatch::services::state::ServiceState;
+use serde::{Deserialize, Serialize};
+
+use crate::SdpSettings;
+
+pub use lb_services_utils::overwatch::recovery::operators::RecoveryBackend as SdpStateStorage;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SdpState {
+    pub declaration_id: Option<DeclarationId>,
+}
+
+impl ServiceState for SdpState {
+    type Error = Infallible;
+    type Settings = SdpSettings;
+
+    fn from_settings(settings: &Self::Settings) -> Result<Self, Self::Error> {
+        Ok(Self {
+            declaration_id: settings.declaration_id,
+        })
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?

Endpoint to set current declaration id used for activity messages. Before we had to set it in config and restart the node. 
Now current declaration id is set when posting a declaration or when using a separate `SetCurrentDeclarationId` message.
When declaration is withdrawn, the current declaration is set to `None`.

SdpService no longer holds `RuntimeDeclaration`, instead it checks it via the ledger every time the sdp operation is performed on that declaration id.

Added state recovery from file and exposed http endpoint.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic @bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
