### PR TITLE
chore(tracing): Appender options for with max files and simple logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,7 +4743,6 @@ dependencies = [
  "futures",
  "hex",
  "http 1.4.0",
- "humantime",
  "libp2p",
  "logos-blockchain-api-service",
  "logos-blockchain-blend",

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -28,7 +28,6 @@ dhat                             = { optional = true, workspace = true }
 futures                          = { workspace = true }
 hex                              = { workspace = true }
 http                             = { workspace = true }
-humantime                        = { workspace = true }
 lb-api-service                   = { workspace = true }
 lb-blend                         = { workspace = true }
 lb-blend-service                 = { workspace = true }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -12,7 +12,7 @@ use color_eyre::eyre::{Result, eyre};
 use lb_libp2p::{Multiaddr, ed25519::SecretKey};
 use lb_tracing::{
     filter::envfilter::{default_envfilter_config, parse_filter_directives},
-    logging::local::AppenderType,
+    logging::local::{AppenderType, CompressionType, RetentionType, RollingConfig, RotationType},
 };
 use serde::Deserialize;
 use tracing::serde::filter::{EnvConfig, Layer};
@@ -200,6 +200,7 @@ impl From<LoggerLayerType> for OsStr {
 #[derive(ValueEnum, Clone, Debug, Default)]
 pub enum LogFileAppenderType {
     #[default]
+    Simple,
     Rolling,
     RollingCompressed,
 }
@@ -207,6 +208,7 @@ pub enum LogFileAppenderType {
 impl From<LogFileAppenderType> for OsStr {
     fn from(value: LogFileAppenderType) -> Self {
         match value {
+            LogFileAppenderType::Simple => "Simple".into(),
             LogFileAppenderType::Rolling => "Rolling".into(),
             LogFileAppenderType::RollingCompressed => "RollingCompressed".into(),
         }
@@ -253,15 +255,6 @@ pub struct LogArgs {
 
     #[clap(long = "log-file-appender", env = "LOG_APPENDER")]
     file_appender: Option<LogFileAppenderType>,
-
-    #[clap(
-        long = "log-compression-interval",
-        env = "LOG_APPENDER_COMPRESSED_INTERVAL",
-        value_parser = humantime::parse_duration,
-        default_value = "1h",
-        required_if_eq("file_appender", LogFileAppenderType::RollingCompressed)
-    )]
-    compression_interval: Option<Duration>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -454,7 +447,6 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
         level,
         filter,
         file_appender: appender,
-        compression_interval,
     } = tracing_args;
 
     if let Some(backend_type) = backend {
@@ -470,11 +462,20 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
             }
             LoggerLayerType::File => {
                 let appender_type = match appender {
-                    Some(LogFileAppenderType::Rolling) | None => AppenderType::Rolling,
+                    Some(LogFileAppenderType::Simple) | None => AppenderType::Simple,
+                    Some(LogFileAppenderType::Rolling) => AppenderType::Rolling(RollingConfig {
+                        rotation: RotationType::Hourly,
+                        retention: RetentionType::None,
+                        compression: CompressionType::None,
+                    }),
                     Some(LogFileAppenderType::RollingCompressed) => {
-                        AppenderType::RollingCompressed {
-                            compression_interval: compression_interval.unwrap(),
-                        }
+                        AppenderType::Rolling(RollingConfig {
+                            rotation: RotationType::Hourly,
+                            retention: RetentionType::None,
+                            compression: CompressionType::Gzip {
+                                compression_threshold: Duration::from_hours(2),
+                            },
+                        })
                     }
                 };
                 tracing.logger.file = Some(FileConfig {

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -203,6 +203,7 @@ pub enum LogFileAppenderType {
     Simple,
     Rolling,
     RollingCompressed,
+    RollingMaxFiles,
 }
 
 impl From<LogFileAppenderType> for OsStr {
@@ -211,6 +212,7 @@ impl From<LogFileAppenderType> for OsStr {
             LogFileAppenderType::Simple => "Simple".into(),
             LogFileAppenderType::Rolling => "Rolling".into(),
             LogFileAppenderType::RollingCompressed => "RollingCompressed".into(),
+            LogFileAppenderType::RollingMaxFiles => "RollingMaxFiles".into(),
         }
     }
 }
@@ -255,6 +257,13 @@ pub struct LogArgs {
 
     #[clap(long = "log-file-appender", env = "LOG_APPENDER")]
     file_appender: Option<LogFileAppenderType>,
+
+    #[clap(
+        long = "log-max-files",
+        env = "LOG_APPENDER_MAX_FILES",
+        required_if_eq("file_appender", LogFileAppenderType::RollingMaxFiles)
+    )]
+    max_files: Option<usize>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -446,7 +455,8 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
         prefix,
         level,
         filter,
-        file_appender: appender,
+        file_appender,
+        max_files,
     } = tracing_args;
 
     if let Some(backend_type) = backend {
@@ -461,7 +471,7 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
                 });
             }
             LoggerLayerType::File => {
-                let appender_type = match appender {
+                let appender_type = match file_appender {
                     Some(LogFileAppenderType::Simple) | None => AppenderType::Simple,
                     Some(LogFileAppenderType::Rolling) => AppenderType::Rolling(RollingConfig {
                         rotation: RotationType::Hourly,
@@ -475,6 +485,15 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
                             compression: CompressionType::Gzip {
                                 compression_threshold: Duration::from_hours(2),
                             },
+                        })
+                    }
+                    Some(LogFileAppenderType::RollingMaxFiles) => {
+                        AppenderType::Rolling(RollingConfig {
+                            rotation: RotationType::Hourly,
+                            retention: RetentionType::MaxFiles {
+                                max_files: max_files.expect("Max files should be set"),
+                            },
+                            compression: CompressionType::None,
                         })
                     }
                 };

--- a/nodes/node/binary/src/config/tracing/serde/logger.rs
+++ b/nodes/node/binary/src/config/tracing/serde/logger.rs
@@ -25,7 +25,7 @@ impl Default for Layers {
             file: Some(FileConfig {
                 directory: PathBuf::from("."),
                 prefix: Some(date_prefix.into()),
-                appender_type: AppenderType::Rolling,
+                appender_type: AppenderType::Simple,
             }),
             stdout: true,
             stderr: false,
@@ -89,7 +89,7 @@ impl Default for FileConfig {
         Self {
             directory: "./logs".into(),
             prefix: None,
-            appender_type: AppenderType::Rolling,
+            appender_type: AppenderType::Simple,
         }
     }
 }

--- a/services/tracing/src/lib.rs
+++ b/services/tracing/src/lib.rs
@@ -178,7 +178,7 @@ impl Default for TracingSettings {
                 file: Some(FileConfig {
                     directory: PathBuf::from("."),
                     prefix: Some(date_prefix.into()),
-                    appender_type: AppenderType::Rolling,
+                    appender_type: AppenderType::Simple,
                 }),
                 stdout: true,
                 stderr: false,

--- a/tests/src/nodes/validator.rs
+++ b/tests/src/nodes/validator.rs
@@ -215,7 +215,7 @@ impl Validator {
                 file: Some(tracing::logger::FileConfig {
                     directory: dir.path().to_owned(),
                     prefix: Some(LOGS_PREFIX.into()),
-                    appender_type: AppenderType::Rolling,
+                    appender_type: AppenderType::Simple,
                 }),
                 loki: None,
                 gelf: None,

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -301,7 +301,7 @@ fn configure_logging(base_dir: &Path, prefix: &str) -> logger::Layers {
                     file: Some(logger::FileConfig {
                         directory: log_dir,
                         prefix: Some(prefix.into()),
-                        appender_type: AppenderType::Rolling,
+                        appender_type: AppenderType::Simple,
                     }),
                     loki: None,
                     gelf: None,
@@ -324,7 +324,7 @@ fn configure_logging(base_dir: &Path, prefix: &str) -> logger::Layers {
         file: Some(logger::FileConfig {
             directory: base_dir.to_owned(),
             prefix: Some(prefix.into()),
-            appender_type: AppenderType::Rolling,
+            appender_type: AppenderType::Simple,
         }),
         loki: None,
         gelf: None,

--- a/tracing/src/compressed_appender.rs
+++ b/tracing/src/compressed_appender.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use flate2::{Compression, write::GzEncoder};
-use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_appender::rolling::RollingFileAppender;
 
 struct CompressionGuard(Arc<AtomicBool>);
 impl Drop for CompressionGuard {
@@ -24,34 +24,29 @@ pub struct CompressedRollingAppender {
     directory: PathBuf,
     prefix: String,
     last_compression: Instant,
-    compression_interval: Duration,
+    compression_threshold: Duration,
     is_compressing: Arc<AtomicBool>,
 }
 
 impl CompressedRollingAppender {
-    pub fn new(directory: PathBuf, prefix: &Path, compression_interval: Duration) -> Self {
-        let prefix_str = prefix.to_string_lossy().to_string();
-        let symlink_name = format!("{prefix_str}.latest");
-
-        let inner = RollingFileAppender::builder()
-            .rotation(Rotation::HOURLY)
-            .filename_prefix(&prefix_str)
-            .latest_symlink(&symlink_name)
-            .build(&directory)
-            .expect("Failed to initialize rolling appender");
-
+    pub fn new(
+        rolling_appender: RollingFileAppender,
+        directory: PathBuf,
+        prefix_str: String,
+        compression_threshold: Duration,
+    ) -> Self {
         Self {
-            inner,
+            inner: rolling_appender,
             directory,
             prefix: prefix_str,
-            last_compression: Instant::now() - compression_interval,
-            compression_interval,
+            last_compression: Instant::now() - compression_threshold,
+            compression_threshold,
             is_compressing: Arc::new(AtomicBool::new(false)),
         }
     }
 
     fn try_spawn_compression(&mut self) {
-        if self.last_compression.elapsed() >= self.compression_interval
+        if self.last_compression.elapsed() >= self.compression_threshold
             && self
                 .is_compressing
                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -67,6 +62,7 @@ impl CompressedRollingAppender {
         let prefix = self.prefix.clone();
         let is_compressing = Arc::clone(&self.is_compressing);
         let symlink_path = dir.join(format!("{prefix}.latest"));
+        let compression_threshold = self.compression_threshold;
 
         std::thread::spawn(move || {
             let _guard = CompressionGuard(is_compressing);
@@ -82,6 +78,11 @@ impl CompressedRollingAppender {
 
             for entry in read_dir.flatten() {
                 let path = entry.path();
+                let metadata = entry.metadata().ok();
+
+                let is_old_enough = metadata
+                    .and_then(|m| m.modified().ok())
+                    .is_some_and(|t| t.elapsed().unwrap_or_default() >= compression_threshold);
 
                 let is_log = path
                     .file_name()
@@ -96,7 +97,13 @@ impl CompressedRollingAppender {
                     .as_ref()
                     .is_some_and(|active| active == &path);
 
-                if path.is_file() && is_log && !is_compressed && !is_symlink && !is_active {
+                if path.is_file()
+                    && is_log
+                    && !is_compressed
+                    && !is_symlink
+                    && !is_active
+                    && is_old_enough
+                {
                     if let Err(e) = compress_file_gzip(&path) {
                         eprintln!("failed to compress {}: {e}", path.display());
                     } else {

--- a/tracing/src/logging/local.rs
+++ b/tracing/src/logging/local.rs
@@ -1,7 +1,7 @@
 use std::{io::Write, path::PathBuf, time::Duration};
 
 use serde::{Deserialize, Serialize};
-use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::{non_blocking::WorkerGuard, rolling::Rotation};
 use tracing_subscriber::fmt::{
     Layer,
     format::{DefaultFields, Format},
@@ -11,10 +11,47 @@ use crate::compressed_appender::CompressedRollingAppender;
 
 pub type FmtLayer<S> = Layer<S, DefaultFields, Format, tracing_appender::non_blocking::NonBlocking>;
 
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum RetentionType {
+    None,
+    MaxFiles { max_files: usize },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RotationType {
+    Minutely,
+    Hourly,
+    Daily,
+}
+
+impl RotationType {
+    #[must_use]
+    pub const fn to_rotation(&self) -> Rotation {
+        match self {
+            Self::Minutely => Rotation::MINUTELY,
+            Self::Hourly => Rotation::HOURLY,
+            Self::Daily => Rotation::DAILY,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum CompressionType {
+    None,
+    Gzip { compression_threshold: Duration },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RollingConfig {
+    pub rotation: RotationType,
+    pub retention: RetentionType,
+    pub compression: CompressionType,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AppenderType {
-    Rolling,
-    RollingCompressed { compression_interval: Duration },
+    Simple,
+    Rolling(RollingConfig),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -24,29 +61,49 @@ pub struct FileConfig {
     pub appender_type: AppenderType,
 }
 
-pub fn create_file_layer<S>(config: FileConfig) -> (FmtLayer<S>, WorkerGuard) {
-    match config.appender_type {
-        AppenderType::Rolling => {
-            let file_appender = tracing_appender::rolling::hourly(
-                config.directory,
-                config
-                    .prefix
-                    .unwrap_or_else(|| PathBuf::from("logos-blockchain.log")),
-            );
-            create_writer_layer(file_appender)
+pub fn create_file_layer<S>(file_config: FileConfig) -> (FmtLayer<S>, WorkerGuard) {
+    let prefix = file_config
+        .prefix
+        .unwrap_or_else(|| "logos-blockchain.log".into());
+    let prefix_str = prefix.to_string_lossy().to_string();
+
+    let mut builder = tracing_appender::rolling::Builder::new().filename_prefix(&prefix_str);
+
+    let (rotation, retention, compression) = match &file_config.appender_type {
+        AppenderType::Rolling(config) => (
+            config.rotation.to_rotation(),
+            config.retention,
+            config.compression,
+        ),
+        AppenderType::Simple => (Rotation::NEVER, RetentionType::None, CompressionType::None),
+    };
+
+    builder = builder.rotation(rotation);
+
+    if let AppenderType::Rolling(_) = file_config.appender_type {
+        builder = builder.latest_symlink(format!("{prefix_str}.latest"));
+        if let RetentionType::MaxFiles { max_files } = retention {
+            builder = builder.max_log_files(max_files);
         }
-        AppenderType::RollingCompressed {
-            compression_interval,
+    }
+
+    let rolling_appender = builder
+        .build(file_config.directory.clone())
+        .expect("Failed to initialize rolling appender");
+
+    match compression {
+        CompressionType::Gzip {
+            compression_threshold,
         } => {
-            let compressed_appender = CompressedRollingAppender::new(
-                config.directory,
-                &config
-                    .prefix
-                    .unwrap_or_else(|| "logos-blockchain.log".into()),
-                compression_interval,
+            let appender = CompressedRollingAppender::new(
+                rolling_appender,
+                file_config.directory,
+                prefix_str,
+                compression_threshold,
             );
-            create_writer_layer(compressed_appender)
+            create_writer_layer(appender)
         }
+        CompressionType::None => create_writer_layer(rolling_appender),
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Follow up to the https://github.com/logos-blockchain/logos-blockchain/pull/2686

Resolving commend:

@hansieodendaal :
As a separate enhancement, it may be useful to support an optional retention bound by hourly file count in addition to compression. For example, keeping only the most recent 24 hourly log files would give operators a simple way to cap disk usage while retaining about a day of logs.

@bacv :
Great suggestion and tracing_appender::rolling already has this functionality, I think the next step would be to expand AppenderType to have configurable rolling appender with roll_interval and retention_bound: RetentionBound{None, Bounded(Duration)}, and if compression is toggled on, the rolling appender is passed to the compression appender as an inner_writer.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal @andrussal @bacv 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
