### PR TITLE
feat(logging): add init log filter

### DIFF
--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use ::tracing::{Level, warn};
+use ::tracing::warn;
 use clap::{Parser, Subcommand, ValueEnum, builder::OsStr};
 use color_eyre::eyre::{Result, eyre};
 use lb_libp2p::{Multiaddr, ed25519::SecretKey};
@@ -156,6 +156,11 @@ pub struct InitArgs {
     /// empty, regardless of any peers passed via `--initial-peers`/`-p`.
     #[clap(long = "no-ibd", default_value_t = false)]
     pub no_ibd: bool,
+
+    /// Log filter directives to write into the generated config, e.g.
+    /// `warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error`.
+    #[clap(long = "log-filter")]
+    pub log_filter: Option<String>,
 
     /// Path for the generated KMS keys YAML file.
     /// Defaults to 'kms.yaml' in the same directory as --output.
@@ -505,22 +510,45 @@ pub fn update_tracing(tracing: &mut TracingConfig, tracing_args: LogArgs) -> Res
         }
     }
 
-    if let Some(level_str) = level {
-        tracing.level = match level_str.to_uppercase().as_str() {
-            "TRACE" => Level::TRACE,
-            "DEBUG" => Level::DEBUG,
-            "INFO" => Level::INFO,
-            "ERROR" => Level::ERROR,
-            "WARN" => Level::WARN,
-            _ => return Err(eyre!("Invalid log level provided: {}", level_str)),
-        };
+    update_tracing_level_and_filter(tracing, level.as_deref(), filter.as_deref())?;
+
+    Ok(())
+}
+
+pub fn update_tracing_level_and_filter(
+    tracing: &mut TracingConfig,
+    level: Option<&str>,
+    filter: Option<&str>,
+) -> Result<()> {
+    if let Some(level) = level {
+        tracing.level = level
+            .parse()
+            .map_err(|_| eyre!("Invalid log level provided: {level}"))?;
     }
 
-    if let Some(filter_string) = filter {
-        tracing.filter = parse_log_filter_layer(&filter_string)?;
+    if let Some(filter) = filter {
+        tracing.filter = parse_log_filter_layer(filter)?;
     } else {
         apply_default_debug_log_filter(tracing);
     }
+
+    Ok(())
+}
+
+pub fn update_tracing_filter_and_derive_level(
+    tracing: &mut TracingConfig,
+    filter: &str,
+) -> Result<()> {
+    let layer = parse_log_filter_layer(filter)?;
+    let Layer::Env(EnvConfig { ref filters }) = layer else {
+        unreachable!("parse_log_filter_layer always returns an env filter");
+    };
+
+    if let Some(level) = filters.values().copied().max() {
+        tracing.level = level;
+    }
+
+    tracing.filter = layer;
 
     Ok(())
 }

--- a/nodes/node/binary/src/init.rs
+++ b/nodes/node/binary/src/init.rs
@@ -26,6 +26,7 @@ use crate::{
         network::serde::{Config as NetworkConfig, nat},
         sdp::serde::RequiredValues as SdpRequiredValues,
         time::serde::Config as TimeConfig,
+        update_tracing_filter_and_derive_level,
         wallet::serde::RequiredValues as WalletConfigRequiredValues,
     },
 };
@@ -114,7 +115,14 @@ pub fn run(args: &InitArgs) -> Result<()> {
         }
     };
 
-    let user_config = build_user_config(args, network_key, keys, blend_listening_address);
+    let tracing_config = build_tracing_config(args)?;
+    let user_config = build_user_config(
+        args,
+        network_key,
+        keys,
+        blend_listening_address,
+        tracing_config,
+    );
 
     if write_kms {
         let kms_yaml = serde_yaml::to_string(&user_config.kms)?;
@@ -230,11 +238,22 @@ fn serialize_with_kms_include(config: &UserConfig, kms_include: &str) -> Result<
     Ok(serde_yaml::to_string(&value)?)
 }
 
+fn build_tracing_config(args: &InitArgs) -> Result<TracingConfig> {
+    let mut tracing_config = TracingConfig::default();
+
+    if let Some(filter) = &args.log_filter {
+        update_tracing_filter_and_derive_level(&mut tracing_config, filter)?;
+    }
+
+    Ok(tracing_config)
+}
+
 fn build_user_config(
     args: &InitArgs,
     network_key: lb_libp2p::ed25519::SecretKey,
     keys: GeneratedKeys,
     blend_listening_address: Multiaddr,
+    tracing_config: TracingConfig,
 ) -> UserConfig {
     let GeneratedKeys {
         blend_signing_key,
@@ -303,8 +322,6 @@ fn build_user_config(
 
     let time_config = TimeConfig::default();
 
-    let tracing_config = TracingConfig::default();
-
     let sdp_config = SdpConfig::with_required_values(SdpRequiredValues { funding_pk });
 
     let api_config = {
@@ -356,6 +373,10 @@ mod tests {
     use std::net::SocketAddr;
 
     use super::*;
+    use crate::config::tracing::serde::{
+        Level,
+        filter::{EnvConfig, Layer},
+    };
 
     fn build_config_from_peers(initial_peers: Vec<Multiaddr>) -> UserConfig {
         build_config(initial_peers, false)
@@ -370,13 +391,16 @@ mod tests {
             http_addr: SocketAddr::from(([0, 0, 0, 0], 8080)),
             external_address: None,
             state_path: None,
-            kms_file: None,
             no_ibd,
+            log_filter: None,
+            kms_file: None,
         };
         let network_key = lb_libp2p::ed25519::SecretKey::generate();
         let keys = generate_keys();
         let blend_addr = Multiaddr::from_str("/ip4/0.0.0.0/udp/3400/quic-v1").unwrap();
-        build_user_config(&args, network_key, keys, blend_addr)
+        let tracing_config = build_tracing_config(&args).unwrap();
+
+        build_user_config(&args, network_key, keys, blend_addr, tracing_config)
     }
 
     #[test]
@@ -420,5 +444,36 @@ mod tests {
         let config = build_config(vec![addr_with_p2p], true);
 
         assert!(config.cryptarchia.network.bootstrap.ibd.peers.is_empty());
+    }
+
+    #[test]
+    fn log_flags_write_env_filter_config() {
+        let args = InitArgs {
+            initial_peers: Vec::new(),
+            output: "test_output.yaml".into(),
+            net_port: 3000,
+            blend_port: 3400,
+            http_addr: SocketAddr::from(([0, 0, 0, 0], 8080)),
+            external_address: None,
+            state_path: None,
+            no_ibd: false,
+            log_filter: Some(
+                "warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error".to_owned(),
+            ),
+            kms_file: None,
+        };
+
+        let tracing_config = build_tracing_config(&args).unwrap();
+        let Layer::Env(EnvConfig { filters }) = tracing_config.filter else {
+            panic!("expected env filter config");
+        };
+
+        assert_eq!(tracing_config.level, Level::DEBUG);
+        assert_eq!(filters.get("*"), Some(&Level::WARN));
+        assert_eq!(filters.get("logos_blockchain"), Some(&Level::DEBUG));
+        assert_eq!(
+            filters.get("libp2p_gossipsub::behaviour"),
+            Some(&Level::ERROR)
+        );
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

To simplify adjusting log levels, this PR adds a `--log-filter` option to the `init` command.

For example, to initialize the generated config with debug logging for the known Logos targets:

    logos-blockchain-node init ... \
      --log-filter warn,logos_blockchain=debug,blend=debug,chain=debug,chain_network=debug,chain_leader=debug,cryptarchia=debug,ledger=debug

This is still a bit cumbersome because not all internal logs currently share the same target prefix. Some use `logos_blockchain`, while others use their own prefixes such as `blend`, `chain`, or `ledger`. We should make sure internal log statements use targets under the `logos_blockchain` prefix, so this can eventually become:

    logos-blockchain-node init ... \
      --log-filter warn,logos_blockchain=debug


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
