### PR TITLE
chore: lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,7 +399,6 @@ shadow_same                        = { level = "allow" }
 shadow_unrelated                   = { level = "allow" }
 tests_outside_test_module          = { level = "allow" }
 todo                               = { level = "allow" }
-unchecked_time_subtraction         = { level = "allow" }
 unimplemented                      = { level = "allow" }
 unreachable                        = { level = "allow" }
 unwrap_in_result                   = { level = "allow" }
@@ -416,8 +415,10 @@ unused_results            = { level = "allow" } # We have Clippy lints to warn o
 ambiguous_negative_literals   = { level = "warn" }
 closure_returning_async_block = { level = "warn" }
 deref_into_dyn_supertrait     = { level = "warn" }
+ffi_unwind_calls              = { level = "warn" }
 impl_trait_redundant_captures = { level = "warn" }
 let_underscore_drop           = { level = "warn" }
+linker_messages               = { level = "warn" }
 macro_use_extern_crate        = { level = "warn" }
 missing_unsafe_on_extern      = { level = "warn" }
 redundant_imports             = { level = "warn" }
@@ -435,12 +436,10 @@ unused_lifetimes              = { level = "warn" }
 unused_macro_rules            = { level = "warn" }
 unused_qualifications         = { level = "warn" }
 
-# TODO: Address these allow-by-default Rustc lints at some point. To allow them, move them to the list of explicitly allowed lints. To enforce them, move them to the list of explicitly warned ones.
+# TODO: Address these allow-by-default Rustc lints at some point. To allow them, simply remove them from this list. To enforce them, move them to the list of explicitly warned ones and mark them as "warn" level.
 absolute_paths_not_starting_with_crate = { level = "allow" }
 elided_lifetimes_in_paths              = { level = "allow" }
-ffi_unwind_calls                       = { level = "allow" }
 impl_trait_overcaptures                = { level = "allow" }
-linker_messages                        = { level = "allow" }
 missing_copy_implementations           = { level = "allow" }
 missing_debug_implementations          = { level = "allow" }
 missing_docs                           = { level = "allow" }

--- a/blend/scheduling/src/session.rs
+++ b/blend/scheduling/src/session.rs
@@ -173,9 +173,10 @@ mod tests {
         ));
         let elapsed = start_time.elapsed();
         assert!(
-            elapsed.abs_diff(session_duration - transition_period) <= time_tolerance,
+            elapsed.abs_diff(session_duration.checked_sub(transition_period).unwrap())
+                <= time_tolerance,
             "elapsed:{elapsed:?}, expected:{:?}",
-            session_duration - transition_period
+            session_duration.checked_sub(transition_period).unwrap()
         );
 
         // TransitionEnd should be emitted after transition_period.

--- a/scripts/check-workspace-dependency-policies.sh
+++ b/scripts/check-workspace-dependency-policies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-# Enforces workspace dependency policy across Cargo manifests.
+# Enforces workspace dependency and lint policy across Cargo manifests.
 #
 # Checks:
 # - Workspace members must declare dependencies using `workspace = true` only
@@ -9,6 +9,8 @@ set -eu
 # - Workspace members must not override `default-features` on workspace deps.
 # - Root `[workspace.dependencies]` entries must set `default-features = false`.
 # - Root `[workspace.dependencies]` entries must not set `features`.
+# - Workspace members must inherit lints from the workspace via a `[lints]`
+#   section containing `workspace = true`.
 #
 # Exit codes:
 # - 0: all checks passed.
@@ -82,6 +84,11 @@ function normalize_dep_name(name) {
 function record_violation(rule, dep, line_no, details) {
   violations += 1
   printf("- [%s] %s:%d dependency=%s %s\n", rule, manifest_path, line_no, dep, details)
+}
+
+function record_manifest_violation(rule, details) {
+  violations += 1
+  printf("- [%s] %s %s\n", rule, manifest_path, details)
 }
 
 function braces_delta(s,    opens, closes, copy) {
@@ -188,6 +195,7 @@ function analyze_dependency_assignment(dep, value_text, line_no) {
 BEGIN {
   violations = 0
   current_section = ""
+  lints_workspace_true = 0
   reset_specific_state()
 }
 
@@ -255,6 +263,17 @@ BEGIN {
       }
     }
     next
+  }
+
+  if (!is_root_manifest && current_section == "lints") {
+    eq_pos = index(line, "=")
+    if (eq_pos > 0) {
+      key = trim(substr(line, 1, eq_pos - 1))
+      value = trim(substr(line, eq_pos + 1))
+      if (key == "workspace" && value ~ /^true([[:space:]]|$)/) {
+        lints_workspace_true = 1
+      }
+    }
   }
 
   if ((is_root_manifest && current_section == "workspace.dependencies") ||

--- a/services/chain/chain-common/Cargo.toml
+++ b/services/chain/chain-common/Cargo.toml
@@ -12,3 +12,6 @@ version     = { workspace = true }
 [dependencies]
 lb-core = { workspace = true }
 serde   = { features = ["derive"], workspace = true }
+
+[lints]
+workspace = true

--- a/tracing/src/compressed_appender.rs
+++ b/tracing/src/compressed_appender.rs
@@ -39,7 +39,9 @@ impl CompressedRollingAppender {
             inner: rolling_appender,
             directory,
             prefix: prefix_str,
-            last_compression: Instant::now() - compression_threshold,
+            last_compression: Instant::now()
+                .checked_sub(compression_threshold)
+                .expect("Specified compression threshold is too large."),
             compression_threshold,
             is_compressing: Arc::new(AtomicBool::new(false)),
         }


### PR DESCRIPTION
## 1. What does this PR implement?

* We add a step to the workspace check script that makes sure all workspace crates inherit the workspace lints. We found one occurrence where this did not happen, in `logos-blockchain-chain-service-common`. This is now enforced in the CI as well.
* We enforce a couple of rustc lints which did not trigger any warnings, specifically [`ffi_unwind_calls`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#ffi-unwind-calls) and [`linker_messages`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#linker-messages)
* We enforce one Clippy lint which triggered a couple of minor warnings, specifically [`unchecked_time_subtraction`](https://rust-lang.github.io/rust-clippy/master/index.html?search=unchecked_time_subtraction#unchecked_time_subtraction)

Except for new lints that will and in future versions of Rust, this is the last set of lints that does not require invasive changes. We should probably enable a bunch of them before mainnet, but we do not have to rush it for now.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.