### PR TITLE
fix(sdp): Don't validate genesis sdp op proofs

### DIFF
--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -83,7 +83,6 @@ impl LedgerState {
             &config.sdp_config,
             utxo_tree,
             epoch_state,
-            tx.hash(),
             tx.sdp_declarations(),
         )?;
 

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -297,22 +297,13 @@ impl SdpLedger {
         config: &Config,
         utxo_tree: &UtxoTree,
         epoch_state: &EpochState,
-        tx_hash: TxHash,
         ops: impl Iterator<Item = (&'a SDPDeclareOp, &'a OpProof)> + 'a,
     ) -> Result<Self, Error> {
         let mut sdp =
             Self::new().with_blend_service(&config.service_rewards_params.blend, epoch_state);
 
-        for (op, proof) in ops {
-            let OpProof::ZkAndEd25519Sigs {
-                zk_sig,
-                ed25519_sig,
-            } = proof
-            else {
-                return Err(Error::InvalidProof);
-            };
-            sdp =
-                sdp.try_apply_sdp_declaration(utxo_tree, op, zk_sig, ed25519_sig, tx_hash, config)?;
+        for (op, _) in ops {
+            sdp = sdp.try_apply_sdp_genesis_declaration(utxo_tree, op, config)?;
         }
 
         let blend = sdp
@@ -393,6 +384,60 @@ impl SdpLedger {
             },
             all_reward_utxos,
         ))
+    }
+
+    pub fn try_apply_sdp_genesis_declaration(
+        mut self,
+        utxo_tree: &UtxoTree,
+        op: &SDPDeclareOp,
+        config: &Config,
+    ) -> Result<Self, Error> {
+        let Some(service_state) = self.services.get_mut(&op.service_type) else {
+            return Err(Error::ServiceNotFound(op.service_type));
+        };
+
+        let Some((utxo, _)) = utxo_tree.utxos().get(&op.locked_note_id) else {
+            return Err(
+                lb_core::mantle::ops::sdp::SdpError::InexistingNote(op.locked_note_id).into(),
+            );
+        };
+        if service_state.contains(&op.id()) {
+            return Err(Error::DuplicateDeclaration(op.id()));
+        }
+
+        if utxo.note.value < config.min_stake.threshold {
+            return Err(lb_core::mantle::ops::sdp::SdpError::NoteInsufficientValue {
+                note_id: op.locked_note_id,
+                value: utxo.note.value,
+            }
+            .into());
+        }
+
+        if self
+            .locked_notes
+            .is_locked_for_service(&op.locked_note_id, &op.service_type)
+        {
+            return Err(
+                lb_core::mantle::ops::sdp::SdpError::NoteAlreadyUsedForService {
+                    note_id: op.locked_note_id,
+                    service_type: op.service_type,
+                }
+                .into(),
+            );
+        }
+
+        // Execute SDP Declare
+        let result = op.execute(SDPDeclareExecutionContext {
+            utxo_tree: utxo_tree.clone(),
+            block_number: self.block_number,
+            declarations: service_state.declarations_clone(),
+            locked_notes: self.locked_notes.clone(),
+            min_stake: config.min_stake,
+        })?;
+
+        self.locked_notes = result.locked_notes;
+        service_state.update_declarations(result.declarations);
+        Ok(self)
     }
 
     pub fn try_apply_sdp_declaration(


### PR DESCRIPTION
## 1. What does this PR implement?

SDP validation context expects zk and ed25519 signatures, and validates them for ordinary sdp declarations.
These proofs are not set in genesis block creation, thus shouldn't be validated during `from_genesis` method.

## 2. Does the code have enough context to be clearly understood?

@danielSanchezQ @thomaslavaur  I feel that you had an intention to verify provider_id proofs, but I can't find any specs or discussion, otherwise why op_proofs are `ed25519` in genesis?

Opened this PR to unblock the stateless genesis in CI. 

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur @danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
