### PR TITLE
test(e2e): fix blend CLI scenario binary

### DIFF
--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1144,7 +1144,7 @@ async fn step_run_blend_sdp_declaration_cli(
         .arg("-p")
         .arg("logos-blockchain-tools")
         .arg("--bin")
-        .arg("api")
+        .arg("logos-blockchain-tools-api")
         .arg("--")
         .arg("sdp")
         .arg("post-blend-declaration")


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes the Blend CLI Cucumber scenario.

The scenario was running `cargo run -p logos-blockchain-tools --bin api`, but the actual Cargo binary target is `logos-blockchain-tools-api`. CI failed before the CLI could run because Cargo could not find an `api` bin target.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
