### PR TITLE
feat(chain-service): broadcast active providers when epoch of LIB changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "derivative",
  "futures",
  "logos-blockchain-core",
+ "logos-blockchain-cryptarchia-engine",
  "overwatch",
  "serde",
  "tokio",

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -490,16 +490,16 @@ impl LedgerState {
     }
 
     #[must_use]
-    pub fn active_session_providers(
+    pub fn active_providers(
         &self,
         service_type: ServiceType,
     ) -> Option<HashMap<ProviderId, ProviderInfo>> {
-        self.mantle_ledger.active_session_providers(service_type)
+        self.mantle_ledger.active_providers(service_type)
     }
 
     #[must_use]
-    pub fn active_sessions(&self) -> HashMap<ServiceType, Epoch> {
-        self.mantle_ledger.active_sessions()
+    pub fn active_snapshot_epochs(&self) -> HashMap<ServiceType, Epoch> {
+        self.mantle_ledger.active_snapshot_epochs()
     }
 
     #[must_use]

--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -116,7 +116,7 @@ impl LedgerState {
     }
 
     #[must_use]
-    pub fn active_session_providers(
+    pub fn active_providers(
         &self,
         service_type: ServiceType,
     ) -> Option<HashMap<ProviderId, ProviderInfo>> {
@@ -124,7 +124,7 @@ impl LedgerState {
     }
 
     #[must_use]
-    pub fn active_sessions(&self) -> HashMap<ServiceType, Epoch> {
+    pub fn active_snapshot_epochs(&self) -> HashMap<ServiceType, Epoch> {
         self.sdp.active_snapshot_epochs()
     }
 

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -220,7 +220,7 @@ async fn handle_new_secret_epoch_info_recreates_handler() {
     let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
 
     let edge_membership = membership(&[core_node], local_node);
-    let membership_info = MembershipInfo::from_membership_and_session_number(edge_membership, 1);
+    let membership_info = MembershipInfo::from_membership_and_epoch(edge_membership, 1);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
@@ -268,8 +268,7 @@ async fn epoch_transition_full_lifecycle() {
     let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
 
     let edge_membership = membership(&[core_node], local_node);
-    let membership_info =
-        MembershipInfo::from_membership_and_session_number(edge_membership.clone(), 1);
+    let membership_info = MembershipInfo::from_membership_and_epoch(edge_membership.clone(), 1);
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
 

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -83,7 +83,7 @@ pub async fn spawn_run(
     }
 
     let session_stream = ReceiverStream::new(session_receiver)
-        .map(|membership| MembershipInfo::from_membership_and_session_number(membership, 1));
+        .map(|membership| MembershipInfo::from_membership_and_epoch(membership, 1));
 
     let settings = settings(local_node, minimal_network_size, node_id_sender);
     let join_handle = tokio::spawn(async move {

--- a/services/blend/src/instance.rs
+++ b/services/blend/src/instance.rs
@@ -627,7 +627,7 @@ mod tests {
             let instance = instance
                 .handle_session_event(
                     // With an empty membership smaller than the minimal size.
-                    SessionEvent::NewSession(MembershipInfo::from_membership_and_session_number(
+                    SessionEvent::NewSession(MembershipInfo::from_membership_and_epoch(
                         membership(&[], local_node),
                         1,
                     )),
@@ -654,7 +654,7 @@ mod tests {
             // Broadcast -> Edge
             let instance = instance
                 .handle_session_event(
-                    SessionEvent::NewSession(MembershipInfo::from_membership_and_session_number(
+                    SessionEvent::NewSession(MembershipInfo::from_membership_and_epoch(
                         membership(&[1], local_node),
                         1,
                     )),
@@ -669,7 +669,7 @@ mod tests {
             // Edge -> Edge (stay)
             let instance = instance
                 .handle_session_event(
-                    SessionEvent::NewSession(MembershipInfo::from_membership_and_session_number(
+                    SessionEvent::NewSession(MembershipInfo::from_membership_and_epoch(
                         membership(&[1], local_node),
                         1,
                     )),
@@ -684,7 +684,7 @@ mod tests {
             // Edge -> Core
             let instance = instance
                 .handle_session_event(
-                    SessionEvent::NewSession(MembershipInfo::from_membership_and_session_number(
+                    SessionEvent::NewSession(MembershipInfo::from_membership_and_epoch(
                         membership(&[1], 1),
                         1,
                     )),

--- a/services/blend/src/membership/mod.rs
+++ b/services/blend/src/membership/mod.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 use futures::Stream;
 use lb_blend::scheduling::membership::Membership;
+use lb_chain_service::Epoch;
 use lb_core::crypto::ZkHash;
 use lb_groth16::fr_to_bytes;
 use lb_key_management_system_service::keys::{Ed25519PublicKey, ZkPublicKey};
@@ -17,16 +18,13 @@ pub struct MembershipInfo<NodeId> {
     pub membership: Membership<NodeId>,
     // `None` if membership is empty.
     pub zk: Option<ZkInfo>,
-    pub session_number: u64,
+    pub epoch: Epoch,
 }
 
 impl<NodeId> MembershipInfo<NodeId> {
     #[cfg(test)]
     #[must_use]
-    pub fn from_membership_and_session_number(
-        membership: Membership<NodeId>,
-        session_number: u64,
-    ) -> Self {
+    pub fn from_membership_and_epoch(membership: Membership<NodeId>, epoch: Epoch) -> Self {
         let zk = if membership.is_empty() {
             None
         } else {
@@ -35,19 +33,19 @@ impl<NodeId> MembershipInfo<NodeId> {
         Self {
             membership,
             zk,
-            session_number,
+            epoch,
         }
     }
 }
 
 #[derive(Clone)]
 #[cfg_attr(test, derive(Default))]
-/// ZK info for a new session.
+/// ZK info for a new epoch.
 pub struct ZkInfo {
     /// The merkle root of the ZK public keys of all core nodes.
     pub root: ZkHash,
     /// The merkle path (and selectors) proving the node's ZK public key is part
-    /// of the session merkle tree. This is `None` for edge nodes.
+    /// of the epoch merkle tree. This is `None` for edge nodes.
     pub core_and_path_selectors: Option<CorePathAndSelectors>,
 }
 

--- a/services/blend/src/membership/service.rs
+++ b/services/blend/src/membership/service.rs
@@ -5,7 +5,7 @@ use lb_blend::{
     crypto::merkle::sort_nodes_and_build_merkle_tree,
     scheduling::membership::{Membership, Node},
 };
-use lb_chain_broadcast_service::{BlockBroadcastMsg, SessionSubscription, SessionUpdate};
+use lb_chain_broadcast_service::{ActiveProviders, ActiveProvidersSubscription, BlockBroadcastMsg};
 use lb_core::sdp::{ProviderId, ProviderInfo};
 use lb_key_management_system_service::keys::{Ed25519PublicKey, ZkPublicKey};
 use overwatch::{
@@ -67,30 +67,25 @@ where
         let signing_public_key = self.signing_public_key;
         let maybe_zk_public_key = self.zk_public_key;
 
-        let session_stream = self.subscribe_stream().await?;
+        let active_providers_stream = self.subscribe_active_providers().await?;
 
         Ok(Box::pin(
-            session_stream
-                .map(
-                    |SessionUpdate {
-                         providers,
-                         session_number,
-                     }| {
-                        (
-                            providers
-                                .iter()
-                                .filter_map(|(provider_id, provider_info)| {
-                                    node_from_provider::<NodeId>(provider_id, provider_info)
-                                })
-                                .collect::<Vec<_>>(),
-                            session_number,
-                        )
-                    },
-                )
+            active_providers_stream
+                .map(|ActiveProviders { providers, epoch }| {
+                    (
+                        providers
+                            .iter()
+                            .filter_map(|(provider_id, provider_info)| {
+                                node_from_provider::<NodeId>(provider_id, provider_info)
+                            })
+                            .collect::<Vec<_>>(),
+                        epoch,
+                    )
+                })
                 // Sort nodes (if any) by their ZK public key to build a Merkle tree, since the
                 // returned `HashMap` from the chain broadcast service is
                 // non-deterministic across different machines.
-                .map(move |(mut nodes, session_number)| {
+                .map(move |(mut nodes, epoch)| {
                     let zk_info = if nodes.is_empty() {
                         None
                     } else {
@@ -119,7 +114,7 @@ where
                     MembershipInfo {
                         membership,
                         zk: zk_info,
-                        session_number,
+                        epoch,
                     }
                 }),
         ))
@@ -132,11 +127,11 @@ where
     NodeId: Sync,
 {
     /// Subscribe to membership updates for the given service type.
-    async fn subscribe_stream(&self) -> Result<SessionSubscription, Error> {
+    async fn subscribe_active_providers(&self) -> Result<ActiveProvidersSubscription, Error> {
         let (sender, receiver) = oneshot::channel();
 
         self.relay
-            .send(BlockBroadcastMsg::SubscribeBlendSession {
+            .send(BlockBroadcastMsg::SubscribeBlendProviders {
                 result_sender: sender,
             })
             .await

--- a/services/chain/broadcast-service/Cargo.toml
+++ b/services/chain/broadcast-service/Cargo.toml
@@ -13,12 +13,13 @@ version     = { workspace = true }
 workspace = true
 
 [dependencies]
-async-trait  = { workspace = true }
-derivative   = { workspace = true }
-futures      = { workspace = true }
-lb-core      = { workspace = true }
-overwatch    = { workspace = true }
-serde        = { features = ["derive"], workspace = true }
-tokio        = { workspace = true }
-tokio-stream = { workspace = true }
-tracing      = { workspace = true }
+async-trait           = { workspace = true }
+derivative            = { workspace = true }
+futures               = { workspace = true }
+lb-core               = { workspace = true }
+lb-cryptarchia-engine = { workspace = true }
+overwatch             = { workspace = true }
+serde                 = { features = ["derive"], workspace = true }
+tokio                 = { workspace = true }
+tokio-stream          = { workspace = true }
+tracing               = { workspace = true }

--- a/services/chain/broadcast-service/src/lib.rs
+++ b/services/chain/broadcast-service/src/lib.rs
@@ -6,8 +6,9 @@ use derivative::Derivative;
 use futures::{Stream, StreamExt as _, future::ready, stream::iter};
 use lb_core::{
     header::HeaderId,
-    sdp::{ProviderId, ProviderInfo, SessionNumber},
+    sdp::{ProviderId, ProviderInfo},
 };
+use lb_cryptarchia_engine::Epoch;
 use overwatch::{
     OpaqueServiceResourcesHandle,
     services::{
@@ -22,11 +23,11 @@ use tracing::{debug, error, info};
 
 const BROADCAST_CHANNEL_SIZE: usize = 128;
 
-pub type SessionSubscription = Pin<Box<dyn Stream<Item = SessionUpdate> + Send + Sync>>;
+pub type ActiveProvidersSubscription = Pin<Box<dyn Stream<Item = ActiveProviders> + Send + Sync>>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SessionUpdate {
-    pub session_number: SessionNumber,
+pub struct ActiveProviders {
+    pub epoch: Epoch,
     pub providers: HashMap<ProviderId, ProviderInfo>,
 }
 
@@ -40,22 +41,22 @@ pub struct BlockInfo {
 #[derivative(Debug)]
 pub enum BlockBroadcastMsg {
     BroadcastFinalizedBlock(BlockInfo),
-    BroadcastBlendSession(SessionUpdate),
+    BroadcastBlendProviders(ActiveProviders),
     SubscribeToFinalizedBlocks {
         result_sender: oneshot::Sender<broadcast::Receiver<BlockInfo>>,
     },
-    SubscribeBlendSession {
+    SubscribeBlendProviders {
         #[derivative(Debug = "ignore")]
-        result_sender: oneshot::Sender<SessionSubscription>,
+        result_sender: oneshot::Sender<ActiveProvidersSubscription>,
     },
 }
 
 pub struct BlockBroadcastService<RuntimeServiceId> {
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
     finalized_blocks: broadcast::Sender<BlockInfo>,
-    blend_session: broadcast::Sender<SessionUpdate>,
-    // For sending latest session on subscription.
-    last_blend_session: Option<SessionUpdate>,
+    blend_providers: broadcast::Sender<ActiveProviders>,
+    // For sending latest blend active providers on subscription.
+    last_blend_providers: Option<ActiveProviders>,
 }
 
 impl<RuntimeServiceId> ServiceData for BlockBroadcastService<RuntimeServiceId> {
@@ -75,13 +76,13 @@ where
         _initial_state: Self::State,
     ) -> Result<Self, overwatch::DynError> {
         let (finalized_blocks, _) = broadcast::channel(BROADCAST_CHANNEL_SIZE);
-        let (blend_session, _) = broadcast::channel(BROADCAST_CHANNEL_SIZE);
+        let (blend_providers, _) = broadcast::channel(BROADCAST_CHANNEL_SIZE);
 
         Ok(Self {
             service_resources_handle,
             finalized_blocks,
-            blend_session,
-            last_blend_session: None,
+            blend_providers,
+            last_blend_providers: None,
         })
     }
 
@@ -99,10 +100,10 @@ where
                         debug!("No listener for finalized blocks. Not broadcasting. ");
                     }
                 }
-                BlockBroadcastMsg::BroadcastBlendSession(session) => {
-                    self.last_blend_session = Some(session.clone());
-                    if self.blend_session.send(session).is_err() {
-                        debug!("No listener for blend sessions. Not broadcasting. ");
+                BlockBroadcastMsg::BroadcastBlendProviders(providers) => {
+                    self.last_blend_providers = Some(providers.clone());
+                    if self.blend_providers.send(providers).is_err() {
+                        debug!("No listener for blend active providers. Not broadcasting. ");
                     }
                 }
                 BlockBroadcastMsg::SubscribeToFinalizedBlocks { result_sender } => {
@@ -113,15 +114,15 @@ where
                         error!("Could not subscribe to new blocks channel: {err:?}");
                     }
                 }
-                BlockBroadcastMsg::SubscribeBlendSession { result_sender } => {
+                BlockBroadcastMsg::SubscribeBlendProviders { result_sender } => {
                     if result_sender
-                        .send(create_session_stream(
-                            self.last_blend_session.clone(),
-                            &self.blend_session,
+                        .send(create_active_providers_stream(
+                            self.last_blend_providers.clone(),
+                            &self.blend_providers,
                         ))
                         .is_err()
                     {
-                        error!("Could not subscribe to blend session channel.");
+                        error!("Could not subscribe to blend active providers channel.");
                     }
                 }
             }
@@ -137,10 +138,10 @@ where
 /// The stream immediately yields the current value if `Some`, else it will wait
 /// for the first `Ok` value as returned by the broadcast channel wrapper
 /// stream.
-fn create_session_stream(
-    current_value: Option<SessionUpdate>,
-    sender: &broadcast::Sender<SessionUpdate>,
-) -> SessionSubscription {
+fn create_active_providers_stream(
+    current_value: Option<ActiveProviders>,
+    sender: &broadcast::Sender<ActiveProviders>,
+) -> ActiveProvidersSubscription {
     Box::pin(
         iter(current_value)
             .chain(BroadcastStream::new(sender.subscribe()).filter_map(|item| ready(item.ok()))),

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -1120,35 +1120,40 @@ mod tests {
 
     #[must_use]
     fn ledger_config() -> lb_ledger::Config {
+        let epoch_config = EpochConfig {
+            epoch_stake_distribution_stabilization: NonZero::new(1).unwrap(),
+            epoch_period_nonce_buffer: NonZero::new(1).unwrap(),
+            epoch_period_nonce_stabilization: NonZero::new(1).unwrap(),
+        };
+        let consensus_config = lb_cryptarchia_engine::Config::new(
+            NonZero::new(1).unwrap(),
+            NonNegativeRatio::new(1, 10.try_into().unwrap()),
+            1f64.try_into().expect("1 > 0"),
+        );
+        let epoch_length = epoch_config
+            .epoch_length(consensus_config.base_period_length())
+            .into();
+
         lb_ledger::Config {
-            epoch_config: EpochConfig {
-                epoch_stake_distribution_stabilization: NonZero::new(1).unwrap(),
-                epoch_period_nonce_buffer: NonZero::new(1).unwrap(),
-                epoch_period_nonce_stabilization: NonZero::new(1).unwrap(),
-            },
-            consensus_config: lb_cryptarchia_engine::Config::new(
-                NonZero::new(1).unwrap(),
-                NonNegativeRatio::new(1, 10.try_into().unwrap()),
-                1f64.try_into().expect("1 > 0"),
-            ),
+            epoch_config,
+            consensus_config,
             sdp_config: lb_ledger::mantle::sdp::Config {
                 service_params: Arc::new(
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            lock_period: 10,
-                            inactivity_period: 20,
-                            retention_period: 100,
-                            timestamp: 0,
-                            session_duration: 10,
+                            lock_period: 10.into(),
+                            inactivity_period: 20.into(),
+                            retention_period: 100.into(),
+                            epoch: 0.into(),
                         },
                     )]
                     .into(),
                 ),
                 service_rewards_params: ServiceRewardsParameters {
                     blend: rewards::blend::RewardsParameters {
-                        rounds_per_session: NonZeroU64::new(10).unwrap(),
-                        message_frequency_per_round: NonNegativeF64::try_from(1.0).unwrap(),
+                        epoch_length,
+                        message_frequency_per_slot: NonNegativeF64::try_from(1.0).unwrap(),
                         num_blend_layers: NonZeroU64::new(3).unwrap(),
                         minimum_network_size: NonZeroU64::new(1).unwrap(),
                         data_replication_factor: 0,

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -24,7 +24,7 @@ use futures::{
     FutureExt as _, Stream, StreamExt as _, TryStreamExt as _, future::join_all, stream,
 };
 use lb_chain_broadcast_service::{
-    BlockBroadcastMsg, BlockBroadcastService, BlockInfo, SessionUpdate,
+    ActiveProviders, BlockBroadcastMsg, BlockBroadcastService, BlockInfo,
 };
 use lb_core::{
     block::{Block, genesis::GenesisBlock},
@@ -433,7 +433,7 @@ impl Cryptarchia {
         self.consensus.branches().get(block_id).is_some()
     }
 
-    fn active_session_providers(
+    fn active_providers(
         &self,
         block_id: &HeaderId,
         service_type: ServiceType,
@@ -444,20 +444,20 @@ impl Cryptarchia {
             .ok_or(Error::HeaderIdNotFound(*block_id))?;
 
         ledger
-            .active_session_providers(service_type)
+            .active_providers(service_type)
             .ok_or(Error::ServiceSessionNotFound(service_type))
     }
 
-    fn active_sessions_numbers(
+    fn active_snapshot_epochs(
         &self,
         block_id: &HeaderId,
-    ) -> Result<HashMap<ServiceType, u64>, Error> {
+    ) -> Result<HashMap<ServiceType, Epoch>, Error> {
         let ledger = self
             .ledger
             .state(block_id)
             .ok_or(Error::HeaderIdNotFound(*block_id))?;
 
-        Ok(ledger.active_sessions())
+        Ok(ledger.active_snapshot_epochs())
     }
 }
 
@@ -1022,11 +1022,11 @@ where
         let header = block.header();
         let prev_lib = cryptarchia.lib();
 
-        let previous_session_numbers = match cryptarchia.active_sessions_numbers(&prev_lib) {
-            Ok(session_numbers) => session_numbers,
+        let previous_snapshot_epochs = match cryptarchia.active_snapshot_epochs(&prev_lib) {
+            Ok(previous_snapshot_epochs) => previous_snapshot_epochs,
             Err(e) => {
-                warn!("Error getting previous session numbers: {e}");
-                ServiceType::iter().map(|s| (s, 0)).collect()
+                warn!("Error getting previous active snapshot epochs: {e}");
+                ServiceType::iter().map(|s| (s, 0.into())).collect()
             }
         };
 
@@ -1100,11 +1100,11 @@ where
                 warn!("No LIB-update subscribers to notify: {e}");
             }
 
-            Self::broadcast_session_updates_for_block(
+            Self::broadcast_new_active_providers_for_block(
                 cryptarchia,
                 &new_lib,
                 relays,
-                Some(&previous_session_numbers),
+                Some(&previous_snapshot_epochs),
             )
             .await;
         }
@@ -1287,7 +1287,8 @@ where
         if let Err(e) = self.new_block_subscription_sender.send(init_event) {
             warn!("No new-block subscribers to notify: {e}");
         }
-        Self::broadcast_session_updates_for_block(&cryptarchia, &init_tip.id(), relays, None).await;
+        Self::broadcast_new_active_providers_for_block(&cryptarchia, &init_tip.id(), relays, None)
+            .await;
 
         // Phase 1: Collect only block IDs in (LIB, tip].
         info!(
@@ -1535,53 +1536,50 @@ where
         (cryptarchia, storage_blocks_to_remove)
     }
 
-    async fn broadcast_session_updates_for_block(
+    async fn broadcast_new_active_providers_for_block(
         cryptarchia: &Cryptarchia,
         block_id: &HeaderId,
         relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
-        previous_sessions: Option<&HashMap<ServiceType, u64>>,
+        previous_epochs: Option<&HashMap<ServiceType, Epoch>>,
     ) {
-        let Ok(new_sessions) = cryptarchia.active_sessions_numbers(block_id) else {
-            error!("Could not get active session numbers for block {block_id:?}");
+        let Ok(new_epochs) = cryptarchia.active_snapshot_epochs(block_id) else {
+            error!("Could not get active snapshot epochs for block {block_id:?}");
             return;
         };
 
-        for (service, new_session_number) in &new_sessions {
-            Self::handle_service_update(
+        for (service, new_epoch) in &new_epochs {
+            Self::broadcast_new_active_providers(
                 cryptarchia,
                 block_id,
                 relays,
-                previous_sessions,
+                previous_epochs,
                 service,
-                new_session_number,
+                *new_epoch,
             )
             .await;
         }
     }
 
-    async fn handle_service_update(
+    async fn broadcast_new_active_providers(
         cryptarchia: &Cryptarchia,
         block_id: &HeaderId,
         relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
-        previous_sessions: Option<&HashMap<ServiceType, u64>>,
+        previous_epochs: Option<&HashMap<ServiceType, Epoch>>,
         service: &ServiceType,
-        new_session_number: &u64,
+        new_epoch: Epoch,
     ) {
-        // If `previous_sessions` is provided, check if the session number has changed.
+        // If `previous_epochs` is provided, check if the epoch has changed.
         // Otherwise, always broadcast (for initialization).
-        if previous_sessions.is_some_and(|prev| {
-            prev.get(service)
-                .copied()
-                .expect("previous session number is set")
-                == *new_session_number
+        if previous_epochs.is_some_and(|prev| {
+            prev.get(service).copied().expect("previous epoch is set") == new_epoch
         }) {
             return;
         }
 
-        match cryptarchia.active_session_providers(block_id, *service) {
+        match cryptarchia.active_providers(block_id, *service) {
             Ok(providers) => {
-                let update = SessionUpdate {
-                    session_number: *new_session_number,
+                let new_active_providers = ActiveProviders {
+                    epoch: new_epoch,
                     providers,
                 };
 
@@ -1589,16 +1587,16 @@ where
 
                 let broadcast_future = match service {
                     ServiceType::BlendNetwork => {
-                        broadcast_blend_session(broadcast_relay, update).boxed()
+                        broadcast_blend_providers(broadcast_relay, new_active_providers).boxed()
                     }
                 };
 
                 if let Err(e) = broadcast_future.await {
-                    error!("Failed to broadcast session update for {service:?}: {e}");
+                    error!("Failed to broadcast new active providers for {service:?}: {e}");
                 }
             }
             Err(e) => {
-                error!("Could not get session providers for service {service:?}: {e}");
+                error!("Could not get new active providers for service {service:?}: {e}");
             }
         }
     }
@@ -1614,12 +1612,12 @@ async fn broadcast_finalized_block(
         .map_err(|(error, _)| Box::new(error) as DynError)
 }
 
-async fn broadcast_blend_session(
+async fn broadcast_blend_providers(
     broadcast_relay: &BroadcastRelay,
-    session: SessionUpdate,
+    providers: ActiveProviders,
 ) -> Result<(), DynError> {
     broadcast_relay
-        .send(BlockBroadcastMsg::BroadcastBlendSession(session))
+        .send(BlockBroadcastMsg::BroadcastBlendProviders(providers))
         .await
         .map_err(|(error, _)| Box::new(error) as DynError)
 }

--- a/services/chain/chain-service/src/states.rs
+++ b/services/chain/chain-service/src/states.rs
@@ -131,31 +131,35 @@ mod tests {
             NonNegativeRatio::new(1, 10.try_into().unwrap()),
             1f64.try_into().expect("1 > 0"),
         );
+        let epoch_config = lb_cryptarchia_engine::EpochConfig {
+            epoch_stake_distribution_stabilization: 1.try_into().unwrap(),
+            epoch_period_nonce_buffer: 1.try_into().unwrap(),
+            epoch_period_nonce_stabilization: 1.try_into().unwrap(),
+        };
+        let epoch_length = epoch_config
+            .epoch_length(cryptarchia_engine_config.base_period_length())
+            .into();
+
         let ledger_config = lb_ledger::Config {
-            epoch_config: lb_cryptarchia_engine::EpochConfig {
-                epoch_stake_distribution_stabilization: 1.try_into().unwrap(),
-                epoch_period_nonce_buffer: 1.try_into().unwrap(),
-                epoch_period_nonce_stabilization: 1.try_into().unwrap(),
-            },
+            epoch_config,
             consensus_config: cryptarchia_engine_config.clone(),
             sdp_config: lb_ledger::mantle::sdp::Config {
                 service_params: Arc::new(
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            lock_period: 10,
-                            inactivity_period: 20,
-                            retention_period: 100,
-                            timestamp: 0,
-                            session_duration: 10,
+                            lock_period: 10.into(),
+                            inactivity_period: 20.into(),
+                            retention_period: 100.into(),
+                            epoch: 0.into(),
                         },
                     )]
                     .into(),
                 ),
                 service_rewards_params: ServiceRewardsParameters {
                     blend: rewards::blend::RewardsParameters {
-                        rounds_per_session: NonZeroU64::new(10).unwrap(),
-                        message_frequency_per_round: NonNegativeF64::try_from(1.0).unwrap(),
+                        epoch_length,
+                        message_frequency_per_slot: NonNegativeF64::try_from(1.0).unwrap(),
                         num_blend_layers: NonZeroU64::new(3).unwrap(),
                         minimum_network_size: NonZeroU64::new(1).unwrap(),
                         data_replication_factor: 0,
@@ -261,31 +265,35 @@ mod tests {
             NonNegativeRatio::new(1, 10.try_into().unwrap()),
             1f64.try_into().expect("1 > 0"),
         );
+        let epoch_config = lb_cryptarchia_engine::EpochConfig {
+            epoch_stake_distribution_stabilization: 1.try_into().unwrap(),
+            epoch_period_nonce_buffer: 1.try_into().unwrap(),
+            epoch_period_nonce_stabilization: 1.try_into().unwrap(),
+        };
+        let epoch_length = epoch_config
+            .epoch_length(cryptarchia_engine_config.base_period_length())
+            .into();
+
         let ledger_config = lb_ledger::Config {
-            epoch_config: lb_cryptarchia_engine::EpochConfig {
-                epoch_stake_distribution_stabilization: 1.try_into().unwrap(),
-                epoch_period_nonce_buffer: 1.try_into().unwrap(),
-                epoch_period_nonce_stabilization: 1.try_into().unwrap(),
-            },
+            epoch_config,
             consensus_config: cryptarchia_engine_config.clone(),
             sdp_config: lb_ledger::mantle::sdp::Config {
                 service_params: Arc::new(
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            lock_period: 10,
-                            inactivity_period: 20,
-                            retention_period: 100,
-                            timestamp: 0,
-                            session_duration: 10,
+                            lock_period: 10.into(),
+                            inactivity_period: 20.into(),
+                            retention_period: 100.into(),
+                            epoch: 0.into(),
                         },
                     )]
                     .into(),
                 ),
                 service_rewards_params: ServiceRewardsParameters {
                     blend: rewards::blend::RewardsParameters {
-                        rounds_per_session: NonZeroU64::new(10).unwrap(),
-                        message_frequency_per_round: NonNegativeF64::try_from(1.0).unwrap(),
+                        epoch_length,
+                        message_frequency_per_slot: NonNegativeF64::try_from(1.0).unwrap(),
                         num_blend_layers: NonZeroU64::new(3).unwrap(),
                         minimum_network_size: NonZeroU64::new(1).unwrap(),
                         data_replication_factor: 0,

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -245,31 +245,35 @@ fn ledger_config(security_param: NonZero<u32>) -> lb_ledger::Config {
     service_params.insert(
         lb_core::sdp::ServiceType::BlendNetwork,
         ServiceParameters {
-            lock_period: 10,
-            inactivity_period: 1,
-            retention_period: 1,
-            timestamp: 0,
-            session_duration: 10,
+            lock_period: 10.into(),
+            inactivity_period: 1.into(),
+            retention_period: 1.into(),
+            epoch: 0.into(),
         },
     );
+    let epoch_config = EpochConfig {
+        epoch_stake_distribution_stabilization: 3.try_into().unwrap(),
+        epoch_period_nonce_buffer: 3.try_into().unwrap(),
+        epoch_period_nonce_stabilization: 4.try_into().unwrap(),
+    };
+    let consensus_config = lb_cryptarchia_engine::Config::new(
+        security_param,
+        NonNegativeRatio::new(1, 10.try_into().unwrap()),
+        1.0.try_into().unwrap(),
+    );
+    let epoch_length = epoch_config
+        .epoch_length(consensus_config.base_period_length())
+        .into();
 
     lb_ledger::Config {
-        epoch_config: EpochConfig {
-            epoch_stake_distribution_stabilization: 3.try_into().unwrap(),
-            epoch_period_nonce_buffer: 3.try_into().unwrap(),
-            epoch_period_nonce_stabilization: 4.try_into().unwrap(),
-        },
-        consensus_config: lb_cryptarchia_engine::Config::new(
-            security_param,
-            NonNegativeRatio::new(1, 10.try_into().unwrap()),
-            1.0.try_into().unwrap(),
-        ),
+        epoch_config,
+        consensus_config,
         sdp_config: lb_ledger::mantle::sdp::Config {
             service_params: Arc::new(service_params),
             service_rewards_params: ServiceRewardsParameters {
                 blend: rewards::blend::RewardsParameters {
-                    rounds_per_session: 10.try_into().unwrap(),
-                    message_frequency_per_round: 1.0.try_into().unwrap(),
+                    epoch_length,
+                    message_frequency_per_slot: 1.0.try_into().unwrap(),
                     num_blend_layers: 3.try_into().unwrap(),
                     minimum_network_size: 1.try_into().unwrap(),
                     data_replication_factor: 0,


### PR DESCRIPTION
## 1. What does this PR implement?

On top of PR #2743 

Previously, chain service was broadcasting new active providers when all of the following conditions are true:
- A new block is added to the honest chain, which means that LIB is changed.
- The session number of the new LIB's SDP active snapshot is greater than the one of the previous LIB's.

Now that we're removing the concept of session, this PR changes the 2nd condition as below:
- The **epoch** of the new LIB's SDP active snapshot is greater than the one of the previous LIB's.  

This PR changes chain-service, broadcast-service, and membership adapter of the blend service. But it doesn't change the blend service internals because I want to get a confirmation whether this approach aligns well with the purpose of removing the concept of session.

## 2. Does the code have enough context to be clearly understood?
yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?
no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
