### PR TITLE
fix: address the `key must be a String` error log

### DIFF
--- a/core/src/mantle/tx.rs
+++ b/core/src/mantle/tx.rs
@@ -27,13 +27,13 @@ use crate::{
         channel_multi_sig_proof::ChannelMultiSigProof,
         leader_claim_proof::{LeaderClaimProof as _, LeaderClaimPublic},
     },
+    utils::serde_bytes_newtype,
 };
 
 /// The hash of a transaction
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Default, Hash, PartialOrd, Ord, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, PartialOrd, Ord)]
 pub struct TxHash(pub Hash);
+serde_bytes_newtype!(TxHash, 32);
 
 impl From<Hash> for TxHash {
     fn from(hash: Hash) -> Self {


### PR DESCRIPTION
## 1. What does this PR implement?

The recent changes to the tx hash meant we were trying to store `[u8; 32]` as part of recovery, but that needs to be serialized into a string first.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.