### PR TITLE
fix(tx-service): fail mempool add on storage error

### DIFF
--- a/services/tx-service/src/backend/pool.rs
+++ b/services/tx-service/src/backend/pool.rs
@@ -95,13 +95,10 @@ where
 
         let timestamp = current_timestamp_millis();
 
-        if let Err(e) = self
-            .storage_adapter
+        self.storage_adapter
             .store_item(key.clone(), item.into())
             .await
-        {
-            tracing::warn!("Failed to store item in storage: {:?}", e);
-        }
+            .map_err(|e| MempoolError::StorageError(format!("{e:?}")))?;
 
         self.removed_items.remove(&key);
         self.pending_items.insert(key);

--- a/services/tx-service/tests/mock.rs
+++ b/services/tx-service/tests/mock.rs
@@ -31,7 +31,9 @@ use lb_tracing_service::{Tracing, TracingSettings};
 use lb_utils::noop_service::NoService;
 use logos_blockchain_tx_service::{
     MempoolMsg, TxMempoolSettings,
-    backend::{MemPool as _, Mempool, PoolRecoveryState, RecoverableMempool as _, Status},
+    backend::{
+        MemPool as _, Mempool, MempoolError, PoolRecoveryState, RecoverableMempool as _, Status,
+    },
     network::adapters::mock::{MOCK_TX_CONTENT_TOPIC, MockAdapter},
     storage::{MempoolStorageAdapter, adapters::rocksdb::RocksStorageAdapter},
     tx::{service::GenericTxMempoolService, state::TxMempoolState},
@@ -93,6 +95,9 @@ struct InMemoryStorageAdapter {
     items: Arc<Mutex<BTreeMap<MockTxId, MockTransaction<MockMessage>>>>,
 }
 
+#[derive(Clone, Default)]
+struct FailingStorageAdapter;
+
 #[async_trait]
 impl MempoolStorageAdapter<RuntimeServiceId> for InMemoryStorageAdapter {
     type Backend = RocksBackend;
@@ -144,6 +149,39 @@ impl MempoolStorageAdapter<RuntimeServiceId> for InMemoryStorageAdapter {
     }
 }
 
+#[async_trait]
+impl MempoolStorageAdapter<RuntimeServiceId> for FailingStorageAdapter {
+    type Backend = RocksBackend;
+    type Item = MockTransaction<MockMessage>;
+    type Key = MockTxId;
+    type Error = MempoolError;
+
+    fn new(
+        _storage_relay: OutboundRelay<
+            <StorageService<Self::Backend, RuntimeServiceId> as ServiceData>::Message,
+        >,
+    ) -> Self {
+        Self
+    }
+
+    async fn store_item(&mut self, _key: Self::Key, _item: Self::Item) -> Result<(), Self::Error> {
+        Err(MempoolError::StorageError(
+            "test storage failure".to_owned(),
+        ))
+    }
+
+    async fn get_items(
+        &self,
+        _keys: &BTreeSet<Self::Key>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Self::Item> + Send>>, Self::Error> {
+        Ok(Box::pin(stream::empty()))
+    }
+
+    async fn remove_items(&mut self, _keys: &[Self::Key]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
 #[test]
 fn test_mock_pool_recovery_state() {
     let recovery_state = PoolRecoveryState::<MockTxId> {
@@ -163,6 +201,30 @@ fn test_mock_pool_recovery_state() {
         deserialized.last_item_timestamp,
         recovery_state.last_item_timestamp
     );
+}
+
+#[tokio::test]
+async fn storage_failure_does_not_mark_tx_pending() {
+    let mut pool = Mempool::<
+        HeaderId,
+        MockTransaction<MockMessage>,
+        MockTxId,
+        FailingStorageAdapter,
+        RuntimeServiceId,
+    >::new((), FailingStorageAdapter);
+
+    let tx = sample_removed_tx();
+    let tx_id = tx.id();
+
+    let error = pool
+        .add_item(tx_id, tx)
+        .await
+        .expect_err("storage failure should reject mempool add");
+
+    assert!(matches!(error, MempoolError::StorageError(_)));
+    assert_eq!(pool.pending_item_count(), 0);
+    assert_eq!(pool.status(&[tx_id]), vec![Status::Unknown]);
+    assert!(pool.save().pending_items.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes the mempool false-success path when storage rejects a transaction write.

Before this, `Mempool::add_item` only logged `store_item` failures and still inserted the tx into `pending_items`, so callers could receive success for a tx whose payload was never stored. This now returns `MempoolError::StorageError` before mutating pending/recovery-visible state.

Added a regression test with a failing storage adapter to prove the tx is rejected, remains `Unknown`, and is not saved into recovery state.

Closes #2371

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
