### PR TITLE
test(e2e): use common wallet funding in zone flows

### DIFF
--- a/tests/src/common/wallet/funding.rs
+++ b/tests/src/common/wallet/funding.rs
@@ -1,6 +1,10 @@
 use std::cmp::Reverse;
 
-use lb_core::mantle::Utxo;
+use lb_core::mantle::{
+    Note, Utxo,
+    ledger::{Inputs, Outputs},
+    ops::transfer::TransferOp,
+};
 use lb_key_management_system_service::keys::{ZkKey, ZkPublicKey};
 use lb_testing_framework::configs::wallet::WalletAccount;
 use lb_wallet::WalletError;
@@ -181,6 +185,52 @@ impl WalletSelectedInputs {
     }
 }
 
+pub struct WalletFundedTransfer {
+    transfer: TransferOp,
+    selected_inputs: Vec<Utxo>,
+}
+
+impl WalletFundedTransfer {
+    #[must_use]
+    pub const fn transfer(&self) -> &TransferOp {
+        &self.transfer
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (TransferOp, Vec<Utxo>) {
+        (self.transfer, self.selected_inputs)
+    }
+}
+
+pub fn build_wallet_funded_transfer(
+    available_utxos: Vec<Utxo>,
+    outputs: Vec<Note>,
+    change_pk: ZkPublicKey,
+) -> Result<WalletFundedTransfer, WalletError> {
+    let output_total = outputs
+        .iter()
+        .fold(0u64, |total, output| total.saturating_add(output.value));
+    let selected_inputs =
+        WalletSelectedInputs::largest_first_covering(available_utxos, output_total)?;
+    let change = selected_inputs.total() - output_total;
+    let mut transfer_outputs = outputs;
+
+    if change > 0 {
+        transfer_outputs.push(Note::new(change, change_pk));
+    }
+
+    let selected_inputs = selected_inputs.into_utxos();
+    let transfer = TransferOp {
+        inputs: Inputs::new(selected_inputs.iter().map(Utxo::id).collect()),
+        outputs: Outputs::new(transfer_outputs),
+    };
+
+    Ok(WalletFundedTransfer {
+        transfer,
+        selected_inputs,
+    })
+}
+
 pub enum WalletFundingOutcome<T> {
     NeedsMoreInputs,
     Funded(T),
@@ -268,8 +318,6 @@ impl WalletReservedInputs {
 
 #[cfg(test)]
 mod tests {
-    use lb_core::mantle::Note;
-
     use super::*;
 
     fn utxo(value: u64, output_index: usize) -> Utxo {

--- a/tests/src/common/wallet/mod.rs
+++ b/tests/src/common/wallet/mod.rs
@@ -15,11 +15,12 @@ pub use chain::{
         WalletSyncedSpend, WalletUtxos, sync_batch_from_chain, sync_batches_from_chain,
     },
 };
+pub use funding::{
+    WalletFundedTransfer, WalletFundingPolicy, WalletFundingResources, WalletFundingSource,
+    WalletReservedInputs, build_wallet_funded_transfer,
+};
 pub(crate) use funding::{
     WalletFundingOutcome, WalletFundingPlan, WalletFundingUtxos, WalletSelectedInputs,
-};
-pub use funding::{
-    WalletFundingPolicy, WalletFundingResources, WalletFundingSource, WalletReservedInputs,
 };
 pub use funding_from_chain::{
     DirectWalletSourceError, WalletFundingSourceFromChainError, current_wallet_funding_source,

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use cucumber::gherkin::Step;
 use futures::future::join_all;
 use lb_common_http_client::CommonHttpClient;
-use lb_core::mantle::ops::channel::inscribe::Inscription;
+use lb_core::mantle::{TxHash, Utxo, ops::channel::inscribe::Inscription};
 use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_testing_framework::LbcManualCluster;
 use lb_zone_sdk::{
@@ -18,24 +18,30 @@ use super::{
     errors::{log_step_error, zone_step_error},
     steps::DEFAULT_ZONE_SEQUENCER,
     support::{
-        DiscardedPayloads, PublishDeadline, StartedZoneNode, ZoneAccountBalances,
-        balance_update_payload, build_zone_deposit, ensure_zone_transactions_included, keygen,
-        prepare_zone_cluster, publish_atomic_zone_withdraw, publish_message_with_retry,
-        sequencer_config, start_balance_aware_policy, start_republish_policy,
-        start_sequencer_event_loop, start_sorted_conflict_policy, start_zone_node,
-        submit_atomic_zone_deposit, submit_zone_deposit, submit_zone_withdraw,
+        AtomicZoneDepositRequest, DiscardedPayloads, PublishDeadline, StartedZoneNode,
+        ZoneAccountBalances, ZoneDeposit, balance_update_payload, build_zone_deposit,
+        ensure_zone_transactions_included, keygen, prepare_zone_cluster,
+        publish_atomic_zone_withdraw, publish_message_with_retry, sequencer_config,
+        start_balance_aware_policy, start_republish_policy, start_sequencer_event_loop,
+        start_sorted_conflict_policy, start_zone_node, submit_atomic_zone_deposit,
+        submit_zone_deposit, submit_zone_withdraw,
         wait_for_zone_network_ready,
     },
     tables::{ConcurrentZoneMessageRow, ZoneBalanceRow, group_zone_messages_by_sequencer},
 };
-use crate::cucumber::{
-    error::{StepError, StepResult},
-    steps::TARGET,
-    world::{CucumberWorld, NodeInfo},
+use crate::{
+    common::wallet::WalletReservedInputs,
+    cucumber::{
+        error::{StepError, StepResult},
+        steps::TARGET,
+        wallet::sync::sync_wallet_state_from_chain,
+        world::{CucumberWorld, NodeInfo},
+    },
 };
 
 const ZONE_CHANNEL_WITHDRAW_THRESHOLD: u16 = 1;
 const ZONE_CHANNEL_DEPOSIT_THRESHOLD: u16 = 1;
+const ZONE_FUNDING_WALLET_NAME: &str = "zone-funding";
 
 pub(super) enum DriveMode {
     Passive,
@@ -215,6 +221,39 @@ fn remember_published_zone_message(
     );
 }
 
+async fn sync_zone_funding_wallet_utxos(
+    world: &mut CucumberWorld,
+    step: &Step,
+) -> Result<Vec<Utxo>, StepError> {
+    let node_name = world.zone.node_name()?.to_owned();
+    let funding_public_key = world.zone.funding_public_key()?;
+
+    Ok(sync_wallet_state_from_chain(
+        world,
+        ZONE_FUNDING_WALLET_NAME,
+        &node_name,
+        funding_public_key,
+    )
+    .await
+    .inspect_err(|e| {
+        tracing::warn!(target: TARGET, "Step `{}` error: {e}", step.value);
+    })?
+    .into_available_utxos())
+}
+
+fn record_zone_wallet_submission(
+    world: &mut CucumberWorld,
+    tx_hash: TxHash,
+    reserved_inputs: Vec<Utxo>,
+) {
+    world.wallets.record_wallet_reservation(
+        ZONE_FUNDING_WALLET_NAME.to_owned(),
+        tx_hash,
+        WalletReservedInputs::new(reserved_inputs, Vec::new()),
+        0,
+    );
+}
+
 pub(super) async fn submit_zone_deposit_transaction(
     world: &mut CucumberWorld,
     step: &Step,
@@ -225,14 +264,16 @@ pub(super) async fn submit_zone_deposit_transaction(
 ) -> StepResult {
     let node_url = log_step_error(step, world.zone_node_url())?;
     let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
-    let deposit = build_zone_deposit(
-        &node_url,
+    let available_utxos = sync_zone_funding_wallet_utxos(world, step).await?;
+    let ZoneDeposit {
+        deposit,
+        reserved_inputs,
+    } = build_zone_deposit(
+        available_utxos,
         world.zone.sequencer_channel_id(&channel_alias)?,
-        funding_public_key,
         amount,
         metadata.into_bytes(),
     )
-    .await
     .map_err(|error| zone_step_error(step, &error))?;
 
     let response = submit_zone_deposit(&node_url, &deposit, funding_public_key)
@@ -242,6 +283,7 @@ pub(super) async fn submit_zone_deposit_transaction(
     world
         .zone
         .remember_submitted_deposit(transaction_alias.clone(), deposit);
+    record_zone_wallet_submission(world, response, reserved_inputs);
     world.remember_submitted_transaction(transaction_alias, response);
 
     Ok(())
@@ -258,17 +300,21 @@ pub(super) async fn submit_atomic_zone_deposit_transaction(
 ) -> StepResult {
     let node_url = log_step_error(step, world.zone_node_url())?;
     let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
+    let available_utxos = sync_zone_funding_wallet_utxos(world, step).await?;
     let sequencer = log_step_error(step, world.zone.sequencer_handle(sequencer_alias))?;
     let inscription_data = format!("Mint {amount} to Alice").into_bytes();
 
     let submission = submit_atomic_zone_deposit(
         &node_url,
         sequencer,
-        world.zone.sequencer_channel_id(sequencer_alias)?,
-        funding_public_key,
-        amount,
-        metadata.into_bytes(),
-        inscription_data.clone(),
+        AtomicZoneDepositRequest {
+            channel_id: world.zone.sequencer_channel_id(sequencer_alias)?,
+            funding_public_key,
+            available_utxos,
+            amount,
+            metadata: metadata.into_bytes(),
+            inscription_data: inscription_data.clone(),
+        },
     )
     .await
     .map_err(|error| zone_step_error(step, &error))?;
@@ -282,6 +328,11 @@ pub(super) async fn submit_atomic_zone_deposit_transaction(
         message_alias,
         inscription_data,
         &submission.publish,
+    );
+    record_zone_wallet_submission(
+        world,
+        submission.publish.inscription_id,
+        submission.reserved_inputs,
     );
     world.remember_submitted_transaction(transaction_alias, submission.publish.inscription_id);
 

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -24,8 +24,7 @@ use super::{
         publish_atomic_zone_withdraw, publish_message_with_retry, sequencer_config,
         start_balance_aware_policy, start_republish_policy, start_sequencer_event_loop,
         start_sorted_conflict_policy, start_zone_node, submit_atomic_zone_deposit,
-        submit_zone_deposit, submit_zone_withdraw,
-        wait_for_zone_network_ready,
+        submit_zone_deposit, submit_zone_withdraw, wait_for_zone_network_ready,
     },
     tables::{ConcurrentZoneMessageRow, ZoneBalanceRow, group_zone_messages_by_sequencer},
 };
@@ -91,6 +90,7 @@ pub(super) async fn start_zone_cluster(world: &mut CucumberWorld, step: &Step) -
         .map_err(|error| zone_step_error(step, &error))?;
 
     let funding_public_key = zone_cluster.funding_public_key;
+    let genesis_block_utxos = zone_cluster.genesis_block_utxos;
     let cluster = zone_cluster.cluster;
 
     let started_zone_node = start_zone_node(&cluster, &world.scenario_base_dir)
@@ -103,7 +103,13 @@ pub(super) async fn start_zone_cluster(world: &mut CucumberWorld, step: &Step) -
 
     let client = started_zone_node.started_node.client.clone();
 
-    remember_zone_cluster(world, cluster, started_zone_node, funding_public_key);
+    remember_zone_cluster(
+        world,
+        cluster,
+        started_zone_node,
+        funding_public_key,
+        genesis_block_utxos,
+    );
 
     info!(target: TARGET, node_url = %client.base_url(), "Started zone cluster");
 
@@ -115,9 +121,11 @@ fn remember_zone_cluster(
     cluster: LbcManualCluster,
     started_zone_node: StartedZoneNode,
     funding_public_key: ZkPublicKey,
+    genesis_block_utxos: Vec<Utxo>,
 ) {
     let node_name = "NODE_1".to_owned();
 
+    world.genesis_block_utxos = genesis_block_utxos;
     world.local_cluster = Some(cluster);
     world.nodes_info.insert(
         node_name.clone(),

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -119,6 +119,7 @@ pub enum ZoneTestError {
 pub struct ZoneClusterTemplate {
     pub cluster: LbcManualCluster,
     pub funding_public_key: ZkPublicKey,
+    pub genesis_block_utxos: Vec<Utxo>,
 }
 
 /// A started single-node zone chain plus the resolved runtime directory used
@@ -203,12 +204,23 @@ pub fn prepare_zone_cluster(
         .consensus_config
         .funding_sk
         .as_public_key();
+    let genesis_block_utxos = deployment
+        .config
+        .genesis_block
+        .as_ref()
+        .map(|genesis_block| {
+            crate::cucumber::steps::manual_nodes::utils::genesis_block_utxos(
+                &genesis_block.genesis_tx(),
+            )
+        })
+        .unwrap_or_default();
 
     let cluster = LbcLocalDeployer::new().manual_cluster_from_descriptors(deployment);
 
     Ok(ZoneClusterTemplate {
         cluster,
         funding_public_key,
+        genesis_block_utxos,
     })
 }
 

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -18,7 +18,7 @@ use lb_common_http_client::{CommonHttpClient, Slot};
 use lb_config::consensus::{ProviderInfo, create_genesis_block_with_declarations};
 use lb_core::{
     mantle::{
-        GenesisTx as _, MantleTx, Note, NoteId, Op, OpProof, Transaction as _, Value,
+        GenesisTx as _, MantleTx, Note, Op, OpProof, Transaction as _, Utxo, Value,
         ledger::{Inputs, Outputs},
         ops::{
             channel::{
@@ -32,10 +32,7 @@ use lb_core::{
 };
 use lb_http_api_common::bodies::{
     channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
-    wallet::{
-        balance::WalletBalanceResponseBody,
-        sign::{WalletSignTxZkRequestBody, WalletSignTxZkResponseBody},
-    },
+    wallet::sign::{WalletSignTxZkRequestBody, WalletSignTxZkResponseBody},
 };
 use lb_key_management_system_service::keys::{
     Ed25519Key, ZkPublicKey, ZkSignature, secured_key::SecuredKey as _,
@@ -66,7 +63,7 @@ use tokio::{
 use tracing::warn;
 
 use crate::{
-    common::chain::wait_for_transactions_inclusion,
+    common::{chain::wait_for_transactions_inclusion, wallet::build_wallet_funded_transfer},
     cucumber::utils::{extract_child_dir_name, matching_child_dirs},
 };
 
@@ -102,10 +99,6 @@ pub enum ZoneTestError {
     FinalizationTimeout,
     #[error("timed out waiting for zone LIB to advance")]
     LibAdvanceTimeout,
-    #[error("failed to fetch wallet balance while preparing a zone deposit: {message}")]
-    WalletBalance { message: String },
-    #[error("failed to find a funding note with value at least {min_value}")]
-    MissingFundingNote { min_value: Value },
     #[error("failed to find a funding note with exact value {value}")]
     MissingExactFundingNote { value: Value },
     #[error("failed to submit zone deposit: {message}")]
@@ -140,6 +133,16 @@ pub struct StartedZoneNode {
 pub struct AtomicZoneDepositSubmission {
     pub deposit: DepositOp,
     pub publish: PublishResult,
+    pub reserved_inputs: Vec<Utxo>,
+}
+
+pub struct AtomicZoneDepositRequest {
+    pub channel_id: ChannelId,
+    pub funding_public_key: ZkPublicKey,
+    pub available_utxos: Vec<Utxo>,
+    pub amount: Value,
+    pub metadata: Vec<u8>,
+    pub inscription_data: Vec<u8>,
 }
 
 /// Result of a withdraw scenario where the zone sequencer signs the channel
@@ -149,9 +152,9 @@ pub struct ZoneWithdrawSubmission {
     pub publish: PublishResult,
 }
 
-struct SelectedNote {
-    id: NoteId,
-    value: Value,
+pub struct ZoneDeposit {
+    pub deposit: DepositOp,
+    pub reserved_inputs: Vec<Utxo>,
 }
 
 pub type DiscardedPayloads = Arc<tokio::sync::Mutex<HashSet<Vec<u8>>>>;
@@ -967,19 +970,24 @@ pub async fn wait_for_lib_advance(
 
 /// Builds a regular channel deposit for an existing funding note with the
 /// exact deposit value.
-pub async fn build_zone_deposit(
-    node_url: &Url,
+pub fn build_zone_deposit(
+    available_utxos: Vec<Utxo>,
     channel_id: ChannelId,
-    funding_public_key: ZkPublicKey,
     amount: Value,
     metadata: Vec<u8>,
-) -> Result<DepositOp, ZoneTestError> {
-    let note = get_note_with_exact_value(node_url, funding_public_key, amount).await?;
+) -> Result<ZoneDeposit, ZoneTestError> {
+    let note = available_utxos
+        .into_iter()
+        .find(|utxo| utxo.note.value == amount)
+        .ok_or(ZoneTestError::MissingExactFundingNote { value: amount })?;
 
-    Ok(DepositOp {
-        channel_id,
-        inputs: Inputs::new(vec![note.id]),
-        metadata,
+    Ok(ZoneDeposit {
+        deposit: DepositOp {
+            channel_id,
+            inputs: Inputs::new(vec![note.id()]),
+            metadata,
+        },
+        reserved_inputs: vec![note],
     })
 }
 
@@ -1019,13 +1027,18 @@ pub async fn submit_zone_deposit(
 pub async fn submit_atomic_zone_deposit(
     node_url: &Url,
     sequencer: &SequencerHandle<ZoneNodeHttpClient>,
-    channel_id: ChannelId,
-    funding_public_key: ZkPublicKey,
-    amount: Value,
-    metadata: Vec<u8>,
-    inscription_data: Vec<u8>,
+    request: AtomicZoneDepositRequest,
 ) -> Result<AtomicZoneDepositSubmission, ZoneTestError> {
-    let transfer = build_atomic_deposit_transfer(node_url, funding_public_key, amount).await?;
+    let AtomicZoneDepositRequest {
+        channel_id,
+        funding_public_key,
+        available_utxos,
+        amount,
+        metadata,
+        inscription_data,
+    } = request;
+    let (transfer, reserved_inputs) =
+        build_atomic_deposit_transfer(available_utxos, funding_public_key, amount)?;
     let deposit = build_atomic_deposit_op(channel_id, metadata, &transfer)?;
 
     let (tx, msg_id, sequencer_sig) = sequencer
@@ -1061,31 +1074,25 @@ pub async fn submit_atomic_zone_deposit(
     Ok(AtomicZoneDepositSubmission {
         deposit,
         publish: result,
+        reserved_inputs,
     })
 }
 
 /// Builds the funding transfer that creates the note consumed by an atomic
 /// zone deposit.
-async fn build_atomic_deposit_transfer(
-    node_url: &Url,
+fn build_atomic_deposit_transfer(
+    available_utxos: Vec<Utxo>,
     funding_public_key: ZkPublicKey,
     amount: Value,
-) -> Result<TransferOp, ZoneTestError> {
-    let funding_note = get_note_with_value(node_url, funding_public_key, amount).await?;
+) -> Result<(TransferOp, Vec<Utxo>), ZoneTestError> {
     let deposit_note = Note::new(amount, funding_public_key);
-    let change = funding_note.value.checked_sub(amount).ok_or_else(|| {
-        ZoneTestError::BuildAtomicDeposit {
-            message: format!(
-                "selected funding note value {} is below deposit amount {amount}",
-                funding_note.value
-            ),
-        }
-    })?;
+    let funded_transfer =
+        build_wallet_funded_transfer(available_utxos, vec![deposit_note], funding_public_key)
+            .map_err(|error| ZoneTestError::BuildAtomicDeposit {
+                message: error.to_string(),
+            })?;
 
-    Ok(TransferOp {
-        inputs: Inputs::new(vec![funding_note.id]),
-        outputs: build_atomic_deposit_outputs(deposit_note, change, funding_public_key),
-    })
+    Ok(funded_transfer.into_parts())
 }
 
 /// Points the channel deposit at the note created by the atomic funding
@@ -1270,60 +1277,6 @@ pub async fn publish_atomic_zone_withdraw(
     })?
 }
 
-/// Selects a wallet note large enough to fund a zone operation.
-async fn get_note_with_value(
-    node_url: &Url,
-    public_key: ZkPublicKey,
-    min_value: Value,
-) -> Result<SelectedNote, ZoneTestError> {
-    let balance = get_wallet_balance(node_url, public_key).await?;
-
-    balance
-        .notes
-        .into_iter()
-        .find(|(_, value)| *value >= min_value)
-        .map(|(id, value)| SelectedNote { id, value })
-        .ok_or(ZoneTestError::MissingFundingNote { min_value })
-}
-
-/// Selects a wallet note that must be consumed directly by a deposit test.
-async fn get_note_with_exact_value(
-    node_url: &Url,
-    public_key: ZkPublicKey,
-    value: Value,
-) -> Result<SelectedNote, ZoneTestError> {
-    let balance = get_wallet_balance(node_url, public_key).await?;
-
-    balance
-        .notes
-        .into_iter()
-        .find(|(_, note_value)| *note_value == value)
-        .map(|(id, value)| SelectedNote { id, value })
-        .ok_or(ZoneTestError::MissingExactFundingNote { value })
-}
-
-/// Reads wallet-visible notes for the test funding key from the node API.
-async fn get_wallet_balance(
-    node_url: &Url,
-    public_key: ZkPublicKey,
-) -> Result<WalletBalanceResponseBody, ZoneTestError> {
-    let request_url = node_url
-        .join(&format!(
-            "wallet/{}/balance",
-            hex::encode(lb_groth16::fr_to_bytes(&public_key.into()))
-        ))
-        .map_err(|error| ZoneTestError::WalletBalance {
-            message: error.to_string(),
-        })?;
-
-    CommonHttpClient::new(None)
-        .get::<(), WalletBalanceResponseBody>(request_url, None)
-        .await
-        .map_err(|error| ZoneTestError::WalletBalance {
-            message: error.to_string(),
-        })
-}
-
 /// Asks the node wallet service to sign a Mantle transaction for the requested
 /// ZK keys.
 async fn sign_tx_zk(
@@ -1351,20 +1304,6 @@ async fn sign_tx_zk(
         })?;
 
     Ok(response.sig)
-}
-
-/// Preserves leftover value from an atomic deposit funding note as wallet
-/// change.
-fn build_atomic_deposit_outputs(
-    deposit_note: Note,
-    change: Value,
-    funding_public_key: ZkPublicKey,
-) -> Outputs {
-    if change > 0 {
-        Outputs::new(vec![deposit_note, Note::new(change, funding_public_key)])
-    } else {
-        Outputs::new(vec![deposit_note])
-    }
 }
 
 /// Builds the single-node deployment shape used by all migrated zone tests.


### PR DESCRIPTION
## 1. What does this PR implement?

Refactors zone deposit funding to use the shared wallet tracking/funding path instead of duplicating wallet balance and note-selection logic inside zone support.

Zone deposit and atomic deposit flows now sync the zone funding key through `TrackedWallets`, select from available wallet UTXOs, and record reserved inputs after submission. Atomic deposit transfer construction also uses the common wallet-funded transfer helper, while sequencer/indexer/deposit orchestration stays in the zone layer.

This moves the logic closer to the intended wallet/zone split: wallet owns funding state and reusable funding mechanics; zone owns channel, sequencer, and indexer behavior.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
