### PR TITLE
chore: Move wallet HTTP routes to admin API

### DIFF
--- a/nodes/node/binary/src/api/admin/backend.rs
+++ b/nodes/node/binary/src/api/admin/backend.rs
@@ -14,7 +14,12 @@ use axum::{
 };
 use http::StatusCode;
 use lb_api_service::Backend;
+use lb_core::{
+    header::HeaderId,
+    mantle::{SignedMantleTx, Transaction},
+};
 use lb_http_api_common::paths;
+use lb_tx_service::{TxMempoolService, backend::Mempool};
 use overwatch::{overwatch::handle::OverwatchHandle, services::AsServiceId};
 use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
@@ -27,9 +32,30 @@ use tower_http::{
 use tracing::Level as TracingLevel;
 
 use crate::{
-    TracingService,
-    api::{admin::handlers::reload_tracing_filter, backend::AxumBackendSettings},
+    TracingService, WalletService,
+    api::{admin::handlers::reload_tracing_filter, backend::AxumBackendSettings, handlers::wallet},
 };
+
+type MempoolStorageAdapter = lb_tx_service::storage::adapters::rocksdb::RocksStorageAdapter<
+    SignedMantleTx,
+    <SignedMantleTx as Transaction>::Hash,
+>;
+type AdminMempoolService<RuntimeServiceId> = TxMempoolService<
+    lb_tx_service::network::adapters::libp2p::Libp2pAdapter<
+        SignedMantleTx,
+        <SignedMantleTx as Transaction>::Hash,
+        RuntimeServiceId,
+    >,
+    Mempool<
+        HeaderId,
+        SignedMantleTx,
+        <SignedMantleTx as Transaction>::Hash,
+        MempoolStorageAdapter,
+        RuntimeServiceId,
+    >,
+    MempoolStorageAdapter,
+    RuntimeServiceId,
+>;
 
 pub struct AdminAxumBackend {
     settings: AxumBackendSettings,
@@ -38,7 +64,15 @@ pub struct AdminAxumBackend {
 #[async_trait::async_trait]
 impl<RuntimeServiceId> Backend<RuntimeServiceId> for AdminAxumBackend
 where
-    RuntimeServiceId: Debug + Sync + Send + Display + Clone + 'static + AsServiceId<TracingService>,
+    RuntimeServiceId: Debug
+        + Sync
+        + Send
+        + Display
+        + Clone
+        + 'static
+        + AsServiceId<TracingService>
+        + AsServiceId<WalletService>
+        + AsServiceId<AdminMempoolService<RuntimeServiceId>>,
 {
     type Error = io::Error;
     type Settings = AxumBackendSettings;
@@ -67,7 +101,15 @@ fn build_router<RuntimeServiceId>(
     settings: &AxumBackendSettings,
 ) -> Result<Router, io::Error>
 where
-    RuntimeServiceId: Debug + Sync + Send + Display + Clone + 'static + AsServiceId<TracingService>,
+    RuntimeServiceId: Debug
+        + Sync
+        + Send
+        + Display
+        + Clone
+        + 'static
+        + AsServiceId<TracingService>
+        + AsServiceId<WalletService>
+        + AsServiceId<AdminMempoolService<RuntimeServiceId>>,
 {
     let router = Router::new();
 
@@ -75,6 +117,26 @@ where
         paths::admin::TRACING_FILTER,
         routing::put(reload_tracing_filter::<RuntimeServiceId>),
     );
+
+    let router = router
+        .route(
+            paths::wallet::BALANCE,
+            routing::get(wallet::get_balance::<WalletService, _>),
+        )
+        .route(
+            paths::wallet::TRANSACTIONS_TRANSFER_FUNDS,
+            routing::post(
+                wallet::post_transactions_transfer_funds::<WalletService, MempoolStorageAdapter, _>,
+            ),
+        )
+        .route(
+            paths::wallet::SIGN_TX_ED25519,
+            routing::post(wallet::sign_tx_ed25519::<WalletService, MempoolStorageAdapter, _>),
+        )
+        .route(
+            paths::wallet::SIGN_TX_ZK,
+            routing::post(wallet::sign_tx_zk::<WalletService, MempoolStorageAdapter, _>),
+        );
 
     let router = router
         .with_state(handle)

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -46,7 +46,7 @@ use utoipa_swagger_ui::SwaggerUi;
 use super::handlers::{
     add_tx, blend_info, block, block_events, blocks_range_stream, blocks_stream,
     cryptarchia_headers, cryptarchia_info, cryptarchia_lib_stream, immutable_blocks, libp2p_info,
-    mantle_metrics, mantle_status, transaction, wallet,
+    mantle_metrics, mantle_status, transaction,
 };
 use crate::{
     BlendBroadcastSettings, BlendService, WalletService,
@@ -288,28 +288,6 @@ where
             .route(
                 paths::LEADER_CLAIM,
                 routing::post(leader_claim::<ChainLeader, RuntimeServiceId>),
-            )
-            .route(
-                paths::wallet::BALANCE,
-                routing::get(wallet::get_balance::<WalletService, _>),
-            )
-            .route(
-                paths::wallet::TRANSACTIONS_TRANSFER_FUNDS,
-                routing::post(
-                    wallet::post_transactions_transfer_funds::<
-                        WalletService,
-                        MempoolStorageAdapter,
-                        _,
-                    >,
-                ),
-            )
-            .route(
-                paths::wallet::SIGN_TX_ED25519,
-                routing::post(wallet::sign_tx_ed25519::<WalletService, MempoolStorageAdapter, _>),
-            )
-            .route(
-                paths::wallet::SIGN_TX_ZK,
-                routing::post(wallet::sign_tx_zk::<WalletService, MempoolStorageAdapter, _>),
             );
 
         let app = app.route(

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -23,8 +23,6 @@ use utoipa::OpenApi;
         crate::api::handlers::block_events,
         crate::api::handlers::blocks_stream,
         crate::api::handlers::transaction,
-        crate::api::handlers::wallet::get_balance,
-        crate::api::handlers::wallet::post_transactions_transfer_funds,
     ),
     components(schemas(schema::Status, schema::MempoolMetrics)),
     tags()

--- a/tests/src/common/manual_cluster.rs
+++ b/tests/src/common/manual_cluster.rs
@@ -181,19 +181,9 @@ pub async fn wait_for_nodes_height(
 }
 
 pub async fn get_wallet_balance(node: &NodeHttpClient, pk: ZkPublicKey) -> u64 {
-    let pk_hex = hex::encode(lb_groth16::fr_to_bytes(&pk.into()));
-    let url = api_url(node, &format!("wallet/{pk_hex}/balance"));
-
     for _ in 0..5 {
-        let response = reqwest::Client::new()
-            .get(url.clone())
-            .send()
-            .await
-            .expect("balance request should not fail");
-
-        if response.status().is_success() {
-            let body: serde_json::Value = response.json().await.unwrap();
-            return body["balance"].as_u64().unwrap_or(0);
+        if let Ok(body) = node.wallet_balance(pk, None).await {
+            return body.balance;
         }
 
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -207,6 +197,14 @@ pub fn api_url(node: &NodeHttpClient, path: &str) -> Url {
     node.base_url()
         .join(path)
         .expect("manual-cluster client base URL should join API path")
+}
+
+#[must_use]
+pub fn admin_api_url(node: &NodeHttpClient, path: &str) -> Url {
+    node.admin_url()
+        .expect("manual-cluster node client should include admin API URL")
+        .join(path)
+        .expect("manual-cluster admin URL should join API path")
 }
 
 #[must_use]

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1091,7 +1091,7 @@ async fn step_run_blend_sdp_declaration_cli(
     let user_config_path = node_user_config_path(world, &declarer_node_name)?;
     let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
 
-    let declarer_api_base_url = world
+    let declarer_client = world
         .nodes_info
         .get(&declarer_node_name)
         .ok_or_else(|| StepError::LogicalError {
@@ -1099,7 +1099,15 @@ async fn step_run_blend_sdp_declaration_cli(
         })?
         .started_node
         .client
-        .base_url()
+        .clone();
+    let declarer_api_base_url = declarer_client.base_url().clone();
+    let declarer_admin_base_url = declarer_client
+        .admin_url()
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!(
+                "Admin API URL for node '{declarer_node_name}' not found in world state"
+            ),
+        })?
         .clone();
 
     // Query notes from the declarer node API so wallet ownership lookups use
@@ -1109,7 +1117,7 @@ async fn step_run_blend_sdp_declaration_cli(
     let mut last_lookup_error: Option<String>;
     let locked_note_id = loop {
         let Ok(wallet_balance) = CommonHttpClient::new(None)
-            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .get_wallet_balance(declarer_admin_base_url.clone(), blend_zk_pk, None)
             .await
         else {
             continue;
@@ -1154,6 +1162,8 @@ async fn step_run_blend_sdp_declaration_cli(
         .arg(locked_note_id)
         .arg("--node-address")
         .arg(declarer_api_base_url.to_string())
+        .arg("--admin-node-address")
+        .arg(declarer_admin_base_url.to_string())
         .output()
         .await?;
 
@@ -1198,7 +1208,7 @@ async fn step_verify_blend_sdp_declaration_included(
 ) -> StepResult {
     let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
 
-    let declarer_api_base_url = world
+    let declarer_client = world
         .nodes_info
         .get(&declarer_node_name)
         .ok_or_else(|| StepError::LogicalError {
@@ -1206,7 +1216,15 @@ async fn step_verify_blend_sdp_declaration_included(
         })?
         .started_node
         .client
-        .base_url()
+        .clone();
+    let declarer_api_base_url = declarer_client.base_url().clone();
+    let declarer_admin_base_url = declarer_client
+        .admin_url()
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!(
+                "Admin API URL for node '{declarer_node_name}' not found in world state"
+            ),
+        })?
         .clone();
 
     let note_lookup_timeout = Duration::from_secs(30);
@@ -1214,7 +1232,7 @@ async fn step_verify_blend_sdp_declaration_included(
     let mut last_lookup_error: Option<String>;
     let locked_note_id = loop {
         let Ok(wallet_balance) = CommonHttpClient::new(None)
-            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .get_wallet_balance(declarer_admin_base_url.clone(), blend_zk_pk, None)
             .await
         else {
             continue;

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -828,9 +828,13 @@ fn add_wallets(
             WalletType::User { .. } => "User",
             WalletType::Funding { .. } => "Funding",
         };
+        let wallet_api_base_url = started_node
+            .client
+            .admin_url()
+            .unwrap_or_else(|| started_node.client.base_url());
         info!(target: TARGET, "{wallet_type} wallet `{}/{node_name}` created: {}",
            wallet_name,
-           format!("{}wallet/{}/balance", started_node.client.base_url(), info.public_key_hex())
+           format!("{wallet_api_base_url}wallet/{}/balance", info.public_key_hex())
         );
     }
 

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -222,10 +222,11 @@ pub(super) async fn submit_zone_deposit_transaction(
     amount: u64,
     metadata: String,
 ) -> StepResult {
-    let node_url = log_step_error(step, world.zone_node_url())?;
+    let node_client = log_step_error(step, world.zone_node_http_client())?;
+    let node_url = node_client.base_url().clone();
     let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
     let deposit = build_zone_deposit(
-        &node_url,
+        &node_client,
         world.zone.sequencer_channel_id(&channel_alias)?,
         funding_public_key,
         amount,
@@ -255,13 +256,13 @@ pub(super) async fn submit_atomic_zone_deposit_transaction(
     amount: u64,
     metadata: String,
 ) -> StepResult {
-    let node_url = log_step_error(step, world.zone_node_url())?;
+    let node_client = log_step_error(step, world.zone_node_http_client())?;
     let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
     let sequencer = log_step_error(step, world.zone.sequencer_handle(sequencer_alias))?;
     let inscription_data = format!("Mint {amount} to Alice").into_bytes();
 
     let submission = submit_atomic_zone_deposit(
-        &node_url,
+        &node_client,
         sequencer,
         world.zone.sequencer_channel_id(sequencer_alias)?,
         funding_public_key,

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -945,13 +945,13 @@ pub async fn wait_for_lib_advance(
 /// Builds a regular channel deposit for an existing funding note with the
 /// exact deposit value.
 pub async fn build_zone_deposit(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     channel_id: ChannelId,
     funding_public_key: ZkPublicKey,
     amount: Value,
     metadata: Vec<u8>,
 ) -> Result<DepositOp, ZoneTestError> {
-    let note = get_note_with_exact_value(node_url, funding_public_key, amount).await?;
+    let note = get_note_with_exact_value(node_client, funding_public_key, amount).await?;
 
     Ok(DepositOp {
         channel_id,
@@ -994,7 +994,7 @@ pub async fn submit_zone_deposit(
 /// Builds and submits a single transaction that both creates the deposit note
 /// and publishes the zone inscription that consumes it.
 pub async fn submit_atomic_zone_deposit(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     sequencer: &SequencerHandle<ZoneNodeHttpClient>,
     channel_id: ChannelId,
     funding_public_key: ZkPublicKey,
@@ -1002,7 +1002,7 @@ pub async fn submit_atomic_zone_deposit(
     metadata: Vec<u8>,
     inscription_data: Vec<u8>,
 ) -> Result<AtomicZoneDepositSubmission, ZoneTestError> {
-    let transfer = build_atomic_deposit_transfer(node_url, funding_public_key, amount).await?;
+    let transfer = build_atomic_deposit_transfer(node_client, funding_public_key, amount).await?;
     let deposit = build_atomic_deposit_op(channel_id, metadata, &transfer)?;
 
     let (tx, msg_id, sequencer_sig) = sequencer
@@ -1015,7 +1015,7 @@ pub async fn submit_atomic_zone_deposit(
             message: error.to_string(),
         })?;
 
-    let user_sig = sign_tx_zk(node_url, &tx, vec![funding_public_key]).await?;
+    let user_sig = sign_tx_zk(node_client, &tx, vec![funding_public_key]).await?;
     let signed_tx = SignedMantleTx::new(
         tx,
         vec![
@@ -1044,11 +1044,11 @@ pub async fn submit_atomic_zone_deposit(
 /// Builds the funding transfer that creates the note consumed by an atomic
 /// zone deposit.
 async fn build_atomic_deposit_transfer(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     funding_public_key: ZkPublicKey,
     amount: Value,
 ) -> Result<TransferOp, ZoneTestError> {
-    let funding_note = get_note_with_value(node_url, funding_public_key, amount).await?;
+    let funding_note = get_note_with_value(node_client, funding_public_key, amount).await?;
     let deposit_note = Note::new(amount, funding_public_key);
     let change = funding_note.value.checked_sub(amount).ok_or_else(|| {
         ZoneTestError::BuildAtomicDeposit {
@@ -1156,11 +1156,11 @@ pub async fn submit_zone_withdraw(
 
 /// Selects a wallet note large enough to fund a zone operation.
 async fn get_note_with_value(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     public_key: ZkPublicKey,
     min_value: Value,
 ) -> Result<SelectedNote, ZoneTestError> {
-    let balance = get_wallet_balance(node_url, public_key).await?;
+    let balance = get_wallet_balance(node_client, public_key).await?;
 
     balance
         .notes
@@ -1172,11 +1172,11 @@ async fn get_note_with_value(
 
 /// Selects a wallet note that must be consumed directly by a deposit test.
 async fn get_note_with_exact_value(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     public_key: ZkPublicKey,
     value: Value,
 ) -> Result<SelectedNote, ZoneTestError> {
-    let balance = get_wallet_balance(node_url, public_key).await?;
+    let balance = get_wallet_balance(node_client, public_key).await?;
 
     balance
         .notes
@@ -1188,20 +1188,11 @@ async fn get_note_with_exact_value(
 
 /// Reads wallet-visible notes for the test funding key from the node API.
 async fn get_wallet_balance(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     public_key: ZkPublicKey,
 ) -> Result<WalletBalanceResponseBody, ZoneTestError> {
-    let request_url = node_url
-        .join(&format!(
-            "wallet/{}/balance",
-            hex::encode(lb_groth16::fr_to_bytes(&public_key.into()))
-        ))
-        .map_err(|error| ZoneTestError::WalletBalance {
-            message: error.to_string(),
-        })?;
-
-    CommonHttpClient::new(None)
-        .get::<(), WalletBalanceResponseBody>(request_url, None)
+    node_client
+        .wallet_balance(public_key, None)
         .await
         .map_err(|error| ZoneTestError::WalletBalance {
             message: error.to_string(),
@@ -1211,12 +1202,17 @@ async fn get_wallet_balance(
 /// Asks the node wallet service to sign a Mantle transaction for the requested
 /// ZK keys.
 async fn sign_tx_zk(
-    node_url: &Url,
+    node_client: &NodeHttpClient,
     tx: &MantleTx,
     public_keys: Vec<ZkPublicKey>,
 ) -> Result<ZkSignature, ZoneTestError> {
+    let admin_url = node_client
+        .admin_url()
+        .ok_or_else(|| ZoneTestError::SignTransaction {
+            message: "admin api unavailable".to_owned(),
+        })?;
     let request_url =
-        node_url
+        admin_url
             .join("wallet/sign/zk")
             .map_err(|error| ZoneTestError::SignTransaction {
                 message: error.to_string(),

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -23,8 +23,8 @@ use lb_testing_framework::{
 };
 use lb_utils::math::NonNegativeRatio;
 use logos_blockchain_tests::common::manual_cluster::{
-    ManualNodeLayout, api_url, get_wallet_balance, start_local_manual_cluster_with_layout,
-    wait_for_nodes_height,
+    ManualNodeLayout, admin_api_url, api_url, get_wallet_balance,
+    start_local_manual_cluster_with_layout, wait_for_nodes_height,
 };
 use serial_test::serial;
 use testing_framework_core::scenario::DynError;
@@ -206,7 +206,7 @@ fn channel_test_config(mut config: RunConfig) -> RunConfig {
 
 async fn get_wallet_note(node: &NodeHttpClient, pk: ZkPublicKey, min_value: u64) -> (NoteId, u64) {
     let pk_hex = hex::encode(lb_groth16::fr_to_bytes(&pk.into()));
-    let url = api_url(node, &format!("wallet/{pk_hex}/balance"));
+    let url = admin_api_url(node, &format!("wallet/{pk_hex}/balance"));
 
     let response = reqwest::Client::new()
         .get(url)

--- a/tests/testing_framework/src/framework/compose/runtime.rs
+++ b/tests/testing_framework/src/framework/compose/runtime.rs
@@ -45,6 +45,7 @@ pub(super) fn build_node_descriptor(
 
     let api_port = node.general.api_config.address.port();
     let testing_port = node.general.api_config.testing_http_address.port();
+    let admin_port = node.general.api_config.admin_http_address.port();
 
     NodeDescriptor::with_loopback_ports(
         node_identifier(index),
@@ -52,7 +53,7 @@ pub(super) fn build_node_descriptor(
         vec![NODE_ENTRYPOINT.to_owned()],
         base_volumes(),
         default_extra_hosts(),
-        vec![api_port, testing_port],
+        vec![api_port, testing_port, admin_port],
         environment,
         platform,
     )

--- a/tests/testing_framework/src/framework/k8s/mod.rs
+++ b/tests/testing_framework/src/framework/k8s/mod.rs
@@ -215,6 +215,10 @@ fn build_node_values(kind: &'static str, index: usize, node: &NodePlan) -> NodeV
                 "testing-http",
                 node.general.api_config.testing_http_address.port(),
             ),
+            NodePortValues::tcp(
+                "admin-http",
+                node.general.api_config.admin_http_address.port(),
+            ),
             NodePortValues::udp("swarm-udp", node.general.network_config.backend.swarm.port),
             NodePortValues::udp(
                 "blend-udp",

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -194,8 +194,11 @@ impl LocalDeployerEnv for LbcEnv {
         let testing_api = endpoints
             .port(&NodeEndpointPort::TestingApi)
             .map(|port| (endpoints.api.ip(), port).into());
+        let admin_api = endpoints
+            .port(&NodeEndpointPort::Custom("admin".to_owned()))
+            .map(|port| (endpoints.api.ip(), port).into());
 
-        Ok(NodeHttpClient::new(endpoints.api, testing_api))
+        Ok(NodeHttpClient::new(endpoints.api, testing_api, admin_api))
     }
 
     fn readiness_endpoint_path() -> &'static str {
@@ -232,6 +235,10 @@ fn add_endpoint_ports(endpoints: &mut NodeEndpoints, config: &RunConfig) {
     endpoints.insert_port(
         NodeEndpointPort::TestingApi,
         config.user.api.testing.listen_address.port(),
+    );
+    endpoints.insert_port(
+        NodeEndpointPort::Custom("admin".to_owned()),
+        config.user.api.admin.listen_address.port(),
     );
     endpoints.insert_port(
         NodeEndpointPort::Network,

--- a/tests/testing_framework/src/framework/mod.rs
+++ b/tests/testing_framework/src/framework/mod.rs
@@ -71,7 +71,7 @@ impl Application for LbcEnv {
         let basic_auth = external_basic_auth(&endpoint);
 
         Ok(NodeHttpClient::from_urls_with_basic_auth(
-            endpoint, None, basic_auth,
+            endpoint, None, None, basic_auth,
         ))
     }
 
@@ -82,7 +82,12 @@ impl Application for LbcEnv {
             .map(|port| Url::parse(&format!("http://{}:{port}", access.host())))
             .transpose()?;
 
-        Ok(NodeHttpClient::from_urls(base_url, testing_url))
+        let admin_url = access
+            .named_port("admin")
+            .map(|port| Url::parse(&format!("http://{}:{port}", access.host())))
+            .transpose()?;
+
+        Ok(NodeHttpClient::from_urls(base_url, testing_url, admin_url))
     }
 
     fn node_readiness_path() -> &'static str {

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -23,36 +23,47 @@ use serde::{Deserialize, Serialize};
 pub struct NodeHttpClient {
     base_url: Url,
     testing_url: Option<Url>,
+    admin_url: Option<Url>,
     http_client: CommonHttpClient,
 }
 
 impl NodeHttpClient {
     #[must_use]
-    pub fn new(base_addr: SocketAddr, testing_addr: Option<SocketAddr>) -> Self {
+    pub fn new(
+        base_addr: SocketAddr,
+        testing_addr: Option<SocketAddr>,
+        admin_addr: Option<SocketAddr>,
+    ) -> Self {
         let base_url = Url::parse(&format!("http://{base_addr}"))
             .expect("SocketAddr should always render as a valid URL host:port");
         let testing_url = testing_addr.map(|addr| {
             Url::parse(&format!("http://{addr}"))
                 .expect("SocketAddr should always render as a valid URL host:port")
         });
+        let admin_url = admin_addr.map(|addr| {
+            Url::parse(&format!("http://{addr}"))
+                .expect("SocketAddr should always render as a valid URL host:port")
+        });
 
-        Self::from_urls(base_url, testing_url)
+        Self::from_urls(base_url, testing_url, admin_url)
     }
 
     #[must_use]
-    pub fn from_urls(base_url: Url, testing_url: Option<Url>) -> Self {
-        Self::from_urls_with_basic_auth(base_url, testing_url, None)
+    pub fn from_urls(base_url: Url, testing_url: Option<Url>, admin_url: Option<Url>) -> Self {
+        Self::from_urls_with_basic_auth(base_url, testing_url, admin_url, None)
     }
 
     #[must_use]
     pub fn from_urls_with_basic_auth(
         base_url: Url,
         testing_url: Option<Url>,
+        admin_url: Option<Url>,
         basic_auth: Option<BasicAuthCredentials>,
     ) -> Self {
         Self {
             base_url,
             testing_url,
+            admin_url,
             http_client: CommonHttpClient::new(basic_auth),
         }
     }
@@ -145,8 +156,24 @@ impl NodeHttpClient {
         &self,
         body: WalletTransferFundsRequestBody,
     ) -> Result<WalletTransferFundsResponseBody, Error> {
+        let admin_url = self
+            .admin_url
+            .clone()
+            .ok_or_else(|| Error::Client("admin api unavailable".to_owned()))?;
+        self.http_client.transfer_funds(admin_url, body).await
+    }
+
+    pub async fn wallet_balance(
+        &self,
+        pk: lb_key_management_system_service::keys::ZkPublicKey,
+        tip: Option<HeaderId>,
+    ) -> Result<lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody, Error> {
+        let admin_url = self
+            .admin_url
+            .clone()
+            .ok_or_else(|| Error::Client("admin api unavailable".to_owned()))?;
         self.http_client
-            .transfer_funds(self.base_url.clone(), body)
+            .get_wallet_balance(admin_url, pk, tip)
             .await
     }
 
@@ -180,6 +207,11 @@ impl NodeHttpClient {
     #[must_use]
     pub const fn testing_url(&self) -> Option<&Url> {
         self.testing_url.as_ref()
+    }
+
+    #[must_use]
+    pub const fn admin_url(&self) -> Option<&Url> {
+        self.admin_url.as_ref()
     }
 
     /// Fetches network info from one explicit base URL.

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -100,6 +100,12 @@ struct PostBlendDeclarationArgs {
     #[arg(long, value_name = "NODE_URL", default_value = "http://localhost:8080")]
     node_address: Url,
 
+    /// Base admin node URL used for wallet operations. Defaults to
+    /// `--node-address` for compatibility with deployments where wallet routes
+    /// are exposed on the same API.
+    #[arg(long, value_name = "ADMIN_NODE_URL")]
+    admin_node_address: Option<Url>,
+
     /// Optional basic auth username for the API.
     #[arg(long, value_name = "USERNAME")]
     username: Option<String>,
@@ -124,6 +130,7 @@ async fn post_blend_declaration(
         locked_note_id,
         blend_addr,
         node_address,
+        admin_node_address,
         user_config_path,
         username,
         password,
@@ -150,7 +157,7 @@ async fn post_blend_declaration(
         locator,
     } = extract_values(
         &client,
-        node_address.clone(),
+        admin_node_address.unwrap_or_else(|| node_address.clone()),
         &user_config,
         locked_note_id,
         blend_addr,
@@ -184,7 +191,7 @@ struct ExtractedUserConfigValues {
 
 async fn extract_values(
     client: &CommonHttpClient,
-    node_address: Url,
+    admin_node_address: Url,
     config: &UserConfig,
     locked_note_id: NoteId,
     blend_address: Option<Locator>,
@@ -204,7 +211,7 @@ async fn extract_values(
 
     let zk_id = extract_blend_zk_key(config)?;
 
-    verify_locked_note_id_value(client, node_address, zk_id, locked_note_id).await?;
+    verify_locked_note_id_value(client, admin_node_address, zk_id, locked_note_id).await?;
 
     Ok(ExtractedUserConfigValues {
         provider_id,
@@ -251,17 +258,17 @@ fn extract_blend_zk_key(config: &UserConfig) -> Result<ZkPublicKey> {
 
 async fn verify_locked_note_id_value(
     client: &CommonHttpClient,
-    node_address: Url,
+    admin_node_address: Url,
     zk_id: ZkPublicKey,
     locked_note_id: NoteId,
 ) -> Result<()> {
     let WalletBalanceResponseBody { notes, .. } = client
-        .get_wallet_balance(node_address, zk_id, None)
+        .get_wallet_balance(admin_node_address, zk_id, None)
         .await
         .context("Failed to fetch wallet balance for Blend ZK ID")?;
 
     // Preflight guard: fail early when the provided note does not belong to the
-    // declaration ZK key according to the wallet view at `node_address`.
+    // declaration ZK key according to the admin wallet view.
     // TODO: Also verify minimum stake amount once that threshold is exposed here.
     if !notes.contains_key(&locked_note_id) {
         bail!(


### PR DESCRIPTION
## 1. What does this PR implement?

For security reasons, wallet HTTP endpoints should live behind the admin API instead of the public node API.

Consider the scenario reproduced locally: a node has a funded wallet loaded, and an external client can reach the public HTTP API. Before this change, that client could call the wallet signing endpoint to obtain a valid ZK signature for an attacker-chosen transaction hash, then call the wallet transfer endpoint to spend funds from the loaded wallet to an arbitrary recipient. The repro moved funds from the victim wallet to a random attacker wallet and observed the victim balance decrease.

This PR moves wallet balance, transfer, and signing routes to the admin API, removes them from the public OpenAPI surface, and updates framework/test/CLI callers that legitimately need wallet access to use the admin endpoint.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal, @bacv 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
