### PR TITLE
fix(test): continuous round robin fail fast

### DIFF
--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -132,7 +132,7 @@ Feature: Transactions
       | NODE_1    | 1             | WALLET_1A   |              |
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
     When node "NODE_1" is at height 2 in 300 seconds
-    When I perform continuous transactions on user wallets with 5 coin split outputs of 100 LGO, 3 transactions of 50 LGO each for 3 cycles
+    When I perform continuous transactions on user wallets with 5 coin split outputs of 100 LGO, 3 transactions of 50 LGO each for 3 cycles and timeout of 300 seconds
     Then I stop all nodes
 
   @local_transactions

--- a/tests/src/cucumber/steps/manual_transactions/steps.rs
+++ b/tests/src/cucumber/steps/manual_transactions/steps.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use cucumber::{gherkin::Step, given, then, when};
+use tokio::time::timeout;
 use tracing::{info, warn};
 
 use crate::{
@@ -520,6 +521,43 @@ async fn step_continuous_user_wallets(
     info!(target: TARGET, "Completed continuous user wallet transactions step");
 
     Ok(())
+}
+
+#[when(
+    expr = "I perform continuous transactions on user wallets with {int} coin split outputs of {int} LGO, {int} transactions of {int} LGO each for {int} cycles and timeout of {int} seconds"
+)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Cucumber step captures map directly to step function arguments."
+)]
+async fn step_continuous_user_wallets_with_timeout(
+    world: &mut CucumberWorld,
+    step: &Step,
+    coin_split_outputs: usize,
+    coin_split_value: u64,
+    transactions: usize,
+    value: u64,
+    cycles: usize,
+    timeout_seconds: u64,
+) -> StepResult {
+    timeout(
+        Duration::from_secs(timeout_seconds),
+        step_continuous_user_wallets(
+            world,
+            step,
+            coin_split_outputs,
+            coin_split_value,
+            transactions,
+            value,
+            cycles,
+        ),
+    )
+    .await
+    .map_err(|_| StepError::Timeout {
+        message: format!(
+            "continuous user wallet transactions did not finish within {timeout_seconds} seconds"
+        ),
+    })?
 }
 
 #[when(


### PR DESCRIPTION
## 1. What does this PR implement?

CI hit the suite timeout because the transaction scenario only logged per-wallet wait/send errors and kept running. This changes it to fail immediately on those errors, so CI reports the actual failure instead of timing out.

Failed run - https://github.com/logos-blockchain/logos-blockchain/actions/runs/26111224503/job/76788699327?pr=2766

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
