### PR TITLE
fix(api): default API listener to localhost

### DIFF
--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -129,7 +129,7 @@ pub struct InitArgs {
     pub blend_port: u16,
 
     /// HTTP API listen address
-    #[clap(long = "http-addr", default_value = "0.0.0.0:8080")]
+    #[clap(long = "http-addr", default_value = "127.0.0.1:8080")]
     pub http_addr: SocketAddr,
 
     /// External address for nodes with a known public IP (disables NAT

--- a/nodes/node/binary/src/config/api/serde.rs
+++ b/nodes/node/binary/src/config/api/serde.rs
@@ -52,7 +52,7 @@ pub struct AxumBackendSettings {
 impl Default for AxumBackendSettings {
     fn default() -> Self {
         Self {
-            listen_address: SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080).into(),
+            listen_address: SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8080).into(),
             cors_origins: Vec::default(),
             timeout: Duration::from_secs(30),
             max_body_size: 10 * 1024 * 1024,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR changes the default HTTP API bind address to `127.0.0.1`, as discussed in [Discord](https://discord.com/channels/973324189794697286/1506232753694445570).

The address can still be overridden through config or `init --http-addr`.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
