### PR TITLE
chore: silence more targets when on level >= DEBUG

### DIFF
--- a/tracing/src/filter/envfilter.rs
+++ b/tracing/src/filter/envfilter.rs
@@ -12,7 +12,18 @@ const DEFAULT_DEBUG_TARGETS: &[&str] = &[
     "cryptarchia",
     "ledger",
 ];
-const DEFAULT_QUIET_TARGETS: &[(&str, Level)] = &[("libp2p_gossipsub", Level::ERROR)];
+const DEFAULT_EXTERNAL_TARGETS: &[(&str, Level)] = &[
+    ("libp2p_gossipsub", Level::ERROR),
+    ("h2", Level::WARN),
+    ("hyper", Level::WARN),
+    ("hyper_util", Level::WARN),
+    ("tonic", Level::WARN),
+    ("tower", Level::WARN),
+    ("reqwest", Level::WARN),
+    ("opentelemetry", Level::WARN),
+    ("opentelemetry_sdk", Level::WARN),
+    ("rustls", Level::WARN),
+];
 const ENVFILTER_GLOBAL_TARGET: &str = "*";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/tracing/src/filter/envfilter.rs
+++ b/tracing/src/filter/envfilter.rs
@@ -12,7 +12,7 @@ const DEFAULT_DEBUG_TARGETS: &[&str] = &[
     "cryptarchia",
     "ledger",
 ];
-const DEFAULT_EXTERNAL_TARGETS: &[(&str, Level)] = &[
+const DEFAULT_QUIET_TARGETS: &[(&str, Level)] = &[
     ("libp2p_gossipsub", Level::ERROR),
     ("h2", Level::WARN),
     ("hyper", Level::WARN),


### PR DESCRIPTION
## 1. What does this PR implement?

OTLP logs are quite chatty because of otlp components themselves. Let's silence those if we are logging at `DEBUG` or lower, so that log entries [like this](https://vlselect.lab.vac.dev/select/vmui/#/?query=telemetry.sdk.name%3A+%22opentelemetry%22+%7C+service.name%3A+%22i-2%22&g0.range_input=25m37s367ms&g0.end_input=2026-04-29T16%3A40%3A01&g0.relative_time=none&limit=5000&displayFields=_msg%2Cscope.name) won't show up anymore.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.