### PR TITLE
test(e2e): use TF binary provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfgsync-adapter"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "cfgsync-artifacts",
  "cfgsync-core",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "cfgsync-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "cfgsync-core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "anyhow",
  "axum",
@@ -6706,7 +6706,7 @@ dependencies = [
  "protobuf-support",
  "tempfile",
  "thiserror 1.0.69",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -8214,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-runner-compose"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-runner-k8s"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8282,19 +8282,20 @@ dependencies = [
 [[package]]
 name = "testing-framework-runner-local"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_04_23_4854942d#4854942dcedd226f6adbe9970afc4661dfdb1e6d"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
 dependencies = [
  "async-trait",
  "fs_extra",
+ "reqwest",
  "serde",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "testing-framework-core",
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
  "tracing",
- "which 6.0.3",
 ]
 
 [[package]]
@@ -9370,18 +9371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9807,12 +9796,6 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfgsync-adapter"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "cfgsync-artifacts",
  "cfgsync-core",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "cfgsync-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "cfgsync-core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "anyhow",
  "axum",
@@ -8214,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-runner-compose"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-runner-k8s"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8282,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "testing-framework-runner-local"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?rev=14fd7130be973f7788a35a87032c9cea1a275931#14fd7130be973f7788a35a87032c9cea1a275931"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-testing.git?tag=dev_snapshot_2026_06_03_4733e56a#4733e56af27e2e8c94b3779151bcaa647ac85432"
 dependencies = [
  "async-trait",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,9 +98,9 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal
-cfgsync-adapter                    = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
-cfgsync-artifacts                  = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
-cfgsync-core                       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+cfgsync-adapter                    = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
+cfgsync-artifacts                  = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
+cfgsync-core                       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
 common-http-client                 = { default-features = false, package = "logos-blockchain-common-http-client", path = "./nodes/node/http-client" }
 hasher                             = { default-features = false, version = "0.1.4" }
 jf-poseidon2                       = { default-features = false, git = "https://github.com/EspressoSystems/jellyfish.git", rev = "dc166cf0f803c3e5067f9dfcc21e3dade986a447" }
@@ -166,10 +166,10 @@ lb-witness-generator               = { default-features = false, package = "logo
 lb-zksign                          = { default-features = false, package = "logos-blockchain-zksign", path = "./zk/proofs/zksign" }
 lb-zone-sdk                        = { default-features = false, package = "logos-blockchain-zone-sdk", path = "./zone-sdk" }
 lbp-error                          = { default-features = false, package = "logos-blockchain-proofs-error", path = "./zk/proofs/error" }
-testing-framework-core             = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
-testing-framework-runner-compose   = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
-testing-framework-runner-k8s       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
-testing-framework-runner-local     = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+testing-framework-core             = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
+testing-framework-runner-compose   = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
+testing-framework-runner-k8s       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
+testing-framework-runner-local     = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_06_03_4733e56a" }
 
 # External
 anyhow                             = { default-features = false, version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,9 +98,9 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal
-cfgsync-adapter                    = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
-cfgsync-artifacts                  = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
-cfgsync-core                       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
+cfgsync-adapter                    = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+cfgsync-artifacts                  = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+cfgsync-core                       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
 common-http-client                 = { default-features = false, package = "logos-blockchain-common-http-client", path = "./nodes/node/http-client" }
 hasher                             = { default-features = false, version = "0.1.4" }
 jf-poseidon2                       = { default-features = false, git = "https://github.com/EspressoSystems/jellyfish.git", rev = "dc166cf0f803c3e5067f9dfcc21e3dade986a447" }
@@ -166,10 +166,10 @@ lb-witness-generator               = { default-features = false, package = "logo
 lb-zksign                          = { default-features = false, package = "logos-blockchain-zksign", path = "./zk/proofs/zksign" }
 lb-zone-sdk                        = { default-features = false, package = "logos-blockchain-zone-sdk", path = "./zone-sdk" }
 lbp-error                          = { default-features = false, package = "logos-blockchain-proofs-error", path = "./zk/proofs/error" }
-testing-framework-core             = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
-testing-framework-runner-compose   = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
-testing-framework-runner-k8s       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
-testing-framework-runner-local     = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", tag = "dev_snapshot_2026_04_23_4854942d" }
+testing-framework-core             = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+testing-framework-runner-compose   = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+testing-framework-runner-k8s       = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
+testing-framework-runner-local     = { default-features = false, git = "https://github.com/logos-blockchain/logos-blockchain-testing.git", rev = "14fd7130be973f7788a35a87032c9cea1a275931" }
 
 # External
 anyhow                             = { default-features = false, version = "1" }

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,14 +53,23 @@ local setup.
 
 ## Setup and Usage (using `cargo test`)
 
-Where tests involve spawning node binaries locally, the testing framework runs:
+Where tests involve spawning node binaries locally, the testing framework uses
+`LOGOS_BLOCKCHAIN_NODE_BIN` when it is set:
+
+```bash
+LOGOS_BLOCKCHAIN_NODE_BIN=/path/to/logos-blockchain-node cargo test ...
+```
+
+If `LOGOS_BLOCKCHAIN_NODE_BIN` is not set, local runs build the testing-featured
+release binary automatically:
 
 ```bash
 cargo build --locked --release -p logos-blockchain-node --features testing
 ```
 
-CI expects `target/release/logos-blockchain-node` to already exist, or `LOGOS_BLOCKCHAIN_NODE_BIN` to point at the
-prebuilt binary.
+CI expects `target/release/logos-blockchain-node` to already exist, or
+`LOGOS_BLOCKCHAIN_NODE_BIN` to point at the prebuilt binary. It does not build
+node binaries inside the test process.
 
 ### 1. Run a specific test
 
@@ -69,20 +78,11 @@ _**MacOS or Linux**_
 ```bash
 cargo test --test test_cryptarchia_happy_path  two_nodes_happy -- --no-capture
 ```
-or 
-```bash
-USE_RELEASE_BINARIES=1 cargo test --test test_cryptarchia_happy_path two_nodes_happy --release -- --no-capture
-```
 
 _**Windows (PowerShell)**_
 
 ```pwsh
 cargo test --test test_cryptarchia_happy_path two_nodes_happy -- --no-capture
-```
-or
-```pwsh
-$env:USE_RELEASE_BINARIES="1"; cargo test --test test_cryptarchia_happy_path two_nodes_happy --release -- --no-capture
-
 ```
 
 ### 2. Run Tests with Debug Feature Flag

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,10 +15,8 @@ Ensure that the following are installed on your system:
 
 ### Using Rust `cargo test`
 
-Integration tests involving nodes run the binaries directly by spawning. Ensure the binaries are built and available in 
-your `target/debug` or `target/release` directory. You can build the project using:
-
-`cargo build` or `cargo build --release`
+Integration tests involving nodes run the binaries directly by spawning. Local test runs build the node binary through
+the testing framework before nodes are started. CI keeps using the binary built by the workflow before the test step.
 
 ## Setup and Usage (using Docker)
 
@@ -55,9 +53,14 @@ local setup.
 
 ## Setup and Usage (using `cargo test`)
 
-Where tests involve spawning node binaries, preference will be given to binaries corresponding to `USE_DEBUG_BINARIES` 
-and `USE_RELEASE_BINARIES` environment variables in the in `target/debug` and in `target/debug` paths respectively. If 
-neither are defined, preference will be given to debug binaries.
+Where tests involve spawning node binaries locally, the testing framework runs:
+
+```bash
+cargo build --locked --release -p logos-blockchain-node --features testing
+```
+
+CI expects `target/release/logos-blockchain-node` to already exist, or `LOGOS_BLOCKCHAIN_NODE_BIN` to point at the
+prebuilt binary.
 
 ### 1. Run a specific test
 
@@ -105,12 +108,8 @@ flag is not used, logs will be written into each nodes temporary directory.
 
 ## Running Cucumber tests
 
-To run the Cucumber tests, ensure the binaries are built (debug or release) and the environment variables below point to 
-the corresponding binaries:
-
-```text
-LOGOS_BLOCKCHAIN__NODE_BIN=/path-to/target/release/logos-blockchain-node
-```
+Local Cucumber tests use the same testing-framework binary provider as the direct e2e tests, so the node binary is built
+before local nodes are started. In CI, Cucumber uses the release binary built by the workflow before the Cucumber suite.
 
 Filtering based on tags can be done using the `--tags` option. For example, to run all tests tagged with `@normal_ci`, 
 use the following command:

--- a/tests/cucumber_tests/stand_alone_tests/cucumber_smoke_local.rs
+++ b/tests/cucumber_tests/stand_alone_tests/cucumber_smoke_local.rs
@@ -13,10 +13,6 @@ use logos_blockchain_tests::cucumber::{
 
 #[tokio::test]
 async fn cucumber_local_idle_smoke() {
-    // Required env vars (set on the command line when running this test):
-    // - `LOGOS_BLOCKCHAIN_NODE_BIN=...`
-    // - `RUST_LOG=info` (optional; better visibility)
-
     init_logging_defaults();
     init_node_log_dir_defaults(
         &DeployerKind::Local,

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -37,7 +37,7 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::{
-    BIN_PATH_DEBUG, BIN_PATH_RELEASE,
+    BIN_PATH_RELEASE,
     common::wallet::{TrackedWallets, WalletDiagnostics},
     cucumber::{
         TARGET,
@@ -1202,7 +1202,11 @@ impl CucumberWorld {
             return Ok(());
         }
 
-        let default_binary = default_node_binary_path().ok_or_else(missing_node_binary_error)?;
+        if !running_in_ci() {
+            return Ok(());
+        }
+
+        let default_binary = ci_node_binary_path().ok_or_else(missing_node_binary_error)?;
         warn_if_overriding_invalid_node_binary(&default_binary);
         let default_binary_display = default_binary.display().to_string();
 
@@ -1550,14 +1554,9 @@ fn host_node_binary_from_env_var_available() -> bool {
         || shared_host_bin_path("logos-blockchain-node").is_file()
 }
 
-fn default_node_binary_path() -> Option<PathBuf> {
+fn ci_node_binary_path() -> Option<PathBuf> {
     let current_dir = env::current_dir().ok()?;
-    let debug_binary = current_dir.join(BIN_PATH_DEBUG);
     let release_binary = current_dir.join(BIN_PATH_RELEASE);
-
-    if matches!(std::fs::exists(&debug_binary), Ok(true)) {
-        return Some(debug_binary);
-    }
 
     if matches!(std::fs::exists(&release_binary), Ok(true)) {
         return Some(release_binary);
@@ -1581,11 +1580,14 @@ fn warn_if_overriding_invalid_node_binary(path: &Path) {
 fn missing_node_binary_error() -> StepError {
     StepError::Preflight {
         message: format!(
-            "Missing Logos host binaries. Set {LOGOS_BLOCKCHAIN_NODE_BIN}, \
-            or run `scripts/run/run-examples.sh host` to restore them into \
-            `testing-framework/assets/stack/bin`."
+            "Missing Logos host binary in CI. Set {LOGOS_BLOCKCHAIN_NODE_BIN}, \
+            or build target/release/logos-blockchain-node before running Cucumber tests."
         ),
     }
+}
+
+fn running_in_ci() -> bool {
+    env::var_os("CI").is_some() || env::var_os("GITHUB_ACTIONS").is_some()
 }
 
 fn nodes_info_display(nodes_info: &HashMap<String, NodeInfo>) -> String {

--- a/tests/src/tests/testing_framework/smoke_local.rs
+++ b/tests/src/tests/testing_framework/smoke_local.rs
@@ -8,9 +8,8 @@ use testing_framework_core::scenario::Deployer as _;
 
 #[tokio::test]
 async fn smoke_two_validators_run_180s() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Required env vars (set on the command line when running this test):
-    // - `LOGOS_BLOCKCHAIN_NODE_BIN=...` (path to `logos-blockchain-node` binary)
-    // - `RUST_LOG=info` (optional; better visibility)
+    // `LOGOS_BLOCKCHAIN_NODE_BIN` can point to a prebuilt node binary; otherwise
+    // the testing framework builds one before starting local nodes.
     let _init_result = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -3,6 +3,7 @@ use std::{
     env, fs, io,
     net::{Ipv4Addr, UdpSocket},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -27,8 +28,9 @@ use lb_node::{
 use rand::Rng as _;
 use testing_framework_core::scenario::{Application, DynError, PeerSelection, StartNodeOptions};
 use testing_framework_runner_local::{
-    BinaryConfig, BinaryResolver, BuiltNodeConfig, LaunchEnvVar, LaunchFile, LocalDeployerEnv,
-    NodeConfigEntry, NodeEndpointPort, NodeEndpoints, ProcessSpawnError, env::Node,
+    BinaryProviderRef, BuildBinaryProvider, BuildCommand, BuiltNodeConfig, EnvBinaryProvider,
+    FallbackBinaryProvider, LaunchEnvVar, LaunchFile, LocalDeployerEnv, NodeConfigEntry,
+    NodeEndpointPort, NodeEndpoints, PathBinaryProvider, ProcessSpawnError, env::Node,
     process::LaunchSpec,
 };
 use tracing::debug;
@@ -168,7 +170,7 @@ impl LocalDeployerEnv for LbcEnv {
         let deployment_yaml =
             serde_yaml::to_string(&config.deployment).map_err(io::Error::other)?;
 
-        Ok(build_node_launch_spec(dir, user_yaml, deployment_yaml))
+        build_node_launch_spec(dir, user_yaml, deployment_yaml)
     }
 
     fn node_endpoints(
@@ -252,14 +254,18 @@ fn allocate_udp_port(label: &'static str) -> Result<u16, DynError> {
         })
 }
 
-fn build_node_launch_spec(dir: &Path, user_yaml: String, deployment_yaml: String) -> LaunchSpec {
+fn build_node_launch_spec(
+    dir: &Path,
+    user_yaml: String,
+    deployment_yaml: String,
+) -> Result<LaunchSpec, DynError> {
     let config_path = dir.join(USER_CONFIG_FILE);
     let deployment_path = dir.join(DEPLOYMENT_CONFIG_FILE);
     let time_backend =
         env::var("LOGOS_BLOCKCHAIN_TIME_BACKEND").unwrap_or_else(|_| "monotonic".to_owned());
 
-    LaunchSpec {
-        binary: BinaryResolver::resolve_path(&node_binary_config()),
+    Ok(LaunchSpec {
+        binary: node_binary_provider().resolve()?,
         files: vec![
             launch_file(USER_CONFIG_FILE, user_yaml.into_bytes()),
             launch_file(DEPLOYMENT_CONFIG_FILE, deployment_yaml.into_bytes()),
@@ -273,7 +279,7 @@ fn build_node_launch_spec(dir: &Path, user_yaml: String, deployment_yaml: String
             "LOGOS_BLOCKCHAIN_TIME_BACKEND",
             time_backend,
         )],
-    }
+    })
 }
 
 fn launch_file(relative_path: &str, contents: Vec<u8>) -> LaunchFile {
@@ -283,15 +289,47 @@ fn launch_file(relative_path: &str, contents: Vec<u8>) -> LaunchFile {
     }
 }
 
-const fn node_binary_config() -> BinaryConfig {
-    BinaryConfig {
-        env_var: "LOGOS_BLOCKCHAIN_NODE_BIN",
-        binary_name: "logos-blockchain-node",
-        fallback_path: concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../target/release/logos-blockchain-node"
-        ),
+fn node_binary_provider() -> BinaryProviderRef {
+    Arc::new(FallbackBinaryProvider::new([
+        Arc::new(EnvBinaryProvider::new("LOGOS_BLOCKCHAIN_NODE_BIN")),
+        default_node_binary_provider(),
+    ]))
+}
+
+fn default_node_binary_provider() -> BinaryProviderRef {
+    if running_in_ci() {
+        Arc::new(PathBinaryProvider::new(release_node_binary_path()))
+    } else {
+        Arc::new(BuildBinaryProvider {
+            command: BuildCommand::new("cargo").with_args([
+                "build",
+                "--locked",
+                "--release",
+                "-p",
+                "logos-blockchain-node",
+                "--features",
+                "testing",
+            ]),
+            output_path: release_node_binary_path(),
+            working_dir: Some(workspace_root()),
+            lock_dir: Some(workspace_root().join("target").join(".tf-binaries")),
+        })
     }
+}
+
+fn release_node_binary_path() -> PathBuf {
+    workspace_root()
+        .join("target")
+        .join("release")
+        .join("logos-blockchain-node")
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn running_in_ci() -> bool {
+    env::var_os("CI").is_some() || env::var_os("GITHUB_ACTIONS").is_some()
 }
 
 fn configure_logging(base_dir: &Path, prefix: &str) -> logger::Layers {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR makes local e2e tests build the node binary automatically when LOGOS_BLOCKCHAIN_NODE_BIN is not set.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
