### PR TITLE
fix(sdp-ledger): advance session only when new LIB crosses border.

### DIFF
--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -42,9 +42,12 @@ pub struct ServiceParameters {
 }
 
 impl ServiceParameters {
+    /// Calculates the current session number based on the current LIB.
+    ///
+    /// We advance sessions only when the new LIB enters a new session.
     #[must_use]
-    pub const fn session_for_block(&self, block_number: BlockNumber) -> SessionNumber {
-        block_number / self.session_duration
+    pub const fn current_session(&self, lib: BlockNumber) -> SessionNumber {
+        lib / self.session_duration
     }
 }
 

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -768,14 +768,14 @@ pub mod tests {
             .unwrap();
         let id = make_id(parent, slot, utxo);
         let proof = generate_proof(&ledger_state, &utxo, slot);
-        let (_, state, _) = ledger.prepare_update::<_, MainnetGasConstants>(
+        let (_, _) = ledger.try_update::<_, MainnetGasConstants>(
             id,
             parent,
             slot,
             &proof,
             std::iter::empty::<&SignedMantleTx>(),
+            0,
         )?;
-        ledger.commit_update(id, state);
         Ok(id)
     }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -133,19 +133,17 @@ where
         }
     }
 
-    /// Prepare adding a new [`LedgerState`] by applying the given proof and
-    /// transactions on top of the parent state.
-    ///
-    /// On success, a new [`LedgerState`] is returned, which can then be
-    /// committed by calling [`Self::commit_update`].
-    pub fn prepare_update<LeaderProof, Constants>(
-        &self,
+    /// Apply the given proof and transactions on top of the parent state.
+    pub fn try_update<LeaderProof, Constants>(
+        &mut self,
         id: Id,
         parent_id: Id,
         slot: Slot,
         proof: &LeaderProof,
         txs: impl Iterator<Item = impl AuthenticatedMantleTx<Context = GasPrices>>,
-    ) -> Result<(Id, LedgerState, Events), LedgerError<Id>>
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
+    ) -> Result<(Id, Events), LedgerError<Id>>
     where
         LeaderProof: leader_proof::LeaderProof,
         Constants: GasConstants,
@@ -155,17 +153,16 @@ where
             .get(&parent_id)
             .ok_or(LedgerError::ParentNotFound(parent_id))?;
 
-        let (new_state, events) =
-            parent_state
-                .clone()
-                .try_update::<_, _, Constants>(slot, proof, txs, &self.config)?;
+        let (new_state, events) = parent_state.clone().try_update::<_, _, Constants>(
+            slot,
+            proof,
+            txs,
+            lib,
+            &self.config,
+        )?;
+        self.states.insert(id, new_state);
 
-        Ok((id, new_state, events))
-    }
-
-    /// Commits a new [`LedgerState`] created by [`Self::prepare_update`].
-    pub fn commit_update(&mut self, id: Id, state: LedgerState) {
-        self.states.insert(id, state);
+        Ok((id, events))
     }
 
     pub fn state(&self, id: &Id) -> Option<&LedgerState> {
@@ -220,13 +217,15 @@ impl LedgerState {
         slot: Slot,
         proof: &LeaderProof,
         txs: impl Iterator<Item = impl AuthenticatedMantleTx<Context = GasPrices>>,
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
         config: &Config,
     ) -> Result<(Self, Events), LedgerError<Id>>
     where
         LeaderProof: leader_proof::LeaderProof,
         Constants: GasConstants,
     {
-        self.try_apply_header(slot, proof, config)?
+        self.try_apply_header(slot, proof, lib, config)?
             .try_apply_contents::<_, Constants>(config, txs)
     }
 
@@ -237,6 +236,8 @@ impl LedgerState {
         self,
         slot: Slot,
         proof: &LeaderProof,
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
         config: &Config,
     ) -> Result<Self, LedgerError<Id>>
     where
@@ -248,6 +249,7 @@ impl LedgerState {
         let (mantle_ledger, reward_utxos) = self.mantle_ledger.try_apply_header(
             cryptarchia_ledger.epoch_state(),
             *proof.voucher_cm(),
+            lib,
             config,
         )?;
 
@@ -889,17 +891,17 @@ mod tests {
         );
 
         let new_id = [1; 32];
-        let (_, state, events) = ledger
-            .prepare_update::<_, MainnetGasConstants>(
+        let (_, events) = ledger
+            .try_update::<_, MainnetGasConstants>(
                 new_id,
                 genesis_id,
                 Slot::from(1u64),
                 &proof,
                 std::iter::once(&tx),
+                0,
             )
             .unwrap();
         assert!(events.is_empty());
-        ledger.commit_update(new_id, state);
 
         // Verify the transaction was applied
         let new_state = ledger.state(&new_id).unwrap();

--- a/ledger/src/mantle/mod.rs
+++ b/ledger/src/mantle/mod.rs
@@ -6,6 +6,7 @@ pub mod sdp;
 use std::collections::HashMap;
 
 use lb_core::{
+    block::BlockNumber,
     crypto::ZkHasher,
     events::Events,
     mantle::{
@@ -167,10 +168,14 @@ impl LedgerState {
         mut self,
         epoch_state: &EpochState,
         voucher: VoucherCm,
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
         config: &Config,
     ) -> Result<(Self, Vec<Utxo>), Error> {
         self.leaders = self.leaders.try_apply_header(epoch_state.epoch, voucher)?;
-        let (new_sdp, reward_utxos) = self.sdp.try_apply_header(&config.sdp_config, epoch_state)?;
+        let (new_sdp, reward_utxos) =
+            self.sdp
+                .try_apply_header(&config.sdp_config, epoch_state, lib)?;
         self.sdp = new_sdp;
         Ok((self, reward_utxos))
     }

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -24,9 +24,11 @@ use lb_core::{
 };
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
 use rewards::{Error as RewardsError, Rewards};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{EpochState, UtxoTree, mantle::sdp::rewards::blend};
+
+const LOG_TARGET: &str = "ledger::mantle::sdp";
 
 type Declarations = rpds::RedBlackTreeMapSync<DeclarationId, Declaration>;
 
@@ -40,6 +42,8 @@ impl Service {
         self,
         block_number: BlockNumber,
         epoch_state: &EpochState,
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
         config: &ServiceParameters,
         rewards_params: &ServiceRewardsParameters,
     ) -> (Self, Vec<Utxo>) {
@@ -48,6 +52,7 @@ impl Service {
                 let (new_state, utxos) = state.try_apply_header(
                     block_number,
                     epoch_state,
+                    lib,
                     config,
                     &rewards_params.blend,
                 );
@@ -212,14 +217,23 @@ impl<R: Rewards> ServiceState<R> {
         mut self,
         block_number: u64,
         epoch_state: &EpochState,
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
         service_params: &ServiceParameters,
         rewards_params: &R::Params,
     ) -> (Self, Vec<Utxo>) {
-        let current_session = service_params.session_for_block(block_number);
+        let current_session = service_params.current_session(lib);
         let reward_utxos;
 
-        // shift all session!
         if current_session == self.active.session_n + 1 {
+            debug!(
+                target: LOG_TARGET,
+                current_session,
+                previous_sessoin = self.active.session_n,
+                lib_height = lib,
+                "Session transition detected. Removing inactive declarations, commiting snapshot, and updating rewards for the new session",
+            );
+
             // Remove expired declarations based on retention_period
             // This essentially duplicates the declaration set so it's only triggered at
             // session boundaries
@@ -359,6 +373,8 @@ impl SdpLedger {
         &self,
         config: &Config,
         epoch_state: &EpochState,
+        // LIB after the given block is applied to Cryptarchia
+        lib: BlockNumber,
     ) -> Result<(Self, Vec<Utxo>), Error> {
         let block_number = self.block_number + 1; // overflow?
         let mut all_reward_utxos = Vec::new();
@@ -374,6 +390,7 @@ impl SdpLedger {
                 let (new_state, reward_utxos) = service_state.clone().try_apply_header(
                     block_number,
                     epoch_state,
+                    lib,
                     service_params,
                     &config.service_rewards_params,
                 );
@@ -757,6 +774,13 @@ mod tests {
         }
     }
 
+    /// Computes the new LIB height using `k`.
+    fn new_lib_height(ledger: &SdpLedger, k: NonZeroU64) -> BlockNumber {
+        (ledger.block_number + 1).saturating_sub(k.into())
+    }
+
+    const K_ONE: NonZeroU64 = NonZeroU64::new(1).unwrap();
+
     #[test]
     fn test_update_active_provider() {
         let config = setup();
@@ -789,10 +813,12 @@ mod tests {
         let declarations = sdp_ledger.get_declarations(service_a).unwrap();
         assert!(declarations.contains_key(&declaration_id));
 
-        // Apply headers to reach block 10 (session boundary)
+        // Apply headers to reach block 11 (session boundary because k=1)
         let mut sdp_ledger = sdp_ledger;
-        for _ in 0..10 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        for _ in 1..=11 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         // At block 10, declaration enters the next session 2
@@ -836,8 +862,10 @@ mod tests {
 
         // Move forward enough blocks to satisfy lock_period
         let mut sdp_ledger = sdp_ledger;
-        for _ in 0..11 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        for _ in 1..=11 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         // Withdraw the declaration
@@ -883,10 +911,12 @@ mod tests {
         let sdp_ledger =
             apply_declare_with_dummies(&utxo_tree, sdp_ledger, op, &zk_key, &config).unwrap();
 
-        // Apply headers to reach block 10 (session boundary for session_duration=10)
+        // Apply headers to reach block 11 (session boundary because to k=1)
         let mut sdp_ledger = sdp_ledger;
-        for _ in 0..10 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        for _ in 1..=11 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         // At block 10: `active` becomes session 1 (was empty `next`),
@@ -900,9 +930,12 @@ mod tests {
         assert_eq!(next_session.session_n, 2);
         assert!(next_session.declarations.contains_key(&declaration_id));
 
-        // Continue to block 20 to see declaration become active
-        for _ in 0..10 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Continue to block 21 to see declaration become active
+        // (session boundary because due to k=1)
+        for _ in 12..=21 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         // At block 20: active becomes session 2 (with declaration)
@@ -921,10 +954,12 @@ mod tests {
         let mut sdp_ledger =
             SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
-        // Apply headers to reach block 9 (still in session 0, promotion happens at
-        // block 10)
-        for _ in 0..9 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Apply headers to reach block 10 (still in session 0. not session boundary
+        // because k=1)
+        for _ in 1..=10 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         // Check active session is still session 0 with no declarations
@@ -947,9 +982,11 @@ mod tests {
         let mut sdp_ledger =
             SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
-        // Apply headers to reach block 10 (session boundary for BlendNetwork)
-        for _ in 0..10 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Apply headers to reach block 11 (session boundary due to k=1)
+        for _ in 1..=11 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         // Check BlendNetwork is promoted to session 1
@@ -972,8 +1009,10 @@ mod tests {
             SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // SESSION 0: Add a declaration at block 5
-        for _ in 0..5 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        for _ in 1..=5 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         let utxo = utxo();
@@ -991,11 +1030,13 @@ mod tests {
             apply_declare_with_dummies(&utxo_tree, sdp_ledger, declare_op, &zk_key, &config)
                 .unwrap();
 
-        // Move to block 9 (last block of session 0)
-        for _ in 6..10 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Move to block 10 (last block of session 0 because k=1)
+        for _ in 6..=10 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        assert_eq!(sdp_ledger.block_number, 9);
+        assert_eq!(sdp_ledger.block_number, 10);
 
         // Declaration is not in active or next sessions yet
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
@@ -1006,26 +1047,29 @@ mod tests {
         assert_eq!(next_session.session_n, 1);
         assert!(next_session.declarations.is_empty());
 
-        // SESSION 1: Cross session boundary to block 10
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
-        assert_eq!(sdp_ledger.block_number, 10);
+        // SESSION 1: Cross session boundary to block 11
+        (sdp_ledger, _) = sdp_ledger
+            .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+            .unwrap();
+        assert_eq!(sdp_ledger.block_number, 11);
 
         // Active session 1 is empty (was the empty next session 1)
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 1);
         assert!(active_session.declarations.is_empty());
 
-        // Next session 2 now has the declaration (snapshot from block 10)
+        // Next session 2 now has the declaration
         let next_session = sdp_ledger.get_next_session(service_a).unwrap();
         assert_eq!(next_session.session_n, 2);
         assert!(next_session.declarations.contains_key(&declaration_id));
 
-        // SESSION 2: Cross to block 20
-        for _ in 11..20 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // SESSION 2: Cross to block 21
+        for _ in 12..=21 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
-        assert_eq!(sdp_ledger.block_number, 20);
+        assert_eq!(sdp_ledger.block_number, 21);
 
         // Now the declaration is active in session 2
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
@@ -1060,17 +1104,21 @@ mod tests {
             apply_declare_with_dummies(&utxo_tree_1, sdp_ledger, declare_op_1, &zk_key_1, &config)
                 .unwrap();
 
-        // Move to block 9 (last block before session boundary)
-        for _ in 1..10 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Move to block 10 (last block before session boundary because k=1)
+        for _ in 1..=10 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
-        // Save state at block 9
-        let sdp_ledger_block_9 = sdp_ledger.clone();
+        // Save state at block 10
+        let sdp_ledger_block_10 = sdp_ledger.clone();
 
-        // Add another declaration at block 10 (after session boundary)
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
-        assert_eq!(sdp_ledger.block_number, 10);
+        // Add another declaration at block 11 (after session boundary because k=1)
+        (sdp_ledger, _) = sdp_ledger
+            .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+            .unwrap();
+        assert_eq!(sdp_ledger.block_number, 11);
 
         let zk_key_2 = create_zk_key(2);
         let utxo_2 = utxo();
@@ -1088,38 +1136,36 @@ mod tests {
             apply_declare_with_dummies(&utxo_tree_2, sdp_ledger, declare_op_2, &zk_key_2, &config)
                 .unwrap();
 
-        // Jump to session 2 (block 20)
-        for _ in 11..20 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Jump to session 2 (block 21)
+        for _ in 12..=21 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
 
         // Active session (session 2) should contain both declarations
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert!(active_session.declarations.contains_key(&declaration_id_1));
         assert!(!active_session.declarations.contains_key(&declaration_id_2));
 
-        // Now test from the block 9 state - jumping directly to block 20
-        let mut sdp_ledger_from_9 = sdp_ledger_block_9;
-        for _ in 10..20 {
-            (sdp_ledger_from_9, _) = sdp_ledger_from_9
-                .try_apply_header(&config, &epoch_state)
+        // Now test from the block 10 state - jumping directly to block 21
+        let mut sdp_ledger = sdp_ledger_block_10;
+        for _ in 11..=21 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
                 .unwrap();
         }
-        (sdp_ledger_from_9, _) = sdp_ledger_from_9
-            .try_apply_header(&config, &epoch_state)
-            .unwrap();
 
         // Active session should only contain declaration_id_1
         // because declaration_id_2 was never added in this timeline
-        let active_session_from_9 = sdp_ledger_from_9.get_active_session(service_a).unwrap();
+        let active_session_from_10 = sdp_ledger.get_active_session(service_a).unwrap();
         assert!(
-            active_session_from_9
+            active_session_from_10
                 .declarations
                 .contains_key(&declaration_id_1)
         );
         assert!(
-            !active_session_from_9
+            !active_session_from_10
                 .declarations
                 .contains_key(&declaration_id_2)
         );
@@ -1137,8 +1183,10 @@ mod tests {
             SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
         // Add declaration at block 3
-        for _ in 0..3 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        for _ in 1..=3 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
 
         let utxo = utxo();
@@ -1157,14 +1205,15 @@ mod tests {
                 .unwrap();
 
         // Jump directly from block 3 to block 25 (skipping session 1 entirely)
-        for _ in 4..25 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        for _ in 4..=25 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
         assert_eq!(sdp_ledger.block_number, 25);
 
         // Declaration snapshots should be taken from the last known state
-        // Active session (session 2, which started at block 20) should contain the
+        // Active session (session 2, which started at block 21) should contain the
         // declaration
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 2);
@@ -1190,11 +1239,13 @@ mod tests {
         let mut sdp_ledger =
             SdpLedger::new().with_blend_service(&config.service_rewards_params.blend, &epoch_state);
 
-        // Move to block 9 (last block of session 0)
-        for _ in 0..9 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Move to block 10 (last block of session 0 because k=1)
+        for _ in 1..=10 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        assert_eq!(sdp_ledger.block_number, 9);
+        assert_eq!(sdp_ledger.block_number, 10);
 
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 0);
@@ -1204,7 +1255,7 @@ mod tests {
         assert_eq!(next_session.session_n, 1);
         assert!(next_session.declarations.is_empty());
 
-        // Create first declaration at block 9
+        // Create first declaration at block 10
         let utxo_1 = utxo();
         let declare_op_1 = &SDPDeclareOp {
             service_type: service_a,
@@ -1220,21 +1271,23 @@ mod tests {
             apply_declare_with_dummies(&utxo_tree_1, sdp_ledger, declare_op_1, &zk_key_1, &config)
                 .unwrap();
 
-        // Cross to block 10 (session boundary - start of session 1)
+        // Cross to block 11 (session boundary because k=1 - start of session 1)
         // At this point, the snapshot for next session 2 is taken
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
-        assert_eq!(sdp_ledger.block_number, 10);
+        (sdp_ledger, _) = sdp_ledger
+            .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+            .unwrap();
+        assert_eq!(sdp_ledger.block_number, 11);
 
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 1);
         assert!(active_session.declarations.is_empty());
 
-        // Next session 2 should contain declaration_1 (made at block 9)
+        // Next session 2 should contain declaration_1 (made at block 10)
         let next_session = sdp_ledger.get_next_session(service_a).unwrap();
         assert_eq!(next_session.session_n, 2);
         assert!(next_session.declarations.contains_key(&declaration_id_1));
 
-        // Create second declaration at block 10 (first block of session 1)
+        // Create second declaration at block 11
         let zk_key_2 = create_zk_key(2);
         let utxo_2 = utxo();
         let declare_op_2 = &SDPDeclareOp {
@@ -1251,38 +1304,39 @@ mod tests {
             apply_declare_with_dummies(&utxo_tree_2, sdp_ledger, declare_op_2, &zk_key_2, &config)
                 .unwrap();
 
-        // Next session 2 still only has declaration_1 (snapshot was already taken at
-        // block 10)
+        // Next session 2 still only has declaration_1 (snapshot was already taken)
         let next_session = sdp_ledger.get_next_session(service_a).unwrap();
         assert_eq!(next_session.session_n, 2);
         assert!(next_session.declarations.contains_key(&declaration_id_1));
         assert!(!next_session.declarations.contains_key(&declaration_id_2));
 
-        // Jump to block 20 (start of session 2)
-        for _ in 11..20 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Jump to block 21 (start of session 2 because k=1)
+        for _ in 12..=21 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
-        assert_eq!(sdp_ledger.block_number, 20);
+        assert_eq!(sdp_ledger.block_number, 21);
 
-        // Active session 2 has declaration_1 (from block 9)
+        // Active session 2 has declaration_1 (from block 10)
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();
         assert_eq!(active_session.session_n, 2);
         assert!(active_session.declarations.contains_key(&declaration_id_1));
         assert!(!active_session.declarations.contains_key(&declaration_id_2));
 
-        // Next session 3 has both declarations (snapshot from block 20)
+        // Next session 3 has both declarations
         let next_session = sdp_ledger.get_next_session(service_a).unwrap();
         assert_eq!(next_session.session_n, 3);
         assert!(next_session.declarations.contains_key(&declaration_id_1));
         assert!(next_session.declarations.contains_key(&declaration_id_2));
 
-        // Jump to block 30 (start of session 3)
-        for _ in 21..30 {
-            (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
+        // Jump to block 31 (start of session 3 because k=1)
+        for _ in 22..=31 {
+            (sdp_ledger, _) = sdp_ledger
+                .try_apply_header(&config, &epoch_state, new_lib_height(&sdp_ledger, K_ONE))
+                .unwrap();
         }
-        (sdp_ledger, _) = sdp_ledger.try_apply_header(&config, &epoch_state).unwrap();
-        assert_eq!(sdp_ledger.block_number, 30);
+        assert_eq!(sdp_ledger.block_number, 31);
 
         // Active session 3 now has both declarations
         let active_session = sdp_ledger.get_active_session(service_a).unwrap();

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -1501,6 +1501,7 @@ mod tests {
     const TIP_SLOT: u64 = 100_000;
     const LIB_SLOT: u64 = 80_000;
     const HEIGHT: u64 = 500;
+    const LIB_HEIGHT: u64 = 450;
     const DEFAULT_LIMIT: usize = 100;
     const DEFAULT_BATCH_SIZE: usize = 100;
 
@@ -1509,6 +1510,7 @@ mod tests {
             lib: HeaderId::from([2; 32]),
             slot: Slot::new(TIP_SLOT),
             lib_slot: Slot::new(LIB_SLOT),
+            lib_height: LIB_HEIGHT,
             height: HEIGHT,
             tip: HeaderId::from([3; 32]),
         }
@@ -1519,6 +1521,7 @@ mod tests {
             lib: HeaderId::from([2; 32]),
             slot: Slot::new(100),
             lib_slot: Slot::new(0),
+            lib_height: 0,
             height: 1,
             tip: HeaderId::from([3; 32]),
         }

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -17,7 +17,7 @@ use lb_chain_service::{
     api::{CryptarchiaServiceApi, CryptarchiaServiceData},
 };
 use lb_core::{
-    block::{Block, Error as BlockError, MAX_BLOCK_TRANSACTIONS},
+    block::{Block, BlockNumber, Error as BlockError, MAX_BLOCK_TRANSACTIONS},
     header::HeaderId,
     mantle::{
         AuthenticatedMantleTx, SignedMantleTx, Transaction, TxHash, TxSelect,
@@ -404,7 +404,7 @@ where
                 tokio::select! {
                     Some(SlotTick { slot, epoch }) = slot_timer.next() => {
                         trace!("Received SlotTick for slot {}, ep {}", u64::from(slot), u32::from(epoch));
-                        let (tip, tip_state) = match Self::get_tip_ledger_state(&cryptarchia_api).await {
+                        let (tip, tip_state, lib_height) = match Self::get_tip_and_lib(&cryptarchia_api).await {
                             Ok(output) => output,
                             Err(e) => {
                                 error!("Failed to get tip ledger state: {e:?}");
@@ -445,6 +445,9 @@ where
                         winning_pol_slot_notifier.process_epoch(&eligible, latest_tree, &epoch_state, &kms_api).await;
 
                        if let Some((proof, signing_key)) = build_proof_for(&eligible, latest_tree, &epoch_state, slot, &winning_pol_slot_notifier, &wallet_api, &kms_api).await {
+                            // Simulate the new LIB height by +1, because we already propose a block on top of the tip,
+                            // which always advances LIB by 1.
+                            let new_lib_height = lib_height + 1;
                             // TODO: spawn as a separate task?
                             match Self::propose_block(
                                 parent,
@@ -454,6 +457,7 @@ where
                                 tx_selector.clone(),
                                 &relays,
                                 tip_state,
+                                new_lib_height,
                                 &ledger_config,
                             )
                             .await
@@ -577,6 +581,7 @@ where
             RuntimeServiceId,
         >,
         mut ledger_state: LedgerState,
+        new_lib_height: BlockNumber,
         ledger_config: &lb_ledger::Config,
     ) -> Result<Block<Mempool::Item>, Error> {
         let txs_stream = relays
@@ -589,7 +594,12 @@ where
 
         ledger_state = ledger_state
             .clone()
-            .try_apply_header::<Groth16LeaderProof, HeaderId>(slot, &proof, ledger_config)?;
+            .try_apply_header::<Groth16LeaderProof, HeaderId>(
+                slot,
+                &proof,
+                new_lib_height,
+                ledger_config,
+            )?;
 
         let mut valid_txs = Vec::new();
         let mut invalid_tx_hashes = Vec::new();
@@ -703,7 +713,7 @@ where
         mempool: &MempoolAdapter<Mempool::Item>,
         config: &LeaderWalletConfig,
     ) -> Result<TxHash, Error> {
-        let (tip, ledger_state) = Self::get_tip_ledger_state(cryptarchia).await?;
+        let (tip, ledger_state, _) = Self::get_tip_and_lib(cryptarchia).await?;
 
         let voucher_nullifier = wallet
             .get_claimable_voucher(Some(tip))
@@ -733,14 +743,15 @@ where
         Ok(tx_hash)
     }
 
-    async fn get_tip_ledger_state(
+    async fn get_tip_and_lib(
         cryptarchia: &CryptarchiaServiceApi<CryptarchiaService, RuntimeServiceId>,
-    ) -> Result<(HeaderId, LedgerState), Error> {
-        let tip = cryptarchia.info().await?.cryptarchia_info.tip;
+    ) -> Result<(HeaderId, LedgerState, BlockNumber), Error> {
+        let info = cryptarchia.info().await?.cryptarchia_info;
+        let (tip, lib_height) = (info.tip, info.lib_height);
         let ledger_state = cryptarchia
             .get_ledger_state(tip)
             .await?
             .ok_or(Error::LedgerStateNotFound(tip))?;
-        Ok((tip, ledger_state))
+        Ok((tip, ledger_state, lib_height))
     }
 }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -374,17 +374,17 @@ impl Cryptarchia {
 
         // Clone/update consensus state first to get the new LIB height
         // before updating ledger.
-        let consensus = self.consensus.clone();
-        let (pruned_blocks, reorged_blocks) = self
-            .consensus
-            .receive_block(id, parent, slot)
-            .map_err(|err| match err {
-                lb_cryptarchia_engine::Error::ParentMissing(parent) => Error::ParentMissing {
-                    parent,
-                    info: Box::new(self.info()),
-                },
-                err => Error::Consensus(err),
-            })?;
+        let mut consensus = self.consensus.clone();
+        let (pruned_blocks, reorged_blocks) =
+            consensus
+                .receive_block(id, parent, slot)
+                .map_err(|err| match err {
+                    lb_cryptarchia_engine::Error::ParentMissing(parent) => Error::ParentMissing {
+                        parent,
+                        info: Box::new(self.info()),
+                    },
+                    err => Error::Consensus(err),
+                })?;
         let new_lib_height = consensus.lib_branch().length();
 
         let (_, events) = self

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -197,6 +197,7 @@ pub struct ChainServiceInfo {
 pub struct CryptarchiaInfo {
     pub lib: HeaderId,
     pub lib_slot: Slot,
+    pub lib_height: u64,
     pub tip: HeaderId,
     pub slot: Slot,
     pub height: u64,
@@ -322,6 +323,7 @@ impl Cryptarchia {
         CryptarchiaInfo {
             lib: lib_branch.id(),
             lib_slot: lib_branch.slot(),
+            lib_height: lib_branch.length(),
             tip: tip_branch.id(),
             slot: tip_branch.slot(),
             height: tip_branch.length(),
@@ -370,24 +372,9 @@ impl Cryptarchia {
             });
         }
 
-        // A block number of this block if it's applied to the chain.
-        let (_, state, events) = self
-            .ledger
-            .prepare_update::<_, MainnetGasConstants>(
-                id,
-                parent,
-                slot,
-                header.leader_proof(),
-                block.transactions(),
-            )
-            .map_err(|err| match err {
-                lb_ledger::LedgerError::ParentNotFound(parent) => Error::ParentMissing {
-                    parent,
-                    info: Box::new(self.info()),
-                },
-                err => Error::Ledger(err),
-            })?;
-
+        // Clone/update consensus state first to get the new LIB height
+        // before updating ledger.
+        let consensus = self.consensus.clone();
         let (pruned_blocks, reorged_blocks) = self
             .consensus
             .receive_block(id, parent, slot)
@@ -398,12 +385,31 @@ impl Cryptarchia {
                 },
                 err => Error::Consensus(err),
             })?;
+        let new_lib_height = consensus.lib_branch().length();
 
-        self.ledger.commit_update(id, state);
+        let (_, events) = self
+            .ledger
+            .try_update::<_, MainnetGasConstants>(
+                id,
+                parent,
+                slot,
+                header.leader_proof(),
+                block.transactions(),
+                new_lib_height,
+            )
+            .map_err(|err| match err {
+                lb_ledger::LedgerError::ParentNotFound(parent) => Error::ParentMissing {
+                    parent,
+                    info: Box::new(self.info()),
+                },
+                err => Error::Ledger(err),
+            })?;
 
         // Prune the ledger states of all the pruned blocks.
         self.prune_ledger_states(pruned_blocks.all());
 
+        // All operations have succeeded. Commit the new consensus state.
+        self.consensus = consensus;
         metrics::emit_consensus_metrics(&self.consensus, &self.ledger);
         metrics::emit_block_imported_metric();
         Ok((pruned_blocks, reorged_blocks, events))

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -374,6 +374,7 @@ mod tests {
                 cryptarchia_info: CryptarchiaInfo {
                     lib: HeaderId::from([0; 32]),
                     lib_slot: self.lib_slot,
+                    lib_height: 0,
                     tip: HeaderId::from([0; 32]),
                     slot: self.lib_slot,
                     height: 0,

--- a/zone-sdk/src/sequencer.rs
+++ b/zone-sdk/src/sequencer.rs
@@ -2154,6 +2154,7 @@ mod tests {
                 cryptarchia_info: CryptarchiaInfo {
                     lib: HeaderId::from([0; 32]),
                     lib_slot: Slot::genesis(),
+                    lib_height: 0,
                     tip: HeaderId::from([0; 32]),
                     slot: Slot::genesis(),
                     height: 0,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes a bug that @ntn-x2 [found](https://discord.com/channels/973324189794697286/1506558022481346590/1506950711899066409).

### Bug
Chain service is yielding a new session only when the new LIB enters the new session. This behavior is correct because we want the blend service to always have the irreversible view.

However, SDP ledger was transitioning sessions as soon as a session boundary block (1st block of the new session) is applied. That is, it causes a time gap.

This time gap caused an issue. Here is the scenario:
- The **SRP** ledger in the SDP ledger built an immutable `TargetSessionState` as soon as the session boundary block is applied (session 26->27).
- But, the blend service didn't know that yet because the chain service didn't yield the session 27 yet (since LIB is still in session 26).
- Unfortunately, before LIB enters the session 27, the new **epoch** 27 was started. This new epoch was yielded immediately from the chain leader service to the blend service. 
- So, blend service began to create blend messages with PoQs generated against the epoch state 27.
- After that, the session info 27 arrived in the blend service, in the end. So, blend service submitted an activity proof to the network.
- But, unfortunately, the activity proof was from the message generated in the epoch 27 (not 26). This proof was rejected by SDP ledger because its `TargetSessionState` didn't have the proof verifier for epoch 27. It had only the epoch 26 verifier because it built the `TargetSessionState` earlier because of the time gap.

### Solution

The solution is removing the time gap.

The behavior of chain service (yielding sessions) is correct. So, this PR changes the way how SDP ledger transitions sessions. In short, now SDP ledger transitions the session only when the new LIB crosses the session border.

Previously, SDP ledger had the following algorithm:
```rust
let current_session = service_params.session_for_block(new_block_number);
if current_session == self.active.session_n + 1 {
  // transition to the new session
```
This PR changes the way how `current_session` is calculated.
```rust
let current_session = service_params.current_session(new_lib);
if current_session == self.active.session_n + 1 {
  // transition to the new session
```
The current session must be always calculated based on the new LIB.

For example, if the new LIB didn't cross the border yet, SDP ledger shouldn't transition the session.
```
// session_duration = 10 blocks
-------b9--|--b10---b11---
        ^            ^
        |            |
       LIB        new_block
// current_session = 0
```
Only when the new LIB crosses the border, SDP ledger should transition the session.
```
// session_duration = 10 blocks
------b9--|--b10---b11---b12---
              ^           ^
              |           |
             LIB       new_block
// current_session = 1
```

## 2. Does the code have enough context to be clearly understood?

I believe so.

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?
we should mention this behavior if there's nothing mentioned about this.

## 5. Does the implementation introduce changes in the specification?
we should mention this behavior if there's nothing mentioned about this.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
