### PR TITLE
fix(blend): SDP snapshot in EpochState

### DIFF
--- a/blend/scheduling/src/session.rs
+++ b/blend/scheduling/src/session.rs
@@ -20,13 +20,9 @@ pub struct UninitializedSessionEventStream<Stream> {
 
 impl<Stream> UninitializedSessionEventStream<Stream> {
     #[must_use]
-    pub const fn new(
-        session_stream: Stream,
-        first_ready_timeout: Duration,
-        transition_period: Duration,
-    ) -> Self {
+    pub const fn new(session_stream: Stream, transition_period: Duration) -> Self {
         Self {
-            stream: UninitializedFirstReadyStream::new(session_stream, first_ready_timeout),
+            stream: UninitializedFirstReadyStream::new(session_stream),
             transition_period,
         }
     }
@@ -40,9 +36,10 @@ where
     /// from the underlying stream.
     ///
     /// It returns the first [`Session`] and the initialized
-    /// [`SessionEventStream`].
-    /// It returns an error if the first session is not yielded within the
-    /// configured timeout.
+    /// [`SessionEventStream`], awaiting the first session for as long as
+    /// necessary.
+    /// It returns an error only if the underlying stream closes before yielding
+    /// a session.
     pub async fn await_first_ready(
         self,
     ) -> Result<(Session, SessionEventStream<Stream>), FirstReadyStreamError> {
@@ -127,7 +124,7 @@ where
 #[cfg(test)]
 mod tests {
     use futures::StreamExt as _;
-    use tokio::time::{Instant, interval, interval_at};
+    use tokio::time::{Instant, interval};
     use tokio_stream::wrappers::IntervalStream;
 
     use super::*;
@@ -232,7 +229,6 @@ mod tests {
             IntervalStream::new(interval(Duration::from_secs(1)))
                 .enumerate()
                 .map(|(i, _)| i),
-            Duration::from_millis(100),
         );
 
         let (first, mut stream) = stream.first().await.expect("first item should be yielded");
@@ -240,23 +236,5 @@ mod tests {
         // Next items are yielded normally.
         assert_eq!(stream.next().await, Some(1));
         assert_eq!(stream.next().await, Some(2));
-    }
-
-    #[tokio::test]
-    async fn first_relay_stream_fails_if_first_item_is_not_ready() {
-        // Use an underlying stream that yield the first item too late.
-        let stream = UninitializedFirstReadyStream::new(
-            IntervalStream::new(interval_at(
-                // The first time will be yieled after 2s.
-                Instant::now() + Duration::from_secs(2),
-                Duration::from_secs(1),
-            )),
-            Duration::from_millis(100),
-        );
-
-        assert!(matches!(
-            stream.first().await,
-            Err(FirstReadyStreamError::FirstItemNotReady)
-        ));
     }
 }

--- a/blend/scheduling/src/stream.rs
+++ b/blend/scheduling/src/stream.rs
@@ -1,22 +1,19 @@
-use core::time::Duration;
-
 use futures::StreamExt as _;
-use tokio::time::timeout;
 
-/// A stream wrapper that expects the underlying stream to yield its first item
-/// within the given timeout.
+/// A stream wrapper that consumes the first item from the underlying stream.
 ///
 /// Instead of implementing [`futures::Stream`], this provides only
-/// [`Self::first`] that explicitly tries to read the first item and returns a
-/// result.
+/// [`Self::first`] that explicitly reads the first item and returns it together
+/// with the remaining stream. It waits for the first item for as long as
+/// necessary: blend membership and the slot clock only become available at
+/// genesis, which may be arbitrarily far in the future, so there is no timeout.
 pub struct UninitializedFirstReadyStream<Stream> {
     stream: Stream,
-    timeout: Duration,
 }
 
 impl<Stream> UninitializedFirstReadyStream<Stream> {
-    pub const fn new(stream: Stream, timeout: Duration) -> Self {
-        Self { stream, timeout }
+    pub const fn new(stream: Stream) -> Self {
+        Self { stream }
     }
 }
 
@@ -24,13 +21,16 @@ impl<Stream> UninitializedFirstReadyStream<Stream>
 where
     Stream: futures::Stream + Unpin,
 {
-    /// Yields the first item if it is yielded within the timeout from the
-    /// underlying stream.
-    /// The remaining stream is also returned for continued use.
+    /// Yields the first item from the underlying stream, awaiting it for as long
+    /// as necessary. The remaining stream is also returned for continued use.
+    ///
+    /// Returns [`FirstReadyStreamError::StreamClosed`] if the underlying stream
+    /// ends before yielding any item.
     pub async fn first(mut self) -> Result<(Stream::Item, Stream), FirstReadyStreamError> {
-        let item = timeout(self.timeout, self.stream.next())
+        let item = self
+            .stream
+            .next()
             .await
-            .map_err(|_| FirstReadyStreamError::FirstItemNotReady)?
             .ok_or(FirstReadyStreamError::StreamClosed)?;
         Ok((item, self.stream))
     }
@@ -38,8 +38,6 @@ where
 
 #[derive(Debug, thiserror::Error)]
 pub enum FirstReadyStreamError {
-    #[error("The first item was not yielded in time")]
-    FirstItemNotReady,
     #[error("The underlying stream was closed before yielding the first item")]
     StreamClosed,
 }

--- a/blend/scheduling/src/stream.rs
+++ b/blend/scheduling/src/stream.rs
@@ -21,8 +21,9 @@ impl<Stream> UninitializedFirstReadyStream<Stream>
 where
     Stream: futures::Stream + Unpin,
 {
-    /// Yields the first item from the underlying stream, awaiting it for as long
-    /// as necessary. The remaining stream is also returned for continued use.
+    /// Yields the first item from the underlying stream, awaiting it for as
+    /// long as necessary. The remaining stream is also returned for
+    /// continued use.
     ///
     /// Returns [`FirstReadyStreamError::StreamClosed`] if the underlying stream
     /// ends before yielding any item.

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -22,9 +22,12 @@ use lb_groth16::{Fr, fr_from_bytes};
 use lb_key_management_system_keys::keys::ZkSignature;
 use lb_utxotree::MerklePath;
 
-use crate::cryptarchia::{
-    block_density::BlockDensity,
-    stake::{PRECISION, StakeInference},
+use crate::{
+    cryptarchia::{
+        block_density::BlockDensity,
+        stake::{PRECISION, StakeInference},
+    },
+    mantle::sdp::SdpLedger,
 };
 
 // corresponds to the denominator of q
@@ -51,7 +54,7 @@ pub type UtxoTree = lb_utxotree::UtxoTree<NoteId, Utxo, ZkHasher>;
 use super::{Balance, Config, LedgerError, mantle};
 use crate::WINDOW_SIZE;
 
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct EpochState {
     /// The epoch this snapshot is for
     pub epoch: Epoch,
@@ -69,10 +72,23 @@ pub struct EpochState {
     pub lottery_0: Fr,
     #[serde(with = "lb_groth16::serde::serde_fr")]
     pub lottery_1: Fr,
+    /// SDP service-provider declarations (membership) snapshot, frozen at the
+    /// same slot as the stake distribution (`stake_distribution_snapshot`).
+    /// Carried forward in ledger state so the epoch's membership is derivable
+    /// from the tip without walking storage.
+    ///
+    /// TODO: This field reaches "up" into the mantle layer (`SdpLedger`), which
+    /// is why the `&SdpLedger` is threaded through `update_from_ledger`,
+    /// `update_epoch_state`, `try_apply_header`, and `epoch_state_for_slot`.
+    /// That threading is scaffolding: long-term, `EpochState` should be lifted
+    /// out of `cryptarchia` to sit alongside `cryptarchia_ledger` and
+    /// `mantle_ledger` in the outer `LedgerState`, where the freeze can read
+    /// both sub-ledgers directly and these `&SdpLedger` parameters disappear.
+    pub sdp: SdpLedger,
 }
 
 impl EpochState {
-    fn update_from_ledger(self, ledger: &LedgerState, config: &Config) -> Self {
+    fn update_from_ledger(self, ledger: &LedgerState, sdp: &SdpLedger, config: &Config) -> Self {
         let nonce_snapshot_slot = config.nonce_snapshot(self.epoch);
         let nonce = if ledger.slot < nonce_snapshot_slot {
             ledger.nonce
@@ -80,11 +96,14 @@ impl EpochState {
             self.nonce
         };
 
+        // The SDP membership snapshot is frozen at the same slot as the stake
+        // distribution, so the two halves of the epoch's public info stay
+        // consistent.
         let stake_snapshot_slot = config.stake_distribution_snapshot(self.epoch);
-        let utxos = if ledger.slot < stake_snapshot_slot {
-            ledger.utxos.clone()
+        let (utxos, sdp) = if ledger.slot < stake_snapshot_slot {
+            (ledger.utxos.clone(), sdp.clone())
         } else {
-            self.utxos
+            (self.utxos, self.sdp)
         };
         Self {
             epoch: self.epoch,
@@ -93,6 +112,7 @@ impl EpochState {
             total_stake: self.total_stake,
             lottery_0: self.lottery_0,
             lottery_1: self.lottery_1,
+            sdp,
         }
     }
 
@@ -136,7 +156,7 @@ impl EpochState {
 /// NOTE: Most collection fields in this struct should use `rpds`
 /// since we keep a copy of this state for each block.
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
-#[derivative(Clone, Eq, PartialEq)]
+#[derivative(Clone, PartialEq)]
 pub struct LedgerState {
     // All available Unspent Transtaction Outputs (UTXOs) at the current slot
     // TODO: move UTXOs in the mantle ledger. There is no reason to keep them here
@@ -178,7 +198,12 @@ impl LedgerState {
         clippy::too_many_lines,
         reason = "TODO: fix/refactor updating next_epoch_state"
     )]
-    fn update_epoch_state<Id>(self, slot: Slot, config: &Config) -> Result<Self, LedgerError<Id>> {
+    fn update_epoch_state<Id>(
+        self,
+        slot: Slot,
+        sdp: &SdpLedger,
+        config: &Config,
+    ) -> Result<Self, LedgerError<Id>> {
         if slot <= self.slot {
             return Err(LedgerError::InvalidSlot {
                 parent: self.slot,
@@ -197,7 +222,7 @@ impl LedgerState {
         let next_epoch_state = self
             .next_epoch_state
             .clone()
-            .update_from_ledger(&self, config);
+            .update_from_ledger(&self, sdp, config);
 
         // There are 3 cases to consider:
         // 1. We are in the same epoch as the parent state: Update the next epoch state
@@ -253,6 +278,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: sdp.clone(),
             };
             let (new_price, new_ema) = update_storage_market(
                 self.storage_gas_price,
@@ -316,6 +342,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: sdp.clone(),
             };
             let next_epoch_state = EpochState {
                 epoch: new_epoch + 1,
@@ -324,6 +351,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: sdp.clone(),
             };
             Ok(Self {
                 slot,
@@ -390,6 +418,7 @@ impl LedgerState {
         self,
         slot: Slot,
         proof: &LeaderProof,
+        sdp: &SdpLedger,
         config: &Config,
     ) -> Result<Self, LedgerError<Id>>
     where
@@ -399,7 +428,7 @@ impl LedgerState {
         // Then, apply the proof and update the nonce. Finally, increment block density
         // since this function is called for a new block.
         Ok(self
-            .update_epoch_state(slot, config)?
+            .update_epoch_state(slot, sdp, config)?
             .try_apply_proof(slot, proof, config)?
             .update_nonce(&proof.entropy(), slot)
             .increment_block_density(slot))
@@ -526,11 +555,12 @@ impl LedgerState {
     pub fn epoch_state_for_slot<Id>(
         &self,
         slot: Slot,
+        sdp: &SdpLedger,
         config: &Config,
     ) -> Result<EpochState, LedgerError<Id>> {
         Ok(self
             .clone()
-            .update_epoch_state(slot, config)?
+            .update_epoch_state(slot, sdp, config)?
             .epoch_state()
             .clone())
     }
@@ -585,6 +615,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: SdpLedger::new(1.into()),
             },
             epoch_state: EpochState {
                 epoch: 0.into(),
@@ -593,6 +624,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: SdpLedger::new(0.into()),
             },
             block_density,
             stake_inference,
@@ -764,7 +796,7 @@ pub mod tests {
             .unwrap()
             .clone()
             .cryptarchia_ledger
-            .update_epoch_state::<HeaderId>(slot, ledger.config())
+            .update_epoch_state::<HeaderId>(slot, &SdpLedger::new(0.into()), ledger.config())
             .unwrap();
         let id = make_id(parent, slot, utxo);
         let proof = generate_proof(&ledger_state, &utxo, slot);
@@ -895,6 +927,7 @@ pub mod tests {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: SdpLedger::new(1.into()),
             },
             epoch_state: EpochState {
                 epoch: 0.into(),
@@ -903,6 +936,7 @@ pub mod tests {
                 total_stake,
                 lottery_0,
                 lottery_1,
+                sdp: SdpLedger::new(0.into()),
             },
             stake_inference,
             fee_window: [0.into(); 120],
@@ -1205,12 +1239,12 @@ pub mod tests {
         let slot = Slot::genesis() + 10;
         let ledger_state2 = ledger_state
             .cryptarchia_ledger
-            .update_epoch_state::<HeaderId>(slot, ledger_config)
+            .update_epoch_state::<HeaderId>(slot, &SdpLedger::new(0.into()), ledger_config)
             .expect("Ledger needs to move forward");
 
         let slot2 = Slot::genesis() + 1;
         let update_epoch_err = ledger_state2
-            .update_epoch_state::<HeaderId>(slot2, ledger_config)
+            .update_epoch_state::<HeaderId>(slot2, &SdpLedger::new(0.into()), ledger_config)
             .err();
 
         // Time cannot flow backwards
@@ -1573,7 +1607,7 @@ pub mod tests {
         // Query for epoch 0 (current epoch) - should return epoch_state
         let epoch_0_slot: Slot = (epoch_length - 1).into();
         let epoch_0_state = ledger_state
-            .epoch_state_for_slot::<HeaderId>(epoch_0_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_0_slot, &SdpLedger::new(0.into()), &config)
             .expect("Should return epoch state for current epoch");
         assert_eq!(epoch_0_state.epoch, 0.into());
         assert_eq!(epoch_0_state.total_stake, initial_total_stake);
@@ -1582,7 +1616,7 @@ pub mod tests {
         // Since epoch 0 has no block, total stake should be reduced
         let epoch_1_slot: Slot = (epoch_length + 1).into();
         let epoch_1_state = ledger_state
-            .epoch_state_for_slot::<HeaderId>(epoch_1_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_1_slot, &SdpLedger::new(0.into()), &config)
             .expect("Should return epoch state for next epoch");
         assert_eq!(epoch_1_state.epoch, 1.into());
         // With 0 density and LEARNING_RATE=1, total stake drops to minimum (1)
@@ -1594,7 +1628,7 @@ pub mod tests {
         // Query for epoch 3 (multiple skipped epochs) - stake stays at minimum
         let epoch_2_slot: Slot = (2 * epoch_length + 1).into();
         let epoch_2_state = ledger_state
-            .epoch_state_for_slot::<HeaderId>(epoch_2_slot, &config)
+            .epoch_state_for_slot::<HeaderId>(epoch_2_slot, &SdpLedger::new(0.into()), &config)
             .expect("Should synthesize epoch state for skipped epoch");
         assert_eq!(epoch_2_state.epoch, 2.into());
         assert_eq!(
@@ -1620,7 +1654,7 @@ pub mod tests {
         assert_eq!(config.epoch(slot), 0.into());
         let proof = generate_proof(&genesis_state, &utxo, slot);
         let ledger_state_1 = genesis_state
-            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &config)
+            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &SdpLedger::new(0.into()), &config)
             .unwrap();
 
         // Now, apply a header from the 2nd slot of epoch 2
@@ -1630,7 +1664,7 @@ pub mod tests {
         // First, synthesize epoch state for epoch 2
         let synthesized_ledger_state = ledger_state_1
             .clone()
-            .update_epoch_state::<HeaderId>(slot, &config)
+            .update_epoch_state::<HeaderId>(slot, &SdpLedger::new(0.into()), &config)
             .unwrap();
         assert_eq!(synthesized_ledger_state.slot, slot);
 
@@ -1642,7 +1676,7 @@ pub mod tests {
         // correctly to epoch 2 as the same as `synthesized_ledger_state`.
         let ledger_state_2 = ledger_state_1
             .clone()
-            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &config)
+            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &SdpLedger::new(0.into()), &config)
             .unwrap();
         assert_eq!(ledger_state_2.slot, slot);
         assert_ne!(ledger_state_2.nonce, ledger_state_1.nonce); // advanced

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -520,6 +520,20 @@ impl LedgerState {
         &self.next_epoch_state
     }
 
+    /// Seeds the genesis epoch-state snapshots with the genesis SDP ledger.
+    ///
+    /// At genesis the cryptarchia ledger is built before the mantle `SdpLedger`
+    /// exists (the mantle ledger is derived from the cryptarchia epoch state),
+    /// so the initial epoch states start with an empty SDP snapshot. Once the
+    /// genesis `SdpLedger` is available, this seeds it into the epoch 0/1
+    /// snapshots so they carry the genesis membership. Genesis use only.
+    #[must_use]
+    pub fn with_genesis_sdp(mut self, sdp: SdpLedger) -> Self {
+        self.next_epoch_state.sdp = sdp.clone();
+        self.epoch_state.sdp = sdp;
+        self
+    }
+
     #[must_use]
     pub const fn latest_utxos(&self) -> &UtxoTree {
         &self.utxos

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -1668,7 +1668,12 @@ pub mod tests {
         assert_eq!(config.epoch(slot), 0.into());
         let proof = generate_proof(&genesis_state, &utxo, slot);
         let ledger_state_1 = genesis_state
-            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &SdpLedger::new(0.into()), &config)
+            .try_apply_header::<DummyProof, HeaderId>(
+                slot,
+                &proof,
+                &SdpLedger::new(0.into()),
+                &config,
+            )
             .unwrap();
 
         // Now, apply a header from the 2nd slot of epoch 2
@@ -1690,7 +1695,12 @@ pub mod tests {
         // correctly to epoch 2 as the same as `synthesized_ledger_state`.
         let ledger_state_2 = ledger_state_1
             .clone()
-            .try_apply_header::<DummyProof, HeaderId>(slot, &proof, &SdpLedger::new(0.into()), &config)
+            .try_apply_header::<DummyProof, HeaderId>(
+                slot,
+                &proof,
+                &SdpLedger::new(0.into()),
+                &config,
+            )
             .unwrap();
         assert_eq!(ledger_state_2.slot, slot);
         assert_ne!(ledger_state_2.nonce, ledger_state_1.nonce); // advanced

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -244,7 +244,15 @@ impl LedgerState {
     {
         let mut cryptarchia_ledger = self
             .cryptarchia_ledger
-            .try_apply_header::<LeaderProof, Id>(slot, proof, config)?;
+            .try_apply_header::<LeaderProof, Id>(
+                slot,
+                proof,
+                // TODO: threading SDP here because EpochState is currently embedded in
+                // CryptarchiaLedger.
+                // In the future, we will pull EpochState up into LedgerState.
+                &self.mantle_ledger.sdp,
+                config,
+            )?;
         let (mantle_ledger, reward_utxos) = self.mantle_ledger.try_apply_header(
             cryptarchia_ledger.epoch_state(),
             *proof.voucher_cm(),
@@ -474,7 +482,8 @@ impl LedgerState {
         slot: Slot,
         config: &Config,
     ) -> Result<EpochState, LedgerError<Id>> {
-        self.cryptarchia_ledger.epoch_state_for_slot(slot, config)
+        self.cryptarchia_ledger
+            .epoch_state_for_slot(slot, &self.mantle_ledger.sdp, config)
     }
 
     #[must_use]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -426,6 +426,9 @@ impl LedgerState {
     pub fn from_utxos(utxos: impl IntoIterator<Item = Utxo>, config: &Config) -> Self {
         let cryptarchia_ledger = CryptarchiaLedger::from_utxos(utxos, config, Fr::ZERO);
         let mantle_ledger = MantleLedger::new(config, cryptarchia_ledger.epoch_state());
+        // Seed the genesis epoch-state membership snapshots from the genesis SDP
+        // ledger, which only exists after the mantle ledger is built.
+        let cryptarchia_ledger = cryptarchia_ledger.with_genesis_sdp(mantle_ledger.sdp.clone());
         Self {
             block_number: 0,
             cryptarchia_ledger,
@@ -445,6 +448,9 @@ impl LedgerState {
             cryptarchia_ledger.latest_utxos(),
             cryptarchia_ledger.epoch_state(),
         )?;
+        // Seed the genesis epoch-state membership snapshots from the genesis SDP
+        // ledger (which carries the genesis declarations applied above).
+        let cryptarchia_ledger = cryptarchia_ledger.with_genesis_sdp(mantle_ledger.sdp.clone());
         Ok((
             Self {
                 block_number: 0,
@@ -773,6 +779,18 @@ mod tests {
         let genesis_state = LedgerState::from_utxos([utxo], &config);
         let ledger = Ledger::new([0; 32], genesis_state, config);
         (ledger, [0; 32], utxo)
+    }
+
+    /// The genesis epoch-state membership snapshots must be seeded from the
+    /// genesis SDP ledger, not left as the empty `SdpLedger::new` placeholder
+    /// the cryptarchia genesis constructor initializes them with.
+    #[test]
+    fn genesis_seeds_epoch_state_sdp_from_mantle() {
+        let config = config();
+        let ledger = LedgerState::from_utxos([utxo()], &config);
+
+        assert_eq!(ledger.epoch_state().sdp, ledger.mantle_ledger.sdp);
+        assert_eq!(ledger.next_epoch_state().sdp, ledger.mantle_ledger.sdp);
     }
 
     fn create_test_keys_with_seed(seed: u8) -> (Ed25519Key, Ed25519PublicKey) {

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -641,6 +641,7 @@ mod tests {
             total_stake: 100,
             lottery_0: Fr::ZERO,
             lottery_1: Fr::ZERO,
+            sdp: SdpLedger::new(epoch),
         }
     }
 

--- a/ledger/src/mantle/sdp/rewards/test_utils.rs
+++ b/ledger/src/mantle/sdp/rewards/test_utils.rs
@@ -66,5 +66,6 @@ pub fn dummy_epoch_state_with(epoch: u32, nonce: u64) -> EpochState {
         total_stake: 0,
         lottery_0: Fr::ZERO,
         lottery_1: Fr::ZERO,
+        sdp: crate::mantle::sdp::SdpLedger::new(epoch.into()),
     }
 }

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -98,7 +98,7 @@ use crate::{
         state::{RecoveryServiceState, ServiceState, StateUpdater as ServiceStateUpdater},
     },
     epoch_info::{
-        ChainApi, EpochEvent, EpochHandler, LeaderInputsMinusQuota, PolEpochInfo,
+        ChainApi, EpochEvent, EpochHandler, PolEpochInfo,
         PolInfoProvider as PolInfoProviderTrait,
     },
     kms::PreloadKmsService,
@@ -635,18 +635,7 @@ where
     })
     .expect("The current session info must be available.");
 
-    let (
-        (
-            LeaderInputsMinusQuota {
-                pol_epoch_nonce,
-                pol_ledger_aged,
-                lottery_0,
-                lottery_1,
-            },
-            current_epoch,
-        ),
-        remaining_clock_stream,
-    ) = async {
+    let ((epoch_state, current_epoch), remaining_clock_stream) = async {
         let (clock_tick, remaining_clock_stream) =
             UninitializedFirstReadyStream::new(clock_stream, Duration::from_secs(5))
                 .first()
@@ -668,11 +657,11 @@ where
 
     let current_public_info = PublicInfo {
         epoch: LeaderInputs {
-            pol_ledger_aged,
-            pol_epoch_nonce,
+            pol_ledger_aged: epoch_state.utxos.root(),
+            pol_epoch_nonce: epoch_state.nonce,
             message_quota: blend_config.session_leadership_quota(),
-            lottery_0,
-            lottery_1,
+            lottery_0: epoch_state.lottery_0,
+            lottery_1: epoch_state.lottery_1,
         },
         session: SessionInfo {
             membership: current_membership_info.public.membership.clone(),
@@ -726,7 +715,7 @@ where
             SessionBlendingTokenCollector::new(
                 &reward::SessionInfo::new(
                     current_membership_info.public.session,
-                    &pol_epoch_nonce,
+                    &epoch_state.nonce,
                     current_membership_info.public.membership.size() as u64,
                     current_membership_info.public.poq_core_public_inputs.quota,
                     blend_config.activity_threshold_sensitivity,
@@ -2105,16 +2094,8 @@ where
     };
 
     match epoch_event {
-        EpochEvent::NewEpoch((
-            LeaderInputsMinusQuota {
-                pol_epoch_nonce,
-                pol_ledger_aged,
-                lottery_0,
-                lottery_1,
-            },
-            new_epoch,
-        )) => {
-            tracing::debug!(target: LOG_TARGET, "New epoch {new_epoch:?} with nonce {pol_epoch_nonce:?} started");
+        EpochEvent::NewEpoch((epoch_state, new_epoch)) => {
+            tracing::debug!(target: LOG_TARGET, "New epoch {new_epoch:?} with nonce {:?} started", epoch_state.nonce);
             if new_epoch <= current_epoch {
                 return (current_public_info, current_epoch);
             }
@@ -2123,10 +2104,10 @@ where
             // the crypto processor and backend verifier to this epoch.
             let new_leader_inputs = LeaderInputs {
                 message_quota: settings.session_leadership_quota(),
-                pol_epoch_nonce,
-                pol_ledger_aged,
-                lottery_0,
-                lottery_1,
+                pol_epoch_nonce: epoch_state.nonce,
+                pol_ledger_aged: epoch_state.utxos.root(),
+                lottery_0: epoch_state.lottery_0,
+                lottery_1: epoch_state.lottery_1,
             };
             let new_public_info = PublicInfo {
                 epoch: new_leader_inputs,
@@ -2145,26 +2126,18 @@ where
 
             (current_public_info, current_epoch)
         }
-        EpochEvent::NewEpochAndOldEpochTransitionExpired((
-            LeaderInputsMinusQuota {
-                pol_epoch_nonce,
-                pol_ledger_aged,
-                lottery_0,
-                lottery_1,
-            },
-            new_epoch,
-        )) => {
-            tracing::debug!(target: LOG_TARGET, "New epoch {new_epoch:?} with nonce {pol_epoch_nonce:?} started and old epoch transition period expired.");
+        EpochEvent::NewEpochAndOldEpochTransitionExpired((epoch_state, new_epoch)) => {
+            tracing::debug!(target: LOG_TARGET, "New epoch {new_epoch:?} with nonce {:?} started and old epoch transition period expired.", epoch_state.nonce);
             if new_epoch <= current_epoch {
                 return (current_public_info, current_epoch);
             }
 
             let new_leader_inputs = LeaderInputs {
                 message_quota: settings.session_leadership_quota(),
-                pol_epoch_nonce,
-                pol_ledger_aged,
-                lottery_0,
-                lottery_1,
+                pol_epoch_nonce: epoch_state.nonce,
+                pol_ledger_aged: epoch_state.utxos.root(),
+                lottery_0: epoch_state.lottery_0,
+                lottery_1: epoch_state.lottery_1,
             };
             let new_public_inputs = PublicInfo {
                 epoch: new_leader_inputs,

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -933,7 +933,9 @@ where
                 handle_release_round_for_old_session(processed_messages_to_release, rng, backend, network_adapter, previous_session_number).await;
             }
             Some(clock_tick) = remaining_clock_stream.next() => {
-                (public_info, epoch) = handle_clock_event(clock_tick, blend_config, epoch_handler, &mut crypto_processor, public_info, epoch).await;
+                if let Some(epoch_event) = epoch_handler.tick(clock_tick).await {
+                    (public_info, epoch) = handle_clock_event(epoch_event, blend_config, &mut crypto_processor, public_info, epoch);
+                }
             }
             Some(pol_info) = secret_pol_info_stream.next() => {
                 if let Some(new_leader_inputs) = handle_new_secret_epoch_info(blend_config, &pol_info, &mut crypto_processor, epoch) {
@@ -1047,7 +1049,9 @@ async fn retire<
                 handle_release_round_for_old_session(processed_messages_to_release, &mut rng, &backend, &network_adapter, crypto_processor.session()).await;
             }
             Some(clock_tick) = remaining_clock_stream.next() => {
-                (public_info, epoch) = handle_clock_event(clock_tick, blend_config, &mut epoch_handler, &mut crypto_processor, public_info, epoch).await;
+                if let Some(epoch_event) = epoch_handler.tick(clock_tick).await {
+                    (public_info, epoch) = handle_clock_event(epoch_event, blend_config, &mut crypto_processor, public_info, epoch);
+                }
             }
             Some(SessionEvent::TransitionPeriodExpired) = remaining_session_stream.next() => {
                 handle_session_transition_expired(&mut backend, blending_token_collector, &sdp_relay).await;
@@ -2061,18 +2065,9 @@ where
 /// complete.
 ///
 /// Returns the updated public info and the new tracked epoch.
-async fn handle_clock_event<
-    NodeId,
-    ProofsGenerator,
-    ProofsVerifier,
-    ChainService,
-    BackendSettings,
-    CorePoQGenerator,
-    RuntimeServiceId,
->(
-    slot_tick: SlotTick,
+fn handle_clock_event<NodeId, ProofsGenerator, ProofsVerifier, BackendSettings, CorePoQGenerator>(
+    epoch_event: EpochEvent,
     settings: &RunningBlendConfig<BackendSettings>,
-    epoch_handler: &mut EpochHandler<ChainService, RuntimeServiceId>,
     cryptographic_processor: &mut CoreCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -2086,13 +2081,7 @@ where
     BackendSettings: Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator>,
     ProofsVerifier: ProofsVerifierTrait,
-    ChainService: ChainApi<RuntimeServiceId> + Sync,
-    RuntimeServiceId: Sync,
 {
-    let Some(epoch_event) = epoch_handler.tick(slot_tick).await else {
-        return (current_public_info, current_epoch);
-    };
-
     match epoch_event {
         EpochEvent::NewEpoch((epoch_state, new_epoch)) => {
             tracing::debug!(target: LOG_TARGET, "New epoch {new_epoch:?} with nonce {:?} started", epoch_state.nonce);

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -98,8 +98,7 @@ use crate::{
         state::{RecoveryServiceState, ServiceState, StateUpdater as ServiceStateUpdater},
     },
     epoch_info::{
-        ChainApi, EpochEvent, EpochHandler, PolEpochInfo,
-        PolInfoProvider as PolInfoProviderTrait,
+        ChainApi, EpochEvent, EpochHandler, PolEpochInfo, PolInfoProvider as PolInfoProviderTrait,
     },
     kms::PreloadKmsService,
     membership::{self, MembershipInfo, ZkInfo},
@@ -230,7 +229,7 @@ impl<
     >
 where
     Backend: BlendBackend<NodeId, BlakeRng, RuntimeServiceId> + Send + Sync,
-    NodeId: Clone + Debug + Send + Eq + Hash + Sync + 'static,
+    NodeId: membership::node_id::TryFrom + Clone + Debug + Send + Eq + Hash + Sync + 'static,
     Network: NetworkAdapter<RuntimeServiceId, BroadcastSettings: Eq + Hash + Unpin> + Send + Sync,
     MembershipAdapter: membership::Adapter<NodeId = NodeId, Error: Send + Sync + 'static> + Send,
     membership::ServiceMessage<MembershipAdapter>: Send + Sync + 'static,
@@ -359,17 +358,14 @@ where
                 .expect("Failed to retrieve non-ephemeral signing key from KMS.")
         };
 
-        let membership_stream = MembershipAdapter::new(
-            overwatch_handle
-                .relay::<<MembershipAdapter as membership::Adapter>::Service>()
-                .await
-                .expect("Failed to get relay channel with membership service."),
-            non_ephemeral_signing_key.public_key(),
-            Some(zk_public_key),
-        )
-        .subscribe()
-        .await
-        .expect("Failed to get membership stream from membership service.");
+        let membership_stream =
+            membership::chain::subscribe::<ChainService, NodeId, TimeBackend, RuntimeServiceId>(
+                overwatch_handle,
+                non_ephemeral_signing_key.public_key(),
+                Some(zk_public_key),
+                blend_config.time.epoch_transition_period_in_slots,
+            )
+            .await;
 
         let sdp_relay = overwatch_handle
             .relay::<SdpService>()

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -104,7 +104,6 @@ use crate::{
     membership::{self, MembershipInfo, ZkInfo},
     message::{NetworkMessage, ProcessedMessage, ServiceMessage},
     session::{CoreSessionInfo, CoreSessionPublicInfo, MaybeEmptyCoreSessionInfo},
-    settings::FIRST_STREAM_ITEM_READY_TIMEOUT,
 };
 
 pub mod backends;
@@ -617,7 +616,6 @@ where
     let (current_membership_info, remaining_session_stream) = Box::pin(
         UninitializedSessionEventStream::new(
             session_stream,
-            FIRST_STREAM_ITEM_READY_TIMEOUT,
             blend_config.time.session_transition_period(),
         )
         .await_first_ready(),
@@ -633,7 +631,7 @@ where
 
     let ((epoch_state, current_epoch), remaining_clock_stream) = async {
         let (clock_tick, remaining_clock_stream) =
-            UninitializedFirstReadyStream::new(clock_stream, Duration::from_secs(5))
+            UninitializedFirstReadyStream::new(clock_stream)
                 .first()
                 .await
                 .expect("The clock system must be available.");

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -929,9 +929,7 @@ where
                 handle_release_round_for_old_session(processed_messages_to_release, rng, backend, network_adapter, previous_session_number).await;
             }
             Some(clock_tick) = remaining_clock_stream.next() => {
-                if let Some(epoch_event) = epoch_handler.tick(clock_tick).await {
-                    (public_info, epoch) = handle_clock_event(epoch_event, blend_config, &mut crypto_processor, public_info, epoch);
-                }
+                (public_info, epoch) = handle_clock_event(clock_tick, blend_config, epoch_handler, &mut crypto_processor, public_info, epoch).await;
             }
             Some(pol_info) = secret_pol_info_stream.next() => {
                 if let Some(new_leader_inputs) = handle_new_secret_epoch_info(blend_config, &pol_info, &mut crypto_processor, epoch) {
@@ -1045,9 +1043,7 @@ async fn retire<
                 handle_release_round_for_old_session(processed_messages_to_release, &mut rng, &backend, &network_adapter, crypto_processor.session()).await;
             }
             Some(clock_tick) = remaining_clock_stream.next() => {
-                if let Some(epoch_event) = epoch_handler.tick(clock_tick).await {
-                    (public_info, epoch) = handle_clock_event(epoch_event, blend_config, &mut crypto_processor, public_info, epoch);
-                }
+                (public_info, epoch) = handle_clock_event(clock_tick, blend_config, &mut epoch_handler, &mut crypto_processor, public_info, epoch).await;
             }
             Some(SessionEvent::TransitionPeriodExpired) = remaining_session_stream.next() => {
                 handle_session_transition_expired(&mut backend, blending_token_collector, &sdp_relay).await;
@@ -2061,9 +2057,18 @@ where
 /// complete.
 ///
 /// Returns the updated public info and the new tracked epoch.
-fn handle_clock_event<NodeId, ProofsGenerator, ProofsVerifier, BackendSettings, CorePoQGenerator>(
-    epoch_event: EpochEvent,
+async fn handle_clock_event<
+    NodeId,
+    ProofsGenerator,
+    ProofsVerifier,
+    ChainService,
+    BackendSettings,
+    CorePoQGenerator,
+    RuntimeServiceId,
+>(
+    slot_tick: SlotTick,
     settings: &RunningBlendConfig<BackendSettings>,
+    epoch_handler: &mut EpochHandler<ChainService, RuntimeServiceId>,
     cryptographic_processor: &mut CoreCryptographicProcessor<
         NodeId,
         CorePoQGenerator,
@@ -2077,7 +2082,13 @@ where
     BackendSettings: Sync,
     ProofsGenerator: CoreAndLeaderProofsGenerator<CorePoQGenerator>,
     ProofsVerifier: ProofsVerifierTrait,
+    ChainService: ChainApi<RuntimeServiceId> + Sync,
+    RuntimeServiceId: Sync,
 {
+    let Some(epoch_event) = epoch_handler.tick(slot_tick).await else {
+        return (current_public_info, current_epoch);
+    };
+
     match epoch_event {
         EpochEvent::NewEpoch((epoch_state, new_epoch)) => {
             tracing::debug!(target: LOG_TARGET, "New epoch {new_epoch:?} with nonce {:?} started", epoch_state.nonce);

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -630,11 +630,10 @@ where
     .expect("The current session info must be available.");
 
     let ((epoch_state, current_epoch), remaining_clock_stream) = async {
-        let (clock_tick, remaining_clock_stream) =
-            UninitializedFirstReadyStream::new(clock_stream)
-                .first()
-                .await
-                .expect("The clock system must be available.");
+        let (clock_tick, remaining_clock_stream) = UninitializedFirstReadyStream::new(clock_stream)
+            .first()
+            .await
+            .expect("The clock system must be available.");
         let Some(EpochEvent::NewEpoch(new_epoch_info)) = epoch_handler.tick(clock_tick).await
         else {
             panic!("First poll result of epoch stream should be a `NewEpoch` event.");

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -1439,22 +1439,24 @@ async fn test_handle_clock_event_new_epoch() {
         EpochHandler::new(TestChainService, 1.try_into().unwrap());
 
     // First tick initializes the epoch handler.
-    let (updated_info, updated_epoch) = match epoch_handler
+    let (updated_info, updated_epoch) = epoch_handler
         .tick(SlotTick {
             epoch: 1.into(),
             slot: 1.into(),
         })
         .await
-    {
-        Some(epoch_event) => handle_clock_event(
-            epoch_event,
-            &settings,
-            &mut processor,
-            public_info.clone(),
-            initial_epoch,
-        ),
-        None => (public_info.clone(), initial_epoch),
-    };
+        .map_or_else(
+            || (public_info.clone(), initial_epoch),
+            |epoch_event| {
+                handle_clock_event(
+                    epoch_event,
+                    &settings,
+                    &mut processor,
+                    public_info.clone(),
+                    initial_epoch,
+                )
+            },
+        );
     assert_eq!(
         updated_epoch,
         Epoch::new(1),
@@ -1468,42 +1470,46 @@ async fn test_handle_clock_event_new_epoch() {
     );
 
     // Tick in the same epoch should not change epoch.
-    let (unchanged_info, unchanged_epoch) = match epoch_handler
+    let (unchanged_info, unchanged_epoch) = epoch_handler
         .tick(SlotTick {
             epoch: 1.into(),
             slot: 2.into(),
         })
         .await
-    {
-        Some(epoch_event) => handle_clock_event(
-            epoch_event,
-            &settings,
-            &mut processor,
-            updated_info.clone(),
-            updated_epoch,
-        ),
-        None => (updated_info.clone(), updated_epoch),
-    };
+        .map_or_else(
+            || (updated_info.clone(), updated_epoch),
+            |epoch_event| {
+                handle_clock_event(
+                    epoch_event,
+                    &settings,
+                    &mut processor,
+                    updated_info.clone(),
+                    updated_epoch,
+                )
+            },
+        );
     assert_eq!(unchanged_epoch, Epoch::new(1));
     assert_eq!(unchanged_info.epoch, updated_info.epoch);
 
     // Tick in a new epoch should advance again.
-    let (final_info, final_epoch) = match epoch_handler
+    let (final_info, final_epoch) = epoch_handler
         .tick(SlotTick {
             epoch: 2.into(),
             slot: 3.into(),
         })
         .await
-    {
-        Some(epoch_event) => handle_clock_event(
-            epoch_event,
-            &settings,
-            &mut processor,
-            unchanged_info.clone(),
-            unchanged_epoch,
-        ),
-        None => (unchanged_info.clone(), unchanged_epoch),
-    };
+        .map_or_else(
+            || (unchanged_info.clone(), unchanged_epoch),
+            |epoch_event| {
+                handle_clock_event(
+                    epoch_event,
+                    &settings,
+                    &mut processor,
+                    unchanged_info.clone(),
+                    unchanged_epoch,
+                )
+            },
+        );
     assert_eq!(
         final_epoch,
         Epoch::new(2),

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -1439,18 +1439,22 @@ async fn test_handle_clock_event_new_epoch() {
         EpochHandler::new(TestChainService, 1.try_into().unwrap());
 
     // First tick initializes the epoch handler.
-    let (updated_info, updated_epoch) = handle_clock_event(
-        SlotTick {
+    let (updated_info, updated_epoch) = match epoch_handler
+        .tick(SlotTick {
             epoch: 1.into(),
             slot: 1.into(),
-        },
-        &settings,
-        &mut epoch_handler,
-        &mut processor,
-        public_info.clone(),
-        initial_epoch,
-    )
-    .await;
+        })
+        .await
+    {
+        Some(epoch_event) => handle_clock_event(
+            epoch_event,
+            &settings,
+            &mut processor,
+            public_info.clone(),
+            initial_epoch,
+        ),
+        None => (public_info.clone(), initial_epoch),
+    };
     assert_eq!(
         updated_epoch,
         Epoch::new(1),
@@ -1464,34 +1468,42 @@ async fn test_handle_clock_event_new_epoch() {
     );
 
     // Tick in the same epoch should not change epoch.
-    let (unchanged_info, unchanged_epoch) = handle_clock_event(
-        SlotTick {
+    let (unchanged_info, unchanged_epoch) = match epoch_handler
+        .tick(SlotTick {
             epoch: 1.into(),
             slot: 2.into(),
-        },
-        &settings,
-        &mut epoch_handler,
-        &mut processor,
-        updated_info.clone(),
-        updated_epoch,
-    )
-    .await;
+        })
+        .await
+    {
+        Some(epoch_event) => handle_clock_event(
+            epoch_event,
+            &settings,
+            &mut processor,
+            updated_info.clone(),
+            updated_epoch,
+        ),
+        None => (updated_info.clone(), updated_epoch),
+    };
     assert_eq!(unchanged_epoch, Epoch::new(1));
     assert_eq!(unchanged_info.epoch, updated_info.epoch);
 
     // Tick in a new epoch should advance again.
-    let (final_info, final_epoch) = handle_clock_event(
-        SlotTick {
+    let (final_info, final_epoch) = match epoch_handler
+        .tick(SlotTick {
             epoch: 2.into(),
             slot: 3.into(),
-        },
-        &settings,
-        &mut epoch_handler,
-        &mut processor,
-        unchanged_info.clone(),
-        unchanged_epoch,
-    )
-    .await;
+        })
+        .await
+    {
+        Some(epoch_event) => handle_clock_event(
+            epoch_event,
+            &settings,
+            &mut processor,
+            unchanged_info.clone(),
+            unchanged_epoch,
+        ),
+        None => (unchanged_info.clone(), unchanged_epoch),
+    };
     assert_eq!(
         final_epoch,
         Epoch::new(2),

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -1439,24 +1439,18 @@ async fn test_handle_clock_event_new_epoch() {
         EpochHandler::new(TestChainService, 1.try_into().unwrap());
 
     // First tick initializes the epoch handler.
-    let (updated_info, updated_epoch) = epoch_handler
-        .tick(SlotTick {
+    let (updated_info, updated_epoch) = handle_clock_event(
+        SlotTick {
             epoch: 1.into(),
             slot: 1.into(),
-        })
-        .await
-        .map_or_else(
-            || (public_info.clone(), initial_epoch),
-            |epoch_event| {
-                handle_clock_event(
-                    epoch_event,
-                    &settings,
-                    &mut processor,
-                    public_info.clone(),
-                    initial_epoch,
-                )
-            },
-        );
+        },
+        &settings,
+        &mut epoch_handler,
+        &mut processor,
+        public_info.clone(),
+        initial_epoch,
+    )
+    .await;
     assert_eq!(
         updated_epoch,
         Epoch::new(1),
@@ -1470,46 +1464,34 @@ async fn test_handle_clock_event_new_epoch() {
     );
 
     // Tick in the same epoch should not change epoch.
-    let (unchanged_info, unchanged_epoch) = epoch_handler
-        .tick(SlotTick {
+    let (unchanged_info, unchanged_epoch) = handle_clock_event(
+        SlotTick {
             epoch: 1.into(),
             slot: 2.into(),
-        })
-        .await
-        .map_or_else(
-            || (updated_info.clone(), updated_epoch),
-            |epoch_event| {
-                handle_clock_event(
-                    epoch_event,
-                    &settings,
-                    &mut processor,
-                    updated_info.clone(),
-                    updated_epoch,
-                )
-            },
-        );
+        },
+        &settings,
+        &mut epoch_handler,
+        &mut processor,
+        updated_info.clone(),
+        updated_epoch,
+    )
+    .await;
     assert_eq!(unchanged_epoch, Epoch::new(1));
     assert_eq!(unchanged_info.epoch, updated_info.epoch);
 
     // Tick in a new epoch should advance again.
-    let (final_info, final_epoch) = epoch_handler
-        .tick(SlotTick {
+    let (final_info, final_epoch) = handle_clock_event(
+        SlotTick {
             epoch: 2.into(),
             slot: 3.into(),
-        })
-        .await
-        .map_or_else(
-            || (unchanged_info.clone(), unchanged_epoch),
-            |epoch_event| {
-                handle_clock_event(
-                    epoch_event,
-                    &settings,
-                    &mut processor,
-                    unchanged_info.clone(),
-                    unchanged_epoch,
-                )
-            },
-        );
+        },
+        &settings,
+        &mut epoch_handler,
+        &mut processor,
+        unchanged_info.clone(),
+        unchanged_epoch,
+    )
+    .await;
     assert_eq!(
         final_epoch,
         Epoch::new(2),

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -57,7 +57,6 @@ use crate::{
     kms::PreloadKmsService,
     membership::{self, MembershipInfo, node_id},
     message::{NetworkInfo, NetworkMessage, ServiceMessage},
-    settings::FIRST_STREAM_ITEM_READY_TIMEOUT,
 };
 
 const LOG_TARGET: &str = blend::service::EDGE;
@@ -291,7 +290,6 @@ where
         run::<Backend, _, ProofsGenerator, _, PolInfoProvider, _>(
             UninitializedSessionEventStream::new(
                 session_stream,
-                FIRST_STREAM_ITEM_READY_TIMEOUT,
                 settings.time.session_transition_period(),
             ),
             clock_stream,

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -230,18 +230,15 @@ where
                 .expect("non-ephemeral signing key should decode into a valid node id");
 
         // Initialize membership stream for session and core-related public PoQ inputs.
-        let session_stream = MembershipAdapter::new(
-            overwatch_handle
-                .relay::<<MembershipAdapter as membership::Adapter>::Service>()
-                .await
-                .expect("Failed to get relay channel with membership service."),
-            non_ephemeral_signing_key.public_key(),
-            // No ZK stuff needs to be computed by edge nodes, so no ZK key is specified here.
-            None,
-        )
-        .subscribe()
-        .await
-        .expect("Failed to get membership stream from membership service.");
+        let session_stream =
+            membership::chain::subscribe::<ChainService, NodeId, TimeBackend, RuntimeServiceId>(
+                &overwatch_handle,
+                non_ephemeral_signing_key.public_key(),
+                // No ZK stuff needs to be computed by edge nodes, so no ZK key is specified here.
+                None,
+                settings.time.epoch_transition_period_in_slots,
+            )
+            .await;
 
         // Initialize clock stream for detecting epoch transitions.
         let clock_stream = async {

--- a/services/blend/src/edge/service_components.rs
+++ b/services/blend/src/edge/service_components.rs
@@ -10,6 +10,10 @@ pub trait ServiceComponents {
     type MembershipAdapter;
     type ProofsGenerator;
     type BackendSettings;
+    /// Chain service, used by the proxy to derive membership from the chain.
+    type ChainService;
+    /// Time backend, used by the proxy to subscribe to slot ticks.
+    type TimeBackend;
 }
 
 impl<
@@ -42,4 +46,6 @@ where
     type BroadcastSettings = BroadcastSettings;
     type MembershipAdapter = MembershipAdapter;
     type ProofsGenerator = ProofsGenerator;
+    type ChainService = ChainService;
+    type TimeBackend = TimeBackend;
 }

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     epoch_info::EpochHandler,
     membership::MembershipInfo,
-    settings::{FIRST_STREAM_ITEM_READY_TIMEOUT, TimingSettings},
+    settings::TimingSettings,
     test_utils::{
         crypto::mock_blend_proof,
         epoch::{OncePolStreamProvider, TestChainService},
@@ -95,11 +95,7 @@ pub async fn spawn_run(
             OncePolStreamProvider,
             _,
         >(
-            UninitializedSessionEventStream::new(
-                session_stream,
-                FIRST_STREAM_ITEM_READY_TIMEOUT,
-                Duration::ZERO,
-            ),
+            UninitializedSessionEventStream::new(session_stream, Duration::ZERO),
             once(ready(SlotTick {
                 epoch: 1.into(),
                 slot: 1.into(),

--- a/services/blend/src/epoch_info.rs
+++ b/services/blend/src/epoch_info.rs
@@ -382,10 +382,7 @@ mod tests {
         );
         assert_eq!(
             next_tick,
-            Some(EpochEvent::NewEpoch((
-                default_epoch_state(),
-                1.into()
-            )))
+            Some(EpochEvent::NewEpoch((default_epoch_state(), 1.into())))
         );
         assert_eq!(
             stream.epoch_tracking_state,
@@ -429,10 +426,7 @@ mod tests {
         );
         assert_eq!(
             next_tick,
-            Some(EpochEvent::NewEpoch((
-                default_epoch_state(),
-                2.into()
-            )))
+            Some(EpochEvent::NewEpoch((default_epoch_state(), 2.into())))
         );
         assert_eq!(
             stream.epoch_tracking_state,
@@ -476,10 +470,7 @@ mod tests {
         let next_tick = stream.tick(ticks_iter.next().unwrap()).await;
         assert_eq!(
             next_tick,
-            Some(EpochEvent::NewEpoch((
-                default_epoch_state(),
-                1.into()
-            )))
+            Some(EpochEvent::NewEpoch((default_epoch_state(), 1.into())))
         );
         assert_eq!(
             stream.epoch_tracking_state,
@@ -581,10 +572,7 @@ mod tests {
         let next_tick = stream.tick(ticks_iter.next().unwrap()).await;
         assert_eq!(
             next_tick,
-            Some(EpochEvent::NewEpoch((
-                default_epoch_state(),
-                1.into()
-            )))
+            Some(EpochEvent::NewEpoch((default_epoch_state(), 1.into())))
         );
         assert_eq!(
             stream.epoch_tracking_state,
@@ -607,10 +595,7 @@ mod tests {
         let next_tick = stream.tick(ticks_iter.next().unwrap()).await;
         assert_eq!(
             next_tick,
-            Some(EpochEvent::NewEpoch((
-                default_epoch_state(),
-                2.into()
-            )))
+            Some(EpochEvent::NewEpoch((default_epoch_state(), 2.into())))
         );
         assert_eq!(
             stream.epoch_tracking_state,
@@ -636,10 +621,7 @@ mod tests {
         let next_tick = stream.tick(ticks_iter.next().unwrap()).await;
         assert_eq!(
             next_tick,
-            Some(EpochEvent::NewEpoch((
-                default_epoch_state(),
-                3.into()
-            )))
+            Some(EpochEvent::NewEpoch((default_epoch_state(), 3.into())))
         );
         assert_eq!(
             stream.epoch_tracking_state,

--- a/services/blend/src/epoch_info.rs
+++ b/services/blend/src/epoch_info.rs
@@ -9,9 +9,8 @@ use async_trait::async_trait;
 use futures::Stream;
 use lb_blend::proofs::quota::inputs::prove::private::ProofOfLeadershipQuotaInputs;
 use lb_chain_service::api::{CryptarchiaServiceApi, CryptarchiaServiceData};
-use lb_core::{crypto::ZkHash, proofs::leader_proof::LeaderPublic};
+use lb_core::proofs::leader_proof::LeaderPublic;
 use lb_cryptarchia_engine::{Epoch, Slot};
-use lb_groth16::Fr;
 use lb_ledger::EpochState;
 use lb_log_targets::blend;
 use lb_time_service::SlotTick;
@@ -78,40 +77,16 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(test, derive(Default))]
-pub struct LeaderInputsMinusQuota {
-    pub pol_ledger_aged: ZkHash,
-    pub pol_epoch_nonce: ZkHash,
-    pub lottery_0: Fr,
-    pub lottery_1: Fr,
-}
-
-impl From<EpochState> for LeaderInputsMinusQuota {
-    fn from(
-        EpochState {
-            nonce,
-            utxos,
-            lottery_0,
-            lottery_1,
-            ..
-        }: EpochState,
-    ) -> Self {
-        Self {
-            pol_epoch_nonce: nonce,
-            pol_ledger_aged: utxos.root(),
-            lottery_0,
-            lottery_1,
-        }
-    }
-}
-
 /// Event related to a given epoch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Carries the full [`EpochState`] so consumers derive whatever they need
+/// (leader inputs, membership) from the one package — keeping every per-epoch
+/// value on the same clock and avoiding cross-stream timing drift.
+#[derive(Debug, Clone, PartialEq)]
 pub enum EpochEvent {
     /// A new epoch is available, which is either ongoing (if the handler is
     /// started mid-epoch) or has just started.
-    NewEpoch((LeaderInputsMinusQuota, Epoch)),
+    NewEpoch((EpochState, Epoch)),
     /// The information about the previous epoch the handler was tracking can
     /// now be discarded since its transition period has elapsed.
     OldEpochTransitionPeriodExpired,
@@ -130,7 +105,7 @@ pub enum EpochEvent {
     /// the epoch that can now be discarded, while `rotate_epoch`
     /// would move from the previous epoch to the new one that is notified about
     /// in this event.
-    NewEpochAndOldEpochTransitionExpired((LeaderInputsMinusQuota, Epoch)),
+    NewEpochAndOldEpochTransitionExpired((EpochState, Epoch)),
 }
 
 /// A slot tick whose values against the previous tick have been validated.
@@ -328,9 +303,9 @@ where
         let epoch_event = if should_notify_about_two_epochs_back
             || self.check_and_consume_past_epoch_transition_period(validated_slot_tick)
         {
-            EpochEvent::NewEpochAndOldEpochTransitionExpired((epoch_state.into(), new_tick.epoch))
+            EpochEvent::NewEpochAndOldEpochTransitionExpired((epoch_state, new_tick.epoch))
         } else {
-            EpochEvent::NewEpoch((epoch_state.into(), new_tick.epoch))
+            EpochEvent::NewEpoch((epoch_state, new_tick.epoch))
         };
 
         Some(epoch_event)
@@ -365,7 +340,7 @@ mod tests {
     use test_log::test;
 
     use crate::{
-        epoch_info::{EpochEvent, EpochHandler, EpochTrackingState, LeaderInputsMinusQuota},
+        epoch_info::{EpochEvent, EpochHandler, EpochTrackingState},
         test_utils::epoch::{TestChainService, default_epoch_state},
     };
 
@@ -408,7 +383,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpoch((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 1.into()
             )))
         );
@@ -455,7 +430,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpoch((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 2.into()
             )))
         );
@@ -502,7 +477,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpoch((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 1.into()
             )))
         );
@@ -528,7 +503,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpochAndOldEpochTransitionExpired((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 2.into()
             )))
         );
@@ -545,7 +520,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpochAndOldEpochTransitionExpired((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 3.into()
             )))
         );
@@ -607,7 +582,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpoch((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 1.into()
             )))
         );
@@ -633,7 +608,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpoch((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 2.into()
             )))
         );
@@ -662,7 +637,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpoch((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 3.into()
             )))
         );
@@ -680,7 +655,7 @@ mod tests {
         assert_eq!(
             next_tick,
             Some(EpochEvent::NewEpochAndOldEpochTransitionExpired((
-                LeaderInputsMinusQuota::from(default_epoch_state()),
+                default_epoch_state(),
                 4.into()
             )))
         );

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -9,10 +9,12 @@ use async_trait::async_trait;
 use futures::StreamExt as _;
 pub use lb_blend::message::{crypto::proofs::RealProofsVerifier, encap::ProofsVerifier};
 use lb_blend::scheduling::session::UninitializedSessionEventStream;
+use lb_chain_service::api::CryptarchiaServiceData;
 use lb_key_management_system_service::{api::KmsServiceApi, keys::PublicKeyEncoding};
 use lb_log_targets::blend;
 use lb_network_service::NetworkService;
 use lb_services_utils::wait_until_services_are_ready;
+use lb_time_service::TimeService;
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
     services::{
@@ -34,7 +36,7 @@ use crate::{
     instance::{Instance, Mode},
     kms::PreloadKmsService,
     membership::{
-        Adapter as _, MembershipInfo,
+        MembershipInfo,
         node_id::{self, TryFrom as _},
     },
     settings::{FIRST_STREAM_ITEM_READY_TIMEOUT, Settings},
@@ -108,8 +110,11 @@ where
     EdgeService: ServiceData<Message = CoreService::Message>
         // We tie the core and edge proofs generator to be the same type, to avoid mistakes in the
         // node configuration where the two services use different verification logic
-        + EdgeServiceComponents<BackendSettings: Clone + Send + Sync>
-        + Send
+        + EdgeServiceComponents<
+            BackendSettings: Clone + Send + Sync,
+            ChainService: CryptarchiaServiceData<Tx: Send + Sync>,
+            TimeBackend: lb_time_service::backends::TimeBackend + Send,
+        > + Send
         + 'static,
     EdgeService::MembershipAdapter:
         membership::Adapter<NodeId = CoreService::NodeId, Error: Send + Sync + 'static> + Send,
@@ -118,7 +123,10 @@ where
         + AsServiceId<CoreService>
         + AsServiceId<EdgeService>
         + AsServiceId<MembershipService<EdgeService>>
-        + AsServiceId<PreloadKmsService<RuntimeServiceId>>
+        + AsServiceId<<EdgeService as EdgeServiceComponents>::ChainService>
+        + AsServiceId<
+            TimeService<<EdgeService as EdgeServiceComponents>::TimeBackend, RuntimeServiceId>,
+        > + AsServiceId<PreloadKmsService<RuntimeServiceId>>
         + AsServiceId<
             NetworkService<
                 NetworkBackendOfService<CoreService, RuntimeServiceId>,
@@ -129,6 +137,7 @@ where
         + Clone
         + Send
         + Sync
+        + Unpin
         + 'static,
 {
     fn init(
@@ -180,17 +189,20 @@ where
             CoreService::NodeId::try_from_provider_id(non_ephemeral_signing_key_public.as_bytes())
                 .expect("non-ephemeral signing public key should decode into a valid node id");
 
-        let membership_stream = <MembershipAdapter<EdgeService> as membership::Adapter>::new(
-            overwatch_handle
-                .relay::<MembershipService<EdgeService>>()
-                .await?,
+        let membership_stream = membership::chain::subscribe::<
+            <EdgeService as EdgeServiceComponents>::ChainService,
+            CoreService::NodeId,
+            <EdgeService as EdgeServiceComponents>::TimeBackend,
+            RuntimeServiceId,
+        >(
+            overwatch_handle,
             non_ephemeral_signing_key_public,
             // We don't need to generate secret zk info in the proxy service, so we ignore the
             // secret key at this level.
             None,
+            settings.common.time.epoch_transition_period_in_slots,
         )
-        .subscribe()
-        .await?;
+        .await;
 
         let (MembershipInfo { membership, .. }, mut remaining_session_stream) =
             UninitializedSessionEventStream::new(

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -39,7 +39,7 @@ use crate::{
         MembershipInfo,
         node_id::{self, TryFrom as _},
     },
-    settings::{FIRST_STREAM_ITEM_READY_TIMEOUT, Settings},
+    settings::Settings,
 };
 
 pub mod core;
@@ -207,7 +207,6 @@ where
         let (MembershipInfo { membership, .. }, mut remaining_session_stream) =
             UninitializedSessionEventStream::new(
                 membership_stream,
-                FIRST_STREAM_ITEM_READY_TIMEOUT,
                 settings.common.time.session_transition_period(),
             )
             .await_first_ready()

--- a/services/blend/src/membership/chain.rs
+++ b/services/blend/src/membership/chain.rs
@@ -1,11 +1,11 @@
 //! Chain-derived membership.
 //!
 //! The membership for each epoch is read from the SDP snapshot frozen into that
-//! epoch's [`EpochState`](lb_ledger::EpochState), queried from the chain on slot
-//! ticks. This puts membership on the **same slot-tick clock** as the leader
-//! inputs (the [`EpochHandler`] PoL path), so both halves share the chain's
-//! per-epoch view and cannot drift — replacing the pushed `ActiveProviders`
-//! broadcast.
+//! epoch's [`EpochState`](lb_ledger::EpochState), queried from the chain on
+//! slot ticks. This puts membership on the **same slot-tick clock** as the
+//! leader inputs (the [`EpochHandler`] `PoL` path), so both halves share the
+//! chain's per-epoch view and cannot drift — replacing the pushed
+//! `ActiveProviders` broadcast.
 
 use core::{hash::Hash, num::NonZeroU64, pin::Pin};
 use std::fmt::{Debug, Display};
@@ -30,7 +30,8 @@ use crate::{
 pub type ChainMembershipStream<NodeId> =
     Pin<Box<dyn Stream<Item = MembershipInfo<NodeId>> + Send + 'static>>;
 
-/// Subscribe to a chain-derived stream of [`MembershipInfo`](super::MembershipInfo).
+/// Subscribe to a chain-derived stream of
+/// [`MembershipInfo`](super::MembershipInfo).
 ///
 /// On every slot tick the chain is queried for the current epoch's
 /// `EpochState`; on each new epoch the membership frozen into its SDP snapshot

--- a/services/blend/src/membership/chain.rs
+++ b/services/blend/src/membership/chain.rs
@@ -1,0 +1,105 @@
+//! Chain-derived membership.
+//!
+//! The membership for each epoch is read from the SDP snapshot frozen into that
+//! epoch's [`EpochState`](lb_ledger::EpochState), queried from the chain on slot
+//! ticks. This puts membership on the **same slot-tick clock** as the leader
+//! inputs (the [`EpochHandler`] PoL path), so both halves share the chain's
+//! per-epoch view and cannot drift — replacing the pushed `ActiveProviders`
+//! broadcast.
+
+use core::{hash::Hash, num::NonZeroU64, pin::Pin};
+use std::fmt::{Debug, Display};
+
+use futures::{Stream, StreamExt as _};
+use lb_chain_service::api::{CryptarchiaServiceApi, CryptarchiaServiceData};
+use lb_key_management_system_service::keys::{Ed25519PublicKey, ZkPublicKey};
+use lb_time_service::{TimeService, TimeServiceMessage, backends::TimeBackend};
+use overwatch::{overwatch::OverwatchHandle, services::AsServiceId};
+use tokio::sync::oneshot;
+
+use crate::{
+    epoch_info::{EpochEvent, EpochHandler},
+    membership::{MembershipInfo, node_id, service::membership_info_from_epoch_state},
+};
+
+/// A chain-derived membership stream.
+///
+/// Unlike [`MembershipStream`](super::MembershipStream) this is not `Sync`,
+/// since producing each item awaits a chain query; consumers only require
+/// `Send + Unpin`.
+pub type ChainMembershipStream<NodeId> =
+    Pin<Box<dyn Stream<Item = MembershipInfo<NodeId>> + Send + 'static>>;
+
+/// Subscribe to a chain-derived stream of [`MembershipInfo`](super::MembershipInfo).
+///
+/// On every slot tick the chain is queried for the current epoch's
+/// `EpochState`; on each new epoch the membership frozen into its SDP snapshot
+/// is yielded. The same `EpochHandler`/`get_epoch_state` mechanism is used by
+/// the leader-input path, so the two are on one clock.
+pub async fn subscribe<ChainService, NodeId, TimeRuntimeBackend, RuntimeServiceId>(
+    overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
+    signing_public_key: Ed25519PublicKey,
+    zk_public_key: Option<ZkPublicKey>,
+    epoch_transition_period_in_slots: NonZeroU64,
+) -> ChainMembershipStream<NodeId>
+where
+    ChainService: CryptarchiaServiceData<Tx: Send + Sync>,
+    NodeId: node_id::TryFrom + Clone + Hash + Eq + Send + Sync + 'static,
+    TimeRuntimeBackend: TimeBackend + Send,
+    RuntimeServiceId: AsServiceId<ChainService>
+        + AsServiceId<TimeService<TimeRuntimeBackend, RuntimeServiceId>>
+        + Clone
+        + Debug
+        + Display
+        + Sync
+        + Send
+        + Unpin
+        + 'static,
+{
+    let chain_service = CryptarchiaServiceApi::<ChainService, RuntimeServiceId>::new(
+        overwatch_handle
+            .relay::<ChainService>()
+            .await
+            .expect("Relay with chain service should be available."),
+    );
+    let epoch_handler = EpochHandler::new(chain_service, epoch_transition_period_in_slots);
+
+    let slot_ticks = {
+        let time_relay = overwatch_handle
+            .relay::<TimeService<_, _>>()
+            .await
+            .expect("Relay with time service should be available.");
+        let (sender, receiver) = oneshot::channel();
+        time_relay
+            .send(TimeServiceMessage::Subscribe { sender })
+            .await
+            .expect("Failed to subscribe to slot clock.");
+        receiver
+            .await
+            .expect("Should not fail to receive slot stream from time service.")
+    };
+
+    Box::pin(futures::stream::unfold(
+        (slot_ticks, epoch_handler, signing_public_key, zk_public_key),
+        async move |(mut slot_ticks, mut epoch_handler, signing_public_key, zk_public_key)| {
+            loop {
+                let tick = slot_ticks.next().await?;
+                if let Some(
+                    EpochEvent::NewEpoch((epoch_state, _))
+                    | EpochEvent::NewEpochAndOldEpochTransitionExpired((epoch_state, _)),
+                ) = epoch_handler.tick(tick).await
+                {
+                    let info = membership_info_from_epoch_state::<NodeId>(
+                        &epoch_state,
+                        &signing_public_key,
+                        zk_public_key,
+                    );
+                    return Some((
+                        info,
+                        (slot_ticks, epoch_handler, signing_public_key, zk_public_key),
+                    ));
+                }
+            }
+        },
+    ))
+}

--- a/services/blend/src/membership/mod.rs
+++ b/services/blend/src/membership/mod.rs
@@ -1,3 +1,4 @@
+pub mod chain;
 pub mod node_id;
 pub mod service;
 

--- a/services/blend/src/membership/service.rs
+++ b/services/blend/src/membership/service.rs
@@ -131,9 +131,11 @@ where
 }
 
 /// Build [`MembershipInfo`] from the SDP membership snapshot frozen into
-/// `epoch_state` (queried from the chain). This is the chain-derived
-/// replacement for the pushed [`ActiveProviders`] broadcast: the membership for
-/// the epoch is read from `EpochState.sdp` instead of a broadcast stream.
+/// `epoch_state`.
+///
+/// This is the chain-derived replacement for the pushed [`ActiveProviders`]
+/// broadcast: the membership for the epoch is read from `EpochState.sdp`
+/// instead of a broadcast stream.
 ///
 /// Note: this intentionally duplicates the node/Merkle construction in
 /// `Adapter::subscribe` rather than sharing it, because the broadcast
@@ -165,9 +167,10 @@ where
     let zk_info = if nodes.is_empty() {
         None
     } else {
-        let zk_tree =
-            sort_nodes_and_build_merkle_tree(&mut nodes, |ZkNode { zk_key, .. }| zk_key.into_inner())
-                .expect("Should not fail to build Merkle tree of core nodes' zk public keys.");
+        let zk_tree = sort_nodes_and_build_merkle_tree(&mut nodes, |ZkNode { zk_key, .. }| {
+            zk_key.into_inner()
+        })
+        .expect("Should not fail to build Merkle tree of core nodes' zk public keys.");
         let core_and_path_selectors = maybe_zk_public_key.and_then(|zk_public_key| {
             let Some(proof) = zk_tree.get_proof_for_key(zk_public_key.as_fr()) else {
                 debug!(

--- a/services/blend/src/membership/service.rs
+++ b/services/blend/src/membership/service.rs
@@ -6,8 +6,9 @@ use lb_blend::{
     scheduling::membership::{Membership, Node},
 };
 use lb_chain_broadcast_service::{ActiveProviders, ActiveProvidersSubscription, BlockBroadcastMsg};
-use lb_core::sdp::{ProviderId, ProviderInfo};
+use lb_core::sdp::{ProviderId, ProviderInfo, ServiceType};
 use lb_key_management_system_service::keys::{Ed25519PublicKey, ZkPublicKey};
+use lb_ledger::EpochState;
 use overwatch::{
     DynError,
     services::{ServiceData, relay::OutboundRelay},
@@ -126,6 +127,71 @@ where
                     }
                 }),
         ))
+    }
+}
+
+/// Build [`MembershipInfo`] from the SDP membership snapshot frozen into
+/// `epoch_state` (queried from the chain). This is the chain-derived
+/// replacement for the pushed [`ActiveProviders`] broadcast: the membership for
+/// the epoch is read from `EpochState.sdp` instead of a broadcast stream.
+///
+/// Note: this intentionally duplicates the node/Merkle construction in
+/// `Adapter::subscribe` rather than sharing it, because the broadcast
+/// `subscribe` path is slated for removal once this becomes the membership
+/// source; sharing logic with code about to be deleted is not worth the churn.
+#[must_use]
+pub fn membership_info_from_epoch_state<NodeId>(
+    epoch_state: &EpochState,
+    signing_public_key: &Ed25519PublicKey,
+    maybe_zk_public_key: Option<ZkPublicKey>,
+) -> MembershipInfo<NodeId>
+where
+    NodeId: node_id::TryFrom + Clone + Hash + Eq,
+{
+    let declarations = epoch_state.sdp.declarations();
+    let mut nodes: Vec<ZkNode<NodeId>> = declarations
+        .iter()
+        .filter(|(service_type, _)| matches!(service_type, ServiceType::BlendNetwork))
+        .flat_map(|(_, declarations)| declarations.values())
+        .filter_map(|declaration| {
+            let provider_info = ProviderInfo {
+                locators: declaration.locators.clone(),
+                zk_id: declaration.zk_id,
+            };
+            node_from_provider::<NodeId>(&declaration.provider_id, &provider_info)
+        })
+        .collect();
+
+    let zk_info = if nodes.is_empty() {
+        None
+    } else {
+        let zk_tree =
+            sort_nodes_and_build_merkle_tree(&mut nodes, |ZkNode { zk_key, .. }| zk_key.into_inner())
+                .expect("Should not fail to build Merkle tree of core nodes' zk public keys.");
+        let core_and_path_selectors = maybe_zk_public_key.and_then(|zk_public_key| {
+            let Some(proof) = zk_tree.get_proof_for_key(zk_public_key.as_fr()) else {
+                debug!(
+                    "Local node's ZK public key not found in membership Merkle tree: node is not a core member."
+                );
+                return None;
+            };
+            Some(proof)
+        });
+        Some(ZkInfo {
+            core_and_path_selectors,
+            root: zk_tree.root(),
+        })
+    };
+    let membership_nodes = nodes
+        .into_iter()
+        .map(|ZkNode { node, .. }| node)
+        .collect::<Vec<_>>();
+    let membership = Membership::new(&membership_nodes, signing_public_key);
+    MembershipInfo {
+        membership,
+        zk: zk_info,
+        // TODO: change `session_number` to `epoch`
+        session_number: epoch_state.epoch().into_inner().into(),
     }
 }
 

--- a/services/blend/src/settings/mod.rs
+++ b/services/blend/src/settings/mod.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -15,8 +13,6 @@ mod edge;
 pub use self::edge::EdgeSettings;
 mod timing;
 pub use self::timing::TimingSettings;
-
-pub(crate) const FIRST_STREAM_ITEM_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Settings<CoreBackendSettings, EdgeBackendSettings> {

--- a/services/blend/src/test_utils/epoch.rs
+++ b/services/blend/src/test_utils/epoch.rs
@@ -19,6 +19,7 @@ pub fn default_epoch_state() -> EpochState {
         utxos: UtxoTree::new(),
         lottery_0: Fr::ZERO,
         lottery_1: Fr::ZERO,
+        sdp: lb_ledger::mantle::sdp::SdpLedger::new(1.into()),
     }
 }
 

--- a/services/chain/chain-leader/src/leadership.rs
+++ b/services/chain/chain-leader/src/leadership.rs
@@ -425,6 +425,7 @@ mod pol_tests {
             total_stake,
             lottery_0,
             lottery_1,
+            sdp: lb_ledger::mantle::sdp::SdpLedger::new(1.into()),
         };
 
         // Create notifier channel (not used in this test)


### PR DESCRIPTION
## 1. What does this PR implement?

Previously we would get our epoch info from two different sources:
1. SDP membership information was pushed by chain-service through chain-broadcast-service to Blend when a block finalizes
2. PoL information was pulled from blend on epoch tick boundaries from chain-services `get_epoch_state()` api.

These two sources of information happen on their own timeline will (and has) lead to cases where these two bits of information are out of sync (POL may update but SDP membership still has not been pushed to blend)

This change moves the SDP snapshot into the EpochState struct so that we fetch everything together at once.

## 2. Does the code have enough context to be clearly understood?

To minimize the diff, I have not removed the old code-path where ActiveProviders is pushed from chain-service -> broadcast-service -> blend. We can do this cleanup in a follow up PR.

But, critically, all active code paths in blend are now using the SDP state from EpochState. and hence guaranteed to be consistent.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @youngjoon-lee @madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

> [!IMPORTANT]
> * Contact the specification author(s) and engage in the necessary conversation to agree on the proposed  
    modification/solutions.
> * Ensure the new changes are on par with the implementation at the end of the process.
> * The PR should not be merged until parity between implementation and specifications has been reached.

## Checklist


* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
