### PR TITLE
test: add unit tests for BoundedVec and NomBoundedVec

### DIFF
--- a/core/src/mantle/nom/array.rs
+++ b/core/src/mantle/nom/array.rs
@@ -1,0 +1,41 @@
+use nom::{IResult, Parser as _, multi::count};
+
+use crate::mantle::nom::{NomDecode, NomEncode, encode_slice};
+
+pub struct NomArray<'a, T, const N: usize>(&'a [T::Output; N])
+where
+    T: NomDecode;
+
+impl<'a, T, const N: usize> From<&'a [T::Output; N]> for NomArray<'a, T, N>
+where
+    T: NomDecode,
+{
+    fn from(array: &'a [T::Output; N]) -> Self {
+        Self(array)
+    }
+}
+
+impl<T, const N: usize> NomEncode for NomArray<'_, T, N>
+where
+    T: NomDecode<Output: NomEncode>,
+{
+    fn encode(&self) -> Vec<u8> {
+        encode_slice(self.0.as_slice())
+    }
+}
+
+impl<T, const N: usize> NomDecode for NomArray<'_, T, N>
+where
+    T: NomDecode,
+{
+    type Output = [T::Output; N];
+
+    fn decode(input: &[u8]) -> IResult<&[u8], Self::Output> {
+        let (input, items) = count(T::decode, N).parse(input)?;
+
+        let Ok(items) = items.try_into() else {
+            panic!("Decoded `N` elements.");
+        };
+        Ok((input, items))
+    }
+}

--- a/core/src/mantle/nom/bounded_vec.rs
+++ b/core/src/mantle/nom/bounded_vec.rs
@@ -1,0 +1,256 @@
+use lb_utils::bounded_vec::BoundedVec;
+use nom::{
+    IResult, Parser as _,
+    bytes::complete::take,
+    error::{Error, ErrorKind},
+    multi::count,
+};
+
+use crate::mantle::nom::{NomDecode, NomEncode, encode_slice};
+
+/// Nom encoder for bounded vectors with a specified number of bytes for the
+/// length prefix.
+pub struct NomBoundedVec<'a, T, const MIN: usize, const MAX: usize, const N_BYTES: usize>(
+    &'a BoundedVec<T::Output, MIN, MAX>,
+)
+where
+    T: NomDecode;
+
+impl<T, const MIN: usize, const MAX: usize, const N_BYTES: usize>
+    NomBoundedVec<'_, T, MIN, MAX, N_BYTES>
+where
+    T: NomDecode,
+{
+    const _N_BYTES_VALUE_CHECK: () = {
+        assert!(
+            matches!(N_BYTES, 1 | 2 | 4 | 8),
+            "N_BYTES must be 1, 2, 4, or 8",
+        );
+        let max_repr: u64 = if N_BYTES == 8 {
+            u64::MAX
+        } else {
+            (1u64 << (N_BYTES * 8)) - 1
+        };
+        assert!(
+            MAX as u64 <= max_repr,
+            "MAX exceeds what N_BYTES can encode"
+        );
+    };
+}
+
+impl<'a, T, const MIN: usize, const MAX: usize, const N_BYTES: usize>
+    From<&'a BoundedVec<T::Output, MIN, MAX>> for NomBoundedVec<'a, T, MIN, MAX, N_BYTES>
+where
+    T: NomDecode,
+{
+    fn from(vec: &'a BoundedVec<T::Output, MIN, MAX>) -> Self {
+        let () = Self::_N_BYTES_VALUE_CHECK;
+
+        Self(vec)
+    }
+}
+
+impl<T, const MIN: usize, const MAX: usize, const N_BYTES: usize> NomEncode
+    for NomBoundedVec<'_, T, MIN, MAX, N_BYTES>
+where
+    T: NomDecode<Output: NomEncode>,
+{
+    fn encode(&self) -> Vec<u8> {
+        let () = Self::_N_BYTES_VALUE_CHECK;
+
+        // Initialize `bytes` with the encoded length prefix.
+        let mut bytes = (self.0.len() as u64).to_le_bytes()[..N_BYTES].to_vec();
+        bytes.extend(encode_slice(self.0.as_slice()));
+
+        bytes
+    }
+}
+
+impl<T, const MIN: usize, const MAX: usize, const N_BYTES: usize> NomDecode
+    for NomBoundedVec<'_, T, MIN, MAX, N_BYTES>
+where
+    T: NomDecode,
+{
+    type Output = BoundedVec<T::Output, MIN, MAX>;
+
+    fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
+        let () = Self::_N_BYTES_VALUE_CHECK;
+
+        let (bytes, len_bytes): (&[u8], &[u8]) = take(N_BYTES).parse(bytes)?;
+        let mut buf = [0u8; 8];
+        buf[..N_BYTES].copy_from_slice(len_bytes);
+        let len = u64::from_le_bytes(buf) as usize;
+
+        // We check length first instead of relying on `BoundedVec::try_from` to avoid
+        // decoding a payload that is too large.
+        if len < MIN {
+            return Err(nom::Err::Error(Error::new(bytes, ErrorKind::LengthValue)));
+        }
+        if len > MAX {
+            return Err(nom::Err::Error(Error::new(bytes, ErrorKind::TooLarge)));
+        }
+
+        let (bytes, items) = count(T::decode, len).parse(bytes)?;
+        Ok((bytes, BoundedVec::new_unchecked(items)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_utils::bounded_vec::BoundedVec;
+    use nom::error::ErrorKind;
+
+    use crate::mantle::nom::{NomBoundedVec, NomDecode as _, NomEncode as _};
+
+    /// Bound used across the tests: between 2 and 4 elements.
+    const MIN: usize = 2;
+    const MAX: usize = 4;
+
+    /// `NomBoundedVec` of `u8` items with a single-byte length prefix.
+    type Bounded = BoundedVec<u8, MIN, MAX>;
+    type Codec = NomBoundedVec<'static, u8, { Bounded::MIN }, { Bounded::MAX }, 1>;
+
+    /// Builds a `BoundedVec` for encoding tests, bypassing the length checks so
+    /// the codec itself remains the thing under test.
+    fn bounded(items: &[u8]) -> Bounded {
+        BoundedVec::new_unchecked(items.to_vec())
+    }
+
+    /// Encodes a borrowed `BoundedVec` through `NomBoundedVec` with the given
+    /// length-prefix width.
+    fn encode<const N_BYTES: usize>(items: &[u8]) -> Vec<u8> {
+        let bv = bounded(items);
+        let codec: NomBoundedVec<'_, u8, MIN, MAX, N_BYTES> = (&bv).into();
+        codec.encode()
+    }
+
+    /// Extracts the [`ErrorKind`] from a nom decode error.
+    fn error_kind(err: nom::Err<nom::error::Error<&[u8]>>) -> ErrorKind {
+        match err {
+            nom::Err::Error(e) | nom::Err::Failure(e) => e.code,
+            nom::Err::Incomplete(_) => panic!("unexpected incomplete error"),
+        }
+    }
+
+    #[test]
+    fn encode_prepends_a_single_byte_length_prefix() {
+        assert_eq!(encode::<1>(&[1, 2, 3]), vec![3, 1, 2, 3]);
+    }
+
+    #[test]
+    fn encode_prefix_width_follows_n_bytes() {
+        // The length prefix is `N_BYTES` little-endian bytes wide.
+        assert_eq!(encode::<2>(&[1, 2, 3]), vec![3, 0, 1, 2, 3]);
+        assert_eq!(encode::<4>(&[1, 2, 3]), vec![3, 0, 0, 0, 1, 2, 3]);
+        assert_eq!(
+            encode::<8>(&[1, 2, 3]),
+            vec![3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn encode_at_the_min_and_max_lengths() {
+        assert_eq!(encode::<1>(&[1, 2]), vec![2, 1, 2]);
+        assert_eq!(encode::<1>(&[1, 2, 3, 4]), vec![4, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn decode_reads_a_well_formed_payload() {
+        let (rest, bv) = Codec::decode(&[3, 1, 2, 3]).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(bv.as_slice(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn decode_leaves_trailing_bytes_untouched() {
+        // Only the prefix and `len` items are consumed; the rest is returned.
+        let (rest, bv) = Codec::decode(&[2, 1, 2, 99, 100]).unwrap();
+        assert_eq!(rest, &[99, 100]);
+        assert_eq!(bv.as_slice(), &[1, 2]);
+    }
+
+    #[test]
+    fn decode_at_the_min_and_max_lengths() {
+        let (_, at_min) = Codec::decode(&[2, 1, 2]).unwrap();
+        assert_eq!(at_min.as_slice(), &[1, 2]);
+
+        let (_, at_max) = Codec::decode(&[4, 1, 2, 3, 4]).unwrap();
+        assert_eq!(at_max.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn decode_rejects_a_length_below_min() {
+        // `len == 1 < MIN`: rejected before any payload is consumed.
+        let err = Codec::decode(&[1, 7]).unwrap_err();
+        assert_eq!(error_kind(err), ErrorKind::LengthValue);
+    }
+
+    #[test]
+    fn decode_rejects_a_zero_length() {
+        let err = Codec::decode(&[0]).unwrap_err();
+        assert_eq!(error_kind(err), ErrorKind::LengthValue);
+    }
+
+    #[test]
+    fn decode_rejects_a_length_above_max() {
+        // `len == 5 > MAX`: rejected up front, so the oversized payload that
+        // would follow is never decoded.
+        let err = Codec::decode(&[5, 1, 2, 3, 4, 5]).unwrap_err();
+        assert_eq!(error_kind(err), ErrorKind::TooLarge);
+    }
+
+    #[test]
+    fn decode_rejects_an_oversized_length_even_without_a_payload() {
+        // The length check happens before items are read, so a bogus prefix
+        // alone is enough to fail.
+        let err = Codec::decode(&[5]).unwrap_err();
+        assert_eq!(error_kind(err), ErrorKind::TooLarge);
+    }
+
+    #[test]
+    fn decode_fails_on_an_empty_input() {
+        // Not even the length prefix can be read.
+        assert!(Codec::decode(&[]).is_err());
+    }
+
+    #[test]
+    fn decode_fails_when_the_length_prefix_is_truncated() {
+        // A 4-byte prefix is expected but only 2 bytes are available.
+        type WideCodec = NomBoundedVec<'static, u8, MIN, MAX, 4>;
+        assert!(WideCodec::decode(&[0, 0]).is_err());
+    }
+
+    #[test]
+    fn decode_fails_when_the_payload_is_truncated() {
+        // The prefix promises 3 items but only 1 byte follows.
+        let err = Codec::decode(&[3, 1]).unwrap_err();
+        assert!(matches!(err, nom::Err::Error(_) | nom::Err::Failure(_)));
+    }
+
+    #[test]
+    fn encode_then_decode_roundtrips() {
+        let original = bounded(&[10, 20, 30, 40]);
+        let codec: NomBoundedVec<'_, u8, MIN, MAX, 1> = (&original).into();
+        let bytes = codec.encode();
+        let (rest, decoded) = Codec::decode(&bytes).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn roundtrips_with_a_multi_byte_item_type() {
+        // `u16` items exercise per-item encoding/decoding within the codec.
+        type U16Codec = NomBoundedVec<'static, u16, MIN, MAX, 2>;
+        let original: BoundedVec<u16, MIN, MAX> =
+            BoundedVec::new_unchecked(vec![0x0102, 0x0304, 0xABCD]);
+        let codec: NomBoundedVec<'_, u16, MIN, MAX, 2> = (&original).into();
+
+        let bytes = codec.encode();
+        // 2-byte length prefix (3) followed by three little-endian `u16`s.
+        assert_eq!(bytes, vec![3, 0, 0x02, 0x01, 0x04, 0x03, 0xCD, 0xAB]);
+
+        let (rest, decoded) = U16Codec::decode(&bytes).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(decoded, original);
+    }
+}

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -1,14 +1,16 @@
-use lb_utils::bounded_vec::BoundedVec;
 use nom::{
     IResult, Parser as _,
-    bytes::take,
     combinator::{map, map_res},
     error::{Error, ErrorKind},
-    multi::count,
     number::complete::{le_u16, le_u32, u8},
 };
 
 use crate::mantle::ops::channel::{ChannelId, Ed25519PublicKey, MsgId};
+
+pub mod array;
+pub use self::array::NomArray;
+pub mod bounded_vec;
+pub use self::bounded_vec::NomBoundedVec;
 
 pub trait NomEncode {
     // TODO: This could be turned into a `BoundedVec<u8, MAX_BYTES>` if we are
@@ -71,131 +73,6 @@ impl NomDecode for u32 {
 // `[T]` since that could be misleading.
 fn encode_slice<T: NomEncode>(items: &[T]) -> Vec<u8> {
     items.iter().flat_map(NomEncode::encode).collect()
-}
-
-pub struct NomArray<'a, T, const N: usize>(&'a [T::Output; N])
-where
-    T: NomDecode;
-
-impl<'a, T, const N: usize> From<&'a [T::Output; N]> for NomArray<'a, T, N>
-where
-    T: NomDecode,
-{
-    fn from(array: &'a [T::Output; N]) -> Self {
-        Self(array)
-    }
-}
-
-impl<T, const N: usize> NomEncode for NomArray<'_, T, N>
-where
-    T: NomDecode<Output: NomEncode>,
-{
-    fn encode(&self) -> Vec<u8> {
-        encode_slice(self.0.as_slice())
-    }
-}
-
-impl<T, const N: usize> NomDecode for NomArray<'_, T, N>
-where
-    T: NomDecode,
-{
-    type Output = [T::Output; N];
-
-    fn decode(input: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (input, items) = count(T::decode, N).parse(input)?;
-
-        let Ok(items) = items.try_into() else {
-            panic!("Decoded `N` elements.");
-        };
-        Ok((input, items))
-    }
-}
-
-/// Nom encoder for bounded vectors with a specified number of bytes for the
-/// length prefix.
-pub struct NomBoundedVec<'a, T, const MIN: usize, const MAX: usize, const N_BYTES: usize>(
-    &'a BoundedVec<T::Output, MIN, MAX>,
-)
-where
-    T: NomDecode;
-
-impl<T, const MIN: usize, const MAX: usize, const N_BYTES: usize>
-    NomBoundedVec<'_, T, MIN, MAX, N_BYTES>
-where
-    T: NomDecode,
-{
-    const _N_BYTES_VALUE_CHECK: () = {
-        assert!(
-            matches!(N_BYTES, 1 | 2 | 4 | 8),
-            "N_BYTES must be 1, 2, 4, or 8",
-        );
-        let max_repr: u64 = if N_BYTES == 8 {
-            u64::MAX
-        } else {
-            (1u64 << (N_BYTES * 8)) - 1
-        };
-        assert!(
-            MAX as u64 <= max_repr,
-            "MAX exceeds what N_BYTES can encode"
-        );
-    };
-}
-
-impl<'a, T, const MIN: usize, const MAX: usize, const N_BYTES: usize>
-    From<&'a BoundedVec<T::Output, MIN, MAX>> for NomBoundedVec<'a, T, MIN, MAX, N_BYTES>
-where
-    T: NomDecode,
-{
-    fn from(vec: &'a BoundedVec<T::Output, MIN, MAX>) -> Self {
-        let () = Self::_N_BYTES_VALUE_CHECK;
-
-        Self(vec)
-    }
-}
-
-impl<T, const MIN: usize, const MAX: usize, const N_BYTES: usize> NomEncode
-    for NomBoundedVec<'_, T, MIN, MAX, N_BYTES>
-where
-    T: NomDecode<Output: NomEncode>,
-{
-    fn encode(&self) -> Vec<u8> {
-        let () = Self::_N_BYTES_VALUE_CHECK;
-
-        // Initialize `bytes` with the encoded length prefix.
-        let mut bytes = (self.0.len() as u64).to_le_bytes()[..N_BYTES].to_vec();
-        bytes.extend(encode_slice(self.0.as_slice()));
-
-        bytes
-    }
-}
-
-impl<T, const MIN: usize, const MAX: usize, const N_BYTES: usize> NomDecode
-    for NomBoundedVec<'_, T, MIN, MAX, N_BYTES>
-where
-    T: NomDecode,
-{
-    type Output = BoundedVec<T::Output, MIN, MAX>;
-
-    fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let () = Self::_N_BYTES_VALUE_CHECK;
-
-        let (bytes, len_bytes): (&[u8], &[u8]) = take(N_BYTES).parse(bytes)?;
-        let mut buf = [0u8; 8];
-        buf[..N_BYTES].copy_from_slice(len_bytes);
-        let len = u64::from_le_bytes(buf) as usize;
-
-        // We check length first instead of relying on `BoundedVec::try_from` to avoid
-        // decoding a payload that is too large.
-        if len < MIN {
-            return Err(nom::Err::Error(Error::new(bytes, ErrorKind::LengthValue)));
-        }
-        if len > MAX {
-            return Err(nom::Err::Error(Error::new(bytes, ErrorKind::TooLarge)));
-        }
-
-        let (bytes, items) = count(T::decode, len).parse(bytes)?;
-        Ok((bytes, BoundedVec::new_unchecked(items)))
-    }
 }
 
 impl NomEncode for ChannelId {

--- a/utils/src/bounded_vec.rs
+++ b/utils/src/bounded_vec.rs
@@ -185,3 +185,217 @@ pub type UpperBoundedVec<T, const MAX: usize> = BoundedVec<T, 0, MAX>;
 pub type LowerBoundedVec<T, const MIN: usize> = BoundedVec<T, MIN, { usize::MAX }>;
 // `[1, MAX]` elements.
 pub type NonEmptyBoundedVec<T, const MAX: usize> = BoundedVec<T, 1, MAX>;
+
+#[cfg(test)]
+mod tests {
+    use crate::bounded_vec::{BoundedError, BoundedVec};
+
+    /// Concrete instantiation used across the tests: between 2 and 4 elements.
+    type TestBoundedVector = BoundedVec<u8, 2, 4>;
+
+    #[test]
+    fn min_max_constants_reflect_the_generic_parameters() {
+        assert_eq!(TestBoundedVector::MIN, 2);
+        assert_eq!(TestBoundedVector::MAX, 4);
+    }
+
+    #[test]
+    fn new_unchecked_wraps_without_validation() {
+        // `new_unchecked` deliberately bypasses the bounds, so it accepts
+        // inputs that `try_from` would reject.
+        let empty = TestBoundedVector::new_unchecked(vec![]);
+        assert!(empty.is_empty());
+
+        let too_long = TestBoundedVector::new_unchecked(vec![1, 2, 3, 4, 5]);
+        assert_eq!(too_long.len(), 5);
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        assert_eq!(bv.len(), 3);
+        assert!(!bv.is_empty());
+
+        assert!(TestBoundedVector::new_unchecked(vec![]).is_empty());
+        assert_eq!(TestBoundedVector::new_unchecked(vec![]).len(), 0);
+    }
+
+    #[test]
+    fn first_returns_the_leading_element() {
+        let bv = TestBoundedVector::try_from(vec![10, 20, 30]).unwrap();
+        assert_eq!(bv.first(), Some(&10));
+
+        assert_eq!(TestBoundedVector::new_unchecked(vec![]).first(), None);
+    }
+
+    #[test]
+    fn iter_yields_every_element_in_order() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        assert_eq!(bv.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn into_inner_returns_the_backing_vec() {
+        let bv = TestBoundedVector::try_from(vec![7, 8]).unwrap();
+        assert_eq!(bv.into_inner(), vec![7, 8]);
+    }
+
+    #[test]
+    fn as_slice_exposes_the_contents() {
+        let bv = TestBoundedVector::try_from(vec![4, 5, 6]).unwrap();
+        assert_eq!(bv.as_slice(), &[4, 5, 6]);
+    }
+
+    #[test]
+    fn try_push_appends_while_under_the_cap() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        assert_eq!(bv.try_push(3), Ok(()));
+        assert_eq!(bv.try_push(4), Ok(()));
+        assert_eq!(bv.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn try_push_rejects_growth_past_max() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
+        assert_eq!(
+            bv.try_push(5),
+            Err(BoundedError::TooLong { actual: 5, max: 4 })
+        );
+        // The failed push must not have mutated the vector.
+        assert_eq!(bv.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn try_from_accepts_lengths_within_bounds() {
+        TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
+    }
+
+    #[test]
+    fn try_from_rejects_input_below_min() {
+        assert_eq!(
+            TestBoundedVector::try_from(vec![]),
+            Err(BoundedError::EmptyInput)
+        );
+        assert_eq!(
+            TestBoundedVector::try_from(vec![1]),
+            Err(BoundedError::EmptyInput)
+        );
+    }
+
+    #[test]
+    fn try_from_rejects_input_above_max() {
+        assert_eq!(
+            TestBoundedVector::try_from(vec![1, 2, 3, 4, 5]),
+            Err(BoundedError::TooLong { actual: 5, max: 4 })
+        );
+    }
+
+    #[test]
+    fn from_single_value_builds_a_one_element_vec() {
+        // `From<T>` requires `MIN >= 1`; `MAX` here comfortably allows one.
+        let bv: BoundedVec<u8, 1, 4> = 42.into();
+        assert_eq!(bv.as_slice(), &[42]);
+    }
+
+    #[test]
+    fn from_owned_array() {
+        let bv: TestBoundedVector = [1, 2, 3].into();
+        assert_eq!(bv.as_slice(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn from_array_reference() {
+        let bv: TestBoundedVector = (&[9, 8, 7]).into();
+        assert_eq!(bv.as_slice(), &[9, 8, 7]);
+    }
+
+    #[test]
+    fn into_vec_unwraps_the_bounded_vec() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let raw: Vec<u8> = bv.into();
+        assert_eq!(raw, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn as_ref_slice_and_vec() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let slice: &[u8] = bv.as_ref();
+        assert_eq!(slice, &[1, 2, 3]);
+        let vec: &Vec<u8> = bv.as_ref();
+        assert_eq!(vec, &vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn into_iterator_by_reference() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let collected: Vec<u8> = (&bv).into_iter().copied().collect();
+        assert_eq!(collected, vec![1, 2, 3]);
+        // `bv` is still usable after iterating by reference.
+        assert_eq!(bv.len(), 3);
+    }
+
+    #[test]
+    fn into_iterator_by_value() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let collected: Vec<u8> = bv.into_iter().collect();
+        assert_eq!(collected, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn equality_and_ordering() {
+        let a = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        let b = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        let c = TestBoundedVector::try_from(vec![1, 3]).unwrap();
+        assert_eq!(a, b);
+        assert!(a < c);
+    }
+
+    #[test]
+    fn serialize_emits_a_plain_sequence() {
+        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        assert_eq!(serde_json::to_string(&bv).unwrap(), "[1,2,3]");
+    }
+
+    #[test]
+    fn deserialize_accepts_input_within_bounds() {
+        let bv: TestBoundedVector = serde_json::from_str("[1,2,3]").unwrap();
+        assert_eq!(bv.as_slice(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn serialize_then_deserialize_roundtrips() {
+        let original = TestBoundedVector::try_from(vec![5, 6, 7, 8]).unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: TestBoundedVector = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn deserialize_rejects_input_below_min() {
+        let err = serde_json::from_str::<TestBoundedVector>("[1]").unwrap_err();
+        assert!(
+            err.to_string().contains("Input cannot be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_empty_input() {
+        let err = serde_json::from_str::<TestBoundedVector>("[]").unwrap_err();
+        assert!(
+            err.to_string().contains("Input cannot be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_input_above_max() {
+        let err = serde_json::from_str::<TestBoundedVector>("[1,2,3,4,5]").unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds static maximum"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?

PR based on top of https://github.com/logos-blockchain/logos-blockchain/pull/2781. Moved `NomBoundedVec` and `NomArray` into their own module, and added tests for `BoundedVec` and `NomBoundedVec`.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.