### PR TITLE
test(e2e): make zone setup explicit

### DIFF
--- a/tests/cucumber_tests/features/zone.feature
+++ b/tests/cucumber_tests/features/zone.feature
@@ -3,12 +3,14 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_sequencer_publish_and_indexer_read
   Scenario: Publish messages and read them from the zone indexer
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data           |
@@ -32,11 +34,14 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_sequencer_checkpoint_resume
   Scenario: Resume zone sequencer from checkpoint
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A      |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data      |
@@ -61,11 +66,14 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_sequencer_stale_checkpoint_resume
   Scenario: Resume zone sequencer from stale checkpoint
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A      |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data  |
@@ -98,14 +106,17 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_sequential_multi_sequencer
   Scenario: Sequential multi-sequencer publishing keeps channel order
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
     And the following zone sequencers share the signing key of "SEQ_A":
       | alias |
       | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data |
@@ -155,15 +166,18 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_concurrent_multi_sequencer
   Scenario: Concurrent multi-sequencer publishing converges without duplicates
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers          |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B, SEQ_C |
     And the following zone sequencers share the signing key of "SEQ_A":
       | alias |
       | SEQ_B |
       | SEQ_C |
-    When the zone node is at height 1 in 120 seconds
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     When I stop zone sequencer "SEQ_A"
     And each listed zone sequencer publishes 20 generated zone messages concurrently with republish policy:
@@ -177,12 +191,14 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_sorted_conflict_resolution
   Scenario: Sorted conflict policy preserves per-sequencer order and converges without duplicates
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" submits zone config transaction:
       | config_name      | posting_timeframe | posting_timeout | authorized_sequencers |
@@ -206,12 +222,14 @@ Feature: Zone SDK
 
   @zone_ci
   Scenario: Round-robin waits for turn and submits pending messages
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencers:
       | alias | indexer | pending_submit_depth | passive_republish_orphans |
       | SEQ_A | true    | 2                    | false                     |
@@ -256,12 +274,14 @@ Feature: Zone SDK
 
   @zone_ci
   Scenario: Round-robin submits all pending messages with no active depth limit
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencers:
       | alias | indexer | pending_submit_depth | passive_republish_orphans |
       | SEQ_A | true    | unlimited            | false                     |
@@ -305,12 +325,14 @@ Feature: Zone SDK
 
   @zone_ci
   Scenario: Round-robin publishes immediately when it is our turn
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" submits zone config transaction:
       | config_name      | posting_timeframe | posting_timeout | authorized_sequencers |
@@ -329,13 +351,14 @@ Feature: Zone SDK
 
   @zone_ci
   Scenario: Round-robin with multiple sequencers dynamically added
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-      | SEQ_C |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers          |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B, SEQ_C |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencers:
       | alias | indexer | pending_submit_depth | passive_republish_orphans |
       | SEQ_A | true    | default              | true                      |
@@ -381,18 +404,19 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_balance_conditioned_republish
   Scenario: Balance-aware republish policy drops unaffordable zone updates
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-      | SEQ_C |
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers          |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B, SEQ_C |
     And the following zone account balances exist:
       | account | balance |
       | alice   | 10      |
       | bob     | 10      |
       | charlie | 10      |
-    When the zone node is at height 1 in 120 seconds
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" submits zone config transaction:
       | config_name      | posting_timeframe | posting_timeout | authorized_sequencers |
@@ -416,13 +440,14 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_concurrent_identical_payloads
   Scenario: Concurrent identical payloads converge to one inscription per publish
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-      | SEQ_B |
-      | SEQ_C |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers          |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B, SEQ_C |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" submits zone config transaction:
       | config_name      | posting_timeframe | posting_timeout | authorized_sequencers |
@@ -440,11 +465,15 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_subscribe_to_finalized_deposit
   Scenario: Finalized deposits are returned by the zone indexer
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A      |
+    When node "NODE_1" is at height 2 in 300 seconds
+    And I do a coin split for "WALLET_1A" of 3 UTXOs valued at 1 LGO tokens each
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data                |
@@ -459,11 +488,14 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_atomic_deposit_inscription
   Scenario: Atomic deposit and inscription are finalized together
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A      |
+    When node "NODE_1" is at height 1 in 120 seconds
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data                |
@@ -482,11 +514,15 @@ Feature: Zone SDK
   @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_subscribe_to_finalized_withdraw
   Scenario: Finalized withdraws are returned by the zone indexer and sequencer
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
-    When the zone node is at height 1 in 120 seconds
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A      |
+    When node "NODE_1" is at height 2 in 300 seconds
+    And I do a coin split for "WALLET_1A" of 3 UTXOs valued at 3 LGO tokens each
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias | data                |
@@ -510,14 +546,18 @@ Feature: Zone SDK
 
   @zone_ci
   Scenario: Atomic withdraw bundle finalizes alongside multi-sequencer publishing
-    Given I have a zone cluster
-    And the following zone sequencers exist:
-      | alias |
-      | SEQ_A |
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers   |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A, SEQ_B |
     And the following zone sequencers share the signing key of "SEQ_A":
       | alias |
       | SEQ_B |
-    When the zone node is at height 1 in 120 seconds
+    When node "NODE_1" is at height 2 in 300 seconds
+    And I do a coin split for "WALLET_1A" of 3 UTXOs valued at 5 LGO tokens each
     And I start zone sequencer "SEQ_A" with indexer
     And sequencer "SEQ_A" publishes the following zone messages:
       | alias    | data                |

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, num::NonZero, sync::Arc, time::Duration};
 
 use cucumber::gherkin::Step;
 use futures::future::join_all;
@@ -7,8 +7,8 @@ use lb_core::mantle::{
     TxHash, Utxo,
     ops::channel::{config::Keys, deposit::Metadata, inscribe::Inscription},
 };
-use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey};
-use lb_testing_framework::{LbcManualCluster, NodeHttpClient};
+use lb_key_management_system_service::keys::Ed25519Key;
+use lb_testing_framework::NodeHttpClient;
 use lb_zone_sdk::{
     adapter::NodeHttpClient as ZoneNodeHttpClient,
     indexer::ZoneIndexer,
@@ -19,21 +19,19 @@ use tokio::{
     task::JoinHandle,
     time::{error::Elapsed, timeout},
 };
-use tracing::info;
 
 use super::{
     errors::{log_step_error, zone_step_error},
     steps::DEFAULT_ZONE_SEQUENCER,
     support::{
-        AtomicZoneDepositRequest, DiscardedPayloads, PublishDeadline, StartedZoneNode,
-        ZoneAccountBalances, ZoneDeposit, build_zone_deposit, ensure_zone_transactions_included,
-        keygen, prepare_zone_cluster, publish_atomic_zone_withdraw, publish_message_with_retry,
-        sequencer_config, sequencer_config_with_pending_submit_depth, start_balance_aware_policy,
+        AtomicZoneDepositRequest, DiscardedPayloads, PublishDeadline, ZoneAccountBalances,
+        ZoneDeposit, build_zone_deposit, ensure_zone_transactions_included, keygen,
+        publish_atomic_zone_withdraw, publish_message_with_retry, sequencer_config,
+        sequencer_config_with_pending_submit_depth, start_balance_aware_policy,
         start_republish_policy, start_sequencer_event_loop, start_sorted_conflict_policy,
-        start_zone_node, submit_atomic_zone_deposit, submit_zone_deposit, submit_zone_withdraw,
-        wait_for_zone_network_ready,
+        submit_atomic_zone_deposit, submit_zone_deposit, submit_zone_withdraw,
     },
-    tables::{ConcurrentZoneMessageRow, group_zone_messages_by_sequencer},
+    tables::{ConcurrentZoneMessageRow, ZoneNodeResourcesRow, group_zone_messages_by_sequencer},
 };
 use crate::{
     common::{
@@ -42,9 +40,18 @@ use crate::{
     },
     cucumber::{
         error::{StepError, StepResult},
-        steps::TARGET,
-        wallet::sync::sync_wallet_state_from_feed,
-        world::{CucumberWorld, NodeInfo},
+        steps::{
+            TARGET,
+            manual_nodes::{
+                config_override::set_deployment_config_override,
+                utils::{
+                    NodesToStartUnordered, WalletStartInfo, start_node,
+                    start_nodes_order_respecting_dependencies,
+                },
+            },
+        },
+        wallet::sync::sync_available_utxos_for_wallet,
+        world::{CucumberWorld, WalletInfo},
     },
 };
 
@@ -53,7 +60,7 @@ const ZONE_CHANNEL_DEPOSIT_THRESHOLD: u16 = 1;
 const SEQUENCER_READY_TIMEOUT: Duration = Duration::from_mins(2);
 const SEQUENCER_READY_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 const SEQUENCER_READY_HEIGHT_ADVANCE_TIMEOUT: Duration = Duration::from_secs(30);
-const ZONE_FUNDING_WALLET_NAME: &str = "zone-funding";
+const ZONE_SECURITY_PARAM: u32 = 5;
 
 pub(super) enum DriveMode {
     Passive {
@@ -99,12 +106,6 @@ struct StartedSequencerRuntime {
     discarded_payloads: Option<DiscardedPayloads>,
 }
 
-pub(super) fn register_zone_sequencers(world: &mut CucumberWorld, aliases: Vec<String>) {
-    for alias in aliases {
-        world.zone.register_sequencer(alias, keygen());
-    }
-}
-
 pub(super) fn register_zone_sequencers_with_shared_key(
     world: &mut CucumberWorld,
     source_alias: &str,
@@ -119,61 +120,97 @@ pub(super) fn register_zone_sequencers_with_shared_key(
     Ok(())
 }
 
-pub(super) async fn start_zone_cluster(world: &mut CucumberWorld, step: &Step) -> StepResult {
-    let zone_cluster = prepare_zone_cluster(world.scenario_base_dir.clone())
-        .map_err(|error| zone_step_error(step, &error))?;
+pub(super) async fn start_nodes_with_zone_resources(
+    world: &mut CucumberWorld,
+    step: &Step,
+    rows: Vec<ZoneNodeResourcesRow>,
+) -> StepResult {
+    apply_zone_timing_defaults(world, &step.value)?;
 
-    let funding_public_key = zone_cluster.funding_public_key;
-    let genesis_block_utxos = zone_cluster.genesis_block_utxos;
-    let cluster = zone_cluster.cluster;
+    let nodes = collect_zone_nodes_to_start(&rows);
+    let nodes = start_nodes_order_respecting_dependencies(nodes).inspect_err(|error| {
+        tracing::warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+    })?;
 
-    let started_zone_node = start_zone_node(&cluster, &world.scenario_base_dir)
-        .await
-        .map_err(|error| zone_step_error(step, &error))?;
+    for (node_name, wallet_start_info, mut initial_peers) in nodes {
+        initial_peers.sort();
+        initial_peers.dedup();
 
-    wait_for_zone_network_ready(&cluster)
-        .await
-        .map_err(|error| zone_step_error(step, &error))?;
+        start_node(
+            world,
+            &step.value,
+            &node_name,
+            &wallet_start_info,
+            &initial_peers,
+            false,
+        )
+        .await?;
+    }
 
-    let client = started_zone_node.started_node.client.clone();
-
-    remember_zone_cluster(
-        world,
-        cluster,
-        started_zone_node,
-        funding_public_key,
-        genesis_block_utxos,
-    );
-
-    info!(target: TARGET, node_url = %client.base_url(), "Started zone cluster");
-
-    Ok(())
+    register_zone_resources(world, rows)
 }
 
-fn remember_zone_cluster(
-    world: &mut CucumberWorld,
-    cluster: LbcManualCluster,
-    started_zone_node: StartedZoneNode,
-    funding_public_key: ZkPublicKey,
-    genesis_block_utxos: Vec<Utxo>,
-) {
-    let node_name = "NODE_1".to_owned();
-
-    world.genesis_block_utxos = genesis_block_utxos;
-    world.local_cluster = Some(cluster);
-    world.nodes_info.insert(
-        node_name.clone(),
-        NodeInfo {
-            name: node_name.clone(),
-            started_node: started_zone_node.started_node,
-            run_config: None,
-            chain_info: HashMap::default(),
-            wallet_info: HashMap::default(),
-            runtime_dir: started_zone_node.runtime_dir,
-            immediate_start: false,
-        },
+fn apply_zone_timing_defaults(world: &mut CucumberWorld, step: &str) -> StepResult {
+    world.set_cryptarchia_security_param(
+        NonZero::new(ZONE_SECURITY_PARAM).expect("zone security parameter is non-zero"),
     );
-    world.zone.initialize_cluster(node_name, funding_public_key);
+    world.set_prolonged_bootstrap_period(Duration::ZERO);
+
+    set_deployment_config_override(world, step, "time.slot_duration", "seconds(1)")?;
+    set_deployment_config_override(
+        world,
+        step,
+        "cryptarchia.slot_activation_coeff.numerator",
+        "1",
+    )?;
+    set_deployment_config_override(
+        world,
+        step,
+        "cryptarchia.slot_activation_coeff.denominator",
+        "2",
+    )
+}
+
+fn collect_zone_nodes_to_start(rows: &[ZoneNodeResourcesRow]) -> NodesToStartUnordered {
+    let mut nodes = HashMap::new();
+
+    for row in rows {
+        let entry = nodes
+            .entry(row.node_name.clone())
+            .or_insert_with(|| (Vec::new(), Vec::new()));
+
+        entry.0.push(WalletStartInfo {
+            wallet_name: row.wallet_name.clone(),
+            account_index: row.account_index,
+        });
+
+        if let Some(peer) = &row.connected_to {
+            entry.1.push(peer.clone());
+        }
+    }
+
+    nodes
+}
+
+fn register_zone_resources(
+    world: &mut CucumberWorld,
+    rows: Vec<ZoneNodeResourcesRow>,
+) -> StepResult {
+    for row in rows {
+        for alias in row.sequencers {
+            if !world.zone.has_sequencer(&alias) {
+                world.zone.register_sequencer(alias.clone(), keygen());
+            }
+
+            world.zone.attach_sequencer_resources(
+                &alias,
+                row.node_name.clone(),
+                row.wallet_name.clone(),
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 pub(super) async fn submit_zone_channel_config(
@@ -206,14 +243,6 @@ pub(super) async fn submit_zone_channel_config(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut checkpoint_rx = world
-        .zone
-        .checkpoint_receiver(sequencer_alias)
-        .ok_or_else(|| StepError::LogicalError {
-            message: format!("Zone sequencer '{sequencer_alias}' has no checkpoint watch"),
-        })?;
-    checkpoint_rx.mark_unchanged();
-
     let (result, finalized) = handle
         .channel_config(
             Keys::new_unchecked(authorized_keys),
@@ -229,9 +258,13 @@ pub(super) async fn submit_zone_channel_config(
 
     drop(finalized);
 
-    // Wait until the SDK has published a checkpoint that contains our newly
-    // submitted tx — the watch is updated by the drive loop on its next
-    // iteration after the actor's reply, so a naive read here races.
+    let mut checkpoint_rx = world
+        .zone
+        .checkpoint_receiver(sequencer_alias)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Zone sequencer '{sequencer_alias}' has no checkpoint watch"),
+        })?;
+    checkpoint_rx.mark_unchanged();
     let checkpoint = timeout(
         Duration::from_secs(30),
         wait_for_checkpoint_with_tx(&mut checkpoint_rx, result.inscription_id),
@@ -245,6 +278,9 @@ pub(super) async fn submit_zone_channel_config(
     })?
     .map_err(|message| StepError::LogicalError { message })?;
 
+    world
+        .zone
+        .set_latest_checkpoint_for(sequencer_alias, checkpoint.clone());
     world
         .zone
         .remember_checkpoint(format!("{transaction_alias}_CHECKPOINT"), checkpoint);
@@ -299,45 +335,39 @@ async fn wait_for_checkpoint_with_tx(
 ) -> Result<SequencerCheckpoint, String> {
     loop {
         let snapshot = rx.borrow_and_update().clone();
-        if let Some(cp) = snapshot
-            && cp.pending_txs.iter().any(|(hash, _)| *hash == tx_hash)
+        if let Some(checkpoint) = snapshot
+            && checkpoint
+                .pending_txs
+                .iter()
+                .any(|(hash, _)| *hash == tx_hash)
         {
-            return Ok(cp);
+            return Ok(checkpoint);
         }
+
         rx.changed()
             .await
-            .map_err(|err| format!("checkpoint watch closed: {err}"))?;
+            .map_err(|error| format!("checkpoint watch closed: {error}"))?;
     }
 }
 
-async fn sync_zone_funding_wallet_utxos(
-    world: &mut CucumberWorld,
-    step: &Step,
-) -> Result<Vec<Utxo>, StepError> {
-    let node_name = world.zone.node_name()?.to_owned();
-    let funding_public_key = world.zone.funding_public_key()?;
+fn resolve_zone_wallet(
+    world: &CucumberWorld,
+    sequencer_alias: &str,
+) -> Result<WalletInfo, StepError> {
+    let wallet_name = world.zone.sequencer_default_wallet_name(sequencer_alias)?;
 
-    Ok(sync_wallet_state_from_feed(
-        world,
-        ZONE_FUNDING_WALLET_NAME,
-        &node_name,
-        funding_public_key,
-    )
-    .await
-    .inspect_err(|e| {
-        tracing::warn!(target: TARGET, "Step `{}` error: {e}", step.value);
-    })?
-    .into_available_utxos())
+    world.resolve_wallet(wallet_name)
 }
 
 fn record_zone_wallet_submission(
     world: &CucumberWorld,
+    wallet_name: &str,
     tx_hash: TxHash,
     reserved_inputs: Vec<Utxo>,
 ) -> StepResult {
     world.with_wallets_mut(|wallets| {
         wallets.record_wallet_reservation(
-            ZONE_FUNDING_WALLET_NAME.to_owned(),
+            wallet_name.to_owned(),
             tx_hash,
             WalletReservedInputs::new(reserved_inputs, Vec::new()),
             0,
@@ -353,9 +383,13 @@ pub(super) async fn submit_zone_deposit_transaction(
     amount: u64,
     metadata: Metadata,
 ) -> StepResult {
-    let node_url = log_step_error(step, world.zone_node_url())?;
-    let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
-    let available_utxos = sync_zone_funding_wallet_utxos(world, step).await?;
+    let node_url = log_step_error(step, world.zone_node_url_for_sequencer(&channel_alias))?;
+    let wallet = log_step_error(step, resolve_zone_wallet(world, &channel_alias))?;
+    let public_key = log_step_error(step, wallet.public_key())?;
+    let available_utxos = log_step_error(
+        step,
+        sync_available_utxos_for_wallet(world, &step.value, &wallet.wallet_name).await,
+    )?;
     let ZoneDeposit {
         deposit,
         reserved_inputs,
@@ -367,14 +401,14 @@ pub(super) async fn submit_zone_deposit_transaction(
     )
     .map_err(|error| zone_step_error(step, &error))?;
 
-    let response = submit_zone_deposit(&node_url, &deposit, funding_public_key)
+    let response = submit_zone_deposit(&node_url, &deposit, public_key)
         .await
         .map_err(|error| zone_step_error(step, &error))?;
 
     world
         .zone
         .remember_submitted_deposit(transaction_alias.clone(), deposit, amount);
-    record_zone_wallet_submission(world, response, reserved_inputs)?;
+    record_zone_wallet_submission(world, &wallet.wallet_name, response, reserved_inputs)?;
     world.remember_submitted_transaction(transaction_alias, response);
 
     Ok(())
@@ -389,9 +423,13 @@ pub(super) async fn submit_atomic_zone_deposit_transaction(
     amount: u64,
     metadata: Metadata,
 ) -> StepResult {
-    let node_url = log_step_error(step, world.zone_node_url())?;
-    let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
-    let available_utxos = sync_zone_funding_wallet_utxos(world, step).await?;
+    let node_url = log_step_error(step, world.zone_node_url_for_sequencer(sequencer_alias))?;
+    let wallet = log_step_error(step, resolve_zone_wallet(world, sequencer_alias))?;
+    let public_key = log_step_error(step, wallet.public_key())?;
+    let available_utxos = log_step_error(
+        step,
+        sync_available_utxos_for_wallet(world, &step.value, &wallet.wallet_name).await,
+    )?;
     let sequencer = log_step_error(step, world.zone.sequencer_handle(sequencer_alias))?;
     let inscription_data = make_inscription(&format!("Mint {amount} to Alice"));
 
@@ -400,7 +438,7 @@ pub(super) async fn submit_atomic_zone_deposit_transaction(
         sequencer,
         AtomicZoneDepositRequest {
             channel_id: world.zone.sequencer_channel_id(sequencer_alias)?,
-            funding_public_key,
+            funding_public_key: public_key,
             available_utxos,
             amount,
             metadata,
@@ -422,6 +460,7 @@ pub(super) async fn submit_atomic_zone_deposit_transaction(
     );
     record_zone_wallet_submission(
         world,
+        &wallet.wallet_name,
         submission.publish.inscription_id,
         submission.reserved_inputs,
     )?;
@@ -438,14 +477,15 @@ pub(super) async fn submit_zone_withdraw_transaction(
     message_alias: String,
     amount: u64,
 ) -> StepResult {
-    let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
+    let wallet = log_step_error(step, resolve_zone_wallet(world, sequencer_alias))?;
+    let public_key = log_step_error(step, wallet.public_key())?;
     let sequencer = log_step_error(step, world.zone.sequencer_handle(sequencer_alias))?;
     let inscription_data = make_inscription(&format!("Burn {amount}"));
 
     let submission = submit_zone_withdraw(
         sequencer,
         world.zone.sequencer_channel_id(sequencer_alias)?,
-        funding_public_key,
+        public_key,
         amount,
         inscription_data.clone(),
     )
@@ -484,7 +524,8 @@ pub(super) async fn publish_atomic_zone_withdraw_transaction(
     message_alias: String,
     withdraw_rows: Vec<(String, Vec<u64>)>,
 ) -> StepResult {
-    let funding_public_key = log_step_error(step, world.zone.funding_public_key())?;
+    let wallet = log_step_error(step, resolve_zone_wallet(world, sequencer_alias))?;
+    let public_key = log_step_error(step, wallet.public_key())?;
     let total: u64 = withdraw_rows
         .iter()
         .flat_map(|(_, outputs)| outputs.iter())
@@ -503,7 +544,7 @@ pub(super) async fn publish_atomic_zone_withdraw_transaction(
         publish_atomic_zone_withdraw(
             &sequencer,
             sequencer_events,
-            funding_public_key,
+            public_key,
             outputs_per_arg,
             inscription_data.clone(),
             PublishDeadline::from_now(Duration::from_mins(3)),
@@ -547,7 +588,7 @@ pub(super) fn initialize_zone_indexer(
     sequencer_alias: impl AsRef<str>,
 ) -> StepResult {
     let sequencer_alias = sequencer_alias.as_ref();
-    let node_url = log_step_error(step, world.zone_node_url())?;
+    let node_url = log_step_error(step, world.zone_node_url_for_sequencer(sequencer_alias))?;
     let indexer = ZoneIndexer::new(
         world.zone.sequencer_channel_id(sequencer_alias)?,
         ZoneNodeHttpClient::new(CommonHttpClient::new(None), node_url),
@@ -565,7 +606,10 @@ pub(super) async fn publish_zone_messages(
     rows: Vec<(String, Inscription)>,
 ) -> StepResult {
     let sequencer_alias = sequencer_alias.as_ref().to_owned();
-    let node = log_step_error(step, world.zone_node_http_client())?;
+    let node = log_step_error(
+        step,
+        world.zone_node_http_client_for_sequencer(&sequencer_alias),
+    )?;
 
     let published = {
         let sequencer =
@@ -706,8 +750,11 @@ async fn start_named_sequencer_with_config(
     let sequencer_alias = sequencer_alias.as_ref().to_owned();
     let signing_key =
         log_step_error(step, world.zone.sequencer_signing_key(&sequencer_alias))?.clone();
-    let node_client = log_step_error(step, world.zone_node_http_client())?;
-    let node_url = log_step_error(step, world.zone_node_url())?;
+    let node_client = log_step_error(
+        step,
+        world.zone_node_http_client_for_sequencer(&sequencer_alias),
+    )?;
+    let node_url = log_step_error(step, world.zone_node_url_for_sequencer(&sequencer_alias))?;
     let (sequencer, handle) = ZoneSequencer::init_with_config(
         world.zone.sequencer_channel_id(&sequencer_alias)?,
         signing_key,
@@ -847,14 +894,4 @@ fn start_sequencer_runtime(
             discarded_payloads: None,
         },
     }
-}
-
-pub(super) fn ensure_zone_sequencer_exists(world: &mut CucumberWorld, sequencer_alias: &str) {
-    if world.zone.sequencer_signing_key(sequencer_alias).is_ok() {
-        return;
-    }
-
-    world
-        .zone
-        .register_sequencer(sequencer_alias.to_owned(), keygen());
 }

--- a/tests/src/cucumber/steps/manual_zone/steps.rs
+++ b/tests/src/cucumber/steps/manual_zone/steps.rs
@@ -9,13 +9,12 @@ use lb_core::mantle::ops::channel::inscribe::Inscription;
 
 use super::{
     actions::{
-        DriveMode, ensure_zone_sequencer_exists, initialize_zone_indexer,
-        publish_atomic_zone_withdraw_transaction, publish_zone_messages,
-        publish_zone_messages_concurrently, register_zone_sequencers,
+        DriveMode, initialize_zone_indexer, publish_atomic_zone_withdraw_transaction,
+        publish_zone_messages, publish_zone_messages_concurrently,
         register_zone_sequencers_with_shared_key, remember_published_zone_message,
         save_zone_checkpoint, start_named_sequencer,
-        start_named_sequencer_with_pending_submit_depth, start_zone_cluster, stop_zone_sequencer,
-        submit_atomic_zone_deposit_transaction, submit_zone_channel_config,
+        start_named_sequencer_with_pending_submit_depth, start_nodes_with_zone_resources,
+        stop_zone_sequencer, submit_atomic_zone_deposit_transaction, submit_zone_channel_config,
         submit_zone_deposit_transaction, submit_zone_withdraw_transaction,
     },
     assertions::{
@@ -37,11 +36,11 @@ use super::{
         generated_zone_message_batches, generated_zone_message_sequencers,
         group_zone_messages_by_sequencer, single_column_table, zone_account_balances,
         zone_atomic_withdraw_rows, zone_balance_rows, zone_config_row, zone_message_rows,
-        zone_sequencer_start_rows, zone_sequencing_state_row,
+        zone_node_resource_rows, zone_sequencer_start_rows, zone_sequencing_state_row,
     },
 };
 use crate::{
-    common::{mantle_inscription::make_inscription, manual_cluster::wait_for_height},
+    common::mantle_inscription::make_inscription,
     cucumber::{
         error::{StepError, StepResult},
         world::{CucumberWorld, ZoneSequencerStartup},
@@ -114,17 +113,15 @@ async fn start_named_sequencer_with_startup(
 }
 const CONCURRENT_DUPLICATE_SETTLE_SECS: u64 = 30;
 
-#[given("I have a zone cluster")]
-async fn step_zone_cluster(world: &mut CucumberWorld, step: &Step) -> StepResult {
-    start_zone_cluster(world, step).await
-}
+#[given("I start nodes with wallet and sequencer resources:")]
+#[when("I start nodes with wallet and sequencer resources:")]
+async fn step_start_nodes_with_wallet_and_sequencer_resources(
+    world: &mut CucumberWorld,
+    step: &Step,
+) -> StepResult {
+    let rows = zone_node_resource_rows(step)?;
 
-#[given("the following zone sequencers exist:")]
-fn step_zone_sequencers_exist(world: &mut CucumberWorld, step: &Step) -> StepResult {
-    let aliases = single_column_table(step, "alias", "zone sequencer aliases")?;
-    register_zone_sequencers(world, aliases);
-
-    Ok(())
+    start_nodes_with_zone_resources(world, step, rows).await
 }
 
 #[given(expr = "the following zone sequencers share the signing key of {string}:")]
@@ -151,16 +148,6 @@ fn step_zone_account_balances(world: &mut CucumberWorld, step: &Step) -> StepRes
     world.zone.set_zone_account_balances(balances);
 
     Ok(())
-}
-
-#[given("a zone sequencer is initialized")]
-#[when("a zone sequencer is initialized")]
-async fn step_default_zone_sequencer_initialized(
-    world: &mut CucumberWorld,
-    step: &Step,
-) -> StepResult {
-    ensure_zone_sequencer_exists(world, DEFAULT_ZONE_SEQUENCER);
-    start_sequencer_with_indexer(world, step, DEFAULT_ZONE_SEQUENCER).await
 }
 
 #[when(expr = "I start zone sequencer {string}")]
@@ -218,28 +205,6 @@ fn step_stop_zone_sequencer(
 ) -> StepResult {
     let _ = step;
     stop_zone_sequencer(world, sequencer_alias)
-}
-
-#[cucumber::when(expr = "the zone node is at height {int} in {int} seconds")]
-#[expect(
-    clippy::needless_pass_by_ref_mut,
-    reason = "Cucumber step functions require `&mut World` as the first parameter"
-)]
-async fn step_zone_node_is_at_height(
-    world: &mut CucumberWorld,
-    step: &Step,
-    height: u64,
-    timeout_seconds: u64,
-) -> StepResult {
-    let client = log_step_error(step, world.zone_node_http_client())?;
-
-    wait_for_height(&client, height, Duration::from_secs(timeout_seconds))
-        .await
-        .map_err(|_| StepError::Timeout {
-            message: format!(
-                "Zone node did not reach height {height} in {timeout_seconds} seconds"
-            ),
-        })
 }
 
 #[cucumber::when(expr = "the zone LIB advances in {int} seconds")]

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -7,18 +7,15 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    num::NonZero,
-    path::{Path, PathBuf},
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
 use futures::StreamExt as _;
 use lb_common_http_client::{CommonHttpClient, Slot};
-use lb_config::consensus::{ProviderInfo, create_genesis_block_with_declarations};
 use lb_core::{
     mantle::{
-        GenesisTx as _, MantleTx, Note, Op, OpProof, Transaction as _, Utxo, Value,
+        MantleTx, Note, Op, OpProof, Transaction as _, Utxo, Value,
         ledger::{Inputs, Outputs, OutputsError},
         ops::{
             channel::{
@@ -31,21 +28,14 @@ use lb_core::{
         },
     },
     proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
-    sdp::{Locator, ServiceType},
 };
 use lb_http_api_common::bodies::{
     channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
     wallet::sign::{WalletSignTxZkRequestBody, WalletSignTxZkResponseBody},
 };
-use lb_key_management_system_service::keys::{
-    Ed25519Key, ZkPublicKey, ZkSignature, secured_key::SecuredKey as _,
-};
-use lb_node::{SignedMantleTx, config::RunConfig};
-use lb_testing_framework::{
-    DeploymentBuilder, LbcEnv, LbcLocalDeployer, LbcManualCluster, NodeHttpClient, TopologyConfig,
-    internal::DeploymentPlan,
-};
-use lb_utils::{bounded_vec::BoundedError, math::NonNegativeRatio};
+use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey, ZkSignature};
+use lb_node::SignedMantleTx;
+use lb_testing_framework::NodeHttpClient;
 use lb_zone_sdk::{
     ZoneMessage,
     adapter::NodeHttpClient as ZoneNodeHttpClient,
@@ -58,31 +48,19 @@ use lb_zone_sdk::{
 };
 use rand::{Rng as _, thread_rng};
 use reqwest::Url;
-use testing_framework_core::scenario::{DynError, StartNodeOptions, StartedNode};
 use tokio::{
     task::JoinHandle,
     time::{sleep, timeout},
 };
 use tracing::warn;
 
-use crate::{
-    common::{
-        chain::wait_for_transactions_inclusion, mantle_inscription::make_inscription,
-        wallet::build_wallet_funded_transfer,
-    },
-    cucumber::utils::{extract_child_dir_name, matching_child_dirs},
+use crate::common::{
+    chain::wait_for_transactions_inclusion, mantle_inscription::make_inscription,
+    wallet::build_wallet_funded_transfer,
 };
 
 #[derive(Debug, thiserror::Error)]
 pub enum ZoneTestError {
-    #[error("failed to build zone deployment: {message}")]
-    BuildDeployment { message: String },
-    #[error("failed to start zone node: {message}")]
-    StartNode { message: String },
-    #[error("failed to resolve zone runtime dir: {message}")]
-    RuntimeDir { message: String },
-    #[error("zone network did not become ready: {message}")]
-    NetworkReady { message: String },
     #[error("timed out waiting for zone sequencer to accept a publish request")]
     PublishTimeout,
     #[error("zone indexer request failed: {message}")]
@@ -124,23 +102,9 @@ pub enum ZoneTestError {
     #[error("zone sequencer event stream stopped before observing the expected event")]
     SequencerStopped,
     #[error(transparent)]
-    BoundedError(#[from] BoundedError),
+    BoundedError(#[from] lb_utils::bounded_vec::BoundedError),
     #[error(transparent)]
     OutputsError(#[from] OutputsError),
-}
-
-/// Prepared deployment resources for the single-node zone test cluster.
-pub struct ZoneClusterTemplate {
-    pub cluster: LbcManualCluster,
-    pub funding_public_key: ZkPublicKey,
-    pub genesis_block_utxos: Vec<Utxo>,
-}
-
-/// A started single-node zone chain plus the resolved runtime directory used
-/// for logs, recovery files, and diagnostics.
-pub struct StartedZoneNode {
-    pub started_node: StartedNode<LbcEnv>,
-    pub runtime_dir: PathBuf,
 }
 
 /// Result of an atomic deposit scenario where a deposit and zone inscription
@@ -201,96 +165,6 @@ impl PublishDeadline {
             .checked_sub(self.started_at.elapsed())
             .ok_or(ZoneTestError::PublishTimeout)
     }
-}
-
-/// Builds the manual-cluster template used by zone scenarios.
-///
-/// The generated genesis state includes the node funding key and Blend
-/// declarations expected by the zone SDK tests. The caller still decides when
-/// to start the node so Cucumber can keep cluster setup and runtime startup
-/// visible as separate scenario phases.
-pub fn prepare_zone_cluster(
-    scenario_base_dir: PathBuf,
-) -> Result<ZoneClusterTemplate, ZoneTestError> {
-    let deployment = build_zone_deployment(scenario_base_dir)?;
-    let funding_public_key = deployment.nodes()[0]
-        .general
-        .consensus_config
-        .funding_sk
-        .as_public_key();
-    let genesis_block_utxos = deployment
-        .config
-        .genesis_block
-        .as_ref()
-        .map(|genesis_block| {
-            crate::cucumber::steps::manual_nodes::utils::genesis_block_utxos(
-                &genesis_block.genesis_tx(),
-            )
-        })
-        .unwrap_or_default();
-
-    let cluster = LbcLocalDeployer::new().manual_cluster_from_descriptors(deployment);
-
-    Ok(ZoneClusterTemplate {
-        cluster,
-        funding_public_key,
-        genesis_block_utxos,
-    })
-}
-
-/// Starts the zone node from a prepared manual cluster and resolves the actual
-/// runtime directory created by the local deployer.
-pub async fn start_zone_node(
-    cluster: &LbcManualCluster,
-    scenario_base_dir: &Path,
-) -> Result<StartedZoneNode, ZoneTestError> {
-    let node_name = "0";
-    let persist_dir = scenario_base_dir.join("node-0");
-
-    let runtime_dir_prefix = format!(
-        "{}_",
-        persist_dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("node-0")
-    );
-    let ignore_list = matching_child_dirs(&persist_dir, &runtime_dir_prefix);
-
-    let started_node = Box::pin(
-        cluster.start_node_with(
-            node_name,
-            StartNodeOptions::default()
-                .with_persist_dir(persist_dir)
-                .create_patch(fast_zone_config_patch),
-        ),
-    )
-    .await
-    .map_err(|error| ZoneTestError::StartNode {
-        message: error.to_string(),
-    })?;
-
-    let runtime_dir_name =
-        extract_child_dir_name(scenario_base_dir, &runtime_dir_prefix, &ignore_list).map_err(
-            |error| ZoneTestError::RuntimeDir {
-                message: error.to_string(),
-            },
-        )?;
-
-    Ok(StartedZoneNode {
-        started_node,
-        runtime_dir: scenario_base_dir.join(runtime_dir_name),
-    })
-}
-
-/// Waits until the local node reports that its networking layer is ready for
-/// the zone SDK to publish transactions through it.
-pub async fn wait_for_zone_network_ready(cluster: &LbcManualCluster) -> Result<(), ZoneTestError> {
-    cluster
-        .wait_network_ready()
-        .await
-        .map_err(|error| ZoneTestError::NetworkReady {
-            message: error.to_string(),
-        })
 }
 
 /// Runs the SDK sequencer event stream in the background and exposes events to
@@ -780,20 +654,22 @@ pub async fn wait_for_channel_view(
     })?
 }
 
+/// Waits until the sequencer emits a turn-to-write notification.
 pub async fn wait_for_turn_to_write(
     turn_rx: &mut tokio::sync::watch::Receiver<TurnNotification>,
     duration: Duration,
-) -> Result<(), ZoneTestError> {
+) -> Result<TurnNotification, ZoneTestError> {
     timeout(duration, async {
         loop {
-            if turn_rx.borrow_and_update().our_turn_to_write {
-                return Ok(());
+            let current = turn_rx.borrow().clone();
+            if current.our_turn_to_write {
+                return Ok(current);
             }
 
             turn_rx
                 .changed()
                 .await
-                .map_err(|error| ZoneTestError::ChannelViewTimeout {
+                .map_err(|error| ZoneTestError::Indexer {
                     message: format!("turn-to-write sender closed: {error}"),
                 })?;
         }
@@ -801,7 +677,7 @@ pub async fn wait_for_turn_to_write(
     .await
     .map_err(|_| ZoneTestError::ChannelViewTimeout {
         message: format!(
-            "turn-to-write notification not received within {} seconds",
+            "turn to write not reached within {} seconds",
             duration.as_secs()
         ),
     })?
@@ -1453,7 +1329,7 @@ pub async fn publish_atomic_zone_withdraw(
                 )?,
             })
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, ZoneTestError>>()?;
 
     sequencer
         .publish_atomic_withdraw(inscription_data.clone(), withdraw_args)
@@ -1527,100 +1403,4 @@ async fn sign_tx_zk(
         })?;
 
     Ok(response.sig)
-}
-
-/// Builds the single-node deployment shape used by all migrated zone tests.
-fn build_zone_deployment(scenario_base_dir: PathBuf) -> Result<DeploymentPlan, ZoneTestError> {
-    let deployment = DeploymentBuilder::new(TopologyConfig::with_node_numbers(1))
-        .scenario_base_dir(scenario_base_dir)
-        .build()
-        .map_err(|error| ZoneTestError::BuildDeployment {
-            message: error.to_string(),
-        })?;
-
-    Ok(add_exact_deposit_notes_to_funding_key(
-        deployment,
-        [1, 3, 5],
-    ))
-}
-
-/// Adds small exact-value notes that make deposit assertions deterministic
-/// without setup transfers inside each scenario.
-fn add_exact_deposit_notes_to_funding_key(
-    mut deployment: DeploymentPlan,
-    note_values: impl IntoIterator<Item = Value>,
-) -> DeploymentPlan {
-    let values = note_values.into_iter().collect::<Vec<_>>();
-
-    if values.is_empty() {
-        return deployment;
-    }
-
-    let funding_public_key = deployment.nodes()[0].general.consensus_config.funding_pk;
-    let mut transfer_op = deployment
-        .config
-        .genesis_block
-        .as_ref()
-        .expect("zone deployment should include a genesis block")
-        .genesis_tx()
-        .genesis_transfer()
-        .clone();
-
-    for value in values {
-        transfer_op
-            .outputs
-            .as_mut()
-            .try_push(Note::new(value, funding_public_key))
-            .expect("zone helper note set should stay within transfer output bounds");
-    }
-
-    let providers = deployment
-        .nodes()
-        .iter()
-        .take(deployment.config.blend_core_nodes)
-        .map(|node| {
-            let (blend_config, provider_sk, zk_sk) = &node.general.blend_config;
-
-            ProviderInfo {
-                service_type: ServiceType::BlendNetwork,
-                provider_sk: provider_sk.clone(),
-                zk_sk: zk_sk.clone(),
-                locator: Locator::new_unchecked(
-                    blend_config.core.backend.listening_address.clone(),
-                ),
-                note: node.general.consensus_config.blend_note.clone(),
-            }
-        })
-        .collect();
-
-    deployment.config.genesis_block = Some(create_genesis_block_with_declarations(
-        transfer_op,
-        providers,
-        deployment.config.test_context.as_deref(),
-    ));
-
-    deployment
-}
-
-/// Shrinks consensus timing for zone Cucumber scenarios while keeping the node
-/// otherwise close to the generated local deployment config.
-fn fast_zone_config_patch(mut config: RunConfig) -> Result<RunConfig, DynError> {
-    if config.user.api.backend.listen_address.port() == 0 {
-        return Err("zone test config patch requires a non-zero API port".into());
-    }
-
-    config.deployment.time.slot_duration = Duration::from_secs(1);
-    config.deployment.cryptarchia.slot_activation_coeff =
-        NonNegativeRatio::new(1, 2.try_into().unwrap());
-
-    config
-        .user
-        .cryptarchia
-        .service
-        .bootstrap
-        .prolonged_bootstrap_period = Duration::ZERO;
-
-    config.deployment.cryptarchia.security_param = NonZero::new(5).unwrap();
-
-    Ok(config)
 }

--- a/tests/src/cucumber/steps/manual_zone/tables.rs
+++ b/tests/src/cucumber/steps/manual_zone/tables.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use cucumber::gherkin::Step;
 use lb_core::mantle::ops::channel::inscribe::Inscription;
@@ -49,6 +49,134 @@ pub(super) struct ZoneConfigRow {
     pub posting_timeframe: u32,
     pub posting_timeout: u32,
     pub authorized_sequencers: Vec<String>,
+}
+
+pub(super) struct ZoneNodeResourcesRow {
+    pub node_name: String,
+    pub account_index: usize,
+    pub wallet_name: String,
+    pub connected_to: Option<String>,
+    pub sequencers: Vec<String>,
+}
+
+pub(super) fn zone_node_resource_rows(step: &Step) -> Result<Vec<ZoneNodeResourcesRow>, StepError> {
+    let rows = parse_zone_table_rows(
+        step,
+        &[
+            "node_name",
+            "account_index",
+            "wallet_name",
+            "connected_to",
+            "sequencers",
+        ],
+        "Zone node resources",
+        parse_zone_node_resource_row,
+    )?;
+
+    ensure_unique_zone_node_resources(&rows)?;
+
+    Ok(rows)
+}
+
+fn parse_zone_node_resource_row(row: &[String]) -> Result<ZoneNodeResourcesRow, StepError> {
+    match row {
+        [
+            node_name,
+            account_index,
+            wallet_name,
+            connected_to,
+            sequencers,
+        ] => {
+            let node_name = required_cell(node_name, "node_name")?;
+            let account_index =
+                account_index
+                    .trim()
+                    .parse()
+                    .map_err(|error| StepError::InvalidArgument {
+                        message: format!("Invalid zone account index '{account_index}': {error}"),
+                    })?;
+            let wallet_name = required_cell(wallet_name, "wallet_name")?;
+            let connected_to = optional_cell(connected_to);
+            let sequencers = comma_separated_aliases(sequencers, "sequencers")?;
+
+            Ok(ZoneNodeResourcesRow {
+                node_name,
+                account_index,
+                wallet_name,
+                connected_to,
+                sequencers,
+            })
+        }
+        _ => invalid_zone_table_row(
+            "Zone node resources",
+            &[
+                "node_name",
+                "account_index",
+                "wallet_name",
+                "connected_to",
+                "sequencers",
+            ],
+            row.len(),
+        ),
+    }
+}
+
+fn ensure_unique_zone_node_resources(rows: &[ZoneNodeResourcesRow]) -> Result<(), StepError> {
+    let mut wallets = HashSet::new();
+    let mut sequencers = HashSet::new();
+
+    for row in rows {
+        if !wallets.insert(row.wallet_name.clone()) {
+            return Err(StepError::InvalidArgument {
+                message: format!("Duplicate zone wallet '{}'", row.wallet_name),
+            });
+        }
+
+        for sequencer in &row.sequencers {
+            if !sequencers.insert(sequencer.clone()) {
+                return Err(StepError::InvalidArgument {
+                    message: format!("Duplicate zone sequencer '{sequencer}'"),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn required_cell(value: &str, name: &str) -> Result<String, StepError> {
+    let value = value.trim();
+
+    if value.is_empty() {
+        return Err(StepError::InvalidArgument {
+            message: format!("Zone node resources `{name}` cannot be empty"),
+        });
+    }
+
+    Ok(value.to_owned())
+}
+
+fn optional_cell(value: &str) -> Option<String> {
+    let value = value.trim();
+
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn comma_separated_aliases(value: &str, name: &str) -> Result<Vec<String>, StepError> {
+    let aliases = value
+        .split(',')
+        .map(str::trim)
+        .filter(|alias| !alias.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+
+    if aliases.is_empty() {
+        return Err(StepError::InvalidArgument {
+            message: format!("Zone node resources `{name}` must list at least one alias"),
+        });
+    }
+
+    Ok(aliases)
 }
 
 pub(super) fn zone_message_rows(step: &Step) -> Result<Vec<(String, Inscription)>, StepError> {

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -147,6 +147,8 @@ pub type ZoneDiscardedPayloads = Arc<tokio::sync::Mutex<HashSet<Inscription>>>;
 pub struct ZoneSequencerIdentity {
     signing_key: Ed25519Key,
     channel_id: ChannelId,
+    node_name: Option<String>,
+    default_wallet_name: Option<String>,
 }
 
 pub struct ZoneSequencerRuntime {
@@ -169,7 +171,6 @@ pub struct ZoneSequencerStartup {
 #[derive(Default)]
 pub struct ZoneState {
     node_name: Option<String>,
-    funding_public_key: Option<ZkPublicKey>,
     indexer: Option<ZoneIndexer<ZoneNodeHttpClient>>,
     sequencers: HashMap<String, ZoneSequencerIdentity>,
     runtimes: HashMap<String, ZoneSequencerRuntime>,
@@ -187,13 +188,6 @@ pub struct ZoneState {
 }
 
 impl ZoneState {
-    pub fn initialize_cluster(&mut self, node_name: String, funding_public_key: ZkPublicKey) {
-        self.reset_zone_state();
-
-        self.node_name = Some(node_name);
-        self.funding_public_key = Some(funding_public_key);
-    }
-
     pub fn clear(&mut self) {
         self.reset_zone_state();
     }
@@ -206,12 +200,24 @@ impl ZoneState {
 
     pub fn register_sequencer(&mut self, alias: String, signing_key: Ed25519Key) -> ChannelId {
         let channel_id = self.channel_for_new_sequencer(&signing_key);
+        let existing_resources = self
+            .sequencers
+            .get(&alias)
+            .map(|sequencer| {
+                (
+                    sequencer.node_name.clone(),
+                    sequencer.default_wallet_name.clone(),
+                )
+            })
+            .unwrap_or_default();
 
         self.sequencers.insert(
             alias.clone(),
             ZoneSequencerIdentity {
                 signing_key,
                 channel_id,
+                node_name: existing_resources.0,
+                default_wallet_name: existing_resources.1,
             },
         );
 
@@ -270,10 +276,57 @@ impl ZoneState {
         self.sequencer_channel_id(&alias)
     }
 
-    pub fn funding_public_key(&self) -> Result<ZkPublicKey, StepError> {
-        self.funding_public_key.ok_or(StepError::LogicalError {
-            message: "Zone funding public key is not initialized".to_owned(),
-        })
+    #[must_use]
+    pub fn has_sequencer(&self, alias: &str) -> bool {
+        self.sequencers.contains_key(alias)
+    }
+
+    pub fn attach_sequencer_resources(
+        &mut self,
+        alias: &str,
+        node_name: String,
+        wallet_name: String,
+    ) -> Result<(), StepError> {
+        if self.node_name.is_none() {
+            self.node_name = Some(node_name.clone());
+        }
+
+        let sequencer = self
+            .sequencers
+            .get_mut(alias)
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Zone sequencer '{alias}' is not registered"),
+            })?;
+
+        sequencer.node_name = Some(node_name);
+        sequencer.default_wallet_name = Some(wallet_name);
+
+        Ok(())
+    }
+
+    pub fn sequencer_node_name(&self, alias: &str) -> Result<&str, StepError> {
+        let sequencer = self
+            .sequencers
+            .get(alias)
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Zone sequencer '{alias}' is not registered"),
+            })?;
+
+        sequencer
+            .node_name
+            .as_deref()
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Zone sequencer '{alias}' is not attached to a node"),
+            })
+    }
+
+    pub fn sequencer_default_wallet_name(&self, alias: &str) -> Result<&str, StepError> {
+        self.sequencers
+            .get(alias)
+            .and_then(|sequencer| sequencer.default_wallet_name.as_deref())
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Zone sequencer '{alias}' does not have a default wallet"),
+            })
     }
 
     pub fn remember_zone_message(
@@ -645,7 +698,6 @@ impl ZoneState {
         self.abort_all_runtimes();
 
         self.node_name = None;
-        self.funding_public_key = None;
         self.indexer = None;
         self.default_sequencer_alias = None;
         self.sorted_total_payloads = None;
@@ -1614,6 +1666,21 @@ impl CucumberWorld {
 
     pub fn zone_node_url(&self) -> Result<Url, StepError> {
         Ok(self.zone_node_http_client()?.base_url().clone())
+    }
+
+    pub fn zone_node_http_client_for_sequencer(
+        &self,
+        sequencer_alias: &str,
+    ) -> Result<NodeHttpClient, StepError> {
+        let node_name = self.zone.sequencer_node_name(sequencer_alias)?;
+        self.resolve_node_http_client(node_name)
+    }
+
+    pub fn zone_node_url_for_sequencer(&self, sequencer_alias: &str) -> Result<Url, StepError> {
+        Ok(self
+            .zone_node_http_client_for_sequencer(sequencer_alias)?
+            .base_url()
+            .clone())
     }
 
     /// Helper to resolve a node http client to the actual started node name.


### PR DESCRIPTION
## 1. What does this PR implement?

This PR makes zone e2e setup explicit in Cucumber scenarios.

Zone tests now declare the cluster, wallet resources, node-to-wallet mapping, and sequencer ownership directly in the feature file instead of relying on hidden zone bootstrap state. This removes the implicit zone funding wallet path and makes sequencer-funded operations use the wallet assigned in the scenario setup.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal , @hansieodendaal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
