### PR TITLE
fix(chain-network): avoid readding included reorged txs

### DIFF
--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -8,6 +8,7 @@ mod sync;
 
 use core::fmt::Debug;
 use std::{
+    collections::HashSet,
     fmt::Display,
     hash::Hash,
     time::{Duration, Instant},
@@ -759,12 +760,18 @@ where
 
     let (tip, reorged_txs) = cryptarchia.apply_block(block.clone()).await?;
     let reorged_tx_count = reorged_txs.len();
-    let included_tx_count = block.transactions().len();
+    let included_tx_hashes = block
+        .transactions()
+        .map(Transaction::hash)
+        .collect::<Vec<_>>();
+
+    let included_tx_count = included_tx_hashes.len();
+    let is_canonical_tip = tip == block.header().id();
 
     // Remove included content from mempool if the block was applied to the honest
     // chain. Otherwise, we keep them in mempool, so they can be included to the
     // honest chain later when this node proposes blocks.
-    if tip == block.header().id() {
+    if is_canonical_tip {
         debug!(
             "Applied block {:?} to the canonical chain; included {} transactions and will reinsert {} reorged transactions",
             block.header().id(),
@@ -772,12 +779,7 @@ where
             reorged_tx_count
         );
         mempool_adapter
-            .remove_transactions(
-                &block
-                    .transactions()
-                    .map(Transaction::hash)
-                    .collect::<Vec<_>>(),
-            )
+            .remove_transactions(&included_tx_hashes)
             .await
             .unwrap_or_else(|e| error!("Could not mark transactions in block: {e}"));
     } else {
@@ -788,6 +790,27 @@ where
             tip
         );
     }
+
+    let reorged_txs = if is_canonical_tip {
+        let included_tx_hashes = included_tx_hashes.into_iter().collect::<HashSet<_>>();
+        let reinserted_txs = reorged_txs
+            .into_iter()
+            .filter(|tx| !included_tx_hashes.contains(&Transaction::hash(tx)))
+            .collect::<Vec<_>>();
+
+        let skipped_tx_count = reorged_tx_count.saturating_sub(reinserted_txs.len());
+        if skipped_tx_count > 0 {
+            debug!(
+                "Skipped {} reorged transactions already included in canonical block {:?}",
+                skipped_tx_count,
+                block.header().id()
+            );
+        }
+
+        reinserted_txs
+    } else {
+        reorged_txs
+    };
 
     // Re-insert reorged txs back into the mempool.
     join_all(reorged_txs.into_iter().map(|tx| {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes mempool reconciliation after a chain reorg.

When a newly applied block becomes the canonical tip, chain-network removes that block’s included transactions from the mempool. It also re-adds transactions from blocks that were reorged out of the old canonical branch.

Before this change, reorged transactions were re-added without checking whether the new canonical block already included the same transaction. This could make an already-included transaction appear pending again in the mempool.

The fix filters reorged transactions against the transactions included in the newly canonical block before re-adding them to the mempool.


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
