### PR TITLE
fix: uniformize block root computation

### DIFF
--- a/core/src/block/mod.rs
+++ b/core/src/block/mod.rs
@@ -171,9 +171,7 @@ impl<Tx> Block<Tx> {
     where
         Tx: Transaction<Hash = TxHash>,
     {
-        let tx_hashes: Vec<TxHash> = transactions.iter().map(Transaction::hash).collect();
-
-        let root_hash = merkle::calculate_merkle_root(&tx_hashes, None);
+        let root_hash = merkle::calculate_block_root(transactions);
         ContentId::from(root_hash)
     }
 

--- a/core/src/header/mod.rs
+++ b/core/src/header/mod.rs
@@ -11,9 +11,9 @@ pub const BEDROCK_VERSION: u8 = 1;
 use crate::{
     codec::SerializeOp as _,
     crypto::Hasher,
-    mantle::{Transaction as _, TxHash, genesis_tx::GenesisTx},
+    mantle::genesis_tx::GenesisTx,
     proofs::leader_proof::{Groth16LeaderProof, LeaderProof as _},
-    utils::{display_hex_bytes_newtype, serde_bytes_newtype},
+    utils::{display_hex_bytes_newtype, merkle, serde_bytes_newtype},
 };
 
 #[derive(Clone, Eq, PartialEq, Copy, Hash, PartialOrd, Ord)]
@@ -138,10 +138,10 @@ impl Header {
 
     #[must_use]
     pub fn genesis(tx: &GenesisTx) -> Self {
-        let tx_hash: TxHash = tx.hash();
+        let block_root = merkle::calculate_block_root(&[tx]);
         Self::new(
             HeaderId([0; 32]),
-            ContentId(tx_hash.into()),
+            ContentId(block_root),
             Slot::from(0u64),
             Groth16LeaderProof::genesis(),
         )

--- a/core/src/utils/merkle.rs
+++ b/core/src/utils/merkle.rs
@@ -1,11 +1,7 @@
-use crate::crypto::{Digest as _, Hasher};
-
-#[must_use]
-pub fn leaf(data: &[u8]) -> [u8; 32] {
-    let mut hasher = Hasher::new();
-    hasher.update(data);
-    hasher.finalize().into()
-}
+use crate::{
+    crypto::{Digest as _, Hash, Hasher},
+    mantle::{Transaction, TxHash},
+};
 
 pub fn node(left: impl AsRef<[u8]>, right: impl AsRef<[u8]>) -> [u8; 32] {
     let mut hasher = Hasher::new();
@@ -14,137 +10,75 @@ pub fn node(left: impl AsRef<[u8]>, right: impl AsRef<[u8]>) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-/// Calculates a 32-byte Merkle root for the given elements, with deterministic
-/// padding.
-///
-/// Padding rules:
-/// - Target size = `max(elements.len()`, `pad_to.unwrap_or(elements.len())`, 1)
-/// - Then rounded up to the next power of two
-/// - Missing leaves are filled using the default value of `T`
-/// - Special case: single leaf (`target_size` = 1) returns leaf hash directly
-///
-/// Examples:
-/// - 0 elements: 1 leaf → `leaf(default_element)`
-/// - 1 element: 1 leaf → leaf(element)
-/// - 2 elements: 2 leaves → node(leaf1, leaf2)
-/// - 3 elements: 4 leaves (padded) → full binary tree structure
-///
-/// Parameters:
-/// - `elements`: Items included in the tree; each converts to a 32-byte leaf.
-/// - `pad_to`: Optional minimum leaf count before rounding up to a power of
-///   two.
-///
-/// Returns:
-/// - The Merkle root as a 32-byte array.
-///
-/// Notes:
-/// - Using a fixed `pad_to` keeps the tree height consistent across varying
-///   input sizes.
-/// - Powers of two that are already satisfied don't trigger padding.
-pub fn calculate_merkle_root<T>(elements: &[T], pad_to: Option<usize>) -> [u8; 32]
-where
-    T: Into<[u8; 32]> + Default + Clone,
-{
-    let mut leaves: Vec<[u8; 32]> = elements
-        .iter()
-        .cloned()
-        .map(|element| leaf(&element.into()))
-        .collect();
+// Calculates a 32-byte Merkle root of transactions
+pub fn calculate_block_root<T: Transaction<Hash = TxHash>>(transactions: &[T]) -> Hash {
+    let mut leaves: Vec<_> = transactions.iter().map(Transaction::hash).collect();
 
-    let target_size = pad_to
-        .map_or(leaves.len(), |padding| leaves.len().max(padding))
-        .max(1)
-        .next_power_of_two();
+    let target_size = leaves.len().max(1).next_power_of_two();
 
-    let zero_leaf = leaf(&T::default().into());
+    let zero_leaf: <T as Transaction>::Hash = [0u8; 32].into();
     leaves.resize(target_size, zero_leaf);
 
     while leaves.len() > 1 {
         leaves = leaves
             .chunks(2)
-            .map(|pair| node(pair[0], pair[1]))
+            .map(|pair| node(pair[0].0, pair[1].0).into())
             .collect();
     }
 
-    leaves[0]
+    leaves[0].into()
 }
 
 #[cfg(test)]
 mod tests {
+    use lb_key_management_system_keys::keys::ZkPublicKey;
 
     use super::*;
-    use crate::mantle::TxHash;
+    use crate::mantle::{
+        MantleTx, Note, Op,
+        encoding::Ops,
+        ledger::{Inputs, Outputs},
+        ops::transfer::TransferOp,
+    };
+
+    fn create_random_tx(seed: u32) -> MantleTx {
+        MantleTx(Ops::new_unchecked(vec![Op::Transfer(TransferOp::new(
+            Inputs::new(vec![]),
+            Outputs::new(vec![Note {
+                value: seed.into(),
+                pk: ZkPublicKey::zero(),
+            }]),
+        ))]))
+    }
 
     #[test]
     fn test_root_two_elements() {
-        let elements = vec![TxHash::from([1u8; 32]), TxHash::from([2u8; 32])];
-        let result = calculate_merkle_root(&elements, Some(2));
-
-        let bytes1: [u8; 32] = elements[0].into();
-        let bytes2: [u8; 32] = elements[1].into();
-        let leaf1 = leaf(&bytes1);
-        let leaf2 = leaf(&bytes2);
-        let expected = node(leaf1, leaf2);
-
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_root_with_padding() {
-        let elements = vec![TxHash::from([1u8; 32]), TxHash::from([2u8; 32])];
-        let result = calculate_merkle_root(&elements, Some(4));
-
-        let bytes1: [u8; 32] = elements[0].into();
-        let bytes2: [u8; 32] = elements[1].into();
-        let zero_hash = TxHash::default();
-        let zero_bytes: [u8; 32] = zero_hash.into();
-
-        let leaf1 = leaf(&bytes1);
-        let leaf2 = leaf(&bytes2);
-        let leaf3 = leaf(&zero_bytes); // padding
-        let leaf4 = leaf(&zero_bytes); // padding
-
-        let branch1 = node(leaf1, leaf2);
-        let branch2 = node(leaf3, leaf4);
-        let expected = node(branch1, branch2);
-
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_root_without_padding() {
-        let elements = vec![TxHash::from([1u8; 32]), TxHash::from([2u8; 32])];
-        let result = calculate_merkle_root(&elements, None);
-
-        let bytes1: [u8; 32] = elements[0].into();
-        let bytes2: [u8; 32] = elements[1].into();
-        let leaf1 = leaf(&bytes1);
-        let leaf2 = leaf(&bytes2);
-        let expected = node(leaf1, leaf2);
+        let txs = vec![create_random_tx(0), create_random_tx(1)];
+        let result = calculate_block_root(&txs);
+        let leaf1 = txs[0].hash();
+        let leaf2 = txs[1].hash();
+        let expected = node(leaf1.0, leaf2.0);
 
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_root_single_element() {
-        let elements = vec![TxHash::from([42u8; 32])];
-        let result = calculate_merkle_root(&elements, None);
+        let txs = vec![create_random_tx(42)];
+        let result = calculate_block_root(&txs);
 
-        let bytes: [u8; 32] = elements[0].into();
-        let expected = leaf(&bytes);
+        let expected = txs[0].hash();
 
-        assert_eq!(result, expected);
+        assert_eq!(result, Hash::from(expected));
     }
 
     #[test]
     fn test_root_empty_elements() {
-        let elements: Vec<TxHash> = vec![];
-        let result = calculate_merkle_root(&elements, None);
+        let txs: Vec<MantleTx> = vec![];
+        let result = calculate_block_root(&txs);
 
-        let zero_hash = TxHash::default();
-        let zero_bytes: [u8; 32] = zero_hash.into();
-        let expected = leaf(&zero_bytes);
+        let expected = [0u8; 32];
 
-        assert_eq!(result, expected);
+        assert_eq!(result, Hash::from(expected));
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR solves #2793. The issue is that the actual block root is computed differently for the genesis block and the other ones. This is happening because the construction is inconsistent: the genesis block construct it itself and other blocks call `compute_merkle_root` which is a general merkle root calculator function.

I propose to specialize this function into `compute_block_root` since it's not used anywhere else that specifically takes `Transactions` as inputs and return the corresponding `block_root`. I also updated the genesis block to call this function to compute its `block_root`.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur for the code
@davidrusu for the spec

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
