### PR TITLE
chore(cli): Init, update and migrate commands

### DIFF
--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr as _,
 };
 
-use lb_node::cli::EmbeddedInitArgs;
+use lb_node::cli::{EmbeddedInitArgs, InitArgs};
 use multiaddr::Multiaddr;
 use tokio::runtime::Runtime;
 
@@ -93,9 +93,9 @@ impl From<GenerateConfigArgs> for EmbeddedInitArgs {
 
 #[must_use]
 pub fn generate_config_sync(args: EmbeddedInitArgs) -> OperationStatus {
+    let init_args: InitArgs = args.into();
     let runtime = Runtime::new().expect("Failed to create Tokio runtime.");
-    let run_result =
-        runtime.block_on(async move { lb_node::cli::config::init::run((&args).into()) });
+    let run_result = runtime.block_on(async move { lb_node::cli::config::init::run(init_args) });
     match run_result {
         Ok(()) => OperationStatus::Ok,
         Err(error) => {

--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr as _,
 };
 
-use lb_node::cli::InitArgs;
+use lb_node::cli::EmbeddedInitArgs;
 use multiaddr::Multiaddr;
 use tokio::runtime::Runtime;
 
@@ -24,7 +24,7 @@ pub struct GenerateConfigArgs {
     pub state_path: *const c_char,
 }
 
-impl From<GenerateConfigArgs> for InitArgs {
+impl From<GenerateConfigArgs> for EmbeddedInitArgs {
     fn from(value: GenerateConfigArgs) -> Self {
         let mut init_args = Self::default();
 
@@ -92,9 +92,10 @@ impl From<GenerateConfigArgs> for InitArgs {
 }
 
 #[must_use]
-pub fn generate_config_sync(args: InitArgs) -> OperationStatus {
+pub fn generate_config_sync(args: EmbeddedInitArgs) -> OperationStatus {
     let runtime = Runtime::new().expect("Failed to create Tokio runtime.");
-    let run_result = runtime.block_on(async move { lb_node::cli::config::init::run(&args) });
+    let run_result =
+        runtime.block_on(async move { lb_node::cli::config::init::run((&args).into()) });
     match run_result {
         Ok(()) => OperationStatus::Ok,
         Err(error) => {
@@ -122,6 +123,6 @@ pub fn generate_config_sync(args: InitArgs) -> OperationStatus {
 #[must_use]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn generate_user_config(args: GenerateConfigArgs) -> OperationStatus {
-    let init_args = InitArgs::from(args);
+    let init_args = EmbeddedInitArgs::from(args);
     generate_config_sync(init_args)
 }

--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -94,7 +94,7 @@ impl From<GenerateConfigArgs> for InitArgs {
 #[must_use]
 pub fn generate_config_sync(args: InitArgs) -> OperationStatus {
     let runtime = Runtime::new().expect("Failed to create Tokio runtime.");
-    let run_result = runtime.block_on(async move { lb_node::cli::init::run(&args) });
+    let run_result = runtime.block_on(async move { lb_node::cli::config::init::run(&args) });
     match run_result {
         Ok(()) => OperationStatus::Ok,
         Err(error) => {

--- a/kms/keys/src/keys/ed25519/mod.rs
+++ b/kms/keys/src/keys/ed25519/mod.rs
@@ -72,7 +72,7 @@ impl Ed25519Key {
 
 impl Hash for Ed25519Key {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.public_key().to_bytes().hash(state);
+        self.public_key().hash(state);
     }
 }
 

--- a/kms/keys/src/keys/ed25519/mod.rs
+++ b/kms/keys/src/keys/ed25519/mod.rs
@@ -1,4 +1,5 @@
 use core::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
 
 use bytes::Bytes;
 use ed25519_dalek::SigningKey;
@@ -66,6 +67,12 @@ impl Ed25519Key {
     #[must_use]
     pub fn into_unsecured(self) -> UnsecuredEd25519Key {
         self.0.clone()
+    }
+}
+
+impl Hash for Ed25519Key {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.public_key().to_bytes().hash(state);
     }
 }
 

--- a/kms/keys/src/keys/zk/mod.rs
+++ b/kms/keys/src/keys/zk/mod.rs
@@ -1,4 +1,5 @@
 use core::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
 
 use lb_groth16::Fr;
 use lb_zksign::ZkSignError;
@@ -66,6 +67,12 @@ impl ZkKey {
     #[must_use]
     pub const fn as_unsecured(&self) -> &UnsecuredZkKey {
         &self.0
+    }
+}
+
+impl Hash for ZkKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.to_public_key().hash(state);
     }
 }
 

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -199,7 +199,7 @@ where
         }
 
         let app = Router::new()
-            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+            .merge(SwaggerUi::new("/swagger-ui").url("../api-docs/openapi.json", ApiDoc::openapi()))
             .route(
                 paths::MANTLE_METRICS,
                 routing::get(mantle_metrics::<MempoolStorageAdapter, RuntimeServiceId>),

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -199,7 +199,7 @@ where
         }
 
         let app = Router::new()
-            .merge(SwaggerUi::new("/swagger-ui").url("../api-docs/openapi.json", ApiDoc::openapi()))
+            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
             .route(
                 paths::MANTLE_METRICS,
                 routing::get(mantle_metrics::<MempoolStorageAdapter, RuntimeServiceId>),

--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -1,502 +1,209 @@
-use core::str::FromStr as _;
-use std::{
-    collections::{HashMap, HashSet},
-    path::{Path, PathBuf},
-};
-
-use color_eyre::eyre::{Result, eyre};
-use lb_groth16::fr_to_bytes;
-use lb_key_management_system_service::{
-    backend::preload::KeyId,
-    keys::{Ed25519Key, Key, ZkKey, ZkPublicKey, secured_key::SecuredKey as _},
-};
+use color_eyre::eyre::Result;
 use libp2p::{Multiaddr, PeerId};
-use num_bigint::BigUint;
-use rand::rngs::OsRng;
 
 use crate::{
-    UserConfig,
-    cli::InitArgs,
+    NetworkArgs, UserConfig,
+    cli::{
+        InitArgs,
+        config::keystore::{KeyTitle, Keystore},
+    },
     config::{
-        ApiConfig, KmsConfig, SdpConfig, StateConfig, StorageConfig, TracingConfig, WalletConfig,
+        ApiConfig, BlendArgs, CryptarchiaArgs, CryptarchiaConfig, KmsConfig, SdpArgs, SdpConfig,
+        StateConfig, StorageConfig, TimeConfig, TracingConfig, WalletConfig,
         blend::serde::{Config as BlendConfig, RequiredValues as BlendConfigRequiredValues},
-        cryptarchia::serde::{
-            Config as CryptarchiaConfig, RequiredValues as CryptarchiaConfigRequiredValues,
-        },
-        network::serde::{Config as NetworkConfig, nat},
-        sdp::serde::RequiredValues as SdpRequiredValues,
-        time::serde::Config as TimeConfig,
-        update_tracing_filter_and_derive_level,
+        cryptarchia::serde::RequiredValues as CryptarchiaConfigRequiredValues,
+        network::serde::Config as NetworkConfig,
+        sdp::serde::RequiredValues as SdpConfigRequiredValues,
+        update_api, update_blend, update_cryptarchia, update_network, update_sdp, update_state,
+        update_tracing,
         wallet::serde::RequiredValues as WalletConfigRequiredValues,
     },
 };
 
-fn key_id(key: &Key) -> KeyId {
-    let key_id_bytes = match key {
-        Key::Ed25519(ed25519_secret_key) => ed25519_secret_key.as_public_key().to_bytes(),
-        Key::Zk(zk_secret_key) => fr_to_bytes(zk_secret_key.as_public_key().as_fr()),
-    };
-    hex::encode(key_id_bytes)
-}
+pub fn run(args: InitArgs) -> Result<()> {
+    let output_path = args.output.clone();
+    let keystore = build_keystore();
+    let user_config = build_user_config(&keystore, args);
 
-fn generate_zk_key_from_random_bytes() -> ZkKey {
-    let mut bytes = [0u8; 32];
-    rand::RngCore::fill_bytes(&mut OsRng, &mut bytes);
-    ZkKey::from(BigUint::from_bytes_le(&bytes))
-}
-
-struct GeneratedKeys {
-    blend_signing_key: Ed25519Key,
-    blend_zk_key: ZkKey,
-    leader_key: ZkKey,
-    funding_key: ZkKey,
-    blend_signing_key_id: KeyId,
-    blend_zk_key_id: KeyId,
-    leader_key_id: KeyId,
-    funding_key_id: KeyId,
-    leader_pk: ZkPublicKey,
-    funding_pk: ZkPublicKey,
-    blend_zk_pk: ZkPublicKey,
-}
-
-fn generate_keys() -> GeneratedKeys {
-    let blend_signing_key = Ed25519Key::generate(&mut OsRng);
-    let blend_zk_key = ZkKey::from(BigUint::from_bytes_le(
-        blend_signing_key.public_key().as_bytes(),
-    ));
-    let leader_key = generate_zk_key_from_random_bytes();
-    let funding_key = generate_zk_key_from_random_bytes();
-
-    let blend_signing_key_id = key_id(&blend_signing_key.clone().into());
-    let blend_zk_key_id = key_id(&blend_zk_key.clone().into());
-    let leader_key_id = key_id(&leader_key.clone().into());
-    let funding_key_id = key_id(&funding_key.clone().into());
-
-    let leader_pk: ZkPublicKey = leader_key.as_public_key();
-    let funding_pk: ZkPublicKey = funding_key.as_public_key();
-    let blend_zk_pk: ZkPublicKey = blend_zk_key.as_public_key();
-
-    GeneratedKeys {
-        blend_signing_key,
-        blend_zk_key,
-        leader_key,
-        funding_key,
-        blend_signing_key_id,
-        blend_zk_key_id,
-        leader_key_id,
-        funding_key_id,
-        leader_pk,
-        funding_pk,
-        blend_zk_pk,
-    }
-}
-
-pub fn run(args: &InitArgs) -> Result<()> {
-    if args.initial_peers.is_empty() {
-        eprintln!("Warning: No initial peers provided. This node will start as a genesis node.");
-    }
-
-    let network_key = lb_libp2p::ed25519::SecretKey::generate();
-
-    let blend_listening_address =
-        Multiaddr::from_str(&format!("/ip4/0.0.0.0/udp/{}/quic-v1", args.blend_port))
-            .map_err(|e| eyre!("Invalid blend listening address: {e}"))?;
-
-    // If --kms-file points to an existing file, reuse its keys instead of
-    // generating new ones.
-    let (keys, kms_path, write_kms) = match &args.kms_file {
-        Some(path) if path.exists() => {
-            let contents = std::fs::read_to_string(path)?;
-            let kms_config: KmsConfig = serde_yaml::from_str(&contents)?;
-            let keys = keys_from_kms_config(&kms_config)?;
-            (keys, path.clone(), false)
-        }
-        _ => {
-            let keys = generate_keys();
-            let path = kms_output_path(args);
-            (keys, path, true)
-        }
-    };
-
-    let tracing_config = build_tracing_config(args)?;
-    let user_config = build_user_config(
-        args,
-        network_key,
-        keys,
-        blend_listening_address,
-        tracing_config,
-    );
-
-    if write_kms {
-        let kms_yaml = serde_yaml::to_string(&user_config.kms)?;
-        std::fs::write(&kms_path, &kms_yaml)?;
-        println!("KMS config written to {}", kms_path.display());
-    }
-
-    let kms_include = kms_include_str(args, &kms_path);
-    let yaml = serialize_with_kms_include(&user_config, &kms_include)?;
-    std::fs::write(&args.output, &yaml)?;
-
-    println!("Config written to {}", args.output.display());
     Ok(())
 }
 
-/// Extracts key material from a parsed KMS config so it can be used to
-/// populate the rest of the node config without generating new keys.
-///
-/// Assumes the KMS config was produced by `init` and follows the layout:
-/// - exactly one Ed25519 key  → blend signing key
-/// - one Zk key derived from the Ed25519 public bytes → blend Zk key
-/// - remaining Zk keys sorted by ID: first → leader, second → funding
-fn keys_from_kms_config(kms_config: &KmsConfig) -> Result<GeneratedKeys> {
-    let (blend_signing_key_id, blend_signing_key) = kms_config
-        .backend
-        .keys
-        .iter()
-        .find_map(|(id, key)| match key {
-            Key::Ed25519(k) => Some((id.clone(), k.clone())),
-            Key::Zk(_) => None,
-        })
-        .ok_or_else(|| eyre!("KMS file contains no Ed25519 key"))?;
-
-    let blend_zk_key = ZkKey::from(BigUint::from_bytes_le(
-        blend_signing_key.public_key().as_bytes(),
-    ));
-    let blend_zk_key_id = key_id(&Key::Zk(blend_zk_key.clone()));
-
-    let mut other_zk: Vec<(KeyId, ZkKey)> = kms_config
-        .backend
-        .keys
-        .iter()
-        .filter_map(|(id, key)| match key {
-            Key::Zk(k) if *id != blend_zk_key_id => Some((id.clone(), k.clone())),
-            _ => None,
-        })
-        .collect();
-
-    other_zk.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-    if other_zk.len() < 2 {
-        return Err(eyre!(
-            "KMS file must contain at least 3 Zk keys (blend, leader, funding), found {}",
-            other_zk.len() + 1
-        ));
-    }
-
-    let (leader_key_id, leader_key) = other_zk.remove(0);
-    let (funding_key_id, funding_key) = other_zk.remove(0);
-    let leader_pk = leader_key.as_public_key();
-    let funding_pk = funding_key.as_public_key();
-    let blend_zk_pk = blend_zk_key.as_public_key();
-
-    Ok(GeneratedKeys {
-        blend_signing_key,
-        blend_zk_key,
-        leader_key,
-        funding_key,
-        blend_signing_key_id,
-        blend_zk_key_id,
-        leader_key_id,
-        funding_key_id,
-        leader_pk,
-        funding_pk,
-        blend_zk_pk,
-    })
-}
-
-fn kms_output_path(args: &InitArgs) -> PathBuf {
-    args.kms_file.clone().unwrap_or_else(|| {
-        args.output
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join("kms.yaml")
-    })
-}
-
-/// Returns the path string to use in `!include <path>` inside the main config.
-///
-/// If the KMS file is in the same directory as the main config, only the
-/// filename is used so the include stays portable when the directory is moved.
-fn kms_include_str(args: &InitArgs, kms_path: &Path) -> String {
-    if let Some(ref kms_file) = args.kms_file {
-        return kms_file.to_string_lossy().into_owned();
-    }
-    // Default: same directory as the output file → reference by filename only.
-    kms_path.file_name().map_or_else(
-        || kms_path.to_string_lossy().into_owned(),
-        |n| n.to_string_lossy().into_owned(),
-    )
-}
-
-fn serialize_with_kms_include(config: &UserConfig, kms_include: &str) -> Result<String> {
-    use serde_yaml::value::{Tag, TaggedValue};
-    let mut value = serde_yaml::to_value(config)?;
-    if let serde_yaml::Value::Mapping(ref mut map) = value {
-        map.insert(
-            serde_yaml::Value::String("kms".into()),
-            serde_yaml::Value::Tagged(Box::new(TaggedValue {
-                tag: Tag::new("include"),
-                value: serde_yaml::Value::String(kms_include.into()),
-            })),
-        );
-    }
-    Ok(serde_yaml::to_string(&value)?)
-}
-
-fn build_tracing_config(args: &InitArgs) -> Result<TracingConfig> {
-    let mut tracing_config = TracingConfig::default();
-
-    if let Some(filter) = &args.log_filter {
-        update_tracing_filter_and_derive_level(&mut tracing_config, filter)?;
-    }
-
-    Ok(tracing_config)
-}
-
-fn build_user_config(
-    args: &InitArgs,
-    network_key: lb_libp2p::ed25519::SecretKey,
-    keys: GeneratedKeys,
-    blend_listening_address: Multiaddr,
-    tracing_config: TracingConfig,
-) -> UserConfig {
-    let GeneratedKeys {
-        blend_signing_key,
-        blend_zk_key,
-        leader_key,
-        funding_key,
-        blend_signing_key_id,
-        blend_zk_key_id,
-        leader_key_id,
-        funding_key_id,
-        leader_pk,
-        funding_pk,
-        blend_zk_pk,
-    } = keys;
-
-    let state_config = args
-        .state_path
-        .as_ref()
-        .map_or_else(StateConfig::default, |path| StateConfig {
-            base_folder: path.clone(),
-        });
-
-    let network_config = build_network_config(args, network_key);
-
-    let blend_config = {
-        let mut base_config = BlendConfig::with_required_values(BlendConfigRequiredValues {
-            non_ephemeral_signing_key_id: blend_signing_key_id.clone(),
-            secret_key_kms_id: blend_zk_key_id.clone(),
-        });
-        base_config.set_listening_address(blend_listening_address);
-        base_config
-    };
-
-    let cryptarchia_config = build_cryptarchia_config(args, funding_pk);
+fn build_user_config(keystore: &Keystore, args: InitArgs) -> UserConfig {
+    let InitArgs {
+        log: log_args,
+        network: network_args,
+        blend: blend_args,
+        cryptarchia: cryptarchia_args,
+        sdp: sdp_args,
+        api: api_args,
+        state: state_args,
+        ..
+    } = args;
 
     let time_config = TimeConfig::default();
 
-    let sdp_config = SdpConfig::with_required_values(SdpRequiredValues { funding_pk });
-
-    let api_config = {
-        let mut base_config = ApiConfig::default();
-        base_config.backend.listen_address = args.http_addr;
-        base_config
-    };
-
     let storage_config = StorageConfig::default();
 
-    let kms_config = {
-        let mut base_config = KmsConfig::default();
-        base_config.backend.keys = HashMap::from([
-            (blend_signing_key_id, blend_signing_key.into()),
-            (blend_zk_key_id.clone(), blend_zk_key.into()),
-            (leader_key_id.clone(), leader_key.into()),
-            (funding_key_id.clone(), funding_key.into()),
-        ]);
-        base_config
-    };
+    let mut state_config = StateConfig::default();
+    update_state(&mut state_config, state_args);
 
-    let wallet_config = {
-        let mut base_config = WalletConfig::with_required_values(WalletConfigRequiredValues {
-            voucher_master_key_id: leader_key_id.clone(),
-        });
-        base_config.known_keys = [
-            (leader_key_id, leader_pk),
-            (funding_key_id, funding_pk),
-            (blend_zk_key_id, blend_zk_pk),
-        ]
-        .into_iter()
-        .collect();
+    let mut api_config = ApiConfig::default();
+    update_api(&mut api_config, api_args);
 
-        base_config
-    };
+    let mut tracing_config = TracingConfig::default();
+    update_tracing(&mut tracing_config, log_args).expect("Cli tracing params can be parsed");
+
+    let initial_peers = network_args.initial_peers.clone();
+    let network_config = build_network_config(keystore, network_args);
+
+    let blend_config = build_blend_config(keystore, blend_args);
+
+    let cryptarchia_config = build_cryptarchia_config(keystore, initial_peers, cryptarchia_args);
+
+    let sdp_config = build_sdp_config(keystore, sdp_args);
+
+    let wallet_config = build_wallet_config(keystore);
+
+    let kms_config = build_kms_config(keystore);
 
     UserConfig {
         network: network_config,
         blend: blend_config,
         cryptarchia: cryptarchia_config,
         time: time_config,
-        tracing: tracing_config,
         sdp: sdp_config,
         api: api_config,
         storage: storage_config,
         kms: kms_config,
         wallet: wallet_config,
+        tracing: tracing_config,
         state: state_config,
     }
 }
 
-fn build_network_config(args: &InitArgs, node_key: lb_libp2p::ed25519::SecretKey) -> NetworkConfig {
-    let mut base_config = NetworkConfig::default();
-    base_config.backend.swarm.port = args.net_port;
-    base_config.backend.swarm.node_key = node_key;
-    base_config
-        .backend
-        .initial_peers
-        .clone_from(&args.initial_peers);
+fn build_network_config(keystore: &Keystore, network_args: NetworkArgs) -> NetworkConfig {
+    let unsecured_key = keystore
+        .get_ed25519(KeyTitle::NetworkSwarm)
+        .map(|(_, key)| key)
+        .expect("Network key set by default");
+    let mut network_secret_key_bytes: [u8; 32] = *unsecured_key.as_bytes();
 
-    if let Some(external_address) = &args.external_address {
-        base_config.backend.swarm.nat = nat::Config::Static {
-            external_address: external_address.clone(),
-        };
-    }
-    base_config
+    let mut network_config = NetworkConfig::default();
+    network_config.backend.swarm.node_key =
+        lb_libp2p::ed25519::SecretKey::try_from_bytes(&mut network_secret_key_bytes)
+            .expect("Valid default secret key structure");
+    update_network(&mut network_config, network_args)
+        .expect("Network configuration should update from cli args");
+
+    network_config
 }
 
-fn build_cryptarchia_config(args: &InitArgs, funding_pk: ZkPublicKey) -> CryptarchiaConfig {
-    let mut base_config =
-        CryptarchiaConfig::with_required_values(CryptarchiaConfigRequiredValues { funding_pk });
-    base_config.network.bootstrap.ibd.peers = if args.ibd {
-        args.initial_peers
+fn build_blend_config(keystore: &Keystore, blend_args: BlendArgs) -> BlendConfig {
+    let (blend_signing_key_id, _) = keystore
+        .get(KeyTitle::BlendSigning)
+        .expect("Blend signing key set by default");
+    let (blend_zk_key_id, _) = keystore
+        .get(KeyTitle::BlendZk)
+        .expect("Blend zk key set by default");
+    let mut blend_config = BlendConfig::with_required_values(BlendConfigRequiredValues {
+        non_ephemeral_signing_key_id: blend_signing_key_id,
+        secret_key_kms_id: blend_zk_key_id,
+    });
+    update_blend(&mut blend_config, blend_args);
+
+    blend_config
+}
+
+fn build_cryptarchia_config(
+    keystore: &Keystore,
+    initial_peers: Option<Vec<Multiaddr>>,
+    cryptarchia_args: CryptarchiaArgs,
+) -> CryptarchiaConfig {
+    let (_, cryptarchia_funding_key) = keystore
+        .get_zk(KeyTitle::LeaderFunding)
+        .expect("Cryptarchia funding key set by default");
+    let mut cryptarchia_config =
+        CryptarchiaConfig::with_required_values(CryptarchiaConfigRequiredValues {
+            funding_pk: cryptarchia_funding_key.to_public_key(),
+        });
+    if let Some(initial_peers) = initial_peers {
+        cryptarchia_config.network.bootstrap.ibd.peers = initial_peers
             .iter()
             .filter_map(|addr| match addr.iter().last() {
                 Some(lb_libp2p::Protocol::P2p(bytes)) => PeerId::from_multihash(bytes.into()).ok(),
                 _ => None,
             })
-            .collect()
-    } else {
-        HashSet::new()
-    };
-    base_config
+            .collect();
+    }
+    update_cryptarchia(&mut cryptarchia_config, cryptarchia_args);
+
+    cryptarchia_config
 }
 
-#[cfg(test)]
-mod tests {
-    use std::net::SocketAddr;
+fn build_sdp_config(keystore: &Keystore, sdp_args: SdpArgs) -> SdpConfig {
+    let (_, sdp_funding_key) = keystore
+        .get_zk(KeyTitle::SdpFunding)
+        .expect("Sdp funding key set by default");
+    let mut sdp_config = SdpConfig::with_required_values(SdpConfigRequiredValues {
+        funding_pk: sdp_funding_key.to_public_key(),
+    });
+    update_sdp(&mut sdp_config, sdp_args);
 
-    use super::*;
-    use crate::config::tracing::serde::{
-        Level,
-        filter::{EnvConfig, Layer},
-    };
+    sdp_config
+}
 
-    fn build_config_from_peers(initial_peers: Vec<Multiaddr>) -> UserConfig {
-        build_config(initial_peers, true)
-    }
+fn build_kms_config(keystore: &Keystore) -> KmsConfig {
+    let mut kms_config = KmsConfig::default();
+    kms_config.backend.keys = KeyTitle::ALL
+        .into_iter()
+        .map(|title| {
+            let (id, key) = keystore.get(title).expect("Key is set by default");
+            (id, key.clone())
+        })
+        .collect();
 
-    fn build_config(initial_peers: Vec<Multiaddr>, ibd: bool) -> UserConfig {
-        let args = InitArgs {
-            initial_peers,
-            output: "test_output.yaml".into(),
-            net_port: 3000,
-            blend_port: 3400,
-            http_addr: SocketAddr::from(([0, 0, 0, 0], 8080)),
-            external_address: None,
-            state_path: None,
-            ibd,
-            log_filter: None,
-            kms_file: None,
-            net_node_key: None,
-            blend_signing_key_id: None,
-            blend_secret_key_id: None,
-            cryptarchia_funding_pk: None,
-            sdp_funding_pk: None,
-        };
-        let network_key = lb_libp2p::ed25519::SecretKey::generate();
-        let keys = generate_keys();
-        let blend_addr = Multiaddr::from_str("/ip4/0.0.0.0/udp/3400/quic-v1").unwrap();
-        let tracing_config = build_tracing_config(&args).unwrap();
+    kms_config
+}
 
-        build_user_config(&args, network_key, keys, blend_addr, tracing_config)
-    }
+fn build_wallet_config(keystore: &Keystore) -> WalletConfig {
+    let wallet_keys = [
+        KeyTitle::BlendZk,
+        KeyTitle::LeaderFunding,
+        KeyTitle::SdpFunding,
+        KeyTitle::BlendFunding,
+        KeyTitle::VaucherMaster,
+    ];
 
-    #[test]
-    fn extracts_peer_ids_into_ibd_config() {
-        let peer1 = PeerId::random();
-        let peer2 = PeerId::random();
+    let (voucher_master_key_id, _) = keystore
+        .get(KeyTitle::VaucherMaster)
+        .expect("Vaucher master key set by default");
 
-        let addr_with_p2p_1: Multiaddr = format!("/ip4/1.2.3.4/udp/3000/quic-v1/p2p/{peer1}")
-            .parse()
-            .unwrap();
-        let addr_with_p2p_2: Multiaddr = format!("/ip4/5.6.7.8/udp/3000/quic-v1/p2p/{peer2}")
-            .parse()
-            .unwrap();
-        let addr_without_p2p: Multiaddr = "/ip4/9.10.11.12/udp/3000/quic-v1".parse().unwrap();
+    let mut wallet_config = WalletConfig::with_required_values(WalletConfigRequiredValues {
+        voucher_master_key_id,
+    });
+    wallet_config.known_keys = wallet_keys
+        .into_iter()
+        .map(|title| {
+            let (id, key) = keystore.get_zk(title).expect("Key is set by default");
+            (id, key.to_public_key())
+        })
+        .collect();
 
-        let config =
-            build_config_from_peers(vec![addr_with_p2p_1, addr_without_p2p, addr_with_p2p_2]);
+    wallet_config
+}
 
-        let ibd_peers = &config.cryptarchia.network.bootstrap.ibd.peers;
-        assert_eq!(ibd_peers.len(), 2);
-        assert!(ibd_peers.contains(&peer1));
-        assert!(ibd_peers.contains(&peer2));
-    }
+fn build_keystore() -> Keystore {
+    let mut keystore = Keystore::default();
 
-    #[test]
-    fn no_peer_ids_yields_empty_ibd_config() {
-        let addr: Multiaddr = "/ip4/1.2.3.4/udp/3000/quic-v1".parse().unwrap();
+    // By default keystore generates the a unique key for every key title.
+    // To simplify the `init` command behaviour we use the same key for sdp and blend funding.
+    // Leader is still using a unique funding key.
+    let funding_key = keystore
+        .get(KeyTitle::BlendFunding)
+        .map(|(_, key)| key.clone())
+        .expect("Blend funding key set by default");
 
-        let config = build_config_from_peers(vec![addr]);
+    keystore.set(KeyTitle::SdpFunding, funding_key);
 
-        assert!(config.cryptarchia.network.bootstrap.ibd.peers.is_empty());
-    }
-
-    #[test]
-    fn no_ibd_flag_clears_ibd_peers_even_with_initial_peers() {
-        let peer = PeerId::random();
-        let addr_with_p2p: Multiaddr = format!("/ip4/1.2.3.4/udp/3000/quic-v1/p2p/{peer}")
-            .parse()
-            .unwrap();
-
-        let config = build_config(vec![addr_with_p2p], false);
-
-        assert!(config.cryptarchia.network.bootstrap.ibd.peers.is_empty());
-    }
-
-    #[test]
-    fn log_flags_write_env_filter_config() {
-        let args = InitArgs {
-            initial_peers: Vec::new(),
-            output: "test_output.yaml".into(),
-            net_port: 3000,
-            blend_port: 3400,
-            http_addr: SocketAddr::from(([0, 0, 0, 0], 8080)),
-            external_address: None,
-            state_path: None,
-            ibd: false,
-            log_filter: Some(
-                "warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error".to_owned(),
-            ),
-            kms_file: None,
-            net_node_key: None,
-            blend_signing_key_id: None,
-            blend_secret_key_id: None,
-            cryptarchia_funding_pk: None,
-            sdp_funding_pk: None,
-        };
-
-        let tracing_config = build_tracing_config(&args).unwrap();
-        let Layer::Env(EnvConfig { filters }) = tracing_config.filter else {
-            panic!("expected env filter config");
-        };
-
-        assert_eq!(tracing_config.level, Level::DEBUG);
-        assert_eq!(filters.get("*"), Some(&Level::WARN));
-        assert_eq!(filters.get("logos_blockchain"), Some(&Level::DEBUG));
-        assert_eq!(
-            filters.get("libp2p_gossipsub::behaviour"),
-            Some(&Level::ERROR)
-        );
-    }
+    keystore
 }

--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use color_eyre::eyre::Result;
 use libp2p::{Multiaddr, PeerId};
+use thiserror::Error;
 
 use crate::{
     NetworkArgs, UserConfig,
@@ -20,15 +23,43 @@ use crate::{
     },
 };
 
+#[derive(Error, Debug)]
+enum InitError {
+    #[error("User configuration file exists. Use `update` command.")]
+    UserFileExists,
+
+    #[error("Keystore file exists. Use `update` command.")]
+    KeystoreFileExists,
+}
+
 pub fn run(args: InitArgs) -> Result<()> {
-    let output_path = args.output.clone();
-    let keystore = build_keystore();
+    let user_config_path = args.output.clone();
+    let keystore_path = user_config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("keystore.yaml");
+
+    if user_config_path.exists() {
+        return Err(InitError::UserFileExists.into());
+    }
+
+    if keystore_path.exists() {
+        return Err(InitError::KeystoreFileExists.into());
+    }
+
+    let keystore = Keystore::default();
     let user_config = build_user_config(&keystore, args);
+
+    let user_config_yaml = serde_yaml::to_string(&user_config)?;
+    std::fs::write(&user_config_path, &user_config_yaml)?;
+
+    let keystore_yaml = serde_yaml::to_string(&keystore)?;
+    std::fs::write(&keystore_path, &keystore_yaml)?;
 
     Ok(())
 }
 
-fn build_user_config(keystore: &Keystore, args: InitArgs) -> UserConfig {
+pub fn build_user_config(keystore: &Keystore, args: InitArgs) -> UserConfig {
     let InitArgs {
         log: log_args,
         network: network_args,
@@ -170,7 +201,6 @@ fn build_wallet_config(keystore: &Keystore) -> WalletConfig {
         KeyTitle::BlendZk,
         KeyTitle::LeaderFunding,
         KeyTitle::SdpFunding,
-        KeyTitle::BlendFunding,
         KeyTitle::VaucherMaster,
     ];
 
@@ -190,20 +220,4 @@ fn build_wallet_config(keystore: &Keystore) -> WalletConfig {
         .collect();
 
     wallet_config
-}
-
-fn build_keystore() -> Keystore {
-    let mut keystore = Keystore::default();
-
-    // By default keystore generates the a unique key for every key title.
-    // To simplify the `init` command behaviour we use the same key for sdp and blend funding.
-    // Leader is still using a unique funding key.
-    let funding_key = keystore
-        .get(KeyTitle::BlendFunding)
-        .map(|(_, key)| key.clone())
-        .expect("Blend funding key set by default");
-
-    keystore.set(KeyTitle::SdpFunding, funding_key);
-
-    keystore
 }

--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -34,10 +34,12 @@ enum InitError {
 
 pub fn run(args: InitArgs) -> Result<()> {
     let user_config_path = args.output.clone();
-    let keystore_path = user_config_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join("keystore.yaml");
+    let keystore_path = args.keystore.clone().unwrap_or_else(|| {
+        user_config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("keystore.yaml")
+    });
 
     if user_config_path.exists() {
         return Err(InitError::UserFileExists.into());
@@ -59,6 +61,7 @@ pub fn run(args: InitArgs) -> Result<()> {
     Ok(())
 }
 
+#[must_use]
 pub fn build_user_config(keystore: &Keystore, args: InitArgs) -> UserConfig {
     let InitArgs {
         log: log_args,

--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -205,6 +205,7 @@ fn build_wallet_config(keystore: &Keystore) -> WalletConfig {
         KeyTitle::LeaderFunding,
         KeyTitle::SdpFunding,
         KeyTitle::VaucherMaster,
+        KeyTitle::Stake,
     ];
 
     let (voucher_master_key_id, _) = keystore

--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -14,9 +14,9 @@ use libp2p::{Multiaddr, PeerId};
 use num_bigint::BigUint;
 use rand::rngs::OsRng;
 
-use super::InitArgs;
 use crate::{
     UserConfig,
+    cli::InitArgs,
     config::{
         ApiConfig, KmsConfig, SdpConfig, StateConfig, StorageConfig, TracingConfig, WalletConfig,
         blend::serde::{Config as BlendConfig, RequiredValues as BlendConfigRequiredValues},

--- a/nodes/node/binary/src/cli/config/keystore.rs
+++ b/nodes/node/binary/src/cli/config/keystore.rs
@@ -1,10 +1,51 @@
 use std::collections::HashMap;
 
-use lb_key_management_system_service::keys::Key;
+use lb_key_management_system_service::keys::{Ed25519Key, Key, ZkKey};
+use num_bigint::BigUint;
+use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Clone, Copy, Debug)]
+pub enum KeyTitle {
+    BlendSigning,
+    BlendZk,
+    LeaderFunding,
+    SdpFunding,
+    BlendFunding,
+    VaucherMaster,
+}
+
+#[derive(Serialize, Deserialize, Default)]
 pub struct Keystore {
-    keys: HashMap<String, Key>,
-    mapping: HashMap<String, String>,
+    keys: HashMap<KeyTitle, Key>,
+}
+
+impl Keystore {
+    pub fn set(&mut self, title: KeyTitle, key: Key) {
+        self.keys.insert(title, key);
+    }
+
+    pub fn get(&self, title: KeyTitle) -> Option<&Key> {
+        self.keys.get(&title)
+    }
+
+    pub fn generate(&mut self, title: KeyTitle) -> &Key {
+        let key = match title {
+            KeyTitle::BlendSigning => Key::Ed25519(Ed25519Key::generate(&mut OsRng)),
+            KeyTitle::BlendZk
+            | KeyTitle::LeaderFunding
+            | KeyTitle::SdpFunding
+            | KeyTitle::BlendFunding
+            | KeyTitle::VaucherMaster => Key::Zk(generate_zk_key_from_random_bytes()),
+        };
+
+        self.keys.insert(title, key);
+        self.keys.get(&title).unwrap()
+    }
+}
+
+fn generate_zk_key_from_random_bytes() -> ZkKey {
+    let mut bytes = [0u8; 32];
+    rand::RngCore::fill_bytes(&mut OsRng, &mut bytes);
+    ZkKey::from(BigUint::from_bytes_le(&bytes))
 }

--- a/nodes/node/binary/src/cli/config/keystore.rs
+++ b/nodes/node/binary/src/cli/config/keystore.rs
@@ -1,12 +1,20 @@
 use std::collections::HashMap;
 
-use lb_key_management_system_service::keys::{Ed25519Key, Key, ZkKey};
+use lb_groth16::fr_to_bytes;
+use lb_key_management_system_service::{
+    backend::preload::KeyId,
+    keys::{
+        Ed25519Key, Key, UnsecuredEd25519Key, UnsecuredZkKey, ZkKey, secured_key::SecuredKey as _,
+    },
+};
 use num_bigint::BigUint;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Clone, Copy, Debug)]
 pub enum KeyTitle {
+    NetworkSwarm,
     BlendSigning,
     BlendZk,
     LeaderFunding,
@@ -15,7 +23,31 @@ pub enum KeyTitle {
     VaucherMaster,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+impl KeyTitle {
+    pub const ALL: [Self; 7] = [
+        Self::NetworkSwarm,
+        Self::BlendSigning,
+        Self::BlendZk,
+        Self::LeaderFunding,
+        Self::SdpFunding,
+        Self::BlendFunding,
+        Self::VaucherMaster,
+    ];
+}
+
+#[derive(Error, Debug)]
+pub enum KeystoreError {
+    #[error("Key for title '{0:?}' not found in keystore")]
+    NotFound(KeyTitle),
+
+    #[error("Ed25519 key expected for '{0:?}'")]
+    Ed25519Expected(KeyTitle),
+
+    #[error("Zk key expected for '{0:?}'")]
+    ZkExpected(KeyTitle),
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct Keystore {
     keys: HashMap<KeyTitle, Key>,
 }
@@ -25,23 +57,68 @@ impl Keystore {
         self.keys.insert(title, key);
     }
 
-    pub fn get(&self, title: KeyTitle) -> Option<&Key> {
-        self.keys.get(&title)
+    #[must_use]
+    pub fn get(&self, title: KeyTitle) -> Option<(KeyId, &Key)> {
+        let key = self.keys.get(&title)?;
+        Some((key_id(key), key))
     }
 
-    pub fn generate(&mut self, title: KeyTitle) -> &Key {
-        let key = match title {
-            KeyTitle::BlendSigning => Key::Ed25519(Ed25519Key::generate(&mut OsRng)),
+    pub fn get_ed25519(
+        &self,
+        title: KeyTitle,
+    ) -> Result<(KeyId, UnsecuredEd25519Key), KeystoreError> {
+        let (id, generic_key) = self.get(title).ok_or(KeystoreError::NotFound(title))?;
+
+        match generic_key {
+            Key::Ed25519(inner_key) => Ok((id, inner_key.clone().into_unsecured())),
+            Key::Zk(_) => Err(KeystoreError::Ed25519Expected(title)),
+        }
+    }
+
+    pub fn get_zk(&self, title: KeyTitle) -> Result<(KeyId, UnsecuredZkKey), KeystoreError> {
+        let (id, generic_key) = self.get(title).ok_or(KeystoreError::NotFound(title))?;
+
+        match generic_key {
+            Key::Zk(inner_key) => Ok((id, inner_key.clone().into_unsecured())),
+            Key::Ed25519(_) => Err(KeystoreError::ZkExpected(title)),
+        }
+    }
+
+    #[must_use]
+    pub fn generate(title: KeyTitle) -> Key {
+        match title {
+            KeyTitle::NetworkSwarm | KeyTitle::BlendSigning => {
+                Key::Ed25519(Ed25519Key::generate(&mut OsRng))
+            }
             KeyTitle::BlendZk
             | KeyTitle::LeaderFunding
             | KeyTitle::SdpFunding
             | KeyTitle::BlendFunding
             | KeyTitle::VaucherMaster => Key::Zk(generate_zk_key_from_random_bytes()),
+        }
+    }
+}
+
+impl Default for Keystore {
+    fn default() -> Self {
+        let mut keystore = Self {
+            keys: HashMap::new(),
         };
 
-        self.keys.insert(title, key);
-        self.keys.get(&title).unwrap()
+        for title in KeyTitle::ALL {
+            keystore.set(title, Self::generate(title));
+        }
+
+        keystore
     }
+}
+
+fn key_id(key: &Key) -> KeyId {
+    let key_id_bytes = match key {
+        Key::Ed25519(ed25519_secret_key) => ed25519_secret_key.as_public_key().to_bytes(),
+        Key::Zk(zk_secret_key) => fr_to_bytes(zk_secret_key.as_public_key().as_fr()),
+    };
+    hex::encode(key_id_bytes)
 }
 
 fn generate_zk_key_from_random_bytes() -> ZkKey {

--- a/nodes/node/binary/src/cli/config/keystore.rs
+++ b/nodes/node/binary/src/cli/config/keystore.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+
+use lb_key_management_system_service::keys::Key;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Keystore {
+    keys: HashMap<String, Key>,
+    mapping: HashMap<String, String>,
+}

--- a/nodes/node/binary/src/cli/config/keystore.rs
+++ b/nodes/node/binary/src/cli/config/keystore.rs
@@ -109,7 +109,7 @@ impl Default for Keystore {
         let mut keystore = Self {
             public_keys: HashMap::new(),
             secret_keys: HashMap::new(),
-            warning: WARNING.to_string(),
+            warning: WARNING.to_owned(),
         };
 
         for title in KeyTitle::ALL {

--- a/nodes/node/binary/src/cli/config/keystore.rs
+++ b/nodes/node/binary/src/cli/config/keystore.rs
@@ -12,25 +12,25 @@ use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+const WARNING: &str = "Do not share your secret keys";
+
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Clone, Copy, Debug)]
 pub enum KeyTitle {
-    NetworkSwarm,
     BlendSigning,
     BlendZk,
     LeaderFunding,
+    NetworkSwarm,
     SdpFunding,
-    BlendFunding,
     VaucherMaster,
 }
 
 impl KeyTitle {
-    pub const ALL: [Self; 7] = [
-        Self::NetworkSwarm,
+    pub const ALL: [Self; 6] = [
         Self::BlendSigning,
         Self::BlendZk,
         Self::LeaderFunding,
+        Self::NetworkSwarm,
         Self::SdpFunding,
-        Self::BlendFunding,
         Self::VaucherMaster,
     ];
 }
@@ -49,17 +49,23 @@ pub enum KeystoreError {
 
 #[derive(Serialize, Deserialize)]
 pub struct Keystore {
-    keys: HashMap<KeyTitle, Key>,
+    // Convenience mapping for users to inspect when serialized.
+    public_keys: HashMap<KeyTitle, KeyId>,
+    secret_keys: HashMap<KeyTitle, Key>,
+
+    #[serde(rename = "WARNING")]
+    warning: String,
 }
 
 impl Keystore {
     pub fn set(&mut self, title: KeyTitle, key: Key) {
-        self.keys.insert(title, key);
+        self.public_keys.insert(title, key_id(&key));
+        self.secret_keys.insert(title, key);
     }
 
     #[must_use]
     pub fn get(&self, title: KeyTitle) -> Option<(KeyId, &Key)> {
-        let key = self.keys.get(&title)?;
+        let key = self.secret_keys.get(&title)?;
         Some((key_id(key), key))
     }
 
@@ -93,7 +99,6 @@ impl Keystore {
             KeyTitle::BlendZk
             | KeyTitle::LeaderFunding
             | KeyTitle::SdpFunding
-            | KeyTitle::BlendFunding
             | KeyTitle::VaucherMaster => Key::Zk(generate_zk_key_from_random_bytes()),
         }
     }
@@ -102,7 +107,9 @@ impl Keystore {
 impl Default for Keystore {
     fn default() -> Self {
         let mut keystore = Self {
-            keys: HashMap::new(),
+            public_keys: HashMap::new(),
+            secret_keys: HashMap::new(),
+            warning: WARNING.to_string(),
         };
 
         for title in KeyTitle::ALL {

--- a/nodes/node/binary/src/cli/config/keystore.rs
+++ b/nodes/node/binary/src/cli/config/keystore.rs
@@ -22,16 +22,18 @@ pub enum KeyTitle {
     NetworkSwarm,
     SdpFunding,
     VaucherMaster,
+    Stake,
 }
 
 impl KeyTitle {
-    pub const ALL: [Self; 6] = [
+    pub const ALL: [Self; 7] = [
         Self::BlendSigning,
         Self::BlendZk,
         Self::LeaderFunding,
         Self::NetworkSwarm,
         Self::SdpFunding,
         Self::VaucherMaster,
+        Self::Stake,
     ];
 }
 
@@ -99,7 +101,8 @@ impl Keystore {
             KeyTitle::BlendZk
             | KeyTitle::LeaderFunding
             | KeyTitle::SdpFunding
-            | KeyTitle::VaucherMaster => Key::Zk(generate_zk_key_from_random_bytes()),
+            | KeyTitle::VaucherMaster
+            | KeyTitle::Stake => Key::Zk(generate_zk_key_from_random_bytes()),
         }
     }
 }

--- a/nodes/node/binary/src/cli/config/migrate.rs
+++ b/nodes/node/binary/src/cli/config/migrate.rs
@@ -1,0 +1,42 @@
+use color_eyre::eyre::Result;
+use thiserror::Error;
+
+use crate::cli::{
+    MigrateArgs,
+    config::{init::build_user_config, keystore::Keystore},
+};
+
+#[derive(Error, Debug)]
+pub enum MigrateError {
+    #[error("Update command cancelled by user.")]
+    UserCancelled,
+
+    #[error("User configuration exists. Use `update` command.")]
+    UserFileExists,
+
+    #[error("Keystore file does not exist. Use `init` command.")]
+    KeystoreFileDoesNotExist,
+}
+
+pub fn run(args: MigrateArgs) -> Result<()> {
+    let user_config_path = args.output.clone();
+    let keystore_path = args.keystore.clone();
+
+    if user_config_path.exists() {
+        return Err(MigrateError::UserFileExists.into());
+    }
+
+    if !keystore_path.exists() {
+        return Err(MigrateError::KeystoreFileDoesNotExist.into());
+    }
+
+    let keystore_yaml = std::fs::read_to_string(&keystore_path)?;
+    let keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;
+
+    let user_config = build_user_config(&keystore, args.into());
+
+    let user_config_yaml = serde_yaml::to_string(&user_config)?;
+    std::fs::write(&user_config_path, &user_config_yaml)?;
+
+    Ok(())
+}

--- a/nodes/node/binary/src/cli/config/mod.rs
+++ b/nodes/node/binary/src/cli/config/mod.rs
@@ -1,0 +1,2 @@
+pub mod init;
+pub mod keystore;

--- a/nodes/node/binary/src/cli/config/mod.rs
+++ b/nodes/node/binary/src/cli/config/mod.rs
@@ -1,2 +1,17 @@
 pub mod init;
 pub mod keystore;
+pub mod migrate;
+pub mod update;
+
+use std::io::Write as _;
+
+pub fn confirm_overwrite(msg: &str) -> Result<bool, std::io::Error> {
+    print!("{msg} (y/N): ");
+    std::io::stdout().flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+
+    let trimmed = input.trim().to_lowercase();
+    Ok(trimmed == "y" || trimmed == "yes")
+}

--- a/nodes/node/binary/src/cli/config/update.rs
+++ b/nodes/node/binary/src/cli/config/update.rs
@@ -1,0 +1,192 @@
+use color_eyre::eyre::Result;
+use libp2p::{Multiaddr, PeerId};
+use thiserror::Error;
+
+use crate::{
+    NetworkArgs, UserConfig,
+    cli::{
+        UpdateArgs,
+        config::{
+            confirm_overwrite,
+            keystore::{KeyTitle, Keystore},
+        },
+    },
+    config::{
+        BlendArgs, BlendConfig, CryptarchiaArgs, CryptarchiaConfig, KmsConfig, NetworkConfig,
+        SdpArgs, SdpConfig, WalletConfig, update_api, update_blend, update_cryptarchia,
+        update_network, update_sdp, update_state, update_tracing,
+    },
+};
+
+#[derive(Error, Debug)]
+pub enum UpdateError {
+    #[error("Update command cancelled by user.")]
+    UserCancelled,
+
+    #[error("User configuration file does not exist. Use `init` command.")]
+    UserFileDoesNotExist,
+
+    #[error("Keystore file does not exist. Use `init` command.")]
+    KeystoreFileDoesNotExist,
+}
+
+pub fn run(args: UpdateArgs) -> Result<()> {
+    let user_config_path = args.user_config.clone();
+    let keystore_path = args.keystore.clone();
+
+    if !user_config_path.exists() {
+        return Err(UpdateError::UserFileDoesNotExist.into());
+    }
+
+    if !keystore_path.exists() {
+        return Err(UpdateError::KeystoreFileDoesNotExist.into());
+    }
+
+    if !args.yes && !confirm_overwrite("Do you want to overwrite existing user configuration?")? {
+        return Err(UpdateError::UserCancelled.into());
+    }
+
+    let user_config_yaml = std::fs::read_to_string(&user_config_path)?;
+    let mut user_config: UserConfig = serde_yaml::from_str(&user_config_yaml)?;
+
+    let keystore_yaml = std::fs::read_to_string(&keystore_path)?;
+    let keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;
+
+    update_user_config(&mut user_config, &keystore, args);
+
+    Ok(())
+}
+
+fn update_user_config(user_config: &mut UserConfig, keystore: &Keystore, args: UpdateArgs) {
+    let UpdateArgs {
+        log: log_args,
+        network: network_args,
+        blend: blend_args,
+        cryptarchia: cryptarchia_args,
+        sdp: sdp_args,
+        api: api_args,
+        state: state_args,
+        ..
+    } = args;
+
+    update_state(&mut user_config.state, state_args);
+
+    update_api(&mut user_config.api, api_args);
+
+    update_tracing(&mut user_config.tracing, log_args).expect("Cli tracing params can be parsed");
+
+    let initial_peers = network_args.initial_peers.clone();
+    update_network_config(keystore, &mut user_config.network, network_args);
+
+    update_blend_config(keystore, &mut user_config.blend, blend_args);
+
+    update_cryptarchia_config(
+        keystore,
+        initial_peers,
+        &mut user_config.cryptarchia,
+        cryptarchia_args,
+    );
+
+    update_sdp_config(keystore, &mut user_config.sdp, sdp_args);
+
+    update_kms_config(keystore, &mut user_config.kms);
+
+    update_wallet_config(keystore, &mut user_config.wallet);
+}
+
+fn update_network_config(
+    keystore: &Keystore,
+    network_config: &mut NetworkConfig,
+    network_args: NetworkArgs,
+) {
+    let unsecured_key = keystore
+        .get_ed25519(KeyTitle::NetworkSwarm)
+        .map(|(_, key)| key)
+        .expect("Network key set by default");
+    let mut network_secret_key_bytes: [u8; 32] = *unsecured_key.as_bytes();
+
+    network_config.backend.swarm.node_key =
+        lb_libp2p::ed25519::SecretKey::try_from_bytes(&mut network_secret_key_bytes)
+            .expect("Valid default secret key structure");
+    update_network(network_config, network_args)
+        .expect("Network configuration should update from cli args");
+}
+
+fn update_blend_config(keystore: &Keystore, blend_config: &mut BlendConfig, blend_args: BlendArgs) {
+    let (blend_signing_key_id, _) = keystore
+        .get(KeyTitle::BlendSigning)
+        .expect("Blend signing key set by default");
+    let (blend_zk_key_id, _) = keystore
+        .get(KeyTitle::BlendZk)
+        .expect("Blend zk key set by default");
+
+    blend_config.set_signing_key_id(blend_signing_key_id);
+    blend_config.set_secret_key_id(blend_zk_key_id);
+
+    update_blend(blend_config, blend_args);
+}
+
+fn update_cryptarchia_config(
+    keystore: &Keystore,
+    initial_peers: Option<Vec<Multiaddr>>,
+    cryptarchia_config: &mut CryptarchiaConfig,
+    cryptarchia_args: CryptarchiaArgs,
+) {
+    let (_, cryptarchia_funding_key) = keystore
+        .get_zk(KeyTitle::LeaderFunding)
+        .expect("Cryptarchia funding key set by default");
+    cryptarchia_config.set_funding_pk(cryptarchia_funding_key.to_public_key());
+
+    if let Some(initial_peers) = initial_peers {
+        cryptarchia_config.network.bootstrap.ibd.peers = initial_peers
+            .iter()
+            .filter_map(|addr| match addr.iter().last() {
+                Some(lb_libp2p::Protocol::P2p(bytes)) => PeerId::from_multihash(bytes.into()).ok(),
+                _ => None,
+            })
+            .collect();
+    }
+
+    update_cryptarchia(cryptarchia_config, cryptarchia_args);
+}
+
+fn update_sdp_config(keystore: &Keystore, sdp_config: &mut SdpConfig, sdp_args: SdpArgs) {
+    let (_, sdp_funding_key) = keystore
+        .get_zk(KeyTitle::SdpFunding)
+        .expect("Sdp funding key set by default");
+    sdp_config.set_funding_pk(sdp_funding_key.to_public_key());
+
+    update_sdp(sdp_config, sdp_args);
+}
+
+fn update_kms_config(keystore: &Keystore, kms_config: &mut KmsConfig) {
+    kms_config.backend.keys = KeyTitle::ALL
+        .into_iter()
+        .map(|title| {
+            let (id, key) = keystore.get(title).expect("Key is set by default");
+            (id, key.clone())
+        })
+        .collect();
+}
+
+fn update_wallet_config(keystore: &Keystore, wallet_config: &mut WalletConfig) {
+    let wallet_keys = [
+        KeyTitle::BlendZk,
+        KeyTitle::LeaderFunding,
+        KeyTitle::SdpFunding,
+        KeyTitle::VaucherMaster,
+    ];
+
+    let (voucher_master_key_id, _) = keystore
+        .get(KeyTitle::VaucherMaster)
+        .expect("Vaucher master key set by default");
+
+    wallet_config.voucher_master_key_id = voucher_master_key_id;
+    wallet_config.known_keys = wallet_keys
+        .into_iter()
+        .map(|title| {
+            let (id, key) = keystore.get_zk(title).expect("Key is set by default");
+            (id, key.to_public_key())
+        })
+        .collect();
+}

--- a/nodes/node/binary/src/cli/config/update.rs
+++ b/nodes/node/binary/src/cli/config/update.rs
@@ -123,8 +123,8 @@ fn update_blend_config(keystore: &Keystore, blend_config: &mut BlendConfig, blen
         .get(KeyTitle::BlendZk)
         .expect("Blend zk key set by default");
 
-    blend_config.set_signing_key_id(blend_signing_key_id);
-    blend_config.set_secret_key_id(blend_zk_key_id);
+    blend_config.set_non_ephemeral_signing_key_id(blend_signing_key_id);
+    blend_config.set_secret_zk_key_id(blend_zk_key_id);
 
     update_blend(blend_config, blend_args);
 }
@@ -178,6 +178,7 @@ fn update_wallet_config(keystore: &Keystore, wallet_config: &mut WalletConfig) {
         KeyTitle::LeaderFunding,
         KeyTitle::SdpFunding,
         KeyTitle::VaucherMaster,
+        KeyTitle::Stake,
     ];
 
     let (voucher_master_key_id, _) = keystore

--- a/nodes/node/binary/src/cli/config/update.rs
+++ b/nodes/node/binary/src/cli/config/update.rs
@@ -54,6 +54,9 @@ pub fn run(args: UpdateArgs) -> Result<()> {
 
     update_user_config(&mut user_config, &keystore, args);
 
+    let user_config_yaml = serde_yaml::to_string(&user_config)?;
+    std::fs::write(&user_config_path, &user_config_yaml)?;
+
     Ok(())
 }
 

--- a/nodes/node/binary/src/cli/init.rs
+++ b/nodes/node/binary/src/cli/init.rs
@@ -407,6 +407,11 @@ mod tests {
             ibd,
             log_filter: None,
             kms_file: None,
+            net_node_key: None,
+            blend_signing_key_id: None,
+            blend_secret_key_id: None,
+            cryptarchia_funding_pk: None,
+            sdp_funding_pk: None,
         };
         let network_key = lb_libp2p::ed25519::SecretKey::generate();
         let keys = generate_keys();
@@ -474,6 +479,11 @@ mod tests {
                 "warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error".to_owned(),
             ),
             kms_file: None,
+            net_node_key: None,
+            blend_signing_key_id: None,
+            blend_secret_key_id: None,
+            cryptarchia_funding_pk: None,
+            sdp_funding_pk: None,
         };
 
         let tracing_config = build_tracing_config(&args).unwrap();

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -2,21 +2,16 @@ pub mod config;
 pub mod get_peer_id;
 pub mod participate;
 
-use std::{
-    net::SocketAddr,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::Result;
-use lb_key_management_system_service::{backend::preload::KeyId, keys::ZkPublicKey};
-use lb_libp2p::Multiaddr;
 
 use crate::config::{
     ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
     LogArgs, NetworkArgs, OnUnknownKeys, RunConfig, SdpArgs, StateArgs, UserConfig,
-    deserialize_config_at_path, parse_hex_public_key, update_api, update_blend, update_cryptarchia,
-    update_network, update_sdp, update_state, update_tracing,
+    deserialize_config_at_path, update_api, update_blend, update_cryptarchia, update_network,
+    update_sdp, update_state, update_tracing,
 };
 
 fn long_version() -> String {
@@ -120,77 +115,30 @@ pub enum Command {
 
 #[derive(Parser, Debug)]
 pub struct InitArgs {
-    /// Trusted peers to bootstrap from (multiaddr format).
-    /// If `--ibd` is set, peers whose multiaddrs include a `PeerId`
-    /// are also used as IBD peers.
-    #[clap(long = "initial-peers", short = 'p', num_args = 1.., value_delimiter = ',')]
-    pub initial_peers: Vec<Multiaddr>,
-
     /// Output file path for the generated config
     #[clap(long = "output", short = 'o', default_value = "user_config.yaml")]
     pub output: PathBuf,
 
-    /// Network listen port
-    #[clap(long = "net-port", default_value = "3000")]
-    pub net_port: u16,
+    #[clap(flatten)]
+    log: LogArgs,
 
-    /// Network swarm key.
-    #[clap(long = "net-node-key", env = "NET_NODE_KEY")]
-    pub net_node_key: Option<String>,
+    #[clap(flatten)]
+    network: NetworkArgs,
 
-    /// Blend listen port
-    #[clap(long = "blend-port", default_value = "3400")]
-    pub blend_port: u16,
+    #[clap(flatten)]
+    blend: BlendArgs,
 
-    /// Blend signing key.
-    #[clap(long = "blend-signing-key-id", env = "BLEND_SIGNING_KEY_ID")]
-    blend_signing_key_id: Option<KeyId>,
+    #[clap(flatten)]
+    cryptarchia: CryptarchiaArgs,
 
-    /// Blend secret key.
-    #[clap(long = "blend-secret-key-id", env = "BLEND_SECRET_KEY_ID")]
-    blend_secret_key_id: Option<KeyId>,
+    #[clap(flatten)]
+    sdp: SdpArgs,
 
-    /// Cryptarchia funding public key.
-    #[clap(
-        long = "cryptarchia-funding-pk",
-        env = "CRYPTARCHIA_FUNDING_PK",
-        value_parser = parse_hex_public_key
-    )]
-    cryptarchia_funding_pk: Option<ZkPublicKey>,
+    #[clap(flatten)]
+    api: ApiArgs,
 
-    #[clap(
-        long = "sdp-funding-pk",
-        env = "SDP_FUNDING_PK",
-        value_parser = parse_hex_public_key
-    )]
-    sdp_funding_pk: Option<ZkPublicKey>,
-
-    /// HTTP API listen address
-    #[clap(long = "http-addr", default_value = "127.0.0.1:8080")]
-    pub http_addr: SocketAddr,
-
-    /// External address for nodes with a known public IP (disables NAT
-    /// traversal). Format: /ip4/<public-ip>/udp/<port>/quic-v1
-    #[clap(long = "external-address")]
-    pub external_address: Option<Multiaddr>,
-
-    #[clap(long = "state-path")]
-    pub state_path: Option<PathBuf>,
-
-    /// Enable Initial Block Download (IBD) using peers
-    /// passed via `--initial-peers`/`-p`.
-    #[clap(long = "ibd", default_value_t = false)]
-    pub ibd: bool,
-
-    /// Log filter directives to write into the generated config, e.g.
-    /// `warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error`.
-    #[clap(long = "log-filter")]
-    pub log_filter: Option<String>,
-
-    /// Path for the generated KMS keys YAML file.
-    /// Defaults to 'kms.yaml' in the same directory as --output.
-    #[clap(long = "kms-file")]
-    pub kms_file: Option<PathBuf>,
+    #[clap(flatten)]
+    state: StateArgs,
 }
 
 #[derive(Parser, Debug)]

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -153,6 +153,7 @@ pub struct InitArgs {
 }
 
 /// Set of arguments for use in c-bindings crate.
+#[derive(Debug)]
 pub struct EmbeddedInitArgs {
     /// Trusted peers to bootstrap from (multiaddr format).
     /// If `--ibd` is set, peers whose multiaddrs include a `PeerId`
@@ -190,8 +191,8 @@ pub struct EmbeddedInitArgs {
     pub kms_file: Option<PathBuf>,
 }
 
-impl From<&EmbeddedInitArgs> for InitArgs {
-    fn from(args: &EmbeddedInitArgs) -> Self {
+impl From<EmbeddedInitArgs> for InitArgs {
+    fn from(args: EmbeddedInitArgs) -> Self {
         let mut init_args = Self {
             output: args.output.clone(),
             keystore: args.kms_file.clone(),

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -1,5 +1,5 @@
+pub mod config;
 pub mod get_peer_id;
-pub mod init;
 pub mod participate;
 
 use std::{
@@ -108,6 +108,8 @@ impl CliArgs {
 pub enum Command {
     /// Initialize a new user config with generated keys
     Init(Box<InitArgs>),
+    /// Initialize a new user config with generated keys
+    Update(Box<UpdateArgs>),
     /// Publish text inscriptions as zone blocks
     Inscribe(lb_tui_zone::InscribeArgs),
     /// Generate stakeholder.yaml and provider.yaml from a user config
@@ -189,6 +191,14 @@ pub struct InitArgs {
     /// Defaults to 'kms.yaml' in the same directory as --output.
     #[clap(long = "kms-file")]
     pub kms_file: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct UpdateArgs {
+    /// Path for the keystore file
+    /// Defaults to 'keystore.yaml' in the same directory as --output.
+    #[clap(long = "keystore")]
+    pub keystore: Option<PathBuf>,
 }
 
 impl Default for InitArgs {

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -12,9 +12,10 @@ use color_eyre::eyre::Result;
 use lb_libp2p::Multiaddr;
 
 use crate::config::{
-    ApiArgs, BlendArgs, DeploymentArgs, DeploymentSettings, DeploymentType, LogArgs, NetworkArgs,
-    OnUnknownKeys, RunConfig, StateArgs, UserConfig, deserialize_config_at_path, update_api,
-    update_blend, update_network, update_state, update_tracing,
+    ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
+    LogArgs, NetworkArgs, OnUnknownKeys, RunConfig, StateArgs, UserConfig,
+    deserialize_config_at_path, update_api, update_blend, update_cryptarchia, update_network,
+    update_state, update_tracing,
 };
 
 fn long_version() -> String {
@@ -68,6 +69,9 @@ pub struct CliArgs {
     /// Overrides blend config.
     #[clap(flatten)]
     blend: BlendArgs,
+    /// Overrides cryptarchia config.
+    #[clap(flatten)]
+    cryptarchia: CryptarchiaArgs,
     /// Overrides http config.
     #[clap(flatten)]
     api: ApiArgs,
@@ -191,6 +195,7 @@ pub fn build_run_config(mut user_config: UserConfig, args: CliArgs) -> Result<Ru
         api: api_args,
         network: network_args,
         blend: blend_args,
+        cryptarchia: cryptarchia_args,
         deployment: deployment_args,
         state: state_args,
         ..
@@ -198,6 +203,7 @@ pub fn build_run_config(mut user_config: UserConfig, args: CliArgs) -> Result<Ru
     update_tracing(&mut user_config.tracing, log_args)?;
     update_network(&mut user_config.network, network_args)?;
     update_blend(&mut user_config.blend, blend_args);
+    update_cryptarchia(&mut user_config.cryptarchia, cryptarchia_args);
     update_api(&mut user_config.api, api_args);
     update_state(&mut user_config.state, state_args);
 

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -2,10 +2,14 @@ pub mod config;
 pub mod get_peer_id;
 pub mod participate;
 
-use std::path::{Path, PathBuf};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::{Path, PathBuf},
+};
 
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::Result;
+use libp2p::Multiaddr;
 
 use crate::config::{
     ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
@@ -121,26 +125,116 @@ pub struct InitArgs {
     #[clap(long = "output", short = 'o', default_value = "user_config.yaml")]
     pub output: PathBuf,
 
-    #[clap(flatten)]
-    log: LogArgs,
+    /// Path for the generated keystore file.
+    /// Defaults to 'keystore.yaml' in the same directory as --output.
+    #[clap(long = "keystore", short = 'k')]
+    pub keystore: Option<PathBuf>,
 
     #[clap(flatten)]
-    network: NetworkArgs,
+    pub log: LogArgs,
 
     #[clap(flatten)]
-    blend: BlendArgs,
+    pub network: NetworkArgs,
 
     #[clap(flatten)]
-    cryptarchia: CryptarchiaArgs,
+    pub blend: BlendArgs,
 
     #[clap(flatten)]
-    sdp: SdpArgs,
+    pub cryptarchia: CryptarchiaArgs,
 
     #[clap(flatten)]
-    api: ApiArgs,
+    pub sdp: SdpArgs,
 
     #[clap(flatten)]
-    state: StateArgs,
+    pub api: ApiArgs,
+
+    #[clap(flatten)]
+    pub state: StateArgs,
+}
+
+/// Set of arguments for use in c-bindings crate.
+pub struct EmbeddedInitArgs {
+    /// Trusted peers to bootstrap from (multiaddr format).
+    /// If `--ibd` is set, peers whose multiaddrs include a `PeerId`
+    /// are also used as IBD peers.
+    pub initial_peers: Vec<Multiaddr>,
+
+    /// Output file path for the generated config
+    pub output: PathBuf,
+
+    /// Network listen port
+    pub net_port: u16,
+
+    /// Blend listen port
+    pub blend_port: u16,
+
+    /// HTTP API listen address
+    pub http_addr: SocketAddr,
+
+    /// External address for nodes with a known public IP (disables NAT
+    /// traversal). Format: /ip4/<public-ip>/udp/<port>/quic-v1
+    pub external_address: Option<Multiaddr>,
+
+    pub state_path: Option<PathBuf>,
+
+    /// Enable Initial Block Download (IBD) using peers
+    /// passed via `--initial-peers`/`-p`.
+    pub ibd: bool,
+
+    /// Log filter directives to write into the generated config, e.g.
+    /// `warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error`.
+    pub log_filter: Option<String>,
+
+    /// Path for the generated KMS keys YAML file.
+    /// Defaults to 'kms.yaml' in the same directory as --output.
+    pub kms_file: Option<PathBuf>,
+}
+
+impl From<&EmbeddedInitArgs> for InitArgs {
+    fn from(args: &EmbeddedInitArgs) -> Self {
+        let mut init_args = Self {
+            output: args.output.clone(),
+            keystore: args.kms_file.clone(),
+            ..Default::default()
+        };
+
+        init_args.log.filter.clone_from(&args.log_filter);
+        init_args.network.port = Some(args.net_port);
+        init_args
+            .network
+            .external_address
+            .clone_from(&args.external_address);
+        init_args.network.initial_peers = Some(args.initial_peers.clone());
+
+        init_args.blend.blend_addr = Some(
+            format!("/ip4/0.0.0.0/tcp/{}", args.blend_port)
+                .parse()
+                .expect("Valid multiaddr structure"),
+        );
+
+        init_args.cryptarchia.disable_ibd_peers = !args.ibd;
+        init_args.api.addr = Some(args.http_addr);
+        init_args.state.path.clone_from(&args.state_path);
+
+        init_args
+    }
+}
+
+impl Default for EmbeddedInitArgs {
+    fn default() -> Self {
+        Self {
+            initial_peers: Vec::new(),
+            output: PathBuf::from("user_config.yaml"),
+            net_port: 3000,
+            blend_port: 3400,
+            http_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000),
+            external_address: None,
+            state_path: None,
+            ibd: false,
+            log_filter: None,
+            kms_file: None,
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -218,8 +312,9 @@ pub struct MigrateArgs {
 
 impl From<MigrateArgs> for InitArgs {
     fn from(migrate: MigrateArgs) -> Self {
-        InitArgs {
+        Self {
             output: migrate.output,
+            keystore: Some(migrate.keystore),
             log: migrate.log,
             network: migrate.network,
             blend: migrate.blend,
@@ -248,7 +343,7 @@ pub struct ParticipateArgs {
     /// Node's public IPv4 address, required when the blend listening address
     /// is 0.0.0.0
     #[arg(long)]
-    pub external_address: Option<std::net::Ipv4Addr>,
+    pub external_address: Option<Ipv4Addr>,
 }
 
 #[derive(Parser, Debug)]

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -106,11 +106,11 @@ impl CliArgs {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Initialize a new user config with generated keys
-    Init(Box<InitArgs>),
+    InitConfig(Box<InitArgs>),
     /// Update existing user config with keys from keystore
-    Update(Box<UpdateArgs>),
+    UpdateConfig(Box<UpdateArgs>),
     /// Migrates a new user config with generated keys
-    Migrate(Box<MigrateArgs>),
+    MigrateConfig(Box<MigrateArgs>),
     /// Publish text inscriptions as zone blocks
     Inscribe(lb_tui_zone::InscribeArgs),
     /// Generate stakeholder.yaml and provider.yaml from a user config

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -9,13 +9,14 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::Result;
+use lb_key_management_system_service::{backend::preload::KeyId, keys::ZkPublicKey};
 use lb_libp2p::Multiaddr;
 
 use crate::config::{
     ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
-    LogArgs, NetworkArgs, OnUnknownKeys, RunConfig, StateArgs, UserConfig,
-    deserialize_config_at_path, update_api, update_blend, update_cryptarchia, update_network,
-    update_state, update_tracing,
+    LogArgs, NetworkArgs, OnUnknownKeys, RunConfig, SdpArgs, StateArgs, UserConfig,
+    deserialize_config_at_path, parse_hex_public_key, update_api, update_blend, update_cryptarchia,
+    update_network, update_sdp, update_state, update_tracing,
 };
 
 fn long_version() -> String {
@@ -72,6 +73,9 @@ pub struct CliArgs {
     /// Overrides cryptarchia config.
     #[clap(flatten)]
     cryptarchia: CryptarchiaArgs,
+    /// Overrides sdp config.
+    #[clap(flatten)]
+    sdp: SdpArgs,
     /// Overrides http config.
     #[clap(flatten)]
     api: ApiArgs,
@@ -103,7 +107,7 @@ impl CliArgs {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Initialize a new user config with generated keys
-    Init(InitArgs),
+    Init(Box<InitArgs>),
     /// Publish text inscriptions as zone blocks
     Inscribe(lb_tui_zone::InscribeArgs),
     /// Generate stakeholder.yaml and provider.yaml from a user config
@@ -128,9 +132,36 @@ pub struct InitArgs {
     #[clap(long = "net-port", default_value = "3000")]
     pub net_port: u16,
 
+    /// Network swarm key.
+    #[clap(long = "net-node-key", env = "NET_NODE_KEY")]
+    pub net_node_key: Option<String>,
+
     /// Blend listen port
     #[clap(long = "blend-port", default_value = "3400")]
     pub blend_port: u16,
+
+    /// Blend signing key.
+    #[clap(long = "blend-signing-key-id", env = "BLEND_SIGNING_KEY_ID")]
+    blend_signing_key_id: Option<KeyId>,
+
+    /// Blend secret key.
+    #[clap(long = "blend-secret-key-id", env = "BLEND_SECRET_KEY_ID")]
+    blend_secret_key_id: Option<KeyId>,
+
+    /// Cryptarchia funding public key.
+    #[clap(
+        long = "cryptarchia-funding-pk",
+        env = "CRYPTARCHIA_FUNDING_PK",
+        value_parser = parse_hex_public_key
+    )]
+    cryptarchia_funding_pk: Option<ZkPublicKey>,
+
+    #[clap(
+        long = "sdp-funding-pk",
+        env = "SDP_FUNDING_PK",
+        value_parser = parse_hex_public_key
+    )]
+    sdp_funding_pk: Option<ZkPublicKey>,
 
     /// HTTP API listen address
     #[clap(long = "http-addr", default_value = "127.0.0.1:8080")]
@@ -196,6 +227,7 @@ pub fn build_run_config(mut user_config: UserConfig, args: CliArgs) -> Result<Ru
         network: network_args,
         blend: blend_args,
         cryptarchia: cryptarchia_args,
+        sdp: sdp_args,
         deployment: deployment_args,
         state: state_args,
         ..
@@ -204,6 +236,7 @@ pub fn build_run_config(mut user_config: UserConfig, args: CliArgs) -> Result<Ru
     update_network(&mut user_config.network, network_args)?;
     update_blend(&mut user_config.blend, blend_args);
     update_cryptarchia(&mut user_config.cryptarchia, cryptarchia_args);
+    update_sdp(&mut user_config.sdp, sdp_args);
     update_api(&mut user_config.api, api_args);
     update_state(&mut user_config.state, state_args);
 

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -248,12 +248,7 @@ pub struct UpdateArgs {
     pub keystore: PathBuf,
 
     /// Auto approve interactive promps.
-    #[arg(
-        short,
-        long,
-        default_value_t = false,
-        help = "Auto approve interactive promps"
-    )]
+    #[arg(short, long, default_value_t = false)]
     pub yes: bool,
 
     #[clap(flatten)]
@@ -337,6 +332,9 @@ pub struct ParticipateArgs {
     /// Path to the user config YAML file
     #[arg(long, default_value = "user_config.yaml")]
     pub config: PathBuf,
+    /// Path to the keystore YAML file
+    #[arg(long, default_value = "keystore.yaml")]
+    pub keystore: PathBuf,
     /// Output directory for `participation_data.yaml`
     #[arg(long, default_value = ".")]
     pub output: PathBuf,

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -103,8 +103,10 @@ impl CliArgs {
 pub enum Command {
     /// Initialize a new user config with generated keys
     Init(Box<InitArgs>),
-    /// Initialize a new user config with generated keys
+    /// Update existing user config with keys from keystore
     Update(Box<UpdateArgs>),
+    /// Migrates a new user config with generated keys
+    Migrate(Box<MigrateArgs>),
     /// Publish text inscriptions as zone blocks
     Inscribe(lb_tui_zone::InscribeArgs),
     /// Generate stakeholder.yaml and provider.yaml from a user config
@@ -115,7 +117,7 @@ pub enum Command {
 
 #[derive(Parser, Debug)]
 pub struct InitArgs {
-    /// Output file path for the generated config
+    /// Output file path for the generated config.
     #[clap(long = "output", short = 'o', default_value = "user_config.yaml")]
     pub output: PathBuf,
 
@@ -143,10 +145,90 @@ pub struct InitArgs {
 
 #[derive(Parser, Debug)]
 pub struct UpdateArgs {
-    /// Path for the keystore file
-    /// Defaults to 'keystore.yaml' in the same directory as --output.
+    /// Output file path for the generated config.
+    #[clap(long = "user-config", short = 'o', default_value = "user_config.yaml")]
+    pub user_config: PathBuf,
+
+    /// Path for the keystore file.
     #[clap(long = "keystore")]
-    pub keystore: Option<PathBuf>,
+    pub keystore: PathBuf,
+
+    /// Auto approve interactive promps.
+    #[arg(
+        short,
+        long,
+        default_value_t = false,
+        help = "Auto approve interactive promps"
+    )]
+    pub yes: bool,
+
+    #[clap(flatten)]
+    log: LogArgs,
+
+    #[clap(flatten)]
+    network: NetworkArgs,
+
+    #[clap(flatten)]
+    blend: BlendArgs,
+
+    #[clap(flatten)]
+    cryptarchia: CryptarchiaArgs,
+
+    #[clap(flatten)]
+    sdp: SdpArgs,
+
+    #[clap(flatten)]
+    api: ApiArgs,
+
+    #[clap(flatten)]
+    state: StateArgs,
+}
+
+#[derive(Parser, Debug)]
+pub struct MigrateArgs {
+    /// Output file path for the generated config.
+    #[clap(long = "output", short = 'o', default_value = "user_config.yaml")]
+    pub output: PathBuf,
+
+    /// Path for the keystore file.
+    #[clap(long = "keystore")]
+    pub keystore: PathBuf,
+
+    #[clap(flatten)]
+    log: LogArgs,
+
+    #[clap(flatten)]
+    network: NetworkArgs,
+
+    #[clap(flatten)]
+    blend: BlendArgs,
+
+    #[clap(flatten)]
+    cryptarchia: CryptarchiaArgs,
+
+    #[clap(flatten)]
+    sdp: SdpArgs,
+
+    #[clap(flatten)]
+    api: ApiArgs,
+
+    #[clap(flatten)]
+    state: StateArgs,
+}
+
+impl From<MigrateArgs> for InitArgs {
+    fn from(migrate: MigrateArgs) -> Self {
+        InitArgs {
+            output: migrate.output,
+            log: migrate.log,
+            network: migrate.network,
+            blend: migrate.blend,
+            cryptarchia: migrate.cryptarchia,
+            sdp: migrate.sdp,
+            api: migrate.api,
+            state: migrate.state,
+        }
+    }
 }
 
 impl Default for InitArgs {

--- a/nodes/node/binary/src/cli/participate.rs
+++ b/nodes/node/binary/src/cli/participate.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[derive(Serialize)]
 struct ParticipationData {
-    stakeholder_identity: ZkPublicKey,
+    stakeholder_identities: Vec<ZkPublicKey>,
     #[serde(skip_serializing_if = "Option::is_none")]
     blend: Option<BlendParticipationData>,
 }
@@ -30,8 +30,9 @@ pub fn run(args: &ParticipateArgs) -> Result<()> {
     let user_config = deserialize_config_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
 
     let (_, stakeholder_identity) = user_config.blend_zk_key().map_err(|e| eyre!("{e}"))?;
+    let (_, blend_zk) = user_config.blend_zk_key().map_err(|e| eyre!("{e}"))?;
     let data = ParticipationData {
-        stakeholder_identity,
+        stakeholder_identities: vec![blend_zk],
         blend: build_blend_data(&user_config, args.external_address)?,
     };
 

--- a/nodes/node/binary/src/cli/participate.rs
+++ b/nodes/node/binary/src/cli/participate.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use super::ParticipateArgs;
 use crate::{
     UserConfig,
+    cli::config::keystore::{KeyTitle, Keystore},
     config::{OnUnknownKeys, deserialize_config_at_path, network::serde::nat},
 };
 
@@ -22,6 +23,7 @@ struct ParticipationData {
 #[derive(Serialize)]
 struct BlendParticipationData {
     provider_id: Ed25519PublicKey,
+    zk_id: ZkPublicKey,
     locators: Locators,
     service_type: ServiceType,
 }
@@ -29,11 +31,27 @@ struct BlendParticipationData {
 pub fn run(args: &ParticipateArgs) -> Result<()> {
     let user_config = deserialize_config_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
 
-    let (_, stakeholder_identity) = user_config.blend_zk_key().map_err(|e| eyre!("{e}"))?;
-    let (_, blend_zk) = user_config.blend_zk_key().map_err(|e| eyre!("{e}"))?;
+    let keystore_yaml = std::fs::read_to_string(&args.keystore)?;
+    let keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;
+
+    let (_, stake_key) = keystore.get_zk(KeyTitle::Stake)?;
+    let (_, leader_funding_key) = keystore.get_zk(KeyTitle::LeaderFunding)?;
+    let (_, sdp_funding_key) = keystore.get_zk(KeyTitle::SdpFunding)?;
+
+    let mut stakeholder_identities = vec![
+        stake_key.to_public_key(),
+        leader_funding_key.to_public_key(),
+        sdp_funding_key.to_public_key(),
+    ];
+
+    let blend = build_blend_data(&user_config, &keystore, args.external_address)?;
+    if let Some(blend) = &blend {
+        stakeholder_identities.push(blend.zk_id);
+    }
+
     let data = ParticipationData {
-        stakeholder_identities: vec![blend_zk],
-        blend: build_blend_data(&user_config, args.external_address)?,
+        stakeholder_identities,
+        blend,
     };
 
     std::fs::create_dir_all(&args.output)?;
@@ -49,6 +67,7 @@ pub fn run(args: &ParticipateArgs) -> Result<()> {
 /// `Err` when the key is present but address resolution fails.
 fn build_blend_data(
     user_config: &UserConfig,
+    keystore: &Keystore,
     external_address: Option<Ipv4Addr>,
 ) -> Result<Option<BlendParticipationData>> {
     let provider_id = match user_config.blend_provider_id() {
@@ -61,8 +80,10 @@ fn build_blend_data(
     let locator_addr = resolve_locator_addr(listen_addr, nat_config, external_address)?;
     let locator = Locator::try_from(locator_addr).map_err(|e| eyre!("{e}"))?;
 
+    let (_, blend_key) = keystore.get_zk(KeyTitle::BlendZk)?;
     Ok(Some(BlendParticipationData {
         provider_id,
+        zk_id: blend_key.to_public_key(),
         locators: Locators::from(locator),
         service_type: ServiceType::BlendNetwork,
     }))

--- a/nodes/node/binary/src/config/blend/serde/core.rs
+++ b/nodes/node/binary/src/config/blend/serde/core.rs
@@ -29,7 +29,7 @@ pub struct BackendConfig {
 impl Default for BackendConfig {
     fn default() -> Self {
         Self {
-            listening_address: "/ip4/0.0.0.0/udp/10000/quic-v1".parse().unwrap(),
+            listening_address: "/ip4/0.0.0.0/udp/3400/quic-v1".parse().unwrap(),
             core_peering_degree: 2..=3,
             edge_node_connection_timeout: Duration::from_secs(1),
             max_edge_node_incoming_connections: 300,

--- a/nodes/node/binary/src/config/blend/serde/mod.rs
+++ b/nodes/node/binary/src/config/blend/serde/mod.rs
@@ -55,7 +55,7 @@ impl Config {
         self.non_ephemeral_signing_key_id = key_id;
     }
 
-    pub fn set_secret_key_id(&mut self, key_id: KeyId) {
+    pub fn set_secret_zk_key_id(&mut self, key_id: KeyId) {
         self.core.zk.secret_key_kms_id = key_id;
     }
 }

--- a/nodes/node/binary/src/config/blend/serde/mod.rs
+++ b/nodes/node/binary/src/config/blend/serde/mod.rs
@@ -46,7 +46,16 @@ impl Config {
             edge: EdgeConfig::default(),
         }
     }
+
     pub fn set_listening_address(&mut self, addr: Multiaddr) {
         self.core.backend.listening_address = addr;
+    }
+
+    pub fn set_signing_key_id(&mut self, key_id: KeyId) {
+        self.non_ephemeral_signing_key_id = key_id;
+    }
+
+    pub fn set_secret_key_id(&mut self, key_id: KeyId) {
+        self.core.zk.secret_key_kms_id = key_id;
     }
 }

--- a/nodes/node/binary/src/config/blend/serde/mod.rs
+++ b/nodes/node/binary/src/config/blend/serde/mod.rs
@@ -51,7 +51,7 @@ impl Config {
         self.core.backend.listening_address = addr;
     }
 
-    pub fn set_signing_key_id(&mut self, key_id: KeyId) {
+    pub fn set_non_ephemeral_signing_key_id(&mut self, key_id: KeyId) {
         self.non_ephemeral_signing_key_id = key_id;
     }
 

--- a/nodes/node/binary/src/config/cryptarchia/serde/mod.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/mod.rs
@@ -32,4 +32,8 @@ impl Config {
             service: service::Config::default(),
         }
     }
+
+    pub const fn set_funding_pk(&mut self, pk: ZkPublicKey) {
+        self.leader.wallet.funding_pk = pk;
+    }
 }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -1,5 +1,6 @@
 use core::{convert::Infallible, str::FromStr};
 use std::{
+    collections::HashSet,
     io::Read,
     net::{IpAddr, SocketAddr, ToSocketAddrs as _},
     path::{Path, PathBuf},
@@ -22,10 +23,6 @@ use lb_tracing::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::config::tracing::serde::{
-    filter::{EnvConfig, Layer},
-    logger::{FileConfig, GelfConfig},
-};
 pub use crate::config::{
     api::serde::Config as ApiConfig,
     blend::serde::Config as BlendConfig,
@@ -39,6 +36,13 @@ pub use crate::config::{
     time::serde::Config as TimeConfig,
     tracing::serde::Config as TracingConfig,
     wallet::serde::Config as WalletConfig,
+};
+use crate::config::{
+    network::serde::nat,
+    tracing::serde::{
+        filter::{EnvConfig, Layer},
+        logger::{FileConfig, GelfConfig},
+    },
 };
 
 pub mod api;
@@ -232,7 +236,18 @@ pub struct NetworkArgs {
     #[clap(long = "net-node-key", env = "NET_NODE_KEY")]
     node_key: Option<String>,
 
-    #[clap(long = "net-initial-peers", env = "NET_INITIAL_PEERS", num_args = 1.., value_delimiter = ',')]
+    /// External address for nodes with a known public IP (disables NAT
+    /// traversal). Format: /ip4/<public-ip>/udp/<port>/quic-v1
+    #[clap(long = "external-address")]
+    pub external_address: Option<Multiaddr>,
+
+    #[clap(
+        long = "net-initial-peers",
+        short = 'p',
+        env = "NET_INITIAL_PEERS",
+        num_args = 1..,
+        value_delimiter = ','
+    )]
     pub initial_peers: Option<Vec<Multiaddr>>,
 }
 
@@ -256,6 +271,10 @@ pub struct CryptarchiaArgs {
         value_parser = parse_hex_public_key
     )]
     cryptarchia_funding_pk: Option<ZkPublicKey>,
+
+    /// Overwrite IBD peer list with an empty list.
+    #[clap(long = "disable-ibd-peers", default_value_t = false)]
+    pub disable_ibd_peers: bool,
 }
 
 #[derive(Parser, Debug, Clone, Copy)]
@@ -477,6 +496,7 @@ pub fn update_network(network: &mut NetworkConfig, network_args: NetworkArgs) ->
         host,
         port,
         node_key,
+        external_address,
         initial_peers,
     } = network_args;
 
@@ -493,6 +513,10 @@ pub fn update_network(network: &mut NetworkConfig, network_args: NetworkArgs) ->
     if let Some(node_key) = node_key {
         let mut key_bytes = hex::decode(node_key)?;
         network.backend.swarm.node_key = SecretKey::try_from_bytes(key_bytes.as_mut_slice())?;
+    }
+
+    if let Some(external_address) = external_address {
+        network.backend.swarm.nat = nat::Config::Static { external_address };
     }
 
     if let Some(peers) = initial_peers {
@@ -522,16 +546,18 @@ pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
     }
 }
 
-pub const fn update_cryptarchia(
-    cryptarchia: &mut CryptarchiaConfig,
-    cryptarchia_args: CryptarchiaArgs,
-) {
+pub fn update_cryptarchia(cryptarchia: &mut CryptarchiaConfig, cryptarchia_args: CryptarchiaArgs) {
     let CryptarchiaArgs {
         cryptarchia_funding_pk: funding_pk,
+        disable_ibd_peers,
     } = cryptarchia_args;
 
     if let Some(pk) = funding_pk {
         cryptarchia.set_funding_pk(pk);
+    }
+
+    if disable_ibd_peers {
+        cryptarchia.network.bootstrap.ibd.peers = HashSet::new();
     }
 }
 

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -255,7 +255,7 @@ pub struct CryptarchiaArgs {
         env = "CRYPTARCHIA_FUNDING_PK",
         value_parser = parse_hex_public_key
     )]
-    funding_pk: Option<ZkPublicKey>,
+    cryptarchia_funding_pk: Option<ZkPublicKey>,
 }
 
 #[derive(Parser, Debug, Clone, Copy)]
@@ -265,7 +265,7 @@ pub struct SdpArgs {
         env = "SDP_FUNDING_PK",
         value_parser = parse_hex_public_key
     )]
-    funding_pk: Option<ZkPublicKey>,
+    sdp_funding_pk: Option<ZkPublicKey>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -526,7 +526,9 @@ pub const fn update_cryptarchia(
     cryptarchia: &mut CryptarchiaConfig,
     cryptarchia_args: CryptarchiaArgs,
 ) {
-    let CryptarchiaArgs { funding_pk } = cryptarchia_args;
+    let CryptarchiaArgs {
+        cryptarchia_funding_pk: funding_pk,
+    } = cryptarchia_args;
 
     if let Some(pk) = funding_pk {
         cryptarchia.set_funding_pk(pk);
@@ -534,7 +536,9 @@ pub const fn update_cryptarchia(
 }
 
 pub const fn update_sdp(sdp: &mut SdpConfig, sdp_args: SdpArgs) {
-    let SdpArgs { funding_pk } = sdp_args;
+    let SdpArgs {
+        sdp_funding_pk: funding_pk,
+    } = sdp_args;
 
     if let Some(pk) = funding_pk {
         sdp.set_funding_pk(pk);

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -10,7 +10,11 @@ use ::tracing::warn;
 use clap::{Parser, ValueEnum, builder::OsStr};
 use color_eyre::eyre::{Result, eyre};
 use lb_core::sdp::ProviderId;
-use lb_key_management_system_service::keys::{Key, ZkPublicKey};
+use lb_groth16::fr_from_bytes;
+use lb_key_management_system_service::{
+    backend::preload::KeyId,
+    keys::{Key, ZkPublicKey},
+};
 use lb_libp2p::{Multiaddr, ed25519::SecretKey};
 use lb_tracing::{
     filter::envfilter::{default_envfilter_config, parse_filter_directives},
@@ -236,6 +240,22 @@ pub struct NetworkArgs {
 pub struct BlendArgs {
     #[clap(long = "blend-addr", env = "BLEND_ADDR")]
     blend_addr: Option<Multiaddr>,
+
+    #[clap(long = "blend-signing-key-id", env = "BLEND_SIGNING_KEY_ID")]
+    blend_signing_key_id: Option<KeyId>,
+
+    #[clap(long = "blend-secret-key-id", env = "BLEND_SECRET_KEY_ID")]
+    blend_secret_key_id: Option<KeyId>,
+}
+
+#[derive(Parser, Debug, Clone, Copy)]
+pub struct CryptarchiaArgs {
+    #[clap(
+        long = "cryptarchia-funding-pk",
+        env = "CRYPTARCHIA_FUNDING_PK",
+        value_parser = parse_hex_public_key
+    )]
+    funding_pk: Option<ZkPublicKey>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -473,10 +493,33 @@ pub fn update_network(network: &mut NetworkConfig, network_args: NetworkArgs) ->
 }
 
 pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
-    let BlendArgs { blend_addr } = blend_args;
+    let BlendArgs {
+        blend_addr,
+        blend_signing_key_id,
+        blend_secret_key_id,
+    } = blend_args;
 
     if let Some(addr) = blend_addr {
         blend.set_listening_address(addr);
+    }
+
+    if let Some(key_id) = blend_signing_key_id {
+        blend.set_signing_key_id(key_id);
+    }
+
+    if let Some(key_id) = blend_secret_key_id {
+        blend.set_secret_key_id(key_id);
+    }
+}
+
+pub const fn update_cryptarchia(
+    cryptarchia: &mut CryptarchiaConfig,
+    cryptarchia_args: CryptarchiaArgs,
+) {
+    let CryptarchiaArgs { funding_pk } = cryptarchia_args;
+
+    if let Some(pk) = funding_pk {
+        cryptarchia.set_funding_pk(pk);
     }
 }
 
@@ -615,4 +658,13 @@ impl From<RunConfig> for UserConfig {
     fn from(value: RunConfig) -> Self {
         value.user
     }
+}
+
+fn parse_hex_public_key(key: &str) -> Result<ZkPublicKey, String> {
+    let bytes = hex::decode(key).map_err(|e| format!("Failed to parse hex string: {e}"))?;
+
+    let fr =
+        fr_from_bytes(&bytes).map_err(|e| format!("Failed to deserialize Fr from bytes: {e}"))?;
+
+    Ok(ZkPublicKey::new(fr))
 }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -538,11 +538,11 @@ pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
     }
 
     if let Some(key_id) = blend_signing_key_id {
-        blend.set_signing_key_id(key_id);
+        blend.set_non_ephemeral_signing_key_id(key_id);
     }
 
     if let Some(key_id) = blend_secret_key_id {
-        blend.set_secret_key_id(key_id);
+        blend.set_secret_zk_key_id(key_id);
     }
 }
 

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -258,6 +258,16 @@ pub struct CryptarchiaArgs {
     funding_pk: Option<ZkPublicKey>,
 }
 
+#[derive(Parser, Debug, Clone, Copy)]
+pub struct SdpArgs {
+    #[clap(
+        long = "sdp-funding-pk",
+        env = "SDP_FUNDING_PK",
+        value_parser = parse_hex_public_key
+    )]
+    funding_pk: Option<ZkPublicKey>,
+}
+
 #[derive(Parser, Debug, Clone)]
 pub struct ApiArgs {
     #[clap(long = "http-host", env = "HTTP_HOST")]
@@ -523,6 +533,14 @@ pub const fn update_cryptarchia(
     }
 }
 
+pub const fn update_sdp(sdp: &mut SdpConfig, sdp_args: SdpArgs) {
+    let SdpArgs { funding_pk } = sdp_args;
+
+    if let Some(pk) = funding_pk {
+        sdp.set_funding_pk(pk);
+    }
+}
+
 pub fn update_api(api: &mut ApiConfig, args: ApiArgs) {
     let ApiArgs { addr, cors_origins } = args;
 
@@ -660,7 +678,7 @@ impl From<RunConfig> for UserConfig {
     }
 }
 
-fn parse_hex_public_key(key: &str) -> Result<ZkPublicKey, String> {
+pub fn parse_hex_public_key(key: &str) -> Result<ZkPublicKey, String> {
     let bytes = hex::decode(key).map_err(|e| format!("Failed to parse hex string: {e}"))?;
 
     let fr =

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -183,7 +183,7 @@ pub struct LogArgs {
         env = "LOG_ADDR",
         required_if_eq("backend", LoggerLayerType::Gelf)
     )]
-    log_addr: Option<String>,
+    pub log_addr: Option<String>,
 
     /// Directory for the File backend
     #[clap(
@@ -191,7 +191,7 @@ pub struct LogArgs {
         env = "LOG_DIR",
         required_if_eq("backend", LoggerLayerType::File)
     )]
-    directory: Option<PathBuf>,
+    pub directory: Option<PathBuf>,
 
     /// Prefix for the File backend
     #[clap(
@@ -199,42 +199,42 @@ pub struct LogArgs {
         env = "LOG_PATH",
         required_if_eq("backend", LoggerLayerType::File)
     )]
-    prefix: Option<PathBuf>,
+    pub prefix: Option<PathBuf>,
 
     /// Backend type
     #[clap(long = "log-backend", env = "LOG_BACKEND", value_enum)]
-    backend: Option<LoggerLayerType>,
+    pub backend: Option<LoggerLayerType>,
 
     #[clap(long = "log-level", env = "LOG_LEVEL")]
-    level: Option<String>,
+    pub level: Option<String>,
 
     /// Per-target log filter directives, e.g.
     /// `libp2p_gossipsub=info,h2=warn`
     #[clap(long = "log-filter", env = "LOG_FILTER")]
-    filter: Option<String>,
+    pub filter: Option<String>,
 
     #[clap(long = "log-file-appender", env = "LOG_APPENDER")]
-    file_appender: Option<LogFileAppenderType>,
+    pub file_appender: Option<LogFileAppenderType>,
 
     #[clap(
         long = "log-max-files",
         env = "LOG_APPENDER_MAX_FILES",
         required_if_eq("file_appender", LogFileAppenderType::RollingMaxFiles)
     )]
-    max_files: Option<usize>,
+    pub max_files: Option<usize>,
 }
 
 #[derive(Parser, Debug, Clone)]
 pub struct NetworkArgs {
     #[clap(long = "net-host", env = "NET_HOST")]
-    host: Option<IpAddr>,
+    pub host: Option<IpAddr>,
 
     #[clap(long = "net-port", env = "NET_PORT")]
-    port: Option<usize>,
+    pub port: Option<u16>,
 
     // TODO: Use either the raw bytes or the key type directly to delegate error handling to clap
     #[clap(long = "net-node-key", env = "NET_NODE_KEY")]
-    node_key: Option<String>,
+    pub node_key: Option<String>,
 
     /// External address for nodes with a known public IP (disables NAT
     /// traversal). Format: /ip4/<public-ip>/udp/<port>/quic-v1
@@ -254,13 +254,13 @@ pub struct NetworkArgs {
 #[derive(Parser, Debug, Clone)]
 pub struct BlendArgs {
     #[clap(long = "blend-addr", env = "BLEND_ADDR")]
-    blend_addr: Option<Multiaddr>,
+    pub blend_addr: Option<Multiaddr>,
 
     #[clap(long = "blend-signing-key-id", env = "BLEND_SIGNING_KEY_ID")]
-    blend_signing_key_id: Option<KeyId>,
+    pub blend_signing_key_id: Option<KeyId>,
 
     #[clap(long = "blend-secret-key-id", env = "BLEND_SECRET_KEY_ID")]
-    blend_secret_key_id: Option<KeyId>,
+    pub blend_secret_key_id: Option<KeyId>,
 }
 
 #[derive(Parser, Debug, Clone, Copy)]
@@ -270,7 +270,7 @@ pub struct CryptarchiaArgs {
         env = "CRYPTARCHIA_FUNDING_PK",
         value_parser = parse_hex_public_key
     )]
-    cryptarchia_funding_pk: Option<ZkPublicKey>,
+    pub cryptarchia_funding_pk: Option<ZkPublicKey>,
 
     /// Overwrite IBD peer list with an empty list.
     #[clap(long = "disable-ibd-peers", default_value_t = false)]
@@ -284,7 +284,7 @@ pub struct SdpArgs {
         env = "SDP_FUNDING_PK",
         value_parser = parse_hex_public_key
     )]
-    sdp_funding_pk: Option<ZkPublicKey>,
+    pub sdp_funding_pk: Option<ZkPublicKey>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -507,7 +507,7 @@ pub fn update_network(network: &mut NetworkConfig, network_args: NetworkArgs) ->
     }
 
     if let Some(port) = port {
-        network.backend.swarm.port = port as u16;
+        network.backend.swarm.port = port;
     }
 
     if let Some(node_key) = node_key {

--- a/nodes/node/binary/src/config/network/serde/mod.rs
+++ b/nodes/node/binary/src/config/network/serde/mod.rs
@@ -56,7 +56,7 @@ impl Default for SwarmConfig {
     fn default() -> Self {
         Self {
             host: Ipv4Addr::UNSPECIFIED,
-            port: 0,
+            port: 3000,
             node_key: SecretKey::generate(),
             gossipsub: gossipsub::Config::default(),
             kademlia: kademlia::Config::default(),

--- a/nodes/node/binary/src/config/sdp/serde.rs
+++ b/nodes/node/binary/src/config/sdp/serde.rs
@@ -40,4 +40,8 @@ impl Config {
             declaration_id: None,
         }
     }
+
+    pub const fn set_funding_pk(&mut self, pk: ZkPublicKey) {
+        self.wallet.funding_pk = pk;
+    }
 }

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -22,7 +22,10 @@ async fn main() -> Result<()> {
                 return logos_blockchain_node::cli::config::init::run(*init_args);
             }
             Command::Update(update_args) => {
-                todo!()
+                return logos_blockchain_node::cli::config::update::run(*update_args);
+            }
+            Command::Migrate(migrate_args) => {
+                return logos_blockchain_node::cli::config::migrate::run(*migrate_args);
             }
             Command::Inscribe(inscribe_args) => {
                 lb_tui_zone::run(inscribe_args).await;

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -18,13 +18,13 @@ async fn main() -> Result<()> {
 
     if let Some(command) = cli_args.command {
         match command {
-            Command::Init(init_args) => {
+            Command::InitConfig(init_args) => {
                 return logos_blockchain_node::cli::config::init::run(*init_args);
             }
-            Command::Update(update_args) => {
+            Command::UpdateConfig(update_args) => {
                 return logos_blockchain_node::cli::config::update::run(*update_args);
             }
-            Command::Migrate(migrate_args) => {
+            Command::MigrateConfig(migrate_args) => {
                 return logos_blockchain_node::cli::config::migrate::run(*migrate_args);
             }
             Command::Inscribe(inscribe_args) => {

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     if let Some(command) = cli_args.command {
         match command {
             Command::Init(init_args) => {
-                return logos_blockchain_node::cli::config::init::run(&init_args);
+                return logos_blockchain_node::cli::config::init::run(*init_args);
             }
             Command::Update(update_args) => {
                 todo!()

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -19,7 +19,10 @@ async fn main() -> Result<()> {
     if let Some(command) = cli_args.command {
         match command {
             Command::Init(init_args) => {
-                return logos_blockchain_node::cli::init::run(&init_args);
+                return logos_blockchain_node::cli::config::init::run(&init_args);
+            }
+            Command::Update(update_args) => {
+                todo!()
             }
             Command::Inscribe(inscribe_args) => {
                 lb_tui_zone::run(inscribe_args).await;


### PR DESCRIPTION
## 1. What does this PR implement?

Replaced kms.yaml with keystore.yaml structure in cli crate. Keystore has human readable mappings and is supposed to contain all keys needed for migration between config or deployment versions.

Renamed `init` command to `init-config`, also added `update-config` and `migrate-config`.
- `init-config` complains if keystore or userconfig files exists.
- `update-config` complains if keystore or userconfig files doesn't exist, asks for confirmation when overwriting config.
- `migrate-config` complains if keystore doesn't exist and if userconfig exists.

In participate command keystore is used to pick zk_id related information. Also stakeholders information now contains multiple user keys.

## 2. Does the code have enough context to be clearly understood?

Mostly node config generation with explicit key titles to better inspect and understand the system. 

## 3. Who are the specification authors and who is accountable for this PR?

@bacv @danielSanchezQ 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
