### PR TITLE
test: add concurrent cucumber option

### DIFF
--- a/.github/actions/run-cucumber-suite/action.yml
+++ b/.github/actions/run-cucumber-suite/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Whether to set CUCUMBER_VERBOSE_CONSOLE=true
     required: false
     default: "false"
+  max_concurrent_scenarios:
+    description: Maximum number of concurrent scenarios to run
+    required: false
+    default: "1"
 
 runs:
   using: composite
@@ -28,6 +32,7 @@ runs:
         CUCUMBER_LOG_LEVEL: debug
         CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL: true
         USE_LOCAL_HOST_NTP_TIME_CONFIG: true
+        MAX_CUCUMBER_CONCURRENT_SCENARIOS: ${{ inputs.max_concurrent_scenarios }}
       with:
         command: test
         args: >-
@@ -44,6 +49,7 @@ runs:
         CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL: true
         USE_LOCAL_HOST_NTP_TIME_CONFIG: true
         CUCUMBER_VERBOSE_CONSOLE: true
+        MAX_CUCUMBER_CONCURRENT_SCENARIOS: ${{ inputs.max_concurrent_scenarios }}
       with:
         command: test
         args: >-

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -155,6 +155,7 @@ jobs:
           suite_tag: "@smoke_ci"
           suite_name: smoke
           artifact_subdir: Smoke
+          max_concurrent_scenarios: "2"
 
       # Feature: Cryptarchia (@cryptarchia_ci)
       - name: Run cucumber suite - cryptarchia
@@ -165,6 +166,7 @@ jobs:
           suite_tag: "@cryptarchia_ci"
           suite_name: cryptarchia
           artifact_subdir: Cryptarchia
+          max_concurrent_scenarios: "2"
 
       # Feature: Blend (@blend_ci)
       - name: Run cucumber suite - blend
@@ -175,6 +177,7 @@ jobs:
           suite_tag: "@blend_ci"
           suite_name: blend
           artifact_subdir: Blend
+          max_concurrent_scenarios: "2"
 
       # Feature: Transactions (@transactions_ci)
       - name: Run cucumber suite - transactions
@@ -186,6 +189,7 @@ jobs:
           suite_name: transactions
           artifact_subdir: Transactions
           verbose_console: "true"
+          max_concurrent_scenarios: "2"
 
       # Feature: Zone SDK (@zone_ci)
       - name: Run cucumber suite - zone
@@ -196,6 +200,7 @@ jobs:
           suite_tag: "@zone_ci"
           suite_name: zone
           artifact_subdir: Zone
+          max_concurrent_scenarios: "2"
 
       # Feature: CLI utility binary (@cli_ci)
       - name: Run cucumber suite - CLI utilities
@@ -206,6 +211,7 @@ jobs:
           suite_tag: "@cli_ci"
           suite_name: CLI
           artifact_subdir: Cli
+          max_concurrent_scenarios: "2"
 
       # Always upload JUnit test results for reporting, even if tests fail
       - name: Upload cucumber JUnit results

--- a/tests/cucumber_tests/cucumber.rs
+++ b/tests/cucumber_tests/cucumber.rs
@@ -34,13 +34,22 @@ use lb_testing_framework::{
 use logos_blockchain_tests::cucumber::{
     defaults::{
         ARTEFACTS, CUCUMBER_DEPLOYER_COMPOSE, CUCUMBER_DEPLOYER_K8S,
-        CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL, create_scenario_output_dir, get_feature_path,
-        get_retries, init_logging_defaults, init_tracing,
+        CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL, MAX_CUCUMBER_CONCURRENT_SCENARIOS,
+        create_scenario_output_dir, get_feature_path, get_retries, init_logging_defaults,
+        init_tracing,
     },
     world::{CucumberWorld, DeployerKind},
 };
 
 type ScenarioAttempts = Arc<Mutex<HashMap<String, u8>>>;
+
+// Get the maximum number of concurrent scenarios from env var, defaults to 1
+fn get_max_concurrent_scenarios() -> usize {
+    std::env::var(MAX_CUCUMBER_CONCURRENT_SCENARIOS)
+        .ok()
+        .and_then(|val| val.parse().ok())
+        .unwrap_or(1)
+}
 
 // Increment and return the attempt count for the given scenario. Counts
 // are tracked per-scenario, and keyed by a combination of feature and
@@ -84,7 +93,7 @@ async fn main() {
         // Re-outputs Failed steps for easier navigation.
         .repeat_failed()
         // .fail_fast() // Remove comment to enable fail-fast behavior for development
-        .max_concurrent_scenarios(1)
+        .max_concurrent_scenarios(get_max_concurrent_scenarios())
         // Ensure that all the steps were covered.
         .fail_on_skipped()
         // Replaces Writer.

--- a/tests/src/cucumber/defaults.rs
+++ b/tests/src/cucumber/defaults.rs
@@ -29,6 +29,7 @@ pub const SNAPSHOT_STATE_SUBDIRS: [&str; 2] = ["db", "recovery"];
 pub const CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL: &str = "CUCUMBER_REMOVE_ARTEFACTS_IF_SUCCESSFUL";
 pub const CUCUMBER_DEPLOYER_COMPOSE: &str = "CUCUMBER_DEPLOYER_COMPOSE";
 pub const CUCUMBER_DEPLOYER_K8S: &str = "CUCUMBER_DEPLOYER_K8S";
+pub const MAX_CUCUMBER_CONCURRENT_SCENARIOS: &str = "MAX_CUCUMBER_CONCURRENT_SCENARIOS";
 
 /// Set an environment variable to a default value if it is not already set.
 pub fn set_default_env(key: &str, value: &str) {


### PR DESCRIPTION
## 1. What does this PR implement?

Cucumber CI tests are taking longer and longer to complete due to all the tests being added. The idea with this PR is to evaluate if running concurrent cucumber scenarios will be stable in CI if we run it like this for a while, set at two concurrent scenarios. Easy enough to change the configuration back to 1 for CI if it proves to be unstable, or up it to 3.

- Added concurrent cucumber scenario override via env var, with default 1.
- Changed CI to run two concurrent scenarios for all cucumber test suites (configurable per test suite).

**Note:** Local stress test was successful running 6 concurrent scenarios for all scenarios.
```
MAX_CUCUMBER_CONCURRENT_SCENARIOS="6" & cargo test -p logos-blockchain-tests --features cucumber --test cucumber -- --tags "@zone_ci or @cli_ci or @blend_ci or @cryptarchia_ci or @smoke_ci or @transactions_ci"
```

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
