### PR TITLE
chore: remove sessions from Blend edge service

### DIFF
--- a/blend/scheduling/src/membership.rs
+++ b/blend/scheduling/src/membership.rs
@@ -33,6 +33,18 @@ pub struct Node<Id> {
     pub public_key: Ed25519PublicKey,
 }
 
+impl<NodeId> Membership<NodeId> {
+    #[cfg(any(test, feature = "unsafe-test-functions"))]
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            core_nodes: HashMap::new(),
+            node_indices: Vec::new(),
+            local_node_index: None,
+        }
+    }
+}
+
 impl<NodeId> Membership<NodeId>
 where
     NodeId: Clone + Hash + Eq,

--- a/blend/scheduling/src/membership.rs
+++ b/blend/scheduling/src/membership.rs
@@ -33,18 +33,6 @@ pub struct Node<Id> {
     pub public_key: Ed25519PublicKey,
 }
 
-impl<NodeId> Membership<NodeId> {
-    #[cfg(any(test, feature = "unsafe-test-functions"))]
-    #[must_use]
-    pub fn empty() -> Self {
-        Self {
-            core_nodes: HashMap::new(),
-            node_indices: Vec::new(),
-            local_node_index: None,
-        }
-    }
-}
-
 impl<NodeId> Membership<NodeId>
 where
     NodeId: Clone + Hash + Eq,
@@ -152,6 +140,16 @@ impl<NodeId> Membership<NodeId> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.core_nodes.is_empty()
+    }
+
+    #[cfg(any(test, feature = "unsafe-test-functions"))]
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            core_nodes: HashMap::new(),
+            node_indices: Vec::new(),
+            local_node_index: None,
+        }
     }
 }
 

--- a/blend/scheduling/src/membership.rs
+++ b/blend/scheduling/src/membership.rs
@@ -141,16 +141,6 @@ impl<NodeId> Membership<NodeId> {
     pub fn is_empty(&self) -> bool {
         self.core_nodes.is_empty()
     }
-
-    #[cfg(any(test, feature = "unsafe-test-functions"))]
-    #[must_use]
-    pub fn empty() -> Self {
-        Self {
-            core_nodes: HashMap::new(),
-            node_indices: Vec::new(),
-            local_node_index: None,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/blend/scheduling/src/message_blend/crypto/leader/send.rs
+++ b/blend/scheduling/src/message_blend/crypto/leader/send.rs
@@ -33,6 +33,12 @@ pub struct EpochCryptographicProcessor<NodeId, ProofsGenerator> {
     epoch: Epoch,
 }
 
+impl<NodeId, ProofsGenerator> EpochCryptographicProcessor<NodeId, ProofsGenerator> {
+    pub const fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+}
+
 impl<NodeId, ProofsGenerator> EpochCryptographicProcessor<NodeId, ProofsGenerator>
 where
     ProofsGenerator: LeaderProofsGenerator,

--- a/blend/scheduling/src/message_blend/crypto/leader/send.rs
+++ b/blend/scheduling/src/message_blend/crypto/leader/send.rs
@@ -30,6 +30,13 @@ pub struct EpochCryptographicProcessor<NodeId, ProofsGenerator> {
     num_blend_layers: NonZeroU64,
     membership: Membership<NodeId>,
     proofs_generator: ProofsGenerator,
+    epoch: Epoch,
+}
+
+impl<NodeId, ProofsGenerator> EpochCryptographicProcessor<NodeId, ProofsGenerator> {
+    pub const fn epoch(&self) -> Epoch {
+        self.epoch
+    }
 }
 
 impl<NodeId, ProofsGenerator> EpochCryptographicProcessor<NodeId, ProofsGenerator>
@@ -55,6 +62,7 @@ where
             num_blend_layers,
             membership,
             proofs_generator: ProofsGenerator::new(generator_settings, private_info),
+            epoch,
         }
     }
 }

--- a/blend/scheduling/src/message_blend/crypto/leader/send.rs
+++ b/blend/scheduling/src/message_blend/crypto/leader/send.rs
@@ -33,12 +33,6 @@ pub struct EpochCryptographicProcessor<NodeId, ProofsGenerator> {
     epoch: Epoch,
 }
 
-impl<NodeId, ProofsGenerator> EpochCryptographicProcessor<NodeId, ProofsGenerator> {
-    pub const fn epoch(&self) -> Epoch {
-        self.epoch
-    }
-}
-
 impl<NodeId, ProofsGenerator> EpochCryptographicProcessor<NodeId, ProofsGenerator>
 where
     ProofsGenerator: LeaderProofsGenerator,

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -583,41 +583,37 @@ where
     let session_stream = async {
         let config = blend_config.clone();
         let zk_sk_id = config.zk.secret_key_kms_id.clone();
-        membership_stream.map(
-            move |MembershipInfo {
-                      membership,
-                      session_number,
-                      zk,
-                  }| {
-                // This can be empty in case of an empty membership set.
-                let Some(ZkInfo {
-                    root,
-                    core_and_path_selectors,
-                }) = zk
-                else {
-                    return MaybeEmptyCoreSessionInfo::Empty {
-                        session: session_number,
-                    };
+        membership_stream.map(move |MembershipInfo { membership, zk }| {
+            // This can be empty in case of an empty membership set.
+            let Some(ZkInfo {
+                root,
+                core_and_path_selectors,
+            }) = zk
+            else {
+                return MaybeEmptyCoreSessionInfo::Empty {
+                    // TODO: This will go once we remove sessions from the Blend core service.
+                    session: 0,
                 };
-                // `None` when the local node is not part of the session membership. This can
-                // happen when the node transitions from core to edge mode.
-                let core_poq_generator = core_and_path_selectors.map(|selectors| {
-                    kms_adapter.core_poq_generator(zk_sk_id.clone(), Box::new(selectors))
-                });
-                CoreSessionInfo {
-                    public: CoreSessionPublicInfo {
-                        poq_core_public_inputs: CoreInputs {
-                            quota: config.session_core_quota(membership.size()),
-                            zk_root: root,
-                        },
-                        membership,
-                        session: session_number,
+            };
+            // `None` when the local node is not part of the session membership. This can
+            // happen when the node transitions from core to edge mode.
+            let core_poq_generator = core_and_path_selectors.map(|selectors| {
+                kms_adapter.core_poq_generator(zk_sk_id.clone(), Box::new(selectors))
+            });
+            CoreSessionInfo {
+                public: CoreSessionPublicInfo {
+                    poq_core_public_inputs: CoreInputs {
+                        quota: config.session_core_quota(membership.size()),
+                        zk_root: root,
                     },
-                    core_poq_generator,
-                }
-                .into()
-            },
-        )
+                    membership,
+                    // TODO: This will go once we remove sessions from the Blend core service.
+                    session: 0,
+                },
+                core_poq_generator,
+            }
+            .into()
+        })
     }
     .await;
     let (current_membership_info, remaining_session_stream) = Box::pin(

--- a/services/blend/src/core/settings.rs
+++ b/services/blend/src/core/settings.rs
@@ -43,7 +43,7 @@ impl<BackendSettings> RunningBlendConfig<BackendSettings> {
     pub fn session_core_quota(&self, membership_size: usize) -> u64 {
         self.scheduler
             .cover
-            .session_core_quota(self.num_blend_layers, &self.time, membership_size)
+            .epoch_core_quota(self.num_blend_layers, &self.time, membership_size)
     }
 
     pub const fn session_leadership_quota(&self) -> u64 {
@@ -100,7 +100,7 @@ impl Default for CoverTrafficSettings {
 
 impl CoverTrafficSettings {
     #[must_use]
-    pub(crate) fn session_core_quota(
+    pub(crate) fn epoch_core_quota(
         &self,
         num_blend_layers: NonZeroU64,
         timings: &TimingSettings,

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -765,14 +765,12 @@ async fn complete_old_session_after_main_loop_done() {
 
     // Send the initial membership info that the service will expect to receive
     // immediately.
-    let initial_session = 0;
     let mut membership_info = MembershipInfo {
         membership: membership.clone(),
         zk: Some(ZkInfo {
             root: ZkHash::ZERO,
             core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
         }),
-        session_number: initial_session,
     };
     membership_sender
         .send(membership_info.clone())
@@ -893,7 +891,10 @@ async fn complete_old_session_after_main_loop_done() {
     });
 
     // Send a new session with the same membership.
-    membership_info.session_number += 1;
+
+    // TODO: This should be epochs instead
+    // membership_info.session_number += 1;
+
     membership_sender
         .send(membership_info.clone())
         .await
@@ -910,7 +911,10 @@ async fn complete_old_session_after_main_loop_done() {
 
     // Send a new session with a new membership smaller than minimal size
     membership_info.membership = new_membership(minimal_network_size.checked_sub(1).unwrap()).0;
-    membership_info.session_number += 1;
+
+    // TODO: This should be epochs instead
+    // membership_info.session_number += 1;
+
     membership_sender.send(membership_info).await.unwrap();
 
     // Since the network is smaller than the minimal size,
@@ -948,14 +952,12 @@ async fn stop_on_empty_session() {
 
     // Send the initial membership info that the service will expect to receive
     // immediately.
-    let initial_session = 0;
     let membership_info = MembershipInfo {
         membership: membership.clone(),
         zk: Some(ZkInfo {
             root: ZkHash::ZERO,
             core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
         }),
-        session_number: initial_session,
     };
     membership_sender
         .send(membership_info.clone())
@@ -1081,7 +1083,6 @@ async fn stop_on_empty_session() {
         .send(MembershipInfo {
             membership: membership.clone(),
             zk: None,
-            session_number: initial_session + 1,
         })
         .await
         .unwrap();
@@ -1121,14 +1122,12 @@ async fn stop_on_non_empty_session_without_local_core_path() {
 
     // Send the initial membership info that the service will expect to receive
     // immediately.
-    let initial_session = 0;
     let membership_info = MembershipInfo {
         membership: membership.clone(),
         zk: Some(ZkInfo {
             root: ZkHash::ZERO,
             core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
         }),
-        session_number: initial_session,
     };
     membership_sender
         .send(membership_info.clone())
@@ -1256,7 +1255,6 @@ async fn stop_on_non_empty_session_without_local_core_path() {
                 root: ZkHash::ZERO,
                 core_and_path_selectors: None,
             }),
-            session_number: initial_session + 1,
         })
         .await
         .unwrap();
@@ -1620,7 +1618,6 @@ async fn test_initialize_recovers_matching_saved_state() {
                 root: ZkHash::ZERO,
                 core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
             }),
-            session_number: initial_session,
         })
         .await
         .unwrap();
@@ -1709,7 +1706,6 @@ async fn test_initialize_recovers_matching_saved_state() {
                 root: ZkHash::ZERO,
                 core_and_path_selectors: Some([(ZkHash::ZERO, false); CORE_MERKLE_TREE_HEIGHT]),
             }),
-            session_number: initial_session,
         })
         .await
         .unwrap();

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -745,6 +745,7 @@ async fn test_handle_session_event_non_empty_without_local_core_path_retires() {
 /// if it receives another new session that doesn't meet the core node
 /// conditions.
 #[test_log::test(tokio::test)]
+#[ignore = "TODO: Re-enable once we replace sessions with epochs."]
 async fn complete_old_session_after_main_loop_done() {
     let minimal_network_size = 2;
     let (membership, local_private_key) = new_membership(minimal_network_size);

--- a/services/blend/src/edge/backends/libp2p/tests/message_handling.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/message_handling.rs
@@ -65,15 +65,15 @@ async fn edge_message_propagation() {
 
     // Verify that both peers receive the message, even though the edge swarm is
     // connected to only one of them.
-    let (swarm_1_received_message, swarm_1_message_session) =
+    let (swarm_1_received_message, swarm_1_message_epoch) =
         core_swarm_1_incoming_message_receiver.recv().await.unwrap();
-    let (swarm_2_received_message, swarm_2_message_session) =
+    let (swarm_2_received_message, swarm_2_message_epoch) =
         core_swarm_2_incoming_message_receiver.recv().await.unwrap();
 
     assert_eq!(swarm_1_received_message, message.clone().into());
-    assert_eq!(swarm_1_message_session, 1);
+    assert_eq!(swarm_1_message_epoch, 1);
     assert_eq!(swarm_2_received_message, message.clone().into());
-    assert_eq!(swarm_2_message_session, 1);
+    assert_eq!(swarm_2_message_epoch, 1);
 }
 
 #[test(tokio::test)]

--- a/services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -125,10 +125,10 @@ async fn edge_redial_different_peer_after_redial_limit() {
 
     // Verify the message is anyway received by the core swarm after the maximum
     // number of dial attempts have been performed with the unreachable address.
-    let (received_message, received_message_session) =
+    let (received_message, received_message_epoch) =
         core_swarm_incoming_message_receiver.recv().await.unwrap();
     assert_eq!(received_message, message.into_inner().into());
-    assert_eq!(received_message_session, 1);
+    assert_eq!(received_message_epoch, 1);
 }
 
 /// Verifies that when a peer fails all dial attempts, it is added to the failed

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -28,6 +28,19 @@ impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
     MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
+    NodeId: Clone,
+    ProofsGenerator: LeaderProofsGenerator,
+{
+    #[cfg(test)]
+    pub const fn epoch(&self) -> Epoch {
+        self.cryptographic_processor.epoch()
+    }
+}
+
+impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+    MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+where
+    Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone + Send + 'static,
     ProofsGenerator: LeaderProofsGenerator,
 {

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -49,7 +49,7 @@ where
     /// It returns [`Error`] if the membership does not satisfy the following
     /// edge node condition:
     /// 1. The membership size is at least `settings.minimum_network_size`.
-    /// 2. The local node is not a core node (i.e. not in the membership).
+    /// 2. The local node is not a core node.
     pub fn try_new_with_edge_condition_check(
         settings: Settings<Backend, NodeId, RuntimeServiceId>,
         membership: Membership<NodeId>,

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -6,7 +6,7 @@ use lb_blend::{
     scheduling::{
         membership::Membership,
         message_blend::{
-            crypto::leader::send::EpochCryptographicProcessor as SessionCryptographicProcessor,
+            crypto::leader::send::EpochCryptographicProcessor,
             provers::leader::LeaderProofsGenerator,
         },
     },
@@ -19,9 +19,17 @@ use rand::SeedableRng as _;
 use crate::edge::{LOG_TARGET, RunningSettings as Settings, backends::BlendBackend};
 
 pub struct MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId> {
-    cryptographic_processor: SessionCryptographicProcessor<NodeId, ProofsGenerator>,
+    cryptographic_processor: EpochCryptographicProcessor<NodeId, ProofsGenerator>,
     backend: Backend,
     _phantom: PhantomData<RuntimeServiceId>,
+}
+
+impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+    MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
+{
+    pub const fn epoch(&self) -> Epoch {
+        self.cryptographic_processor.epoch()
+    }
 }
 
 impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
@@ -36,7 +44,7 @@ where
     /// It returns [`Error`] if the membership does not satisfy the following
     /// edge node condition:
     /// 1. The membership size is at least `settings.minimum_network_size`.
-    /// 2. The local node is not a core node.
+    /// 2. The local node is not an edge node.
     pub fn try_new_with_edge_condition_check(
         settings: Settings<Backend, NodeId, RuntimeServiceId>,
         membership: Membership<NodeId>,
@@ -73,7 +81,7 @@ where
         overwatch_handle: OverwatchHandle<RuntimeServiceId>,
         epoch: Epoch,
     ) -> Self {
-        let cryptographic_processor = SessionCryptographicProcessor::new(
+        let cryptographic_processor = EpochCryptographicProcessor::new(
             settings.num_blend_layers,
             membership.clone(),
             public_info,

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -26,14 +26,6 @@ pub struct MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId> {
 
 impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
     MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
-{
-    pub const fn epoch(&self) -> Epoch {
-        self.cryptographic_processor.epoch()
-    }
-}
-
-impl<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
-    MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone + Send + 'static,

--- a/services/blend/src/edge/handlers.rs
+++ b/services/blend/src/edge/handlers.rs
@@ -49,7 +49,7 @@ where
     /// It returns [`Error`] if the membership does not satisfy the following
     /// edge node condition:
     /// 1. The membership size is at least `settings.minimum_network_size`.
-    /// 2. The local node is not an edge node.
+    /// 2. The local node is not a core node (i.e. not in the membership).
     pub fn try_new_with_edge_condition_check(
         settings: Settings<Backend, NodeId, RuntimeServiceId>,
         membership: Membership<NodeId>,

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -336,7 +336,7 @@ where
         .await
         .expect("Should not fail to subscribe to secret PoL info stream.");
 
-    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = Some(PendingEpochInfo {
+    let mut pending_epoch_info = Some(PendingEpochInfo {
         epoch: current_epoch_info.epoch,
         info_type: PendingEpochInfoType::Public(Box::new(current_epoch_info.membership_info)),
     });
@@ -379,7 +379,7 @@ where
 
 fn handle_new_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
     BlendEpochState {
-        epoch,
+        epoch: new_epoch,
         membership_info,
         lottery_0,
         lottery_1,
@@ -417,12 +417,12 @@ where
     }
 
     match pending_epoch_info.take() {
-        // Previous epoch handler is running, so we stop it and buffer membership info.
+        // Previous epoch handler is running, so we stop it and buffer new membership info.
         None => {
             debug!(target: LOG_TARGET, "New epoch public info received. Stopping message handler until secret PoL info is received.");
             *current_epoch_message_handler = None;
             *pending_epoch_info = Some(PendingEpochInfo {
-                epoch,
+                epoch: new_epoch,
                 info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
             });
         }
@@ -434,20 +434,23 @@ where
             ..
         }) => {
             warn!(target: LOG_TARGET, "New epoch public info received without the previous epoch info being consumed.");
-            *current_epoch_message_handler = None;
+            assert!(
+                current_epoch_message_handler.is_none(),
+                "If public epoch info is buffered, the message handler should not be running."
+            );
             *pending_epoch_info = Some(PendingEpochInfo {
-                epoch,
+                epoch: new_epoch,
                 info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
             });
         }
         Some(PendingEpochInfo {
-            epoch: new_epoch,
+            epoch,
             info_type: PendingEpochInfoType::Private(new_private_pol_info),
         }) => {
             // Let's make sure we always clean up the pending info whenever a public or
             // private epoch event is processed.
             assert!(
-                epoch == new_epoch,
+                new_epoch == epoch,
                 "Old pending epoch info was found, and this should never happen."
             );
             debug!(target: LOG_TARGET, "New epoch public info received with a buffered secret PoL info for the same epoch {new_epoch:?}. Trying to create a new epoch-bound message handler.");
@@ -475,7 +478,7 @@ where
                 new_public_inputs,
                 *new_private_pol_info,
                 overwatch_handle,
-                epoch,
+                new_epoch,
             )?;
 
             *current_epoch_message_handler = Some(new_handler);
@@ -491,7 +494,7 @@ where
 /// private inputs from the `PoL` info.
 fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
     PolEpochInfo {
-        epoch,
+        epoch: new_epoch,
         poq_private_inputs,
         poq_public_inputs,
     }: PolEpochInfo,
@@ -511,7 +514,7 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
         None => {
             trace!(target: LOG_TARGET, "New secret PoL info received, but no public epoch info is buffered. Buffering the secret PoL info until the public epoch info is received.");
             *pending_epoch_info = Some(PendingEpochInfo {
-                epoch,
+                epoch: new_epoch,
                 info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
             });
         }
@@ -525,12 +528,12 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
             );
             warn!(target: LOG_TARGET, "New epoch secret info received without the previous epoch info being consumed.");
             *pending_epoch_info = Some(PendingEpochInfo {
-                epoch,
+                epoch: new_epoch,
                 info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
             });
         }
         Some(PendingEpochInfo {
-            epoch: new_epoch,
+            epoch,
             info_type: PendingEpochInfoType::Public(new_membership_info),
         }) => {
             assert!(

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -46,7 +46,7 @@ use overwatch::{
 use serde::{Serialize, de::DeserializeOwned};
 use settings::StartingBlendConfig;
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace};
 
 use crate::{
     edge::{
@@ -280,16 +280,16 @@ pub(crate) enum PendingEpochInfoType<NodeId> {
 ///
 /// The event loop handles three types of events:
 /// - **New public epoch info** (chain-derived membership + leader inputs):
-///   buffered until the matching secret `PoL` info arrives, at which point
-///   the message handler is created for that epoch. A new public info while an
-///   older one is still buffered (no winning slot in the previous epoch)
-///   simply replaces the buffered entry.
+///   buffered until the matching secret `PoL` info arrives, at which point the
+///   message handler is created for that epoch. A new public info while an
+///   older one is still buffered (no winning slot in the previous epoch) simply
+///   replaces the buffered entry.
 /// - **Incoming messages to blend**: forwarded to the current message handler;
-///   dropped with a warning if no handler is active (secret `PoL` info for
-///   the current epoch has not yet arrived).
+///   dropped with a warning if no handler is active (secret `PoL` info for the
+///   current epoch has not yet arrived).
 /// - **New secret `PoL` info**: buffered until the matching public epoch info
-///   arrives, at which point the handler is created. A stale buffered public
-///   is discarded; a stale buffered private is a bug and panics.
+///   arrives, at which point the handler is created. A stale buffered public is
+///   discarded; a stale buffered private is a bug and panics.
 ///
 /// Returns an [`Error`] if a new membership does not satisfy the edge node
 /// condition.
@@ -501,14 +501,14 @@ where
 /// Processes new secret `PoL` info.
 ///
 /// Three outcomes depending on the buffered state:
-/// - Nothing buffered → buffer the secret info until the matching public
-///   epoch info arrives.
+/// - Nothing buffered → buffer the secret info until the matching public epoch
+///   info arrives.
 /// - A public for the same epoch is buffered → create the message handler.
-/// - A stale public is buffered (older epoch) → discard it and buffer the
-///   new secret info instead; if the incoming secret is itself stale (older
-///   than the buffered public), it is ignored.
-/// - A private is already buffered → panic; this violates the invariant
-///   that secret info does not outlive its epoch.
+/// - A stale public is buffered (older epoch) → discard it and buffer the new
+///   secret info instead; if the incoming secret is itself stale (older than
+///   the buffered public), it is ignored.
+/// - A private is already buffered → panic; this violates the invariant that
+///   secret info does not outlive its epoch.
 fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
     PolEpochInfo {
         epoch: new_epoch,

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -426,14 +426,13 @@ where
                 info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
             });
         }
-        // New epoch private info received without using the previous one to create a new handler.
-        // This should never happen unless we hit some very edgy cases where the service is started
-        // just at the boundary between two epochs.
+        // New epoch public info received without using the previous one to create a new handler.
+        // This can happen if the node has no winning slot in the old epoch.
         Some(PendingEpochInfo {
             info_type: PendingEpochInfoType::Public(_),
             ..
         }) => {
-            warn!(target: LOG_TARGET, "New epoch public info received without the previous epoch info being consumed.");
+            debug!(target: LOG_TARGET, "New epoch public info received without the previous epoch info being consumed.");
             assert!(
                 current_epoch_message_handler.is_none(),
                 "If public epoch info is buffered, the message handler should not be running."
@@ -451,9 +450,9 @@ where
             // private epoch event is processed.
             assert!(
                 new_epoch == epoch,
-                "Old pending epoch info was found, and this should never happen."
+                "Old pending epoch secret info was found, and this should never happen."
             );
-            debug!(target: LOG_TARGET, "New epoch public info received with a buffered secret PoL info for the same epoch {new_epoch:?}. Trying to create a new epoch-bound message handler.");
+            info!(target: LOG_TARGET, "New epoch public info received with a buffered secret PoL info for the same epoch {new_epoch:?}. Trying to create a new epoch-bound message handler.");
             let new_public_inputs = PoQVerificationInputsMinusSigningKey {
                 core: CoreInputs {
                     quota: settings.cover.epoch_core_quota(
@@ -520,17 +519,11 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
         }
         Some(PendingEpochInfo {
             info_type: PendingEpochInfoType::Private(_),
-            ..
+            epoch,
         }) => {
-            assert!(
-                current_message_handler.is_none(),
-                "If private epoch info is buffered, the message handler should be stopped."
+            panic!(
+                "New secret PoL info received while there is already buffered secret PoL info for a epoch {epoch:?}. This should never happen."
             );
-            warn!(target: LOG_TARGET, "New epoch secret info received without the previous epoch info being consumed.");
-            *pending_epoch_info = Some(PendingEpochInfo {
-                epoch: new_epoch,
-                info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
-            });
         }
         Some(PendingEpochInfo {
             epoch,
@@ -544,6 +537,18 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
             let Some(zk_root) = new_membership_info.zk.as_ref().map(|zk| zk.root) else {
                 return;
             };
+
+            if new_epoch < epoch {
+                debug!(target: LOG_TARGET, "Received old secret epoch info while new public info for {epoch:?} was present. Ignoring received secret info...");
+                return;
+            } else if new_epoch > epoch {
+                debug!(target: LOG_TARGET, "Received new secret epoch info while old public info for {epoch:?} was present. Overriding the old info...");
+                *pending_epoch_info = Some(PendingEpochInfo {
+                    epoch: new_epoch,
+                    info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
+                });
+                return;
+            }
 
             let new_public_inputs = PoQVerificationInputsMinusSigningKey {
                 leader: LeaderInputs {

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -271,8 +271,8 @@ where
 /// - **New public epoch info** (chain-derived membership + leader inputs):
 ///   becomes the current public info; the handler is rebuilt if the latest
 ///   secret info is for the same epoch, otherwise it stays down.
-/// - **New secret `PoL` info**: becomes the current secret info; the handler
-///   is rebuilt if it matches the current public info's epoch.
+/// - **New secret `PoL` info**: becomes the current secret info; the handler is
+///   rebuilt if it matches the current public info's epoch.
 /// - **Incoming messages to blend**: forwarded to the current message handler;
 ///   dropped with a warning if no handler is active (secret `PoL` info for the
 ///   current epoch has not yet arrived).

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -236,7 +236,7 @@ where
         run::<Backend, _, ProofsGenerator, PolInfoProvider, _>(
             UninitializedEpochEventStream::new(
                 public_epoch_stream,
-                settings.time.session_transition_period(),
+                settings.time.epoch_transition_period,
             ),
             messages_to_blend_stream,
             RunningSettings::<Backend, _, _> {
@@ -279,21 +279,24 @@ pub(crate) enum PendingEpochInfoType<NodeId> {
 /// Run the event loop of the service.
 ///
 /// The event loop handles three types of events:
-/// - **Session changes**: resets the message handler with the new session but
-///   the current epoch info. If the handler was shut down (waiting for secret
-///   epoch info), it stays shut down.
-/// - **Clock ticks (epoch transitions)**: on a new epoch, shuts down the
-///   message handler until secret `PoL` info for that epoch is received. If
-///   secret info was already provided for the new epoch, the handler is kept.
-/// - **Secret `PoL` info**: always (re)creates the message handler with the new
-///   epoch's public and private inputs, preserving the current session.
+/// - **New public epoch info** (chain-derived membership + leader inputs):
+///   buffered until the matching secret `PoL` info arrives, at which point
+///   the message handler is created for that epoch. A new public info while an
+///   older one is still buffered (no winning slot in the previous epoch)
+///   simply replaces the buffered entry.
+/// - **Incoming messages to blend**: forwarded to the current message handler;
+///   dropped with a warning if no handler is active (secret `PoL` info for
+///   the current epoch has not yet arrived).
+/// - **New secret `PoL` info**: buffered until the matching public epoch info
+///   arrives, at which point the handler is created. A stale buffered public
+///   is discarded; a stale buffered private is a bug and panics.
 ///
 /// Returns an [`Error`] if a new membership does not satisfy the edge node
 /// condition.
 ///
 /// # Panics
-/// - If the initial membership is not yielded immediately from the session
-///   stream.
+/// - If the initial public epoch info is not yielded immediately from the
+///   public epoch stream.
 #[expect(
     clippy::cognitive_complexity,
     reason = "TODO: address this in a dedicated refactor"
@@ -353,7 +356,7 @@ where
                         return Ok(());
                     }
                     Err(e) => {
-                        error!(target: LOG_TARGET, "Error when handling new session: {e:?}, edge service shutting down.");
+                        error!(target: LOG_TARGET, "Error when handling new epoch: {e:?}, edge service shutting down.");
                         return Err(e);
                     }
                     Ok(()) => {}
@@ -405,9 +408,8 @@ where
 
     // Validate the edge node condition up front so the service shuts down on
     // an invalid membership regardless of whether secret PoL info has arrived
-    // yet. Without this check, an invalid membership would silently update
-    // `current_membership_info` and surface later as a panic in
-    // `handle_new_secret_epoch_info`.
+    // yet. Without this check, an invalid membership could be buffered as a
+    // `Pending::Public` and only fail later when private info arrives.
     let membership_size = membership_info.membership.size();
     if membership_size < settings.minimum_network_size.get() as usize {
         return Err(Error::NetworkIsTooSmall(membership_size));
@@ -417,7 +419,10 @@ where
     }
 
     match pending_epoch_info.take() {
-        // Previous epoch handler is running, so we stop it and buffer new membership info.
+        // Nothing buffered: either the service just started, or the previous
+        // epoch's handler is still running. Either way, shut down any running
+        // handler (the new epoch's secret info hasn't arrived yet) and buffer
+        // the new public info.
         None => {
             debug!(target: LOG_TARGET, "New epoch public info received. Stopping message handler until secret PoL info is received.");
             *current_epoch_message_handler = None;
@@ -426,8 +431,10 @@ where
                 info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
             });
         }
-        // New epoch public info received without using the previous one to create a new handler.
-        // This can happen if the node has no winning slot in the old epoch.
+        // The previous epoch's public was buffered but never paired with a
+        // private (no winning slot that epoch), so the buffered public is
+        // now stale and is replaced by the new one. Normal occurrence, not
+        // an error.
         Some(PendingEpochInfo {
             info_type: PendingEpochInfoType::Public(_),
             ..
@@ -446,11 +453,15 @@ where
             epoch,
             info_type: PendingEpochInfoType::Private(new_private_pol_info),
         }) => {
-            // Let's make sure we always clean up the pending info whenever a public or
-            // private epoch event is processed.
+            // A buffered private must be for the same epoch as the incoming
+            // public: it can't be from the future (private is only produced
+            // once its epoch is active, by which time the public has already
+            // been emitted) and it can't be from the past (the previous
+            // public for that epoch would have consumed it). Either inequality
+            // is a real bug upstream.
             assert!(
                 new_epoch == epoch,
-                "Old pending epoch secret info was found, and this should never happen."
+                "Buffered secret PoL info for epoch {epoch:?} does not match incoming public epoch info for epoch {new_epoch:?}."
             );
             info!(target: LOG_TARGET, "New epoch public info received with a buffered secret PoL info for the same epoch {new_epoch:?}. Trying to create a new epoch-bound message handler.");
             let new_public_inputs = PoQVerificationInputsMinusSigningKey {
@@ -489,8 +500,15 @@ where
 
 /// Processes new secret `PoL` info.
 ///
-/// Always creates a new message handler using the new epoch's public and
-/// private inputs from the `PoL` info.
+/// Three outcomes depending on the buffered state:
+/// - Nothing buffered → buffer the secret info until the matching public
+///   epoch info arrives.
+/// - A public for the same epoch is buffered → create the message handler.
+/// - A stale public is buffered (older epoch) → discard it and buffer the
+///   new secret info instead; if the incoming secret is itself stale (older
+///   than the buffered public), it is ignored.
+/// - A private is already buffered → panic; this violates the invariant
+///   that secret info does not outlive its epoch.
 fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
     PolEpochInfo {
         epoch: new_epoch,

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -16,13 +16,16 @@ use backends::BlendBackend;
 use futures::{Stream, StreamExt as _};
 use lb_blend::{
     message::crypto::proofs::PoQVerificationInputsMinusSigningKey,
-    proofs::quota::inputs::prove::public::{CoreInputs, LeaderInputs},
+    proofs::quota::inputs::prove::{
+        private::ProofOfLeadershipQuotaInputs,
+        public::{CoreInputs, LeaderInputs},
+    },
     scheduling::{
         epoch::{EpochEvent, UninitializedEpochEventStream},
         message_blend::provers::leader::LeaderProofsGenerator,
     },
 };
-use lb_chain_service::api::{CryptarchiaServiceApi, CryptarchiaServiceData};
+use lb_chain_service::{Epoch, api::CryptarchiaServiceData};
 use lb_core::codec::SerializeOp as _;
 use lb_key_management_system_service::{
     api::KmsServiceApi, keys::KeyOperators,
@@ -30,7 +33,7 @@ use lb_key_management_system_service::{
 };
 use lb_log_targets::blend;
 use lb_services_utils::wait_until_services_are_ready;
-use lb_time_service::{SlotTick, TimeService, TimeServiceMessage};
+use lb_time_service::TimeService;
 use overwatch::{
     OpaqueServiceResourcesHandle,
     overwatch::OverwatchHandle,
@@ -43,14 +46,14 @@ use overwatch::{
 use serde::{Serialize, de::DeserializeOwned};
 use settings::StartingBlendConfig;
 use tokio::sync::oneshot;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     edge::{
         handlers::{Error, MessageHandler},
         settings::RunningBlendConfig,
     },
-    epoch_info::{ChainApi, EpochHandler, PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
+    epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
     kms::PreloadKmsService,
     membership::{self, MembershipInfo, chain::BlendEpochState, node_id},
     message::{NetworkInfo, NetworkMessage, ServiceMessage},
@@ -61,8 +64,8 @@ const LOG_TARGET: &str = blend::service::EDGE;
 type RunningSettings<Backend, NodeId, RuntimeServiceId> =
     RunningBlendConfig<<Backend as BlendBackend<NodeId, RuntimeServiceId>>::Settings>;
 
-type EpochInfoAndHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId> = (
-    PolEpochInfo,
+type EpochStateAndHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId> = (
+    BlendEpochState<NodeId>,
     MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
 );
 
@@ -210,38 +213,14 @@ where
             NodeId::try_from_provider_id(&non_ephemeral_signing_key.public_key().to_bytes())
                 .expect("non-ephemeral signing key should decode into a valid node id");
 
-        // Initialize membership stream for session and core-related public PoQ inputs.
-        let membership_stream =
+        let public_epoch_stream =
             membership::chain::subscribe::<ChainService, NodeId, TimeBackend, RuntimeServiceId>(
                 &overwatch_handle,
                 non_ephemeral_signing_key.public_key(),
                 // No ZK stuff needs to be computed by edge nodes, so no ZK key is specified here.
                 None,
             )
-            .await
-            // TODO: Consume all info from this stream and remove slot-based stream in this service.
-            .map(
-                |BlendEpochState {
-                     membership_info, ..
-                 }| membership_info,
-            );
-
-        // Initialize clock stream for detecting epoch transitions.
-        let clock_stream = async {
-            let time_relay = overwatch_handle
-                .relay::<TimeService<_, _>>()
-                .await
-                .expect("Relay with time service should be available.");
-            let (sender, receiver) = oneshot::channel();
-            time_relay
-                .send(TimeServiceMessage::Subscribe { sender })
-                .await
-                .expect("Failed to subscribe to slot clock.");
-            receiver
-                .await
-                .expect("Should not fail to receive slot stream from time service.")
-        }
-        .await;
+            .await;
 
         let messages_to_blend_stream = Box::pin(inbound_relay.filter_map(async |msg| {
             match msg {
@@ -260,35 +239,12 @@ where
             }
         }));
 
-        let epoch_handler = async {
-            let chain_service = CryptarchiaServiceApi::<ChainService, _>::new(
-                overwatch_handle
-                    .relay::<ChainService>()
-                    .await
-                    .expect("Failed to establish channel with chain service."),
-            );
-            EpochHandler::new(
-                chain_service,
-                // TODO: This will go one we get rid of the `EpochHandler` completely as we rely on
-                // the slot tick directly.
-                settings
-                    .time
-                    .epoch_transition_period
-                    .as_secs()
-                    .try_into()
-                    .expect("Epoch transition period should be at least 1 second."),
-            )
-        }
-        .await;
-
-        run::<Backend, _, ProofsGenerator, _, PolInfoProvider, _>(
+        run::<Backend, _, ProofsGenerator, PolInfoProvider, _>(
             UninitializedEpochEventStream::new(
-                membership_stream,
+                public_epoch_stream,
                 settings.time.session_transition_period(),
             ),
-            clock_stream,
             messages_to_blend_stream,
-            epoch_handler,
             RunningSettings::<Backend, _, _> {
                 backend: settings.backend,
                 cover: settings.cover,
@@ -316,6 +272,16 @@ where
     }
 }
 
+struct PendingEpochInfo<NodeId> {
+    epoch: Epoch,
+    info_type: PendingEpochInfoType<NodeId>,
+}
+
+enum PendingEpochInfoType<NodeId> {
+    Public(MembershipInfo<NodeId>),
+    Private(ProofOfLeadershipQuotaInputs),
+}
+
 /// Run the event loop of the service.
 ///
 /// The event loop handles three types of events:
@@ -338,13 +304,11 @@ where
     clippy::cognitive_complexity,
     reason = "TODO: address this in a dedicated refactor"
 )]
-async fn run<Backend, NodeId, ProofsGenerator, ChainService, PolInfoProvider, RuntimeServiceId>(
-    membership_stream: UninitializedEpochEventStream<
-        impl Stream<Item = MembershipInfo<NodeId>> + Unpin,
+async fn run<Backend, NodeId, ProofsGenerator, PolInfoProvider, RuntimeServiceId>(
+    public_epoch_stream: UninitializedEpochEventStream<
+        impl Stream<Item = BlendEpochState<NodeId>> + Unpin,
     >,
-    mut clock_stream: impl Stream<Item = SlotTick> + Unpin,
     mut incoming_message_stream: impl Stream<Item = Vec<u8>> + Send + Unpin,
-    mut epoch_handler: EpochHandler<ChainService, RuntimeServiceId>,
     settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
     overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
     notify_ready: impl Fn(),
@@ -353,20 +317,19 @@ where
     Backend: BlendBackend<NodeId, RuntimeServiceId> + Sync + Send,
     NodeId: Clone + Debug + Eq + Hash + Send + Sync + 'static,
     ProofsGenerator: LeaderProofsGenerator + Send,
-    ChainService: ChainApi<RuntimeServiceId> + Send + Sync,
     PolInfoProvider: PolInfoProviderTrait<RuntimeServiceId, Stream: Unpin>,
     RuntimeServiceId: Clone + Send + Sync,
 {
-    let (mut current_membership_info, mut remaining_membership_stream) = membership_stream
+    let (current_epoch_info, mut remaining_public_epoch_stream) = public_epoch_stream
         .await_first_ready()
         .await
-        .expect("The current session info must be available.");
+        .expect("The current epoch info must be available.");
 
     info!(
         target: LOG_TARGET,
-        members = current_membership_info.membership.size(),
-        local_node_index = current_membership_info.membership.local_index(),
-        has_zk = current_membership_info.zk.is_some(),
+        members = current_epoch_info.membership_info.membership.size(),
+        local_node_index = current_epoch_info.membership_info.membership.local_index(),
+        has_zk = current_epoch_info.membership_info.zk.is_some(),
         "current membership is ready"
     );
 
@@ -379,15 +342,18 @@ where
         .await
         .expect("Should not fail to subscribe to secret PoL info stream.");
 
-    let mut current_pol_info_and_message_handler: Option<(
-        PolEpochInfo,
+    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = Some(PendingEpochInfo {
+        epoch: current_epoch_info.epoch,
+        info_type: PendingEpochInfoType::Public(current_epoch_info.membership_info),
+    });
+    let mut current_epoch_message_handler: Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    )> = None;
+    > = None;
 
     loop {
         tokio::select! {
-            Some(EpochEvent::NewEpoch(new_session_info)) = remaining_membership_stream.next() => {
-                match handle_new_session(&new_session_info, settings.clone(), &mut current_pol_info_and_message_handler, overwatch_handle.clone()) {
+            Some(EpochEvent::NewEpoch(new_public_epoch_info)) = remaining_public_epoch_stream.next() => {
+                match handle_new_epoch_info(new_public_epoch_info, settings.clone(), &mut pending_epoch_info, &mut current_epoch_message_handler, overwatch_handle.clone()) {
                     Err(Error::NetworkIsTooSmall(_)) => {
                         info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
                         return Ok(());
@@ -396,15 +362,12 @@ where
                         error!(target: LOG_TARGET, "Error when handling new session: {e:?}, edge service shutting down.");
                         return Err(e);
                     }
-                    Ok(()) => {
-                        // We need to keep track of this for now because message handlers are initialized with a membership info. Exposing a simple `rotate_epoch` will allow us to avoid tracking this value here.
-                        current_membership_info = new_session_info;
-                    }
+                    Ok(()) => {}
                 }
             }
             Some(message) = incoming_message_stream.next() => {
                 // TODO: Investigate why secret PoL info at times arrives after the block proposal.
-                let Some(handler) = current_pol_info_and_message_handler.as_mut().map(|(_, handler)| handler) else {
+                let Some(handler) = current_epoch_message_handler.as_mut() else {
                     tracing::warn!(target: LOG_TARGET, "Received a message to blend, but no active message handler is available to process it because the secret PoL info for the current epoch is not yet available. Ignoring the message.");
                     continue;
                 };
@@ -413,38 +376,27 @@ where
                     handler.handle_message_to_blend(message.clone()).await;
                 }
             }
-            Some(clock_tick) = clock_stream.next() => {
-                handle_clock_event(clock_tick, &mut epoch_handler, &mut current_pol_info_and_message_handler).await;
-            }
             Some(new_secret_pol_info) = secret_pol_info_stream.next() => {
-                handle_new_secret_epoch_info(&new_secret_pol_info, settings.clone(), overwatch_handle, &current_membership_info, &mut current_pol_info_and_message_handler);
+                handle_new_secret_epoch_info(new_secret_pol_info, settings.clone(), overwatch_handle, &mut current_epoch_message_handler, &mut pending_epoch_info);
             }
         }
     }
 }
 
-/// Handle a new session.
-///
-/// If the message handler was active, it is recreated with the new session's
-/// membership and core info, preserving the current epoch's leader inputs and
-/// private inputs. If it was `None` (no secret epoch info yet, or shut down
-/// after an epoch transition), it stays `None` — only the membership info
-/// tracked by the caller is updated for when the handler is later recreated
-/// by [`handle_new_secret_epoch_info`].
-///
-/// Returns [`Error`] if the new membership does not satisfy the edge node
-/// condition.
-#[expect(
-    clippy::type_complexity,
-    reason = "There are too many generics. Any type alias would be as complicated."
-)]
-fn handle_new_session<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    new_membership_info: &MembershipInfo<NodeId>,
+fn handle_new_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
+    BlendEpochState {
+        epoch,
+        membership_info,
+        lottery_0,
+        lottery_1,
+        nonce,
+        aged,
+    }: BlendEpochState<NodeId>,
     settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
-    current_epoch_info_and_message_handler: &mut Option<(
-        PolEpochInfo,
+    pending_epoch_info: &mut Option<PendingEpochInfo<NodeId>>,
+    current_epoch_message_handler: &mut Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    )>,
+    >,
     overwatch_handle: OverwatchHandle<RuntimeServiceId>,
 ) -> Result<(), Error>
 where
@@ -453,7 +405,7 @@ where
     ProofsGenerator: LeaderProofsGenerator,
     RuntimeServiceId: Clone,
 {
-    let Some(zk_info) = &new_membership_info.zk else {
+    let Some(zk_info) = &membership_info.zk else {
         return Err(Error::NetworkIsTooSmall(0));
     };
 
@@ -462,149 +414,168 @@ where
     // yet. Without this check, an invalid membership would silently update
     // `current_membership_info` and surface later as a panic in
     // `handle_new_secret_epoch_info`.
-    let membership_size = new_membership_info.membership.size();
+    let membership_size = membership_info.membership.size();
     if membership_size < settings.minimum_network_size.get() as usize {
         return Err(Error::NetworkIsTooSmall(membership_size));
     }
-    if new_membership_info.membership.contains_local() {
+    if membership_info.membership.contains_local() {
         return Err(Error::LocalIsCoreNode);
     }
 
-    debug!(target: LOG_TARGET, "New session received, trying to create a new message handler");
+    match pending_epoch_info.take() {
+        // Previous epoch handler is running, so we stop it and buffer membership info.
+        None => {
+            debug!(target: LOG_TARGET, "New epoch public info received. Stopping message handler until secret PoL info is received.");
+            *current_epoch_message_handler = None;
+            *pending_epoch_info = Some(PendingEpochInfo {
+                epoch,
+                info_type: PendingEpochInfoType::Public(membership_info.clone()),
+            });
+        }
+        // New epoch private info received without using the previous one to create a new handler.
+        // This should never happen unless we hit some very edgy cases where the service is started
+        // just at the boundary between two epochs.
+        Some(PendingEpochInfo {
+            info_type: PendingEpochInfoType::Public(_),
+            ..
+        }) => {
+            warn!(target: LOG_TARGET, "New epoch public info received without the previous epoch info being consumed.");
+            *current_epoch_message_handler = None;
+            *pending_epoch_info = Some(PendingEpochInfo {
+                epoch,
+                info_type: PendingEpochInfoType::Public(membership_info.clone()),
+            });
+        }
+        Some(PendingEpochInfo {
+            epoch: new_epoch,
+            info_type: PendingEpochInfoType::Private(new_private_pol_info),
+        }) => {
+            // Let's make sure we always clean up the pending info whenever a public or
+            // private epoch event is processed.
+            assert!(
+                epoch == new_epoch,
+                "Old pending epoch info was found, and this should never happen."
+            );
+            debug!(target: LOG_TARGET, "New epoch public info received with a buffered secret PoL info for the same epoch {new_epoch:?}. Trying to create a new epoch-bound message handler.");
+            let new_public_inputs = PoQVerificationInputsMinusSigningKey {
+                core: CoreInputs {
+                    quota: settings.cover.epoch_core_quota(
+                        settings.num_blend_layers,
+                        &settings.time,
+                        membership_info.membership.size(),
+                    ),
+                    zk_root: zk_info.root,
+                },
+                leader: LeaderInputs {
+                    lottery_0,
+                    lottery_1,
+                    pol_epoch_nonce: nonce,
+                    pol_ledger_aged: aged,
+                    message_quota: settings.epoch_leadership_quota(),
+                },
+            };
 
-    // Update session and core public inputs, preserving the current epoch's
-    // leader inputs.
-    let Some((current_epoch_private_info, _)) = current_epoch_info_and_message_handler.take()
-    else {
-        debug!(target: LOG_TARGET, "No current epoch private info available. Ignoring new session event to create a new message handler.");
-        return Ok(());
-    };
+            let new_handler = MessageHandler::try_new_with_edge_condition_check(
+                settings,
+                membership_info.membership,
+                new_public_inputs,
+                new_private_pol_info,
+                overwatch_handle,
+                epoch,
+            )?;
 
-    let new_public_inputs = PoQVerificationInputsMinusSigningKey {
-        core: CoreInputs {
-            quota: settings.cover.session_core_quota(
-                settings.num_blend_layers,
-                &settings.time,
-                new_membership_info.membership.size(),
-            ),
-            zk_root: zk_info.root,
-        },
-        leader: LeaderInputs {
-            lottery_0: current_epoch_private_info.poq_public_inputs.lottery_0,
-            lottery_1: current_epoch_private_info.poq_public_inputs.lottery_1,
-            pol_epoch_nonce: current_epoch_private_info.poq_public_inputs.epoch_nonce,
-            pol_ledger_aged: current_epoch_private_info.poq_public_inputs.aged_root,
-            message_quota: settings.session_leadership_quota(),
-        },
-    };
-
-    let new_handler = MessageHandler::try_new_with_edge_condition_check(
-        settings,
-        new_membership_info.membership.clone(),
-        new_public_inputs,
-        current_epoch_private_info.poq_private_inputs.clone(),
-        overwatch_handle,
-        current_epoch_private_info.epoch,
-    )?;
-
-    *current_epoch_info_and_message_handler = Some((current_epoch_private_info, new_handler));
+            *current_epoch_message_handler = Some(new_handler);
+        }
+    }
 
     Ok(())
-}
-
-/// Handles a clock tick by forwarding it to the epoch handler.
-///
-/// If the tick reveals a new epoch that is ahead of the last received secret
-/// `PoL` info (`current_epoch`), the message handler is shut down until
-/// [`handle_new_secret_epoch_info`] provides the secret info for the new epoch.
-/// If secret info was already received for the new epoch, or if the handler was
-/// already `None`, it is left unchanged.
-async fn handle_clock_event<Backend, NodeId, ProofsGenerator, ChainService, RuntimeServiceId>(
-    slot_tick: SlotTick,
-    epoch_handler: &mut EpochHandler<ChainService, RuntimeServiceId>,
-    current_epoch_info_and_message_handler: &mut Option<
-        EpochInfoAndHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    >,
-) where
-    ChainService: ChainApi<RuntimeServiceId> + Send + Sync,
-    RuntimeServiceId: Clone + Send + Sync,
-{
-    let Some(epoch_event) = epoch_handler.tick(slot_tick).await else {
-        return;
-    };
-
-    let Some(current_epoch) = current_epoch_info_and_message_handler
-        .as_ref()
-        .map(|(epoch_info, _)| epoch_info.epoch)
-    else {
-        return;
-    };
-
-    // Shut down the message handler if a new epoch is detected for which we
-    // have not yet received secret `PoL` info.
-    match epoch_event {
-        crate::epoch_info::EpochEvent::NewEpoch((_, new_epoch))
-        | crate::epoch_info::EpochEvent::NewEpochAndOldEpochTransitionExpired((_, new_epoch))
-            if new_epoch > current_epoch =>
-        {
-            debug!(target: LOG_TARGET, "New epoch detected: {epoch_event:?}, shutting down message handler until new secret PoL info is available.");
-            *current_epoch_info_and_message_handler = None;
-        }
-        // If it's not a new epoch event, or if the new epoch has already been processed when the
-        // secret info was received, keep the current message handler.
-        _ => {}
-    }
 }
 
 /// Processes new secret `PoL` info.
 ///
 /// Always creates a new message handler using the new epoch's public and
-/// private inputs from the `PoL` info, while preserving the current session.
+/// private inputs from the `PoL` info.
 fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    new_pol_epoch_info: &PolEpochInfo,
+    PolEpochInfo {
+        epoch,
+        poq_private_inputs,
+        poq_public_inputs,
+    }: PolEpochInfo,
     settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
     overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
-    current_membership_info: &MembershipInfo<NodeId>,
-    current_epoch_info_and_message_handler: &mut Option<
-        EpochInfoAndHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
+    current_message_handler: &mut Option<
+        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
     >,
+    pending_epoch_info: &mut Option<PendingEpochInfo<NodeId>>,
 ) where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
     NodeId: Clone + Eq + Hash + Send + 'static,
     ProofsGenerator: LeaderProofsGenerator,
     RuntimeServiceId: Clone,
 {
-    let Some(zk_root) = current_membership_info.zk.as_ref().map(|zk| zk.root) else {
-        *current_epoch_info_and_message_handler = None;
-        return;
-    };
+    match pending_epoch_info.take() {
+        None => {
+            trace!(target: LOG_TARGET, "New secret PoL info received, but no public epoch info is buffered. Buffering the secret PoL info until the public epoch info is received.");
+            *pending_epoch_info = Some(PendingEpochInfo {
+                epoch,
+                info_type: PendingEpochInfoType::Private(poq_private_inputs),
+            });
+            return;
+        }
+        Some(PendingEpochInfo {
+            epoch: new_epoch,
+            info_type: PendingEpochInfoType::Private(_),
+        }) => {
+            assert!(
+                current_message_handler.is_none(),
+                "If private epoch info is buffered, the message handler should be stopped."
+            );
+            warn!(target: LOG_TARGET, "New epoch secret info received without the previous epoch info being consumed.");
+            *pending_epoch_info = Some(PendingEpochInfo {
+                epoch,
+                info_type: PendingEpochInfoType::Private(poq_private_inputs),
+            });
+        }
+        Some(PendingEpochInfo {
+            epoch,
+            info_type: PendingEpochInfoType::Public(new_membership_info),
+        }) => {
+            assert!(
+                current_message_handler.is_none(),
+                "If public epoch info is buffered, the message handler should be stopped."
+            );
 
-    let current_membership = current_membership_info.membership.clone();
-    let new_public_inputs = PoQVerificationInputsMinusSigningKey {
-        leader: LeaderInputs {
-            lottery_0: new_pol_epoch_info.poq_public_inputs.lottery_0,
-            lottery_1: new_pol_epoch_info.poq_public_inputs.lottery_1,
-            pol_epoch_nonce: new_pol_epoch_info.poq_public_inputs.epoch_nonce,
-            pol_ledger_aged: new_pol_epoch_info.poq_public_inputs.aged_root,
-            message_quota: settings.session_leadership_quota(),
-        },
-        core: CoreInputs {
-            quota: settings.cover.session_core_quota(
-                settings.num_blend_layers,
-                &settings.time,
-                current_membership.size(),
-            ),
-            zk_root,
-        },
-    };
-    let new_handler = MessageHandler::try_new_with_edge_condition_check(
-        settings,
-        current_membership,
-        new_public_inputs,
-        new_pol_epoch_info.poq_private_inputs.clone(),
-        overwatch_handle.clone(),
-        new_pol_epoch_info.epoch,
-    ).expect("Should not fail to re-create message handler on epoch rotation after private inputs are set.");
+            let Some(zk_root) = new_membership_info.zk.as_ref().map(|zk| zk.root) else {
+                return;
+            };
 
-    *current_epoch_info_and_message_handler = Some((new_pol_epoch_info.clone(), new_handler));
+            let new_public_inputs = PoQVerificationInputsMinusSigningKey {
+                leader: LeaderInputs {
+                    lottery_0: poq_public_inputs.lottery_0,
+                    lottery_1: poq_public_inputs.lottery_1,
+                    pol_epoch_nonce: poq_public_inputs.epoch_nonce,
+                    pol_ledger_aged: poq_public_inputs.aged_root,
+                    message_quota: settings.epoch_leadership_quota(),
+                },
+                core: CoreInputs {
+                    quota: settings.cover.epoch_core_quota(
+                        settings.num_blend_layers,
+                        &settings.time,
+                        new_membership_info.membership.size(),
+                    ),
+                    zk_root,
+                },
+            };
+
+            let new_handler = MessageHandler::try_new_with_edge_condition_check(
+                settings,
+                new_membership_info.membership,
+                new_public_inputs,
+                poq_private_inputs,
+                overwatch_handle.clone(),
+                epoch,
+            ).expect("Should not fail to re-create message handler on epoch rotation after private inputs are set.");
+            *current_message_handler = Some(new_handler);
+        }
+    }
 }

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -64,11 +64,6 @@ const LOG_TARGET: &str = blend::service::EDGE;
 type RunningSettings<Backend, NodeId, RuntimeServiceId> =
     RunningBlendConfig<<Backend as BlendBackend<NodeId, RuntimeServiceId>>::Settings>;
 
-type EpochStateAndHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId> = (
-    BlendEpochState<NodeId>,
-    MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-);
-
 pub struct BlendService<
     Backend,
     NodeId,
@@ -116,7 +111,6 @@ where
     type Message = ServiceMessage<BroadcastSettings, NodeId>;
 }
 
-#[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
 #[async_trait::async_trait]
 impl<
     Backend,
@@ -272,14 +266,14 @@ where
     }
 }
 
-struct PendingEpochInfo<NodeId> {
+pub(crate) struct PendingEpochInfo<NodeId> {
     epoch: Epoch,
     info_type: PendingEpochInfoType<NodeId>,
 }
 
-enum PendingEpochInfoType<NodeId> {
-    Public(MembershipInfo<NodeId>),
-    Private(ProofOfLeadershipQuotaInputs),
+pub(crate) enum PendingEpochInfoType<NodeId> {
+    Public(Box<MembershipInfo<NodeId>>),
+    Private(Box<ProofOfLeadershipQuotaInputs>),
 }
 
 /// Run the event loop of the service.
@@ -344,7 +338,7 @@ where
 
     let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = Some(PendingEpochInfo {
         epoch: current_epoch_info.epoch,
-        info_type: PendingEpochInfoType::Public(current_epoch_info.membership_info),
+        info_type: PendingEpochInfoType::Public(Box::new(current_epoch_info.membership_info)),
     });
     let mut current_epoch_message_handler: Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
@@ -429,7 +423,7 @@ where
             *current_epoch_message_handler = None;
             *pending_epoch_info = Some(PendingEpochInfo {
                 epoch,
-                info_type: PendingEpochInfoType::Public(membership_info.clone()),
+                info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
             });
         }
         // New epoch private info received without using the previous one to create a new handler.
@@ -443,7 +437,7 @@ where
             *current_epoch_message_handler = None;
             *pending_epoch_info = Some(PendingEpochInfo {
                 epoch,
-                info_type: PendingEpochInfoType::Public(membership_info.clone()),
+                info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
             });
         }
         Some(PendingEpochInfo {
@@ -479,7 +473,7 @@ where
                 settings,
                 membership_info.membership,
                 new_public_inputs,
-                new_private_pol_info,
+                *new_private_pol_info,
                 overwatch_handle,
                 epoch,
             )?;
@@ -518,13 +512,12 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
             trace!(target: LOG_TARGET, "New secret PoL info received, but no public epoch info is buffered. Buffering the secret PoL info until the public epoch info is received.");
             *pending_epoch_info = Some(PendingEpochInfo {
                 epoch,
-                info_type: PendingEpochInfoType::Private(poq_private_inputs),
+                info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
             });
-            return;
         }
         Some(PendingEpochInfo {
-            epoch: new_epoch,
             info_type: PendingEpochInfoType::Private(_),
+            ..
         }) => {
             assert!(
                 current_message_handler.is_none(),
@@ -533,11 +526,11 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
             warn!(target: LOG_TARGET, "New epoch secret info received without the previous epoch info being consumed.");
             *pending_epoch_info = Some(PendingEpochInfo {
                 epoch,
-                info_type: PendingEpochInfoType::Private(poq_private_inputs),
+                info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
             });
         }
         Some(PendingEpochInfo {
-            epoch,
+            epoch: new_epoch,
             info_type: PendingEpochInfoType::Public(new_membership_info),
         }) => {
             assert!(
@@ -573,7 +566,7 @@ fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeService
                 new_public_inputs,
                 poq_private_inputs,
                 overwatch_handle.clone(),
-                epoch,
+                new_epoch,
             ).expect("Should not fail to re-create message handler on epoch rotation after private inputs are set.");
             *current_message_handler = Some(new_handler);
         }

--- a/services/blend/src/edge/mod.rs
+++ b/services/blend/src/edge/mod.rs
@@ -16,16 +16,13 @@ use backends::BlendBackend;
 use futures::{Stream, StreamExt as _};
 use lb_blend::{
     message::crypto::proofs::PoQVerificationInputsMinusSigningKey,
-    proofs::quota::inputs::prove::{
-        private::ProofOfLeadershipQuotaInputs,
-        public::{CoreInputs, LeaderInputs},
-    },
+    proofs::quota::inputs::prove::public::{CoreInputs, LeaderInputs},
     scheduling::{
         epoch::{EpochEvent, UninitializedEpochEventStream},
         message_blend::provers::leader::LeaderProofsGenerator,
     },
 };
-use lb_chain_service::{Epoch, api::CryptarchiaServiceData};
+use lb_chain_service::api::CryptarchiaServiceData;
 use lb_core::codec::SerializeOp as _;
 use lb_key_management_system_service::{
     api::KmsServiceApi, keys::KeyOperators,
@@ -46,7 +43,7 @@ use overwatch::{
 use serde::{Serialize, de::DeserializeOwned};
 use settings::StartingBlendConfig;
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info};
 
 use crate::{
     edge::{
@@ -55,7 +52,7 @@ use crate::{
     },
     epoch_info::{PolEpochInfo, PolInfoProvider as PolInfoProviderTrait},
     kms::PreloadKmsService,
-    membership::{self, MembershipInfo, chain::BlendEpochState, node_id},
+    membership::{self, chain::BlendEpochState, node_id},
     message::{NetworkInfo, NetworkMessage, ServiceMessage},
 };
 
@@ -266,30 +263,19 @@ where
     }
 }
 
-pub(crate) struct PendingEpochInfo<NodeId> {
-    epoch: Epoch,
-    info_type: PendingEpochInfoType<NodeId>,
-}
-
-pub(crate) enum PendingEpochInfoType<NodeId> {
-    Public(Box<MembershipInfo<NodeId>>),
-    Private(Box<ProofOfLeadershipQuotaInputs>),
-}
-
 /// Run the event loop of the service.
 ///
-/// The event loop handles three types of events:
+/// The event loop keeps track of the latest public epoch info and the latest
+/// secret `PoL` info independently and rebuilds the message handler whenever
+/// the two line up on the same epoch. It handles three types of events:
 /// - **New public epoch info** (chain-derived membership + leader inputs):
-///   buffered until the matching secret `PoL` info arrives, at which point the
-///   message handler is created for that epoch. A new public info while an
-///   older one is still buffered (no winning slot in the previous epoch) simply
-///   replaces the buffered entry.
+///   becomes the current public info; the handler is rebuilt if the latest
+///   secret info is for the same epoch, otherwise it stays down.
+/// - **New secret `PoL` info**: becomes the current secret info; the handler
+///   is rebuilt if it matches the current public info's epoch.
 /// - **Incoming messages to blend**: forwarded to the current message handler;
 ///   dropped with a warning if no handler is active (secret `PoL` info for the
 ///   current epoch has not yet arrived).
-/// - **New secret `PoL` info**: buffered until the matching public epoch info
-///   arrives, at which point the handler is created. A stale buffered public is
-///   discarded; a stale buffered private is a bug and panics.
 ///
 /// Returns an [`Error`] if a new membership does not satisfy the edge node
 /// condition.
@@ -317,7 +303,7 @@ where
     PolInfoProvider: PolInfoProviderTrait<RuntimeServiceId, Stream: Unpin>,
     RuntimeServiceId: Clone + Send + Sync,
 {
-    let (current_epoch_info, mut remaining_public_epoch_stream) = public_epoch_stream
+    let (mut current_epoch_info, mut remaining_public_epoch_stream) = public_epoch_stream
         .await_first_ready()
         .await
         .expect("The current epoch info must be available.");
@@ -339,10 +325,7 @@ where
         .await
         .expect("Should not fail to subscribe to secret PoL info stream.");
 
-    let mut pending_epoch_info = Some(PendingEpochInfo {
-        epoch: current_epoch_info.epoch,
-        info_type: PendingEpochInfoType::Public(Box::new(current_epoch_info.membership_info)),
-    });
+    let mut current_secret_epoch_info: Option<PolEpochInfo> = None;
     let mut current_epoch_message_handler: Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
     > = None;
@@ -350,13 +333,28 @@ where
     loop {
         tokio::select! {
             Some(EpochEvent::NewEpoch(new_public_epoch_info)) = remaining_public_epoch_stream.next() => {
-                match handle_new_epoch_info(new_public_epoch_info, settings.clone(), &mut pending_epoch_info, &mut current_epoch_message_handler, overwatch_handle.clone()) {
+                current_epoch_info = new_public_epoch_info;
+                match handle_new_epoch_event(&current_epoch_info, current_secret_epoch_info.as_ref(), &mut current_epoch_message_handler, settings.clone(), overwatch_handle.clone()) {
                     Err(Error::NetworkIsTooSmall(_)) => {
                         info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
                         return Ok(());
                     }
                     Err(e) => {
-                        error!(target: LOG_TARGET, "Error when handling new epoch: {e:?}, edge service shutting down.");
+                        error!(target: LOG_TARGET, "Error when handling new public epoch: {e:?}, edge service shutting down.");
+                        return Err(e);
+                    }
+                    Ok(()) => {}
+                }
+            }
+            Some(new_secret_pol_info) = secret_pol_info_stream.next() => {
+                current_secret_epoch_info = Some(new_secret_pol_info);
+                match handle_new_epoch_event(&current_epoch_info, current_secret_epoch_info.as_ref(), &mut current_epoch_message_handler, settings.clone(), overwatch_handle.clone()) {
+                    Err(Error::NetworkIsTooSmall(_)) => {
+                        info!(target: LOG_TARGET, "New membership does not satisfy edge node condition, edge service shutting down.");
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        error!(target: LOG_TARGET, "Error when handling new secret epoch: {e:?}, edge service shutting down.");
                         return Err(e);
                     }
                     Ok(()) => {}
@@ -373,228 +371,90 @@ where
                     handler.handle_message_to_blend(message.clone()).await;
                 }
             }
-            Some(new_secret_pol_info) = secret_pol_info_stream.next() => {
-                handle_new_secret_epoch_info(new_secret_pol_info, settings.clone(), overwatch_handle, &mut current_epoch_message_handler, &mut pending_epoch_info);
-            }
         }
     }
 }
 
-fn handle_new_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    BlendEpochState {
-        epoch: new_epoch,
-        membership_info,
-        lottery_0,
-        lottery_1,
-        nonce,
-        aged,
-    }: BlendEpochState<NodeId>,
-    settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
-    pending_epoch_info: &mut Option<PendingEpochInfo<NodeId>>,
+fn handle_new_epoch_event<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
+    current_public_epoch_info: &BlendEpochState<NodeId>,
+    current_secret_epoch_info: Option<&PolEpochInfo>,
     current_epoch_message_handler: &mut Option<
         MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
     >,
+    settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
     overwatch_handle: OverwatchHandle<RuntimeServiceId>,
 ) -> Result<(), Error>
 where
     Backend: BlendBackend<NodeId, RuntimeServiceId>,
-    NodeId: Clone + Eq + Hash + Send + 'static,
+    NodeId: Clone + Send + Eq + Hash + 'static,
     ProofsGenerator: LeaderProofsGenerator,
-    RuntimeServiceId: Clone,
 {
-    let Some(zk_info) = &membership_info.zk else {
+    // Whatever happens on a new epoch, we shut down the previous handler.
+    // It will be rebuilt below if the current public and secret info line up
+    // on the same epoch.
+    drop(current_epoch_message_handler.take());
+
+    let Some(zk_info) = &current_public_epoch_info.membership_info.zk else {
         return Err(Error::NetworkIsTooSmall(0));
     };
 
     // Validate the edge node condition up front so the service shuts down on
-    // an invalid membership regardless of whether secret PoL info has arrived
-    // yet. Without this check, an invalid membership could be buffered as a
-    // `Pending::Public` and only fail later when private info arrives.
-    let membership_size = membership_info.membership.size();
+    // an invalid membership regardless of whether secret PoL info is available
+    // yet for the current epoch.
+    let membership_size = current_public_epoch_info.membership_info.membership.size();
     if membership_size < settings.minimum_network_size.get() as usize {
         return Err(Error::NetworkIsTooSmall(membership_size));
     }
-    if membership_info.membership.contains_local() {
+    if current_public_epoch_info
+        .membership_info
+        .membership
+        .contains_local()
+    {
         return Err(Error::LocalIsCoreNode);
     }
 
-    match pending_epoch_info.take() {
-        // Nothing buffered: either the service just started, or the previous
-        // epoch's handler is still running. Either way, shut down any running
-        // handler (the new epoch's secret info hasn't arrived yet) and buffer
-        // the new public info.
-        None => {
-            debug!(target: LOG_TARGET, "New epoch public info received. Stopping message handler until secret PoL info is received.");
-            *current_epoch_message_handler = None;
-            *pending_epoch_info = Some(PendingEpochInfo {
-                epoch: new_epoch,
-                info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
-            });
-        }
-        // The previous epoch's public was buffered but never paired with a
-        // private (no winning slot that epoch), so the buffered public is
-        // now stale and is replaced by the new one. Normal occurrence, not
-        // an error.
-        Some(PendingEpochInfo {
-            info_type: PendingEpochInfoType::Public(_),
-            ..
-        }) => {
-            debug!(target: LOG_TARGET, "New epoch public info received without the previous epoch info being consumed.");
-            assert!(
-                current_epoch_message_handler.is_none(),
-                "If public epoch info is buffered, the message handler should not be running."
-            );
-            *pending_epoch_info = Some(PendingEpochInfo {
-                epoch: new_epoch,
-                info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
-            });
-        }
-        Some(PendingEpochInfo {
-            epoch,
-            info_type: PendingEpochInfoType::Private(new_private_pol_info),
-        }) => {
-            // A buffered private must be for the same epoch as the incoming
-            // public: it can't be from the future (private is only produced
-            // once its epoch is active, by which time the public has already
-            // been emitted) and it can't be from the past (the previous
-            // public for that epoch would have consumed it). Either inequality
-            // is a real bug upstream.
-            assert!(
-                new_epoch == epoch,
-                "Buffered secret PoL info for epoch {epoch:?} does not match incoming public epoch info for epoch {new_epoch:?}."
-            );
-            info!(target: LOG_TARGET, "New epoch public info received with a buffered secret PoL info for the same epoch {new_epoch:?}. Trying to create a new epoch-bound message handler.");
-            let new_public_inputs = PoQVerificationInputsMinusSigningKey {
-                core: CoreInputs {
-                    quota: settings.cover.epoch_core_quota(
-                        settings.num_blend_layers,
-                        &settings.time,
-                        membership_info.membership.size(),
-                    ),
-                    zk_root: zk_info.root,
-                },
-                leader: LeaderInputs {
-                    lottery_0,
-                    lottery_1,
-                    pol_epoch_nonce: nonce,
-                    pol_ledger_aged: aged,
-                    message_quota: settings.epoch_leadership_quota(),
-                },
-            };
+    let Some(current_secret_epoch_info) = current_secret_epoch_info else {
+        assert!(
+            current_epoch_message_handler.is_none(),
+            "If there is no secret PoL info, there should not be an active message handler."
+        );
+        debug!(target: LOG_TARGET, "No secret PoL info available for the new epoch, cannot create message handler until it arrives.");
+        return Ok(());
+    };
 
-            let new_handler = MessageHandler::try_new_with_edge_condition_check(
-                settings,
-                membership_info.membership,
-                new_public_inputs,
-                *new_private_pol_info,
-                overwatch_handle,
-                new_epoch,
-            )?;
-
-            *current_epoch_message_handler = Some(new_handler);
-        }
+    if current_public_epoch_info.epoch != current_secret_epoch_info.epoch {
+        debug!(target: LOG_TARGET, "Public and secret epoch info on different epochs (public: {:?}, secret: {:?}). Cannot create new handler.", current_public_epoch_info.epoch, current_secret_epoch_info.epoch);
+        return Ok(());
     }
 
+    let new_public_inputs = PoQVerificationInputsMinusSigningKey {
+        core: CoreInputs {
+            quota: settings.cover.epoch_core_quota(
+                settings.num_blend_layers,
+                &settings.time,
+                current_public_epoch_info.membership_info.membership.size(),
+            ),
+            zk_root: zk_info.root,
+        },
+        leader: LeaderInputs {
+            lottery_0: current_public_epoch_info.lottery_0,
+            lottery_1: current_public_epoch_info.lottery_1,
+            pol_epoch_nonce: current_public_epoch_info.nonce,
+            pol_ledger_aged: current_public_epoch_info.aged,
+            message_quota: settings.epoch_leadership_quota(),
+        },
+    };
+
+    debug!(target: LOG_TARGET, "Creating new handler for epoch {:?}", current_public_epoch_info.epoch);
+    let new_handler = MessageHandler::try_new_with_edge_condition_check(
+        settings,
+        current_public_epoch_info.membership_info.membership.clone(),
+        new_public_inputs,
+        current_secret_epoch_info.poq_private_inputs.clone(),
+        overwatch_handle,
+        current_public_epoch_info.epoch,
+    )?;
+
+    *current_epoch_message_handler = Some(new_handler);
     Ok(())
-}
-
-/// Processes new secret `PoL` info.
-///
-/// Three outcomes depending on the buffered state:
-/// - Nothing buffered → buffer the secret info until the matching public epoch
-///   info arrives.
-/// - A public for the same epoch is buffered → create the message handler.
-/// - A stale public is buffered (older epoch) → discard it and buffer the new
-///   secret info instead; if the incoming secret is itself stale (older than
-///   the buffered public), it is ignored.
-/// - A private is already buffered → panic; this violates the invariant that
-///   secret info does not outlive its epoch.
-fn handle_new_secret_epoch_info<Backend, NodeId, ProofsGenerator, RuntimeServiceId>(
-    PolEpochInfo {
-        epoch: new_epoch,
-        poq_private_inputs,
-        poq_public_inputs,
-    }: PolEpochInfo,
-    settings: RunningSettings<Backend, NodeId, RuntimeServiceId>,
-    overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
-    current_message_handler: &mut Option<
-        MessageHandler<Backend, NodeId, ProofsGenerator, RuntimeServiceId>,
-    >,
-    pending_epoch_info: &mut Option<PendingEpochInfo<NodeId>>,
-) where
-    Backend: BlendBackend<NodeId, RuntimeServiceId>,
-    NodeId: Clone + Eq + Hash + Send + 'static,
-    ProofsGenerator: LeaderProofsGenerator,
-    RuntimeServiceId: Clone,
-{
-    match pending_epoch_info.take() {
-        None => {
-            trace!(target: LOG_TARGET, "New secret PoL info received, but no public epoch info is buffered. Buffering the secret PoL info until the public epoch info is received.");
-            *pending_epoch_info = Some(PendingEpochInfo {
-                epoch: new_epoch,
-                info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
-            });
-        }
-        Some(PendingEpochInfo {
-            info_type: PendingEpochInfoType::Private(_),
-            epoch,
-        }) => {
-            panic!(
-                "New secret PoL info received while there is already buffered secret PoL info for a epoch {epoch:?}. This should never happen."
-            );
-        }
-        Some(PendingEpochInfo {
-            epoch,
-            info_type: PendingEpochInfoType::Public(new_membership_info),
-        }) => {
-            assert!(
-                current_message_handler.is_none(),
-                "If public epoch info is buffered, the message handler should be stopped."
-            );
-
-            let Some(zk_root) = new_membership_info.zk.as_ref().map(|zk| zk.root) else {
-                return;
-            };
-
-            if new_epoch < epoch {
-                debug!(target: LOG_TARGET, "Received old secret epoch info while new public info for {epoch:?} was present. Ignoring received secret info...");
-                return;
-            } else if new_epoch > epoch {
-                debug!(target: LOG_TARGET, "Received new secret epoch info while old public info for {epoch:?} was present. Overriding the old info...");
-                *pending_epoch_info = Some(PendingEpochInfo {
-                    epoch: new_epoch,
-                    info_type: PendingEpochInfoType::Private(Box::new(poq_private_inputs)),
-                });
-                return;
-            }
-
-            let new_public_inputs = PoQVerificationInputsMinusSigningKey {
-                leader: LeaderInputs {
-                    lottery_0: poq_public_inputs.lottery_0,
-                    lottery_1: poq_public_inputs.lottery_1,
-                    pol_epoch_nonce: poq_public_inputs.epoch_nonce,
-                    pol_ledger_aged: poq_public_inputs.aged_root,
-                    message_quota: settings.epoch_leadership_quota(),
-                },
-                core: CoreInputs {
-                    quota: settings.cover.epoch_core_quota(
-                        settings.num_blend_layers,
-                        &settings.time,
-                        new_membership_info.membership.size(),
-                    ),
-                    zk_root,
-                },
-            };
-
-            let new_handler = MessageHandler::try_new_with_edge_condition_check(
-                settings,
-                new_membership_info.membership,
-                new_public_inputs,
-                poq_private_inputs,
-                overwatch_handle.clone(),
-                new_epoch,
-            ).expect("Should not fail to re-create message handler on epoch rotation after private inputs are set.");
-            *current_message_handler = Some(new_handler);
-        }
-    }
 }

--- a/services/blend/src/edge/settings.rs
+++ b/services/blend/src/edge/settings.rs
@@ -30,7 +30,7 @@ pub struct RunningBlendConfig<BackendSettings> {
 }
 
 impl<BackendSettings> RunningBlendConfig<BackendSettings> {
-    pub const fn session_leadership_quota(&self) -> u64 {
+    pub const fn epoch_leadership_quota(&self) -> u64 {
         let num_blend_layers = self.num_blend_layers.get();
         let additional_encapsulations = num_blend_layers
             .checked_mul(self.data_replication_factor)

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -188,7 +188,7 @@ fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> Blend
 
 /// Two consecutive public epoch infos with no private in between (e.g. the
 /// node had no winning slot in the first epoch). The handler must stay down
-/// as long as no secret PoL info is available.
+/// as long as no secret `PoL` info is available.
 #[test_log::test(tokio::test)]
 async fn two_publics_without_private_in_between() {
     let local_node = NodeId(99);

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -11,14 +11,13 @@ use tokio::time::sleep;
 
 use crate::{
     edge::{
-        PendingEpochInfo, PendingEpochInfoType,
         handlers::Error,
         tests::utils::{
             MockLeaderProofsGenerator, NodeId, TestBackend, overwatch_handle, settings, spawn_run,
         },
     },
     epoch_info::PolEpochInfo,
-    membership::{MembershipInfo, chain::BlendEpochState},
+    membership::chain::BlendEpochState,
     test_utils::membership::membership,
 };
 
@@ -129,68 +128,51 @@ fn test_pol_epoch_info(epoch: Epoch) -> PolEpochInfo {
     }
 }
 
-/// `handle_new_secret_epoch_info` creates a new message handler with the
-/// provided epoch's public and private inputs.
+/// `handle_new_epoch_event` creates a new message handler with the provided
+/// epoch's public and private inputs, and replaces it on the next epoch.
 #[test_log::test(tokio::test)]
 async fn handle_new_secret_epoch_info_recreates_handler() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
     let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
 
-    let edge_membership = membership(&[core_node], local_node);
-    let membership_info = MembershipInfo::from(edge_membership);
-
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
 
-    // Start with no handler (e.g. after an epoch transition shut it down).
     let mut handler_state: Option<
         super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
     > = None;
-    let mut buffered_epoch_info = Some(PendingEpochInfo {
-        epoch: Epoch::new(2),
-        info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
-    });
 
-    // Provide secret PoL info for epoch 2.
-    let new_pol_info = test_pol_epoch_info(Epoch::new(2));
-    super::handle_new_secret_epoch_info(
-        new_pol_info,
-        settings.clone(),
-        &overwatch,
+    // Public + secret for epoch 2 -> handler is created.
+    let public_2 = test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node));
+    let secret_2 = test_pol_epoch_info(Epoch::new(2));
+    super::handle_new_epoch_event(
+        &public_2,
+        Some(&secret_2),
         &mut handler_state,
-        &mut buffered_epoch_info,
-    );
+        settings.clone(),
+        overwatch.clone(),
+    )
+    .unwrap();
     assert!(
         handler_state.is_some(),
-        "Handler should be created after secret PoL info is provided"
+        "Handler should be created when public and secret info for the same epoch are present"
     );
     assert_eq!(handler_state.as_ref().unwrap().epoch(), Epoch::new(2));
-    assert!(
-        buffered_epoch_info.is_none(),
-        "Buffered epoch info should be consumed when handler is created"
-    );
 
-    handler_state = None; // Simulate handler shutdown after an epoch transition.
-    buffered_epoch_info = Some(PendingEpochInfo {
-        epoch: Epoch::new(3),
-        info_type: PendingEpochInfoType::Public(Box::new(membership_info)),
-    });
-    // Provide secret PoL info for epoch 3 - handler should be replaced.
-    let newer_pol_info = test_pol_epoch_info(Epoch::new(3));
-    super::handle_new_secret_epoch_info(
-        newer_pol_info,
-        settings,
-        &overwatch,
+    // Public + secret for epoch 3 -> handler is replaced.
+    let public_3 = test_blend_epoch_state(Epoch::new(3), membership(&[core_node], local_node));
+    let secret_3 = test_pol_epoch_info(Epoch::new(3));
+    super::handle_new_epoch_event(
+        &public_3,
+        Some(&secret_3),
         &mut handler_state,
-        &mut buffered_epoch_info,
-    );
+        settings,
+        overwatch,
+    )
+    .unwrap();
     assert!(handler_state.is_some());
     assert_eq!(handler_state.as_ref().unwrap().epoch(), Epoch::new(3));
-    assert!(
-        buffered_epoch_info.is_none(),
-        "Buffered epoch info should be consumed when handler is created"
-    );
 }
 
 fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> BlendEpochState<NodeId> {
@@ -206,7 +188,7 @@ fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> Blend
 
 /// Two consecutive public epoch infos with no private in between (e.g. the
 /// node had no winning slot in the first epoch). The handler must stay down
-/// and the pending buffer must hold the latest public info.
+/// as long as no secret PoL info is available.
 #[test_log::test(tokio::test)]
 async fn two_publics_without_private_in_between() {
     let local_node = NodeId(99);
@@ -219,52 +201,38 @@ async fn two_publics_without_private_in_between() {
     let mut handler_state: Option<
         super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
     > = None;
-    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = None;
 
-    // First public: nothing buffered, nothing running -> buffer Public(1).
-    super::handle_new_epoch_info(
-        test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        settings.clone(),
-        &mut pending_epoch_info,
+    // First public, no secret yet -> handler must stay down.
+    super::handle_new_epoch_event(
+        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        None,
         &mut handler_state,
+        settings.clone(),
         overwatch.clone(),
     )
     .unwrap();
-
     assert!(
         handler_state.is_none(),
         "Handler must not be created without the private info"
     );
-    let pending = pending_epoch_info
-        .as_ref()
-        .expect("Public info must be buffered");
-    assert_eq!(pending.epoch, Epoch::new(1));
-    assert!(matches!(pending.info_type, PendingEpochInfoType::Public(_)));
 
-    // Second public for a later epoch with no private in between: stale public
-    // gets overwritten by the new one, handler stays down.
-    super::handle_new_epoch_info(
-        test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node)),
-        settings,
-        &mut pending_epoch_info,
+    // Second public for a later epoch, still no secret -> handler stays down.
+    super::handle_new_epoch_event(
+        &test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node)),
+        None,
         &mut handler_state,
+        settings,
         overwatch,
     )
     .unwrap();
-
     assert!(
         handler_state.is_none(),
         "Handler must remain down: no private info has been received"
     );
-    let pending = pending_epoch_info
-        .as_ref()
-        .expect("Latest public info must be buffered");
-    assert_eq!(pending.epoch, Epoch::new(2));
-    assert!(matches!(pending.info_type, PendingEpochInfoType::Public(_)));
 }
 
-/// Public arrives first, then private for the same epoch: handler is created,
-/// pending buffer is cleared.
+/// Public arrives first, then private for the same epoch: handler is created
+/// on the second call once both sides line up on the same epoch.
 #[test_log::test(tokio::test)]
 async fn public_then_private_same_epoch_creates_handler() {
     let local_node = NodeId(99);
@@ -277,27 +245,29 @@ async fn public_then_private_same_epoch_creates_handler() {
     let mut handler_state: Option<
         super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
     > = None;
-    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = None;
 
-    super::handle_new_epoch_info(
-        test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        settings.clone(),
-        &mut pending_epoch_info,
+    let public_1 = test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node));
+
+    // Public for epoch 1, no secret yet -> no handler.
+    super::handle_new_epoch_event(
+        &public_1,
+        None,
         &mut handler_state,
+        settings.clone(),
         overwatch.clone(),
     )
     .unwrap();
     assert!(handler_state.is_none());
-    assert!(pending_epoch_info.is_some());
 
-    super::handle_new_secret_epoch_info(
-        test_pol_epoch_info(Epoch::new(1)),
-        settings,
-        &overwatch,
+    // Secret for epoch 1 arrives, same public -> handler is created.
+    super::handle_new_epoch_event(
+        &public_1,
+        Some(&test_pol_epoch_info(Epoch::new(1))),
         &mut handler_state,
-        &mut pending_epoch_info,
-    );
-
+        settings,
+        overwatch,
+    )
+    .unwrap();
     assert_eq!(
         handler_state
             .as_ref()
@@ -305,14 +275,10 @@ async fn public_then_private_same_epoch_creates_handler() {
             .epoch(),
         Epoch::new(1)
     );
-    assert!(
-        pending_epoch_info.is_none(),
-        "Pending buffer must be consumed when the handler is created"
-    );
 }
 
-/// Private arrives first, then public for the same epoch: handler is created,
-/// pending buffer is cleared.
+/// Secret arrives for an epoch ahead of the current public (mismatch), then
+/// public catches up to the same epoch: handler is created on the match.
 #[test_log::test(tokio::test)]
 async fn private_then_public_same_epoch_creates_handler() {
     let local_node = NodeId(99);
@@ -325,43 +291,34 @@ async fn private_then_public_same_epoch_creates_handler() {
     let mut handler_state: Option<
         super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
     > = None;
-    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = None;
 
-    super::handle_new_secret_epoch_info(
-        test_pol_epoch_info(Epoch::new(1)),
+    // Secret for epoch 1 while public is still on epoch 0 -> epochs mismatch,
+    // no handler.
+    let secret_1 = test_pol_epoch_info(Epoch::new(1));
+    super::handle_new_epoch_event(
+        &test_blend_epoch_state(Epoch::new(0), membership(&[core_node], local_node)),
+        Some(&secret_1),
+        &mut handler_state,
         settings.clone(),
-        &overwatch,
-        &mut handler_state,
-        &mut pending_epoch_info,
-    );
+        overwatch.clone(),
+    )
+    .unwrap();
     assert!(handler_state.is_none());
-    let pending = pending_epoch_info
-        .as_ref()
-        .expect("Private info must be buffered");
-    assert_eq!(pending.epoch, Epoch::new(1));
-    assert!(matches!(
-        pending.info_type,
-        PendingEpochInfoType::Private(_)
-    ));
 
-    super::handle_new_epoch_info(
-        test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
-        settings,
-        &mut pending_epoch_info,
+    // Public catches up to epoch 1 -> handler is created.
+    super::handle_new_epoch_event(
+        &test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        Some(&secret_1),
         &mut handler_state,
+        settings,
         overwatch,
     )
     .unwrap();
-
     assert_eq!(
         handler_state
             .as_ref()
             .expect("Handler must be created")
             .epoch(),
         Epoch::new(1)
-    );
-    assert!(
-        pending_epoch_info.is_none(),
-        "Pending buffer must be consumed when the handler is created"
     );
 }

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -168,6 +168,7 @@ async fn handle_new_secret_epoch_info_recreates_handler() {
         "Buffered epoch info should be consumed when handler is created"
     );
 
+    handler_state = None; // Simulate handler shutdown after an epoch transition.
     buffered_epoch_info = Some(PendingEpochInfo {
         epoch: Epoch::new(3),
         info_type: PendingEpochInfoType::Public(Box::new(membership_info)),

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -1,28 +1,22 @@
 use core::time::Duration;
 
-use lb_blend::{
-    message::crypto::proofs::PoQVerificationInputsMinusSigningKey,
-    proofs::quota::inputs::prove::{
-        private::ProofOfLeadershipQuotaInputs,
-        public::{CoreInputs, LeaderInputs},
-    },
-};
+use lb_blend::proofs::quota::inputs::prove::private::ProofOfLeadershipQuotaInputs;
 use lb_chain_service::Epoch;
 use lb_core::{crypto::ZkHash, proofs::leader_proof::LeaderPublic};
 use lb_groth16::{Field as _, Fr};
-use lb_time_service::SlotTick;
 use tokio::time::sleep;
 
 use crate::{
     edge::{
+        PendingEpochInfo, PendingEpochInfoType,
         handlers::Error,
         tests::utils::{
             MockLeaderProofsGenerator, NodeId, TestBackend, overwatch_handle, settings, spawn_run,
         },
     },
-    epoch_info::{EpochHandler, PolEpochInfo},
+    epoch_info::PolEpochInfo,
     membership::MembershipInfo,
-    test_utils::{epoch::TestChainService, membership::membership},
+    test_utils::membership::membership,
 };
 
 pub mod utils;
@@ -30,7 +24,7 @@ pub mod utils;
 /// [`run`] forwards messages to the core nodes in the updated membership.
 #[test_log::test(tokio::test)]
 #[ignore = "We need a different test setup since we are not blocking the edge tokio task until the secret PoL info is fetched, which makes this test flaky."]
-async fn run_with_session_transition() {
+async fn run_with_epoch_transition() {
     let local_node = NodeId(99);
     let mut core_node = NodeId(0);
     let minimal_network_size = 1;
@@ -132,84 +126,6 @@ fn test_pol_epoch_info(epoch: Epoch) -> PolEpochInfo {
     }
 }
 
-fn poq_verification_inputs() -> PoQVerificationInputsMinusSigningKey {
-    PoQVerificationInputsMinusSigningKey {
-        leader: LeaderInputs {
-            pol_ledger_aged: ZkHash::ZERO,
-            pol_epoch_nonce: ZkHash::ZERO,
-            message_quota: 10,
-            lottery_0: Fr::ZERO,
-            lottery_1: Fr::ZERO,
-        },
-        core: CoreInputs {
-            quota: 1,
-            zk_root: Fr::ZERO,
-        },
-    }
-}
-
-/// `handle_clock_event` shuts down the message handler when a new epoch is
-/// detected ahead of the current handler's epoch.
-#[test_log::test(tokio::test)]
-async fn handle_clock_event_new_epoch_shuts_down_handler() {
-    let local_node = NodeId(99);
-    let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
-
-    let edge_membership = membership(&[core_node], local_node);
-    let pol_info = test_pol_epoch_info(Epoch::new(1));
-
-    let handler = super::handlers::MessageHandler::<
-        TestBackend,
-        NodeId,
-        MockLeaderProofsGenerator,
-        usize,
-    >::try_new_with_edge_condition_check(
-        settings(local_node, 1, node_id_sender),
-        edge_membership,
-        poq_verification_inputs(),
-        pol_info.poq_private_inputs.clone(),
-        overwatch_handle(),
-        Epoch::new(1),
-    )
-    .unwrap();
-
-    let mut handler_state = Some((pol_info, handler));
-
-    // Create an EpochHandler and initialize it with an epoch-1 tick.
-    let mut epoch_handler = EpochHandler::new(TestChainService, 1.try_into().unwrap());
-    super::handle_clock_event::<TestBackend, NodeId, MockLeaderProofsGenerator, _, _>(
-        SlotTick {
-            epoch: Epoch::new(1),
-            slot: 1.into(),
-        },
-        &mut epoch_handler,
-        &mut handler_state,
-    )
-    .await;
-    // After the first tick (matching handler's epoch), handler should still be up.
-    assert!(
-        handler_state.is_some(),
-        "Handler should remain active for a tick within the same epoch"
-    );
-
-    // Send a tick for epoch 2, which is ahead of the handler's epoch (1).
-    super::handle_clock_event::<TestBackend, NodeId, MockLeaderProofsGenerator, _, _>(
-        SlotTick {
-            epoch: Epoch::new(2),
-            slot: 2.into(),
-        },
-        &mut epoch_handler,
-        &mut handler_state,
-    )
-    .await;
-    // The handler should be shut down because epoch 2 > handler's epoch 1.
-    assert!(
-        handler_state.is_none(),
-        "Handler should be shut down when clock tick reveals a newer epoch"
-    );
-}
-
 /// `handle_new_secret_epoch_info` creates a new message handler with the
 /// provided epoch's public and private inputs.
 #[test_log::test(tokio::test)]
@@ -219,118 +135,56 @@ async fn handle_new_secret_epoch_info_recreates_handler() {
     let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
 
     let edge_membership = membership(&[core_node], local_node);
-    let membership_info = MembershipInfo::from_membership_and_session_number(edge_membership, 1);
+    let membership_info = MembershipInfo::from(edge_membership);
 
     let settings = settings(local_node, 1, node_id_sender);
     let overwatch = overwatch_handle();
 
     // Start with no handler (e.g. after an epoch transition shut it down).
-    let mut handler_state: Option<(
-        PolEpochInfo,
+    let mut handler_state: Option<
         super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
-    )> = None;
+    > = None;
+    let mut buffered_epoch_info = Some(PendingEpochInfo {
+        epoch: Epoch::new(2),
+        info_type: PendingEpochInfoType::Public(Box::new(membership_info.clone())),
+    });
 
     // Provide secret PoL info for epoch 2.
     let new_pol_info = test_pol_epoch_info(Epoch::new(2));
     super::handle_new_secret_epoch_info(
-        &new_pol_info,
+        new_pol_info,
         settings.clone(),
         &overwatch,
-        &membership_info,
         &mut handler_state,
+        &mut buffered_epoch_info,
     );
     assert!(
         handler_state.is_some(),
         "Handler should be created after secret PoL info is provided"
     );
-    assert_eq!(handler_state.as_ref().unwrap().0.epoch, Epoch::new(2));
+    assert_eq!(handler_state.as_ref().unwrap().epoch(), Epoch::new(2));
+    assert!(
+        buffered_epoch_info.is_none(),
+        "Buffered epoch info should be consumed when handler is created"
+    );
 
+    buffered_epoch_info = Some(PendingEpochInfo {
+        epoch: Epoch::new(3),
+        info_type: PendingEpochInfoType::Public(Box::new(membership_info)),
+    });
     // Provide secret PoL info for epoch 3 - handler should be replaced.
     let newer_pol_info = test_pol_epoch_info(Epoch::new(3));
     super::handle_new_secret_epoch_info(
-        &newer_pol_info,
+        newer_pol_info,
         settings,
         &overwatch,
-        &membership_info,
         &mut handler_state,
+        &mut buffered_epoch_info,
     );
     assert!(handler_state.is_some());
-    assert_eq!(handler_state.as_ref().unwrap().0.epoch, Epoch::new(3));
-}
-
-/// Full epoch lifecycle: handler active → clock advances epoch → handler shut
-/// down → new secret `PoL` info → handler recreated.
-#[test_log::test(tokio::test)]
-async fn epoch_transition_full_lifecycle() {
-    let local_node = NodeId(99);
-    let core_node = NodeId(0);
-    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
-
-    let edge_membership = membership(&[core_node], local_node);
-    let membership_info =
-        MembershipInfo::from_membership_and_session_number(edge_membership.clone(), 1);
-    let settings = settings(local_node, 1, node_id_sender);
-    let overwatch = overwatch_handle();
-
-    // Start with handler active at epoch 1.
-    let pol_info = test_pol_epoch_info(Epoch::new(1));
-    let handler = super::handlers::MessageHandler::<
-        TestBackend,
-        NodeId,
-        MockLeaderProofsGenerator,
-        usize,
-    >::try_new_with_edge_condition_check(
-        settings.clone(),
-        edge_membership,
-        poq_verification_inputs(),
-        pol_info.poq_private_inputs.clone(),
-        overwatch.clone(),
-        Epoch::new(1),
-    )
-    .unwrap();
-    let mut handler_state = Some((pol_info, handler));
-
-    let mut epoch_handler = EpochHandler::new(TestChainService, 1.try_into().unwrap());
-
-    // Initialize epoch handler with epoch-1 tick.
-    super::handle_clock_event::<TestBackend, NodeId, MockLeaderProofsGenerator, _, _>(
-        SlotTick {
-            epoch: Epoch::new(1),
-            slot: 1.into(),
-        },
-        &mut epoch_handler,
-        &mut handler_state,
-    )
-    .await;
-    assert!(handler_state.is_some());
-
-    // Clock advances to epoch 2 - handler shut down.
-    super::handle_clock_event::<TestBackend, NodeId, MockLeaderProofsGenerator, _, _>(
-        SlotTick {
-            epoch: Epoch::new(2),
-            slot: 2.into(),
-        },
-        &mut epoch_handler,
-        &mut handler_state,
-    )
-    .await;
+    assert_eq!(handler_state.as_ref().unwrap().epoch(), Epoch::new(3));
     assert!(
-        handler_state.is_none(),
-        "Handler should be shut down on epoch advance"
+        buffered_epoch_info.is_none(),
+        "Buffered epoch info should be consumed when handler is created"
     );
-
-    // Secret PoL info arrives for epoch 2 - handler recreated.
-    let new_pol_info = test_pol_epoch_info(Epoch::new(2));
-    super::handle_new_secret_epoch_info(
-        &new_pol_info,
-        settings,
-        &overwatch,
-        &membership_info,
-        &mut handler_state,
-    );
-    assert!(
-        handler_state.is_some(),
-        "Handler should be recreated after secret PoL info"
-    );
-    assert_eq!(handler_state.as_ref().unwrap().0.epoch, Epoch::new(2));
 }

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -1,6 +1,9 @@
 use core::time::Duration;
 
-use lb_blend::proofs::quota::inputs::prove::private::ProofOfLeadershipQuotaInputs;
+use lb_blend::{
+    proofs::quota::inputs::prove::private::ProofOfLeadershipQuotaInputs,
+    scheduling::membership::Membership,
+};
 use lb_chain_service::Epoch;
 use lb_core::{crypto::ZkHash, proofs::leader_proof::LeaderPublic};
 use lb_groth16::{Field as _, Fr};
@@ -15,7 +18,7 @@ use crate::{
         },
     },
     epoch_info::PolEpochInfo,
-    membership::MembershipInfo,
+    membership::{MembershipInfo, chain::BlendEpochState},
     test_utils::membership::membership,
 };
 
@@ -187,5 +190,178 @@ async fn handle_new_secret_epoch_info_recreates_handler() {
     assert!(
         buffered_epoch_info.is_none(),
         "Buffered epoch info should be consumed when handler is created"
+    );
+}
+
+fn test_blend_epoch_state(epoch: Epoch, membership: Membership<NodeId>) -> BlendEpochState<NodeId> {
+    BlendEpochState {
+        epoch,
+        nonce: Fr::ZERO,
+        aged: Fr::ZERO,
+        lottery_0: Fr::ZERO,
+        lottery_1: Fr::ZERO,
+        membership_info: membership.into(),
+    }
+}
+
+/// Two consecutive public epoch infos with no private in between (e.g. the
+/// node had no winning slot in the first epoch). The handler must stay down
+/// and the pending buffer must hold the latest public info.
+#[test_log::test(tokio::test)]
+async fn two_publics_without_private_in_between() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+
+    let settings = settings(local_node, 1, node_id_sender);
+    let overwatch = overwatch_handle();
+
+    let mut handler_state: Option<
+        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
+    > = None;
+    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = None;
+
+    // First public: nothing buffered, nothing running -> buffer Public(1).
+    super::handle_new_epoch_info(
+        test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        settings.clone(),
+        &mut pending_epoch_info,
+        &mut handler_state,
+        overwatch.clone(),
+    )
+    .unwrap();
+
+    assert!(
+        handler_state.is_none(),
+        "Handler must not be created without the private info"
+    );
+    let pending = pending_epoch_info
+        .as_ref()
+        .expect("Public info must be buffered");
+    assert_eq!(pending.epoch, Epoch::new(1));
+    assert!(matches!(pending.info_type, PendingEpochInfoType::Public(_)));
+
+    // Second public for a later epoch with no private in between: stale public
+    // gets overwritten by the new one, handler stays down.
+    super::handle_new_epoch_info(
+        test_blend_epoch_state(Epoch::new(2), membership(&[core_node], local_node)),
+        settings,
+        &mut pending_epoch_info,
+        &mut handler_state,
+        overwatch,
+    )
+    .unwrap();
+
+    assert!(
+        handler_state.is_none(),
+        "Handler must remain down: no private info has been received"
+    );
+    let pending = pending_epoch_info
+        .as_ref()
+        .expect("Latest public info must be buffered");
+    assert_eq!(pending.epoch, Epoch::new(2));
+    assert!(matches!(pending.info_type, PendingEpochInfoType::Public(_)));
+}
+
+/// Public arrives first, then private for the same epoch: handler is created,
+/// pending buffer is cleared.
+#[test_log::test(tokio::test)]
+async fn public_then_private_same_epoch_creates_handler() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+
+    let settings = settings(local_node, 1, node_id_sender);
+    let overwatch = overwatch_handle();
+
+    let mut handler_state: Option<
+        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
+    > = None;
+    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = None;
+
+    super::handle_new_epoch_info(
+        test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        settings.clone(),
+        &mut pending_epoch_info,
+        &mut handler_state,
+        overwatch.clone(),
+    )
+    .unwrap();
+    assert!(handler_state.is_none());
+    assert!(pending_epoch_info.is_some());
+
+    super::handle_new_secret_epoch_info(
+        test_pol_epoch_info(Epoch::new(1)),
+        settings,
+        &overwatch,
+        &mut handler_state,
+        &mut pending_epoch_info,
+    );
+
+    assert_eq!(
+        handler_state
+            .as_ref()
+            .expect("Handler must be created")
+            .epoch(),
+        Epoch::new(1)
+    );
+    assert!(
+        pending_epoch_info.is_none(),
+        "Pending buffer must be consumed when the handler is created"
+    );
+}
+
+/// Private arrives first, then public for the same epoch: handler is created,
+/// pending buffer is cleared.
+#[test_log::test(tokio::test)]
+async fn private_then_public_same_epoch_creates_handler() {
+    let local_node = NodeId(99);
+    let core_node = NodeId(0);
+    let (node_id_sender, _node_id_receiver) = tokio::sync::mpsc::channel(1);
+
+    let settings = settings(local_node, 1, node_id_sender);
+    let overwatch = overwatch_handle();
+
+    let mut handler_state: Option<
+        super::handlers::MessageHandler<TestBackend, NodeId, MockLeaderProofsGenerator, usize>,
+    > = None;
+    let mut pending_epoch_info: Option<PendingEpochInfo<NodeId>> = None;
+
+    super::handle_new_secret_epoch_info(
+        test_pol_epoch_info(Epoch::new(1)),
+        settings.clone(),
+        &overwatch,
+        &mut handler_state,
+        &mut pending_epoch_info,
+    );
+    assert!(handler_state.is_none());
+    let pending = pending_epoch_info
+        .as_ref()
+        .expect("Private info must be buffered");
+    assert_eq!(pending.epoch, Epoch::new(1));
+    assert!(matches!(
+        pending.info_type,
+        PendingEpochInfoType::Private(_)
+    ));
+
+    super::handle_new_epoch_info(
+        test_blend_epoch_state(Epoch::new(1), membership(&[core_node], local_node)),
+        settings,
+        &mut pending_epoch_info,
+        &mut handler_state,
+        overwatch,
+    )
+    .unwrap();
+
+    assert_eq!(
+        handler_state
+            .as_ref()
+            .expect("Handler must be created")
+            .epoch(),
+        Epoch::new(1)
+    );
+    assert!(
+        pending_epoch_info.is_none(),
+        "Pending buffer must be consumed when the handler is created"
     );
 }

--- a/services/blend/src/edge/tests/mod.rs
+++ b/services/blend/src/edge/tests/mod.rs
@@ -31,7 +31,7 @@ async fn run_with_epoch_transition() {
     let local_node = NodeId(99);
     let mut core_node = NodeId(0);
     let minimal_network_size = 1;
-    let (_, session_sender, msg_sender, mut node_id_receiver) = spawn_run(
+    let (_, epoch_sender, msg_sender, mut node_id_receiver) = spawn_run(
         local_node,
         minimal_network_size,
         Some(membership(&[core_node], local_node)),
@@ -45,9 +45,9 @@ async fn run_with_epoch_transition() {
         core_node
     );
 
-    // Send a new session with another core node 1.
+    // Send a new epoch with another core node 1.
     core_node = NodeId(1);
-    session_sender
+    epoch_sender
         .send(membership(&[core_node], local_node))
         .await
         .expect("channel opened");
@@ -68,15 +68,15 @@ async fn run_shuts_down_if_new_membership_is_small() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
     let minimal_network_size = 1;
-    let (join_handle, session_sender, _, _) = spawn_run(
+    let (join_handle, epoch_sender, _, _) = spawn_run(
         local_node,
         minimal_network_size,
         Some(membership(&[core_node], local_node)),
     )
     .await;
 
-    // Send a new session with an empty membership (smaller than the min size).
-    session_sender
+    // Send a new epoch with an empty membership (smaller than the min size).
+    epoch_sender
         .send(membership(&[], local_node))
         .await
         .expect("channel opened");
@@ -89,15 +89,15 @@ async fn run_fails_if_local_is_core_in_new_membership() {
     let local_node = NodeId(99);
     let core_node = NodeId(0);
     let minimal_network_size = 1;
-    let (join_handle, session_sender, _, _) = spawn_run(
+    let (join_handle, epoch_sender, _, _) = spawn_run(
         local_node,
         minimal_network_size,
         Some(membership(&[core_node], local_node)),
     )
     .await;
 
-    // Send a new session with a membership where the local node is core.
-    session_sender
+    // Send a new epoch with a membership where the local node is core.
+    epoch_sender
         .send(membership(&[local_node], local_node))
         .await
         .expect("channel opened");

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -15,7 +15,6 @@ use lb_blend::{
     },
 };
 use lb_key_management_system_service::keys::UnsecuredEd25519Key;
-use lb_ledger::EpochState;
 use overwatch::overwatch::{OverwatchHandle, commands::OverwatchCommand};
 use rand::{RngCore, rngs::OsRng};
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -25,14 +24,10 @@ use crate::{
     core::settings::CoverTrafficSettings,
     edge::{
         backends::BlendBackend, handlers::Error, run, settings::RunningBlendConfig as BlendConfig,
+        tests::test_blend_epoch_state,
     },
-    membership::chain::BlendEpochState,
     settings::TimingSettings,
-    test_utils::{
-        crypto::mock_blend_proof,
-        epoch::{OncePolStreamProvider, default_epoch_state},
-        membership::key,
-    },
+    test_utils::{crypto::mock_blend_proof, epoch::OncePolStreamProvider, membership::key},
 };
 
 pub struct MockLeaderProofsGenerator;
@@ -72,7 +67,8 @@ pub async fn spawn_run(
             .expect("channel opened");
     }
 
-    let epoch_stream = ReceiverStream::new(epoch_receiver).map(default_blend_epoch_state);
+    let epoch_stream = ReceiverStream::new(epoch_receiver)
+        .map(|membership| test_blend_epoch_state(0.into(), membership));
 
     let settings = settings(local_node, minimal_network_size, node_id_sender);
     let join_handle = tokio::spawn(async move {
@@ -93,25 +89,6 @@ pub async fn spawn_run(
     });
 
     (join_handle, epoch_sender, msg_sender, node_id_receiver)
-}
-
-fn default_blend_epoch_state(membership: Membership<NodeId>) -> BlendEpochState<NodeId> {
-    let EpochState {
-        epoch,
-        lottery_0,
-        lottery_1,
-        nonce,
-        utxos,
-        ..
-    } = default_epoch_state();
-    BlendEpochState {
-        aged: utxos.root(),
-        epoch,
-        lottery_0,
-        lottery_1,
-        nonce,
-        membership_info: membership.into(),
-    }
 }
 
 pub fn settings(

--- a/services/blend/src/edge/tests/utils.rs
+++ b/services/blend/src/edge/tests/utils.rs
@@ -2,13 +2,12 @@ use core::{num::NonZeroU64, time::Duration};
 use std::fmt::{Debug, Display};
 
 use async_trait::async_trait;
-use futures::{StreamExt as _, future::ready, stream::once};
+use futures::StreamExt as _;
 use lb_blend::{
     message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader,
     proofs::quota::inputs::prove::private::ProofOfLeadershipQuotaInputs,
     scheduling::{
-        // TODO: Remove all mentions of sessions.
-        epoch::UninitializedEpochEventStream as UninitializedSessionEventStream,
+        epoch::UninitializedEpochEventStream,
         membership::Membership,
         message_blend::provers::{
             BlendLayerProof, ProofsGeneratorSettings, leader::LeaderProofsGenerator,
@@ -16,7 +15,7 @@ use lb_blend::{
     },
 };
 use lb_key_management_system_service::keys::UnsecuredEd25519Key;
-use lb_time_service::SlotTick;
+use lb_ledger::EpochState;
 use overwatch::overwatch::{OverwatchHandle, commands::OverwatchCommand};
 use rand::{RngCore, rngs::OsRng};
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -27,12 +26,11 @@ use crate::{
     edge::{
         backends::BlendBackend, handlers::Error, run, settings::RunningBlendConfig as BlendConfig,
     },
-    epoch_info::EpochHandler,
-    membership::MembershipInfo,
+    membership::chain::BlendEpochState,
     settings::TimingSettings,
     test_utils::{
         crypto::mock_blend_proof,
-        epoch::{OncePolStreamProvider, TestChainService},
+        epoch::{OncePolStreamProvider, default_epoch_state},
         membership::key,
     },
 };
@@ -63,19 +61,18 @@ pub async fn spawn_run(
     mpsc::Sender<Vec<u8>>,
     mpsc::Receiver<NodeId>,
 ) {
-    let (session_sender, session_receiver) = mpsc::channel(1);
+    let (epoch_sender, epoch_receiver) = mpsc::channel(1);
     let (msg_sender, msg_receiver) = mpsc::channel(1);
     let (node_id_sender, node_id_receiver) = mpsc::channel(1);
 
     if let Some(initial_membership) = initial_membership {
-        session_sender
+        epoch_sender
             .send(initial_membership)
             .await
             .expect("channel opened");
     }
 
-    let session_stream = ReceiverStream::new(session_receiver)
-        .map(|membership| MembershipInfo::from_membership_and_session_number(membership, 1));
+    let epoch_stream = ReceiverStream::new(epoch_receiver).map(default_blend_epoch_state);
 
     let settings = settings(local_node, minimal_network_size, node_id_sender);
     let join_handle = tokio::spawn(async move {
@@ -83,17 +80,11 @@ pub async fn spawn_run(
             TestBackend,
             _,
             MockLeaderProofsGenerator,
-            _,
             OncePolStreamProvider,
             _,
         >(
-            UninitializedSessionEventStream::new(session_stream, Duration::ZERO),
-            once(ready(SlotTick {
-                epoch: 1.into(),
-                slot: 1.into(),
-            })),
+            UninitializedEpochEventStream::new(epoch_stream, Duration::ZERO),
             ReceiverStream::new(msg_receiver),
-            EpochHandler::new(TestChainService, 1.try_into().unwrap()),
             settings,
             &overwatch_handle(),
             || {},
@@ -101,7 +92,26 @@ pub async fn spawn_run(
         .await
     });
 
-    (join_handle, session_sender, msg_sender, node_id_receiver)
+    (join_handle, epoch_sender, msg_sender, node_id_receiver)
+}
+
+fn default_blend_epoch_state(membership: Membership<NodeId>) -> BlendEpochState<NodeId> {
+    let EpochState {
+        epoch,
+        lottery_0,
+        lottery_1,
+        nonce,
+        utxos,
+        ..
+    } = default_epoch_state();
+    BlendEpochState {
+        aged: utxos.root(),
+        epoch,
+        lottery_0,
+        lottery_1,
+        nonce,
+        membership_info: membership.into(),
+    }
 }
 
 pub fn settings(

--- a/services/blend/src/instance.rs
+++ b/services/blend/src/instance.rs
@@ -627,7 +627,7 @@ mod tests {
             let instance = instance
                 .handle_epoch_event(
                     // With an empty membership smaller than the minimal size.
-                    EpochEvent::NewEpoch(Membership::empty().into()),
+                    EpochEvent::NewEpoch(membership(&[], local_node).into()),
                     handle,
                     minimal_network_size,
                     LOCAL_NODE_ID,
@@ -675,7 +675,7 @@ mod tests {
             // Edge -> Core
             let instance = instance
                 .handle_epoch_event(
-                    EpochEvent::NewEpoch(membership(&[1], local_node).into()),
+                    EpochEvent::NewEpoch(membership(&[1], 1).into()),
                     handle,
                     minimal_network_size,
                     LOCAL_NODE_ID,

--- a/services/blend/src/instance.rs
+++ b/services/blend/src/instance.rs
@@ -627,10 +627,7 @@ mod tests {
             let instance = instance
                 .handle_epoch_event(
                     // With an empty membership smaller than the minimal size.
-                    EpochEvent::NewEpoch(MembershipInfo::from_membership_and_session_number(
-                        membership(&[], local_node),
-                        1,
-                    )),
+                    EpochEvent::NewEpoch(Membership::empty().into()),
                     handle,
                     minimal_network_size,
                     LOCAL_NODE_ID,
@@ -654,10 +651,7 @@ mod tests {
             // Broadcast -> Edge
             let instance = instance
                 .handle_epoch_event(
-                    EpochEvent::NewEpoch(MembershipInfo::from_membership_and_session_number(
-                        membership(&[1], local_node),
-                        1,
-                    )),
+                    EpochEvent::NewEpoch(membership(&[1], local_node).into()),
                     handle,
                     minimal_network_size,
                     LOCAL_NODE_ID,
@@ -669,10 +663,7 @@ mod tests {
             // Edge -> Edge (stay)
             let instance = instance
                 .handle_epoch_event(
-                    EpochEvent::NewEpoch(MembershipInfo::from_membership_and_session_number(
-                        membership(&[1], local_node),
-                        1,
-                    )),
+                    EpochEvent::NewEpoch(membership(&[1], local_node).into()),
                     handle,
                     minimal_network_size,
                     LOCAL_NODE_ID,
@@ -684,10 +675,7 @@ mod tests {
             // Edge -> Core
             let instance = instance
                 .handle_epoch_event(
-                    EpochEvent::NewEpoch(MembershipInfo::from_membership_and_session_number(
-                        membership(&[1], 1),
-                        1,
-                    )),
+                    EpochEvent::NewEpoch(membership(&[1], local_node).into()),
                     handle,
                     minimal_network_size,
                     LOCAL_NODE_ID,

--- a/services/blend/src/membership/chain.rs
+++ b/services/blend/src/membership/chain.rs
@@ -10,7 +10,7 @@
 use core::{hash::Hash, pin::Pin};
 use std::fmt::{Debug, Display};
 
-use futures::{Stream, StreamExt as _};
+use futures::{Stream, StreamExt as _, stream::unfold};
 use lb_chain_service::{
     Epoch,
     api::{CryptarchiaServiceApi, CryptarchiaServiceData},
@@ -93,47 +93,40 @@ where
     };
 
     // TODO: Refactor into a function or own type that replaces `EpochHandler`.
-    Box::pin(
-        slot_ticks
-            .scan(None, move |last_epoch, SlotTick { epoch, slot }| {
-                let is_new_epoch = Some(epoch) != *last_epoch;
-                if is_new_epoch {
-                    *last_epoch = Some(epoch);
+    Box::pin(unfold(
+        (slot_ticks, None::<Epoch>, chain_service),
+        move |(mut slot_ticks, mut last_epoch, chain_service)| async move {
+            loop {
+                let SlotTick { epoch, slot } = slot_ticks.next().await?;
+                if Some(epoch) == last_epoch {
+                    continue;
                 }
-                let chain_service = chain_service.clone();
-                let signing_public_key = signing_public_key;
-                let zk_public_key = zk_public_key;
-                async move {
-                    if !is_new_epoch {
-                        return Some(None);
+                match chain_service.get_epoch_state(slot).await {
+                    Ok(Ok(epoch_state)) => {
+                        last_epoch = Some(epoch);
+                        let membership_info = membership_info_from_epoch_state::<NodeId>(
+                            &epoch_state,
+                            &signing_public_key,
+                            zk_public_key,
+                        );
+                        let item = BlendEpochState {
+                            epoch,
+                            nonce: epoch_state.nonce,
+                            aged: epoch_state.utxo_merkle_root(),
+                            lottery_0: epoch_state.lottery_0,
+                            lottery_1: epoch_state.lottery_1,
+                            membership_info,
+                        };
+                        return Some((item, (slot_ticks, last_epoch, chain_service)));
                     }
-                    match chain_service.get_epoch_state(slot).await {
-                        Ok(Ok(epoch_state)) => {
-                            let membership_info = membership_info_from_epoch_state::<NodeId>(
-                                &epoch_state,
-                                &signing_public_key,
-                                zk_public_key,
-                            );
-                            Some(Some(BlendEpochState {
-                                epoch,
-                                nonce: epoch_state.nonce,
-                                aged: epoch_state.utxo_merkle_root(),
-                                lottery_0: epoch_state.lottery_0,
-                                lottery_1: epoch_state.lottery_1,
-                                membership_info,
-                            }))
-                        }
-                        Ok(Err(e)) => {
-                            tracing::warn!(target: LOG_TARGET, "Chain service returned error for epoch state at slot {slot:?}: {e:?}");
-                            Some(None)
-                        }
-                        Err(e) => {
-                            tracing::warn!(target: LOG_TARGET, "Failed to query epoch state at slot {slot:?}: {e:?}");
-                            Some(None)
-                        }
+                    Ok(Err(e)) => {
+                        tracing::warn!(target: LOG_TARGET, "Chain service returned error for epoch state at slot {slot:?}: {e:?}; will retry on next slot of epoch {epoch:?}");
+                    }
+                    Err(e) => {
+                        tracing::warn!(target: LOG_TARGET, "Failed to query epoch state at slot {slot:?}: {e:?}; will retry on next slot of epoch {epoch:?}");
                     }
                 }
-            })
-            .filter_map(async move |maybe| { maybe }),
-    )
+            }
+        },
+    ))
 }

--- a/services/blend/src/membership/chain.rs
+++ b/services/blend/src/membership/chain.rs
@@ -30,6 +30,7 @@ use crate::{
 pub struct BlendEpochState<NodeId> {
     pub epoch: Epoch,
     pub nonce: Fr,
+    pub aged: Fr,
     pub lottery_0: Fr,
     pub lottery_1: Fr,
     pub membership_info: MembershipInfo<NodeId>,
@@ -116,6 +117,7 @@ where
                             Some(Some(BlendEpochState {
                                 epoch,
                                 nonce: epoch_state.nonce,
+                                aged: epoch_state.utxo_merkle_root(),
                                 lottery_0: epoch_state.lottery_0,
                                 lottery_1: epoch_state.lottery_1,
                                 membership_info,

--- a/services/blend/src/membership/chain.rs
+++ b/services/blend/src/membership/chain.rs
@@ -91,20 +91,26 @@ where
 
     // TODO: Refactor into a function or own type that replaces `EpochHandler`.
     Box::pin(unfold(
-        (slot_ticks, None::<Epoch>, chain_service),
-        move |(mut slot_ticks, mut last_epoch, chain_service)| async move {
+        (
+            slot_ticks,
+            None::<Epoch>,
+            chain_service,
+            signing_public_key,
+            zk_public_key,
+        ),
+        async move |(mut ticks, mut last_epoch, chain_api, signing_pk, zk_pk)| {
             loop {
-                let SlotTick { epoch, slot } = slot_ticks.next().await?;
+                let SlotTick { epoch, slot } = ticks.next().await?;
                 if Some(epoch) == last_epoch {
                     continue;
                 }
-                match chain_service.get_epoch_state(slot).await {
+                match chain_api.get_epoch_state(slot).await {
                     Ok(Ok(epoch_state)) => {
                         last_epoch = Some(epoch);
                         let membership_info = membership_info_from_epoch_state::<NodeId>(
                             &epoch_state,
-                            &signing_public_key,
-                            zk_public_key,
+                            &signing_pk,
+                            zk_pk,
                         );
                         let item = BlendEpochState {
                             epoch,
@@ -114,7 +120,7 @@ where
                             lottery_1: epoch_state.lottery_1,
                             membership_info,
                         };
-                        return Some((item, (slot_ticks, last_epoch, chain_service)));
+                        return Some((item, (ticks, last_epoch, chain_api, signing_pk, zk_pk)));
                     }
                     Ok(Err(e)) => {
                         tracing::warn!(target: LOG_TARGET, "Chain service returned error for epoch state at slot {slot:?}: {e:?}; will retry on next slot of epoch {epoch:?}");

--- a/services/blend/src/membership/chain.rs
+++ b/services/blend/src/membership/chain.rs
@@ -1,11 +1,10 @@
-//! Chain-derived membership.
+//! Chain-derived per-epoch state.
 //!
-//! The membership for each epoch is read from the SDP snapshot frozen into that
-//! epoch's [`EpochState`](lb_ledger::EpochState), queried from the chain on
-//! slot ticks. This puts membership on the **same slot-tick clock** as the
-//! leader inputs (the [`EpochHandler`] `PoL` path), so both halves share the
-//! chain's per-epoch view and cannot drift — replacing the pushed
-//! `ActiveProviders` broadcast.
+//! On every slot tick the chain is queried for the current epoch's
+//! [`EpochState`](lb_ledger::EpochState); on each new epoch the membership and
+//! leader inputs frozen into its SDP snapshot are yielded together as a
+//! [`BlendEpochState`]. Both halves come from the same chain query, so they
+//! cannot drift — replacing the pushed `ActiveProviders` broadcast.
 
 use core::{hash::Hash, pin::Pin};
 use std::fmt::{Debug, Display};
@@ -36,21 +35,19 @@ pub struct BlendEpochState<NodeId> {
     pub membership_info: MembershipInfo<NodeId>,
 }
 
-/// A chain-derived membership stream.
+/// A chain-derived per-epoch state stream.
 ///
-/// Unlike [`MembershipStream`](super::MembershipStream) this is not `Sync`,
-/// since producing each item awaits a chain query; consumers only require
-/// `Send + Unpin`.
+/// Not `Sync`, since producing each item awaits a chain query; consumers only
+/// require `Send + Unpin`.
 pub type BlendEpochStateStream<NodeId> =
     Pin<Box<dyn Stream<Item = BlendEpochState<NodeId>> + Send + 'static>>;
 
-/// Subscribe to a chain-derived stream of
-/// [`BlendEpochState`](super::BlendEpochState).
+/// Subscribe to a chain-derived stream of [`BlendEpochState`].
 ///
-/// On every slot tick the chain is queried for the current epoch's
-/// `EpochState`; on each new epoch the membership frozen into its SDP snapshot
-/// is yielded. The same `EpochHandler`/`get_epoch_state` mechanism is used by
-/// the leader-input path, so the two are on one clock.
+/// One item is yielded per epoch — the first slot of the epoch whose chain
+/// query succeeds. Slot ticks within an already-yielded epoch are ignored;
+/// failed chain queries do not advance the tracked epoch, so the next slot of
+/// the same epoch is retried.
 pub async fn subscribe<ChainService, NodeId, TimeRuntimeBackend, RuntimeServiceId>(
     overwatch_handle: &OverwatchHandle<RuntimeServiceId>,
     signing_public_key: Ed25519PublicKey,

--- a/services/blend/src/membership/mod.rs
+++ b/services/blend/src/membership/mod.rs
@@ -14,27 +14,18 @@ pub struct MembershipInfo<NodeId> {
     pub membership: Membership<NodeId>,
     // `None` if membership is empty.
     pub zk: Option<ZkInfo>,
-    // TODO: Remove session info
-    pub session_number: u64,
 }
 
-impl<NodeId> MembershipInfo<NodeId> {
-    #[cfg(test)]
-    #[must_use]
-    pub fn from_membership_and_session_number(
-        membership: Membership<NodeId>,
-        session_number: u64,
-    ) -> Self {
+#[cfg(test)]
+impl<NodeId> From<Membership<NodeId>> for MembershipInfo<NodeId> {
+    fn from(membership: Membership<NodeId>) -> Self {
         let zk = if membership.is_empty() {
             None
         } else {
             Some(ZkInfo::default())
         };
-        Self {
-            membership,
-            zk,
-            session_number,
-        }
+
+        Self { membership, zk }
     }
 }
 

--- a/services/blend/src/membership/service.rs
+++ b/services/blend/src/membership/service.rs
@@ -82,8 +82,6 @@ where
     MembershipInfo {
         membership,
         zk: zk_info,
-        // TODO: remove session info completely
-        session_number: epoch_state.epoch().into_inner().into(),
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Changed the logic in the Blend edge service to remove sessions. Also, we now buffer epoch info slightly differently, since we don't have to deal with intra-session epoch transitions. On each new public/private epoch info, we check if the other half for the current epoch is set, and proceed to create the message handler. Else, update/clear the buffer depending on the condition. I also cleaned up mentions of `session` from the edge folder wherever possible.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.