### PR TITLE
chore(ci): Add env with gh variable for taiki-e

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -161,6 +161,8 @@ jobs:
         uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # Version 2.49.35
         with:
           tool: cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cargo test all except end-to-end integration tests
         timeout-minutes: 90

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -158,11 +158,9 @@ jobs:
 
       - name: Install cargo-nextest
         if: ${{ !cancelled()}}
-        uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # Version 2.49.35
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # Version 2.79.11
         with:
           tool: cargo-nextest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cargo test all except end-to-end integration tests
         timeout-minutes: 90

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           tool: cargo-nextest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Ensure a local NTP server is running for deterministic time sync in e2e and cucumber tests
       - name: Verify Local NTP Server

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -82,6 +82,8 @@ jobs:
         uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # Version 2.49.35
         with:
           tool: cargo-nextest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Ensure a local NTP server is running for deterministic time sync in e2e and cucumber tests
       - name: Verify Local NTP Server

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -79,11 +79,9 @@ jobs:
         uses: ./.github/actions/prune-disk-space
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # Version 2.49.35
+        uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # Version 2.79.11
         with:
           tool: cargo-nextest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Ensure a local NTP server is running for deterministic time sync in e2e and cucumber tests
       - name: Verify Local NTP Server


### PR DESCRIPTION
## 1. What does this PR implement?

The change adds required env var to make authenticated github api requests via `cargo-binstall`.

Taiki-e install action [fallbacks](https://github.com/taiki-e/install-action#supported-tools) on cargo binstall when the tool is not found locally. Github [rate limits unauthenticated](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-authenticated-users) user to 60 requests per hour.

Recently the taiki-e action related jobs started failing on github ubuntu-latest and our self-hosted runners. Tried to search what changed in these runners [perinstalled toolsets](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), but there were no recent changes.

## 2. Does the code have enough context to be clearly understood?

Failing jobs:
https://github.com/logos-blockchain/logos-blockchain/actions/runs/26526101559/job/78130037267
https://github.com/logos-blockchain/logos-blockchain/actions/runs/26526101500/job/78141129482

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
