### PR TITLE
fix(chain): apply block after storage succeeds

### DIFF
--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -1045,12 +1045,12 @@ where
         let header = block.header();
         let prev_lib = cryptarchia.lib();
 
+        let mut candidate = cryptarchia.clone();
         let (pruned_blocks, reorged_blocks, events) =
-            cryptarchia.try_apply_block(&block, current_slot)?;
-        let new_lib = cryptarchia.lib();
+            candidate.try_apply_block(&block, current_slot)?;
+        let new_lib = candidate.lib();
 
         let tx_count = block.transactions().count();
-        metrics::emit_block_transactions_metric(tx_count);
 
         relays
             .storage_adapter()
@@ -1062,10 +1062,13 @@ where
             &pruned_blocks,
             Some(prev_lib),
             new_lib,
-            cryptarchia.consensus.lib_branch().slot(),
+            candidate.consensus.lib_branch().slot(),
             relays.storage_adapter(),
         )
         .await?;
+
+        *cryptarchia = candidate;
+        metrics::emit_block_transactions_metric(tx_count);
 
         let processed_block_event = {
             let tip = cryptarchia.tip_branch();

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -25,6 +25,7 @@ use lb_ledger::{
 };
 use lb_storage_service::{
     StorageMsg, StorageService,
+    api::{StorageApiRequest, chain::requests::ChainApiRequest},
     backends::{
         StorageBackend as _,
         rocksdb::{RocksBackend, RocksBackendSettings},
@@ -237,6 +238,135 @@ async fn get_block_ids() {
         stream.next().await.unwrap(),
         Err(Error::ParentIdNotFound(_))
     ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn process_block_does_not_mutate_state_when_storage_send_fails() {
+    let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
+    let (storage_tx, storage_rx) = mpsc::channel(10);
+    drop(storage_rx);
+    let (time_tx, _time_rx) = mpsc::channel(10);
+    let relays =
+        CryptarchiaConsensusRelays::<SignedMantleTx, RocksBackend, TestRuntimeServiceId>::new(
+            OutboundRelay::new(broadcast_tx),
+            OutboundRelay::new(storage_tx),
+            OutboundRelay::new(time_tx),
+        )
+        .await;
+    let (new_block_tx, mut new_block_rx) = broadcast::channel(10);
+    let (lib_tx, mut lib_rx) = broadcast::channel(10);
+
+    let (mut cryptarchia, block) = test_chain_with_next_block();
+    let initial_info = cryptarchia.info();
+    let block_slot = block.header().slot();
+
+    let result = CryptarchiaConsensus::<
+        _,
+        RocksBackend,
+        SystemTimeBackend,
+        TestRuntimeServiceId,
+    >::process_block(
+        &mut cryptarchia,
+        block,
+        block_slot,
+        &relays,
+        &new_block_tx,
+        &lib_tx,
+    )
+    .await;
+
+    match &result {
+        Err(Error::Storage(_)) => {}
+        Err(e) => panic!("expected storage error, got {e:?}"),
+        Ok(_) => panic!("expected storage error, got Ok"),
+    }
+    assert_eq!(cryptarchia.info(), initial_info);
+    assert!(new_block_rx.try_recv().is_err());
+    assert!(lib_rx.try_recv().is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() {
+    let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
+    let (storage_tx, mut storage_rx) = mpsc::channel(10);
+    let (time_tx, _time_rx) = mpsc::channel(10);
+    let relays =
+        CryptarchiaConsensusRelays::<SignedMantleTx, RocksBackend, TestRuntimeServiceId>::new(
+            OutboundRelay::new(broadcast_tx),
+            OutboundRelay::new(storage_tx),
+            OutboundRelay::new(time_tx),
+        )
+        .await;
+    let (new_block_tx, mut new_block_rx) = broadcast::channel(10);
+    let (lib_tx, mut lib_rx) = broadcast::channel(10);
+
+    let storage_task = tokio::spawn(async move {
+        let Some(StorageMsg::Api {
+            request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
+        }) = storage_rx.recv().await
+        else {
+            panic!("expected store block request");
+        };
+
+        response_tx
+            .send(Ok(()))
+            .expect("store block reply should be received");
+    });
+
+    let (mut cryptarchia, block) = test_chain_with_next_block();
+    let initial_info = cryptarchia.info();
+    let block_slot = block.header().slot();
+
+    let result = CryptarchiaConsensus::<
+        _,
+        RocksBackend,
+        SystemTimeBackend,
+        TestRuntimeServiceId,
+    >::process_block(
+        &mut cryptarchia,
+        block,
+        block_slot,
+        &relays,
+        &new_block_tx,
+        &lib_tx,
+    )
+    .await;
+    storage_task.await.unwrap();
+
+    match &result {
+        Err(Error::Storage(_)) => {}
+        Err(e) => panic!("expected storage error, got {e:?}"),
+        Ok(_) => panic!("expected storage error, got Ok"),
+    }
+    assert_eq!(cryptarchia.info(), initial_info);
+    assert!(new_block_rx.try_recv().is_err());
+    assert!(lib_rx.try_recv().is_err());
+}
+
+fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx>) {
+    let k = 3.try_into().unwrap();
+    let config = ledger_config(k);
+    let genesis_id = [0; 32].into();
+    let (zk_key, utxo) = utxo();
+    let cryptarchia = Cryptarchia::from_lib(
+        genesis_id,
+        LedgerState::from_utxos([utxo], &config),
+        genesis_id,
+        config,
+        lb_cryptarchia_engine::State::Online,
+        Slot::genesis(),
+        0,
+    );
+    let block = try_build_block(
+        &cryptarchia,
+        cryptarchia.tip(),
+        utxo,
+        &zk_key,
+        Slot::genesis() + 1,
+    )
+    .unwrap();
+
+    (cryptarchia, block)
 }
 
 #[must_use]

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -303,23 +303,36 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
     let (lib_tx, mut lib_rx) = broadcast::channel(10);
 
     let storage_task = tokio::spawn(async move {
-        let Some(msg) = storage_rx.recv().await else {
-            return Err("expected store block request, storage channel closed");
-        };
+        while let Some(msg) = storage_rx.recv().await {
+            match msg {
+                StorageMsg::Api {
+                    request:
+                        StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
+                } => {
+                    response_tx
+                        .send(Ok(()))
+                        .map_err(|_| "store block reply receiver dropped")?;
+                }
+                StorageMsg::Api {
+                    request:
+                        StorageApiRequest::Chain(ChainApiRequest::StoreImmutableBlockIds {
+                            response_tx,
+                            ..
+                        }),
+                } => {
+                    response_tx
+                        .send(Err(
+                            "StoreImmutableBlockIds is rejected by this test".to_owned()
+                        ))
+                        .map_err(|_| "immutable index reply receiver dropped")?;
 
-        let StorageMsg::Api {
-            request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
-        } = msg
-        else {
-            return Err("expected store block request");
-        };
+                    return Ok(());
+                }
+                _ => return Err("unexpected storage request"),
+            }
+        }
 
-        response_tx
-            .send(Ok(()))
-            .map_err(|_| "store block reply receiver dropped")?;
-
-        // Drop the receiver so the following immutable-index write fails at send time.
-        Ok(())
+        Err("expected immutable index write request, storage channel closed")
     });
 
     let (mut cryptarchia, block) = test_chain_with_next_block();
@@ -343,7 +356,7 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
     storage_task
         .await
         .expect("storage task should not panic")
-        .expect("storage task should handle initial StoreBlock request");
+        .expect("storage task should reject immutable index write");
 
     match &result {
         Err(Error::Storage(_)) => {}
@@ -369,14 +382,8 @@ fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx>) {
         Slot::genesis(),
         0,
     );
-    let block = try_build_block(
-        &cryptarchia,
-        cryptarchia.tip(),
-        utxo,
-        &zk_key,
-        Slot::genesis() + 1,
-    )
-    .unwrap();
+    let block =
+        try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, Slot::new(1)).unwrap();
 
     (cryptarchia, block)
 }

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -244,6 +244,8 @@ async fn get_block_ids() {
 async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
     let (storage_tx, storage_rx) = mpsc::channel(10);
+    // Close the storage relay before processing so the initial StoreBlock request
+    // fails.
     drop(storage_rx);
     let (time_tx, _time_rx) = mpsc::channel(10);
     let relays =
@@ -301,16 +303,23 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
     let (lib_tx, mut lib_rx) = broadcast::channel(10);
 
     let storage_task = tokio::spawn(async move {
-        let Some(StorageMsg::Api {
+        let Some(msg) = storage_rx.recv().await else {
+            return Err("expected store block request, storage channel closed");
+        };
+
+        let StorageMsg::Api {
             request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
-        }) = storage_rx.recv().await
+        } = msg
         else {
-            panic!("expected store block request");
+            return Err("expected store block request");
         };
 
         response_tx
             .send(Ok(()))
-            .expect("store block reply should be received");
+            .map_err(|_| "store block reply receiver dropped")?;
+
+        // Drop the receiver so the following immutable-index write fails at send time.
+        Ok(())
     });
 
     let (mut cryptarchia, block) = test_chain_with_next_block();
@@ -331,7 +340,10 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
         &lib_tx,
     )
     .await;
-    storage_task.await.unwrap();
+    storage_task
+        .await
+        .expect("storage task should not panic")
+        .expect("storage task should handle initial StoreBlock request");
 
     match &result {
         Err(Error::Storage(_)) => {}


### PR DESCRIPTION
## 1. What does this PR implement?

This PR prevents chain state from being committed before the required block storage writes succeed.

Previously process_block applied the block to in-memory Cryptarchia state before storing the block and immutable block indexes. If a storage write failed after that point, runtime state could advance while persisted/recoverable state was incomplete, which could lead to restart/recovery inconsistency. This now applies the block against a candidate state, stores the required data first, and only commits the candidate state after storage succeeds.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
