### PR TITLE
fix(ci): configure curl user agent for tool installs

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -156,6 +156,13 @@ jobs:
             --locked -p logos-blockchain-node --features testing 
             -- nodes/node/standalone-node-config.yaml --check-config --deployment nodes/node/standalone-deployment-config.yaml
 
+      - name: Configure curl user-agent for crates.io
+        run: |
+          curlrc="$HOME/.curlrc"
+          user_agent='user-agent = "logos-blockchain-ci (https://github.com/logos-blockchain/logos-blockchain)"'
+          touch "$curlrc"
+          grep -qxF "$user_agent" "$curlrc" || echo "$user_agent" >> "$curlrc"
+
       - name: Install cargo-nextest
         if: ${{ !cancelled()}}
         uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # Version 2.49.35

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -78,6 +78,13 @@ jobs:
       - name: Prune disk space (cache-aware, self-hosted)
         uses: ./.github/actions/prune-disk-space
 
+      - name: Configure curl user-agent for crates.io
+        run: |
+          curlrc="$HOME/.curlrc"
+          user_agent='user-agent = "logos-blockchain-ci (https://github.com/logos-blockchain/logos-blockchain)"'
+          touch "$curlrc"
+          grep -qxF "$user_agent" "$curlrc" || echo "$user_agent" >> "$curlrc"
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@5651179950649c44da31d346537e20c0534f0f25 # Version 2.49.35
         with:


### PR DESCRIPTION
## 1. What does this PR implement?

This PR configures an explicit curl user-agent in CI before installing Rust tools with `taiki-e/install-action`.

Crates.io can reject generic curl requests with `403`, which breaks tool installation when the action resolves `cargo-nextest`. Adding an identifying user-agent in `~/.curlrc` makes those requests comply with crates.io API access policy and keeps the setup idempotent on self-hosted runners.

Example of failed run: https://github.com/logos-blockchain/logos-blockchain/actions/runs/26556339977/job/78228878556

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
