### PR TITLE
chore: update Rust toolchain to 1.96

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746  # Version 1.0.6
         with:
           # The same version must be used in the `.pre-commit-config.yaml` file
-          toolchain: nightly-2026-02-28
+          toolchain: nightly-2026-04-11
           profile: minimal
           components: rustfmt
           override: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         # We're running `fmt` with `--all` and `pass_filenames: false` to format the entire workspace at once.
         # Otherwise, `pre-commit` passes staged files one by one, which can lead to inconsistent results
         # due to, presumably, the lack of full workspace context.
-        entry: cargo +nightly-2026-02-28 fmt
+        entry: cargo +nightly-2026-04-11 fmt
         pass_filenames: false
       - id: clippy
         name: cargo clippy

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     rust-overlay = {
-      url = "github:oxalica/rust-overlay/8087ff1f47fff983a1fba70fa88b759f2fd8ae97";
+      url = "github:oxalica/rust-overlay/40b0a3a193e0840c76174b4a322874c8f6dd0a63";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -41,7 +41,7 @@
           overlays = [ rust-overlay.overlays.default ];
         };
 
-      rustVersion = "1.95.0";
+      rustVersion = "1.96.0";
     in
     {
       packages = forAll (

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,6 +6,6 @@
 # * .github/workflows/code-check.yml (fmt job)
 # * .pre-commit-config.yml (fmt hook)
 # Then, if there is any new allow-by-default rustc lint introduced/stabilized, add it to the respective entry in our `config.toml`.
-channel = "1.95.0"
+channel = "1.96.0"
 # Even if clippy should be included in the default profile, in some cases it is not installed. So we force it with an explicit declaration.
 components = ["clippy"]

--- a/testnet/Dockerfile
+++ b/testnet/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION=v0.4.2
 # ===========================
 # BUILD IMAGE
 # ===========================
-FROM rust:1.95.0-slim-bookworm AS builder
+FROM rust:1.96.0-slim-bookworm AS builder
 
 ARG VERSION
 


### PR DESCRIPTION
Fixes https://github.com/logos-blockchain/logos-blockchain/issues/2823.