### PR TITLE
fix(chain-leader): cap proposed block txs by size

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -17,10 +17,10 @@ use lb_chain_service::{
     api::{CryptarchiaServiceApi, CryptarchiaServiceData},
 };
 use lb_core::{
-    block::{Block, Error as BlockError, MAX_BLOCK_TRANSACTIONS},
+    block::{Block, Error as BlockError, MAX_BLOCK_SIZE, MAX_BLOCK_TRANSACTIONS},
     header::HeaderId,
     mantle::{
-        AuthenticatedMantleTx, SignedMantleTx, Transaction, TxHash, TxSelect,
+        AuthenticatedMantleTx, SignedMantleTx, StorageSize, Transaction, TxHash, TxSelect,
         gas::MainnetGasConstants, ops::leader_claim::LeaderClaimOp,
     },
     proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate, LeaderPublic},
@@ -627,11 +627,7 @@ where
         }
 
         let valid_tx_stream = stream::iter(valid_txs);
-        let selected_txs_stream = tx_selector.select_tx_from(valid_tx_stream);
-        let txs: Vec<_> = selected_txs_stream
-            .take(MAX_BLOCK_TRANSACTIONS)
-            .collect()
-            .await;
+        let txs = txs_for_block(tx_selector.select_tx_from(valid_tx_stream)).await;
 
         let block = Block::create(parent, slot, proof, txs, signing_key)?;
 
@@ -742,5 +738,93 @@ where
             .await?
             .ok_or(Error::LedgerStateNotFound(tip))?;
         Ok((tip, ledger_state))
+    }
+}
+
+async fn txs_for_block<Tx, S>(mut txs: S) -> Vec<Tx>
+where
+    Tx: StorageSize,
+    S: futures::Stream<Item = Tx> + Unpin,
+{
+    let mut block_size: usize = 0;
+    let mut selected_txs = Vec::new();
+
+    while selected_txs.len() < MAX_BLOCK_TRANSACTIONS {
+        let Some(tx) = txs.next().await else {
+            break;
+        };
+
+        let tx_size = tx.storage_size();
+        let Some(next_block_size) = block_size.checked_add(tx_size) else {
+            continue;
+        };
+
+        if next_block_size > MAX_BLOCK_SIZE {
+            continue;
+        }
+
+        block_size = next_block_size;
+        selected_txs.push(tx);
+    }
+
+    selected_txs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestTx {
+        size: usize,
+    }
+
+    impl StorageSize for TestTx {
+        fn storage_size(&self) -> usize {
+            self.size
+        }
+    }
+
+    #[tokio::test]
+    async fn block_tx_selection_respects_transaction_count_limit() {
+        let txs = stream::iter(vec![TestTx { size: 1 }; MAX_BLOCK_TRANSACTIONS + 1]);
+
+        let selected = txs_for_block(txs).await;
+
+        assert_eq!(selected.len(), MAX_BLOCK_TRANSACTIONS);
+    }
+
+    #[tokio::test]
+    async fn block_tx_selection_respects_block_size_limit() {
+        let txs = stream::iter(vec![
+            TestTx {
+                size: MAX_BLOCK_SIZE / 2,
+            },
+            TestTx {
+                size: MAX_BLOCK_SIZE / 2,
+            },
+            TestTx { size: 1 },
+        ]);
+
+        let selected = txs_for_block(txs).await;
+        let selected_size: usize = selected.iter().map(StorageSize::storage_size).sum();
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected_size, MAX_BLOCK_SIZE);
+    }
+
+    #[tokio::test]
+    async fn block_tx_selection_skips_oversized_transactions() {
+        let txs = stream::iter(vec![
+            TestTx {
+                size: MAX_BLOCK_SIZE + 1,
+            },
+            TestTx { size: 1 },
+        ]);
+
+        let selected = txs_for_block(txs).await;
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].storage_size(), 1);
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

This fixes transaction selection during block proposal.

Previously, the leader capped selected transactions only by `MAX_BLOCK_TRANSACTIONS`. If enough large transactions were pending, selection could exceed `MAX_BLOCK_SIZE`, and `Block::create` would reject the proposed block.

Now selected transactions are capped by both transaction count and cumulative transaction size. Unit tests cover the count limit, size limit, and oversized transaction handling.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
