### PR TITLE
fix(test): use the new GC schedule for e2e test

### DIFF
--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -63,7 +63,9 @@ async fn sdp_blend_activity() {
 
     // Wait past the point where declarations would be removed if no activity
     // proofs were submitted.
-    let survival_epochs = INACTIVITY_PERIOD + RETENTION_PERIOD + 1.into(); // +1 margin
+    let initial_active_epoch = declarations[0].active;
+    let survival_epochs =
+        initial_active_epoch + INACTIVITY_PERIOD + RETENTION_PERIOD + Epoch::new(2); // +1 margin
     let survival_slots = Slot::new(u64::from(u32::from(survival_epochs)) * slots_per_epoch);
     wait_for_nodes_tip_slot(
         &[&node0.client, &node1.client],
@@ -100,7 +102,8 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
     };
     config.deployment.cryptarchia.security_param = NonZero::new(2).unwrap();
     config.deployment.cryptarchia.slot_activation_coeff =
-        NonNegativeRatio::new(1, 10.try_into().unwrap());
+        NonNegativeRatio::new(1, 2.try_into().unwrap());
+    config.deployment.cryptarchia.learning_rate = 0.5.try_into().unwrap();
 
     slots_per_epoch.store(
         config.deployment.cryptarchia.slots_per_epoch(),

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     num::NonZero,
     sync::{
         Arc,
@@ -8,7 +9,7 @@ use std::{
 };
 
 use lb_chain_service::Epoch;
-use lb_core::sdp::{NumberOfEpochs, ServiceType};
+use lb_core::sdp::{Declaration, NumberOfEpochs, ProviderId, ServiceType};
 use lb_node::config::{RunConfig, cryptarchia::deployment::EpochConfig};
 use lb_testing_framework::{DeploymentBuilder, NodeHttpClient, TopologyConfig as TfTopologyConfig};
 use lb_utils::math::NonNegativeRatio;
@@ -63,7 +64,7 @@ async fn sdp_blend_activity() {
 
     // Wait past the point where declarations would be removed if no activity
     // proofs were submitted.
-    let initial_active_epoch = declarations[0].active;
+    let initial_active_epoch = declarations.values().next().unwrap().active;
     let survival_epochs =
         initial_active_epoch + INACTIVITY_PERIOD + RETENTION_PERIOD + Epoch::new(2); // +1 margin
     let survival_slots = Slot::new(u64::from(u32::from(survival_epochs)) * slots_per_epoch);
@@ -76,11 +77,7 @@ async fn sdp_blend_activity() {
 
     // Declarations must still be present — this proves that activity messages were
     // submitted/accepted, keeping the declarations alive.
-    let declarations_after = node0
-        .client
-        .get_sdp_declarations()
-        .await
-        .expect("querying SDP declarations should succeed");
+    let declarations_after = wait_for_declarations(&node0.client, Duration::from_secs(30)).await;
 
     // Check if at least one declaration is still present because blocks may have
     // been produced by only one nodes by coincidence
@@ -88,6 +85,16 @@ async fn sdp_blend_activity() {
         !declarations_after.is_empty(),
         "At least one blend declaration should survive past the inactivity window. Activity proofs may not have been submitted/accepted"
     );
+
+    // Check that the declarations have the refreshed `active` epoch number.
+    for (provider_id, declaration) in declarations {
+        let old_active = declaration.active;
+        let new_active = declarations_after.get(&provider_id).unwrap().active;
+        assert!(
+            new_active > old_active,
+            "Declaration must have the refreshed `active` epoch number larger than the initial one ({old_active:?}), but got {new_active:?}"
+        );
+    }
 }
 
 const INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
@@ -103,7 +110,6 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
     config.deployment.cryptarchia.security_param = NonZero::new(2).unwrap();
     config.deployment.cryptarchia.slot_activation_coeff =
         NonNegativeRatio::new(1, 2.try_into().unwrap());
-    config.deployment.cryptarchia.learning_rate = 0.5.try_into().unwrap();
 
     slots_per_epoch.store(
         config.deployment.cryptarchia.slots_per_epoch(),
@@ -128,11 +134,14 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
 async fn wait_for_declarations(
     node: &NodeHttpClient,
     duration: Duration,
-) -> Vec<lb_core::sdp::Declaration> {
+) -> HashMap<ProviderId, Declaration> {
     tokio::time::timeout(duration, async {
         loop {
             if let Ok(declarations) = node.get_sdp_declarations().await {
-                return declarations;
+                return declarations
+                    .into_iter()
+                    .map(|declaration| (declaration.provider_id, declaration))
+                    .collect();
             }
             sleep(Duration::from_millis(200)).await;
         }


### PR DESCRIPTION
## 1. What does this PR implement?

We have the `sdp_blend_activity` e2e test that checks that the declarations are successfully refreshed by activity messages submitted by the blend service.

The test was waiting `inactivity + retention + 1` period to check if the declarations still survive. But this waiting period must be changed because the [RFC](https://app.notion.com/p/nomos-tech/RFC-Remove-Concept-of-a-Session-f39261aa09df826db83e81613bb454dc?source=copy_link#366261aa09df80f683bfd05ce34a045b) initializes `Declaration.active` with `created + 2`. This PR changes the waiting period to `declaration.active + inactivity + retention + 1`.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
