### PR TITLE
feat: re-enable applying locally produced blocks before blending

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -11,7 +11,7 @@ use core::fmt::Debug;
 use std::{fmt::Display, iter, pin::Pin, time::Duration};
 
 use futures::{StreamExt as _, stream};
-use lb_chain_network_service::api::ChainNetworkServiceData;
+use lb_chain_network_service::api::{ChainNetworkServiceApi, ChainNetworkServiceData};
 use lb_chain_service::{
     Epoch,
     api::{CryptarchiaServiceApi, CryptarchiaServiceData},
@@ -44,7 +44,7 @@ use overwatch::{
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use tokio::sync::{oneshot, watch};
-use tracing::{Level, debug, error, info, instrument, span, trace};
+use tracing::{Level, error, info, instrument, span, trace};
 use tracing_futures::Instrument as _;
 
 pub use crate::wallet::LeaderWalletConfig;
@@ -315,6 +315,14 @@ where
                 .expect("Failed to estabilish connection with Cryptarchia"),
         );
 
+        let chain_network_api = ChainNetworkServiceApi::<ChainNetwork, RuntimeServiceId>::new(
+            self.service_resources_handle
+                .overwatch_handle
+                .relay::<ChainNetwork>()
+                .await
+                .expect("Failed to estabilish connection with ChainNetwork"),
+        );
+
         let LeaderSettings {
             config: ledger_config,
             transaction_selector_settings,
@@ -459,7 +467,7 @@ where
                             .await
                             {
                                 Ok(block) => {
-                                    Self::publish_block_proposal(block, &blend_adapter).await;
+                                    Self::apply_and_publish_block_proposal(block, &chain_network_api, &blend_adapter).await;
                                 }
                                 Err(e) => {
                                     metrics::consensus_proposals_create_failed();
@@ -645,18 +653,20 @@ where
         Ok(block)
     }
 
-    /// Publish our own proposed block to the blend network.
-    async fn publish_block_proposal(
+    /// Apply our own proposed block to the chain and publish it to the blend
+    /// network.
+    async fn apply_and_publish_block_proposal(
         block: Block<Mempool::Item>,
+        chain_network_api: &ChainNetworkServiceApi<ChainNetwork, RuntimeServiceId>,
         blend_adapter: &BlendAdapter<BlendService>,
     ) {
-        // TODO: enable this once we elimnate sessions from Blend and so on
-        // Now we're disabling this to avoid a case which a proposing node
-        // transitions to a new session much earlier than other nodes.
-        debug!(
-            target: LOG_TARGET, header_id = ?block.header().id(),
-            "skipping self-applying block and just publishing it",
-        );
+        if let Err(e) = chain_network_api
+            .apply_block_and_reconcile_mempool(block.clone())
+            .await
+        {
+            error!(target: LOG_TARGET, "Failed to apply our own proposed block {:?}: {e:?}", block.header().id());
+            return;
+        }
 
         blend_adapter.publish_proposal(block.to_proposal()).await;
         metrics::consensus_proposals_created_local();

--- a/services/network/src/backends/libp2p/swarm/gossipsub.rs
+++ b/services/network/src/backends/libp2p/swarm/gossipsub.rs
@@ -70,14 +70,8 @@ impl<R: Clone + Send + RngCore + 'static> SwarmHandler<R> {
                     target: LOG_TARGET,
                     "Broadcasted message with id: {id} to topic: {topic}"
                 );
-                // self-notification because libp2p doesn't do it.
-                // Only do this on first attempt; if a previous attempt already
-                // injected the message locally due to InsufficientPeers, avoid
-                // notifying local subscribers twice.
-                // TODO: Remove this logic once we start re-applying blocks produced locally. In
-                // that case, we don't need to bubble this up since we have already applied the
-                // block before broadcasting it.
-                if retry_count == 0 && self.swarm.is_subscribed(&topic) {
+                // self-notification because libp2p doesn't do it
+                if self.swarm.is_subscribed(&topic) {
                     log_error!(self.pubsub_messages_tx.send(gossipsub::Message {
                         source: None,
                         data: message.into(),
@@ -87,21 +81,6 @@ impl<R: Clone + Send + RngCore + 'static> SwarmHandler<R> {
                 }
             }
             Err(gossipsub::PublishError::InsufficientPeers) if retry_count < MAX_RETRY => {
-                // TODO: Remove this logic once we start re-applying blocks produced locally. In
-                // that case, we don't need to bubble this up since we have already applied the
-                // block before broadcasting it. In single-node or transiently isolated setups,
-                // publish can fail with InsufficientPeers. Still surface the
-                // message locally once so higher layers can progress while
-                // retries continue for eventual dissemination.
-                if retry_count == 0 && self.swarm.is_subscribed(&topic) {
-                    log_error!(self.pubsub_messages_tx.send(gossipsub::Message {
-                        source: None,
-                        data: message.clone().into(),
-                        sequence_number: None,
-                        topic: topic_hash(&topic),
-                    }));
-                }
-
                 let wait = exp_backoff(retry_count);
                 tracing::trace!(
                     target: LOG_TARGET,


### PR DESCRIPTION
## 1. What does this PR implement?

Re-enable applying blocks before broadcasting them, and remove gossipsub workaround that is never meant to happen now, bringing the codebase state to where it was before self-applying blocks was skipped.

The PRs considered when this one was implemented are https://github.com/logos-blockchain/logos-blockchain/pull/2538 for re-introducing applying local blocks and for reverting the gossipsub workaround.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.