### PR TITLE
chore: check validity of generated deployment settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2050,7 +2050,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4238,6 +4238,7 @@ dependencies = [
  "logos-blockchain-key-management-system-keys",
  "logos-blockchain-node",
  "logos-blockchain-sdp-service",
+ "logos-blockchain-utils",
  "logos-blockchain-wallet-service",
  "multiaddr",
  "num-bigint",
@@ -4925,7 +4926,6 @@ dependencies = [
  "overwatch",
  "rand 0.8.6",
  "serde",
- "serde_ignored",
  "serde_json",
  "serde_urlencoded",
  "serde_with",
@@ -5173,6 +5173,7 @@ dependencies = [
  "logos-blockchain-http-api-common",
  "logos-blockchain-key-management-system-keys",
  "logos-blockchain-node",
+ "logos-blockchain-utils",
  "num-bigint",
  "serde",
  "serde_with",
@@ -5285,11 +5286,13 @@ dependencies = [
  "const-hex",
  "futures",
  "humantime",
+ "logos-blockchain-log-targets",
  "nistrs",
  "overwatch",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -5297,6 +5300,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -17,6 +17,7 @@ lb-groth16                    = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-node                       = { workspace = true }
 lb-sdp-service                = { workspace = true }
+lb-utils                      = { workspace = true }
 lb-wallet-service             = { workspace = true }
 log                           = { workspace = true }
 multiaddr                     = { workspace = true }

--- a/c-bindings/src/api/lifecycle.rs
+++ b/c-bindings/src/api/lifecycle.rs
@@ -3,12 +3,12 @@ use std::{ffi::c_char, path::PathBuf};
 use lb_node::{
     UserConfig,
     config::{
-        DeploymentType, OnUnknownKeys, RunConfig,
+        DeploymentType, RunConfig,
         deployment::{DeploymentSettings, WellKnownDeployment},
-        deserialize_config_at_path,
     },
     get_services_to_start, run_node_from_config,
 };
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use tokio::runtime::Runtime;
 
 use crate::{
@@ -103,11 +103,12 @@ fn get_user_config(config_path: *const c_char) -> StatusResult<UserConfig> {
             log::error!("Could not convert the config path to string: {e}");
             OperationStatus::InitializationError
         })?;
-    deserialize_config_at_path::<UserConfig>(user_config_path.as_ref(), OnUnknownKeys::Warn)
-        .map_err(|e| {
+    deserialize_value_at_path::<UserConfig>(user_config_path.as_ref(), OnUnknownKeys::Warn).map_err(
+        |e| {
             log::error!("Could not parse config file: {e}");
             OperationStatus::InitializationError
-        })
+        },
+    )
 }
 
 fn get_deployment_config(deployment_arg: *const c_char) -> StatusResult<DeploymentSettings> {
@@ -129,7 +130,7 @@ fn get_deployment_config(deployment_arg: *const c_char) -> StatusResult<Deployme
     match deployment_type {
         DeploymentType::WellKnown(well_known_deployment) => Ok(well_known_deployment.into()),
         DeploymentType::Custom(path) => {
-            deserialize_config_at_path::<DeploymentSettings>(path.as_ref(), OnUnknownKeys::Warn)
+            deserialize_value_at_path::<DeploymentSettings>(path.as_ref(), OnUnknownKeys::Warn)
                 .map_err(|e| {
                     log::error!("Could not parse deployment file: {e}");
                     OperationStatus::InitializationError

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -54,7 +54,6 @@ nutype                           = { features = ["serde"], workspace = true }
 overwatch                        = { workspace = true }
 rand                             = { workspace = true }
 serde                            = { workspace = true }
-serde_ignored                    = { workspace = true }
 serde_json                       = { workspace = true }
 serde_with                       = { workspace = true }
 serde_yaml                       = { workspace = true }

--- a/nodes/node/binary/src/cli/get_peer_id.rs
+++ b/nodes/node/binary/src/cli/get_peer_id.rs
@@ -1,15 +1,13 @@
 use color_eyre::eyre::Result;
 use lb_libp2p::ed25519;
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use libp2p::PeerId;
 
 use super::GetPeerIdArgs;
-use crate::{
-    UserConfig,
-    config::{OnUnknownKeys, deserialize_config_at_path},
-};
+use crate::UserConfig;
 
 pub fn run(args: &GetPeerIdArgs) -> Result<()> {
-    let user_config = deserialize_config_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
+    let user_config = deserialize_value_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
 
     let node_key = user_config.network.backend.swarm.node_key;
     let keypair = libp2p::identity::Keypair::from(ed25519::Keypair::from(node_key));

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -10,15 +10,15 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::Result;
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use libp2p::Multiaddr;
 
 use crate::{
     cli::keys::{AddKeyArgs, GenerateKeyArgs, RemoveKeyArgs},
     config::{
         ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
-        LogArgs, NetworkArgs, OnUnknownKeys, RunConfig, SdpArgs, StateArgs, UserConfig,
-        deserialize_config_at_path, update_api, update_blend, update_cryptarchia, update_network,
-        update_sdp, update_state, update_tracing,
+        LogArgs, NetworkArgs, RunConfig, SdpArgs, StateArgs, UserConfig, update_api, update_blend,
+        update_cryptarchia, update_network, update_sdp, update_state, update_tracing,
     },
 };
 
@@ -405,7 +405,7 @@ pub fn build_run_config(mut user_config: UserConfig, args: CliArgs) -> Result<Ru
     let deployment_settings = match deployment_args.deployment_type() {
         DeploymentType::WellKnown(well_known_deployment) => (*well_known_deployment).into(),
         DeploymentType::Custom(custom_deployment_config_path) => {
-            deserialize_config_at_path::<DeploymentSettings>(
+            deserialize_value_at_path::<DeploymentSettings>(
                 custom_deployment_config_path,
                 OnUnknownKeys::Warn,
             )?

--- a/nodes/node/binary/src/cli/participate.rs
+++ b/nodes/node/binary/src/cli/participate.rs
@@ -4,13 +4,14 @@ use color_eyre::eyre::{Result, bail, eyre};
 use lb_core::sdp::{Locator, Locators, ServiceType};
 use lb_key_management_system_service::keys::{Ed25519PublicKey, ZkPublicKey};
 use lb_libp2p::{Multiaddr, Protocol};
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use serde::Serialize;
 
 use super::ParticipateArgs;
 use crate::{
     UserConfig,
     cli::config::keystore::{KeyTitle, Keystore},
-    config::{OnUnknownKeys, deserialize_config_at_path, network::serde::nat},
+    config::network::serde::nat,
 };
 
 #[derive(Serialize)]
@@ -29,7 +30,7 @@ struct BlendParticipationData {
 }
 
 pub fn run(args: &ParticipateArgs) -> Result<()> {
-    let user_config = deserialize_config_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
+    let user_config = deserialize_value_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
 
     let keystore_yaml = std::fs::read_to_string(&args.keystore)?;
     let keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;

--- a/nodes/node/binary/src/config/deployment/mod.rs
+++ b/nodes/node/binary/src/config/deployment/mod.rs
@@ -5,12 +5,13 @@ use core::{
 };
 
 use lb_ledger::mantle::sdp::rewards::blend::RewardsParameters;
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_from_reader};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
-    OnUnknownKeys, blend::deployment::Settings as BlendDeploymentSettings,
+    blend::deployment::Settings as BlendDeploymentSettings,
     cryptarchia::deployment::Settings as CryptarchiaDeploymentSettings,
-    deserialize_config_from_reader, mempool::deployment::Settings as MempoolDeploymentSettings,
+    mempool::deployment::Settings as MempoolDeploymentSettings,
     network::deployment::Settings as NetworkDeploymentSettings,
     time::deployment::Settings as TimeDeploymentSettings,
 };
@@ -57,7 +58,7 @@ impl From<WellKnownDeployment> for DeploymentSettings {
     fn from(value: WellKnownDeployment) -> Self {
         match value {
             WellKnownDeployment::Devnet => {
-                deserialize_config_from_reader(devnet::SERIALIZED_DEPLOYMENT, OnUnknownKeys::Fail)
+                deserialize_value_from_reader(devnet::SERIALIZED_DEPLOYMENT, OnUnknownKeys::Fail)
                     .expect("Devnet deployment config is valid.")
             }
         }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -1,13 +1,11 @@
 use core::{convert::Infallible, str::FromStr};
 use std::{
     collections::HashSet,
-    io::Read,
     net::{IpAddr, SocketAddr, ToSocketAddrs as _},
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::Duration,
 };
 
-use ::tracing::warn;
 use clap::{Parser, ValueEnum, builder::OsStr};
 use color_eyre::eyre::{Result, eyre};
 use lb_core::sdp::ProviderId;
@@ -17,7 +15,6 @@ use lb_key_management_system_service::{
     keys::{Key, UnsecuredZkKey, ZkPublicKey},
 };
 use lb_libp2p::{Multiaddr, ed25519::SecretKey};
-use lb_log_targets::node;
 use lb_tracing::{
     filter::envfilter::{default_envfilter_config, parse_filter_directives},
     logging::local::{AppenderType, CompressionType, RetentionType, RollingConfig, RotationType},
@@ -46,8 +43,6 @@ use crate::config::{
         logger::{FileConfig, GelfConfig},
     },
 };
-
-const LOG_TARGET: &str = node::CONFIG;
 
 pub mod api;
 pub mod blend;
@@ -591,108 +586,6 @@ pub fn update_state(state: &mut StateConfig, args: StateArgs) {
 
     if let Some(path) = path {
         state.base_folder = path;
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum ConfigDeserializationError<Config> {
-    #[error("Unrecognized fields in config: {fields:?}")]
-    UnrecognizedFields { fields: Vec<String>, config: Config },
-    #[error(transparent)]
-    IoError(#[from] std::io::Error),
-    #[error(transparent)]
-    SerdeError(#[from] serde_yaml::Error),
-    #[error("YAML include error: {0}")]
-    IncludeError(String),
-}
-
-pub enum OnUnknownKeys {
-    Fail,
-    Warn,
-}
-
-impl<C> From<lb_utils::yaml::YamlIncludeError> for ConfigDeserializationError<C> {
-    fn from(e: lb_utils::yaml::YamlIncludeError) -> Self {
-        use lb_utils::yaml::YamlIncludeError as E;
-        match e {
-            E::Io(e) => Self::IoError(e),
-            E::Serde(e) => Self::SerdeError(e),
-            E::InvalidInclude(msg) => Self::IncludeError(msg),
-        }
-    }
-}
-
-pub fn deserialize_config_at_path<Config>(
-    config_path: &Path,
-    unknown_keys_strategy: OnUnknownKeys,
-) -> Result<Config, ConfigDeserializationError<Config>>
-where
-    Config: for<'de> Deserialize<'de>,
-{
-    let base_dir = config_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .to_path_buf();
-    let file = std::fs::File::open(config_path)?;
-    let raw: serde_yaml::Value = serde_yaml::from_reader(file)?;
-    let resolved = lb_utils::yaml::resolve_includes(raw, &base_dir)
-        .map_err(ConfigDeserializationError::from)?;
-    deserialize_from_value(resolved, unknown_keys_strategy)
-}
-
-fn deserialize_from_value<Config>(
-    value: serde_yaml::Value,
-    unknown_keys_strategy: OnUnknownKeys,
-) -> Result<Config, ConfigDeserializationError<Config>>
-where
-    Config: for<'de> Deserialize<'de>,
-{
-    use serde::de::IntoDeserializer as _;
-    let mut ignored_fields = Vec::new();
-    let config = serde_ignored::deserialize::<_, _, Config>(value.into_deserializer(), |path| {
-        ignored_fields.push(path.to_string());
-    })?;
-    apply_unknown_keys_strategy(config, ignored_fields, unknown_keys_strategy)
-}
-
-pub fn deserialize_config_from_reader<Config, Reader>(
-    reader: Reader,
-    unknown_keys_strategy: OnUnknownKeys,
-) -> Result<Config, ConfigDeserializationError<Config>>
-where
-    Config: for<'de> Deserialize<'de>,
-    Reader: Read,
-{
-    let mut ignored_fields = Vec::new();
-    let config = serde_ignored::deserialize::<_, _, Config>(
-        serde_yaml::Deserializer::from_reader(reader),
-        |path| {
-            ignored_fields.push(path.to_string());
-        },
-    )?;
-    apply_unknown_keys_strategy(config, ignored_fields, unknown_keys_strategy)
-}
-
-fn apply_unknown_keys_strategy<Config>(
-    config: Config,
-    ignored_fields: Vec<String>,
-    strategy: OnUnknownKeys,
-) -> Result<Config, ConfigDeserializationError<Config>> {
-    match (ignored_fields, strategy) {
-        (ignored_fields, _) if ignored_fields.is_empty() => Ok(config),
-        (ignored_fields, OnUnknownKeys::Warn) => {
-            warn!(
-                target: LOG_TARGET,
-                "The following unrecognized fields were found in the config: {ignored_fields:?}."
-            );
-            Ok(config)
-        }
-        (ignored_fields, OnUnknownKeys::Fail) => {
-            Err(ConfigDeserializationError::UnrecognizedFields {
-                fields: ignored_fields,
-                config,
-            })
-        }
     }
 }
 

--- a/nodes/node/binary/src/config/tests.rs
+++ b/nodes/node/binary/src/config/tests.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use lb_key_management_system_service::keys::ZkPublicKey;
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use tracing::Level;
 
 use crate::{
@@ -244,8 +245,7 @@ fn standalone_node_config_deserializes() {
     let parsed: Result<UserConfig, serde_yaml::Error> = serde_yaml::from_slice(&bytes);
     assert!(parsed.is_ok(), "standalone node config should deserialize");
 
-    let parsed =
-        super::deserialize_config_at_path::<UserConfig>(&yaml_path, super::OnUnknownKeys::Fail);
+    let parsed = deserialize_value_at_path::<UserConfig>(&yaml_path, OnUnknownKeys::Fail);
     assert!(
         parsed.is_ok(),
         "standalone node config should deserialize via loader, got: {:?}",
@@ -268,10 +268,7 @@ fn standalone_deployment_config_deserializes() {
         "standalone deployment config should deserialize"
     );
 
-    let parsed = super::deserialize_config_at_path::<DeploymentSettings>(
-        &yaml_path,
-        super::OnUnknownKeys::Fail,
-    );
+    let parsed = deserialize_value_at_path::<DeploymentSettings>(&yaml_path, OnUnknownKeys::Fail);
     assert!(
         parsed.is_ok(),
         "standalone deployment config should deserialize via loader, got: {:?}",

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -1,11 +1,10 @@
 use clap::Parser as _;
 use color_eyre::eyre::{Result, eyre};
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use logos_blockchain_node::{
     UserConfig,
     cli::{CliArgs, Command, build_run_config},
-    config::{
-        DeploymentType, OnUnknownKeys, deployment::DeploymentSettings, deserialize_config_at_path,
-    },
+    config::{DeploymentType, deployment::DeploymentSettings},
     get_services_to_start, run_node_from_config,
 };
 
@@ -55,13 +54,13 @@ async fn main() -> Result<()> {
     // configs are found or exit successfully if deserializations succeed.
     if is_dry_run {
         // Check user config.
-        drop(deserialize_config_at_path::<UserConfig>(
+        drop(deserialize_value_at_path::<UserConfig>(
             cli_args.config_path(),
             OnUnknownKeys::Fail,
         )?);
         // If custom, check deployment config.
         if let DeploymentType::Custom(custom_deployment_config_file) = cli_args.deployment_type() {
-            drop(deserialize_config_at_path::<DeploymentSettings>(
+            drop(deserialize_value_at_path::<DeploymentSettings>(
                 custom_deployment_config_file,
                 OnUnknownKeys::Fail,
             )?);
@@ -79,10 +78,10 @@ async fn main() -> Result<()> {
 
     let run_config = {
         let user_config =
-            deserialize_config_at_path::<UserConfig>(cli_args.config_path(), OnUnknownKeys::Warn)
+            deserialize_value_at_path::<UserConfig>(cli_args.config_path(), OnUnknownKeys::Warn)
                 .inspect_err(|e| {
-                eprintln!("\nExiting... {e}.\n");
-            })?;
+                    eprintln!("\nExiting... {e}.\n");
+                })?;
         build_run_config(user_config, cli_args)?
     };
 

--- a/tools/blockchain-tools/Cargo.toml
+++ b/tools/blockchain-tools/Cargo.toml
@@ -19,6 +19,7 @@ lb-groth16                    = { workspace = true }
 lb-http-api-common            = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-node                       = { workspace = true }
+lb-utils                      = { workspace = true }
 serde                         = { features = ["derive"], workspace = true }
 serde_with                    = { features = ["hex"], workspace = true }
 serde_yml                     = { workspace = true }

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -9,7 +9,8 @@ use lb_core::{
 };
 use lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody;
 use lb_key_management_system_keys::keys::ZkPublicKey;
-use lb_node::config::{OnUnknownKeys, UserConfig, deserialize_config_at_path};
+use lb_node::config::UserConfig;
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use serde::{Deserialize, de::IntoDeserializer as _};
 use url::Url;
 
@@ -130,7 +131,7 @@ async fn post_blend_declaration(
     }: PostBlendDeclarationArgs,
 ) -> Result<()> {
     let user_config =
-        deserialize_config_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Warn)
+        deserialize_value_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Warn)
             .with_context(|| {
                 format!(
                     "Failed to read user config at '{}'",

--- a/tools/blockchain-tools/src/bin/genesis.rs
+++ b/tools/blockchain-tools/src/bin/genesis.rs
@@ -1,3 +1,4 @@
+use core::fmt::Debug;
 use std::{
     fs,
     io::{self, Write as _},
@@ -15,6 +16,7 @@ use lb_core::{
     },
 };
 use lb_node::config::deployment::{DeploymentSettings, WellKnownDeployment};
+use lb_utils::yaml::{OnUnknownKeys, deserialize_value_from_reader};
 use logos_blockchain_tools::{
     genesis::{
         distribution::{self, Faucet, ProviderInfo, StakeHolderInfo},
@@ -260,6 +262,8 @@ fn run_ceremony(args: &CeremonyArgs) -> Result<()> {
     let faucet_patch = wrap_as_cryptarchia_faucet_pk(faucet_pk_value);
     let final_config = overwrite_yaml(config_value, faucet_patch);
 
+    ensure_valid_deployment_settings(&final_config)?;
+
     write_yaml(&final_config, args.output.as_deref())
 }
 
@@ -273,6 +277,8 @@ fn run_config(args: &ConfigArgs) -> Result<()> {
         let patch = resolve_override(raw)?;
         config = overwrite_yaml(config, patch);
     }
+
+    ensure_valid_deployment_settings(&config)?;
 
     write_yaml(&config, args.output.as_deref())
 }
@@ -465,10 +471,25 @@ fn struct_to_yaml_value<T: serde::Serialize>(value: &T) -> Result<Value> {
     serde_yml::from_str(&yaml_string).map_err(Into::into)
 }
 
-fn load_yaml_file<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+fn ensure_valid_deployment_settings(value: &Value) -> Result<()> {
+    let yaml = serde_yml::to_string(value)?;
+    drop(
+        deserialize_value_from_reader::<DeploymentSettings, _>(
+            yaml.as_bytes(),
+            OnUnknownKeys::Fail,
+        )
+        .context("generated config is not a valid DeploymentSettings value")?,
+    );
+    Ok(())
+}
+
+fn load_yaml_file<T>(path: &Path) -> Result<T>
+where
+    T: serde::de::DeserializeOwned + Send + Sync + Debug + 'static,
+{
     let content =
         fs::read_to_string(path).with_context(|| format!("cannot read '{}'", path.display()))?;
-    serde_yml::from_str(&content)
+    deserialize_value_from_reader(content.as_bytes(), OnUnknownKeys::Fail)
         .with_context(|| format!("cannot parse YAML from '{}'", path.display()))
 }
 

--- a/tools/blockchain-tools/src/genesis/distribution.rs
+++ b/tools/blockchain-tools/src/genesis/distribution.rs
@@ -12,7 +12,7 @@ use lb_key_management_system_keys::keys::{Ed25519PublicKey, ZkPublicKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct StakeHolderInfo {
     pub zk_id: ZkPublicKey,
     pub stake: NoteValue,

--- a/tools/blockchain-tools/src/genesis/inscription.rs
+++ b/tools/blockchain-tools/src/genesis/inscription.rs
@@ -12,7 +12,7 @@ use serde_with::{hex::Hex, serde_as};
 use time::OffsetDateTime;
 
 #[serde_as]
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug)]
 pub struct InscribeParams {
     pub chain_id: String,
     #[serde(with = "time::serde::iso8601")]

--- a/tracing/targets/src/node.rs
+++ b/tracing/targets/src/node.rs
@@ -3,7 +3,6 @@ use lb_log_targets_macros::log_targets;
 log_targets! {
     root = node;
 
-    CONFIG,
     api::{
         TRACING,
     },

--- a/tracing/targets/src/utils.rs
+++ b/tracing/targets/src/utils.rs
@@ -4,4 +4,5 @@ log_targets! {
     root = utils;
 
     RECOVERY,
+    YAML,
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,20 +13,23 @@ version     = { workspace = true }
 workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
-blake2      = { optional = true, workspace = true }
-cipher      = { workspace = true }
-const-hex   = { features = ["alloc"], workspace = true }
-futures     = { optional = true, workspace = true }
-humantime   = { optional = true, workspace = true }
-overwatch   = { workspace = true }
-rand        = { features = ["getrandom"], workspace = true }
-serde       = { features = ["alloc", "derive"], workspace = true }
-serde_with  = { optional = true, workspace = true }
-serde_yaml  = { workspace = true }
-thiserror   = { workspace = true }
-time        = { features = ["serde-human-readable"], optional = true, workspace = true }
-tokio       = { optional = true, workspace = true }
+async-trait    = { workspace = true }
+blake2         = { optional = true, workspace = true }
+cipher         = { workspace = true }
+const-hex      = { features = ["alloc"], workspace = true }
+futures        = { optional = true, workspace = true }
+humantime      = { optional = true, workspace = true }
+lb-log-targets = { workspace = true }
+overwatch      = { workspace = true }
+rand           = { features = ["getrandom"], workspace = true }
+serde          = { features = ["alloc", "derive"], workspace = true }
+serde_ignored  = { workspace = true }
+serde_with     = { optional = true, workspace = true }
+serde_yaml     = { workspace = true }
+thiserror      = { workspace = true }
+time           = { features = ["serde-human-readable"], optional = true, workspace = true }
+tokio          = { optional = true, workspace = true }
+tracing        = { workspace = true }
 
 [features]
 rng   = ["dep:blake2"]

--- a/utils/src/yaml.rs
+++ b/utils/src/yaml.rs
@@ -1,6 +1,103 @@
-use std::path::{Path, PathBuf};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
 
+use serde::Deserialize;
 use serde_yaml::Value;
+use tracing::warn;
+
+const LOG_TARGET: &str = lb_log_targets::utils::YAML;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ValueDeserializationError<Value> {
+    #[error("Unrecognized fields in value: {fields:?}")]
+    UnrecognizedFields { fields: Vec<String>, value: Value },
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    SerdeError(#[from] serde_yaml::Error),
+    #[error("YAML include error: {0}")]
+    IncludeError(String),
+}
+
+pub enum OnUnknownKeys {
+    Fail,
+    Warn,
+}
+
+pub fn deserialize_value_at_path<Value>(
+    path: &Path,
+    unknown_keys_strategy: OnUnknownKeys,
+) -> Result<Value, ValueDeserializationError<Value>>
+where
+    Value: for<'de> Deserialize<'de>,
+{
+    let base_dir = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let file = std::fs::File::open(path)?;
+    let raw: serde_yaml::Value = serde_yaml::from_reader(file)?;
+    let resolved = resolve_includes(raw, &base_dir).map_err(ValueDeserializationError::from)?;
+    deserialize_from_value(resolved, unknown_keys_strategy)
+}
+
+fn deserialize_from_value<Value>(
+    value: serde_yaml::Value,
+    unknown_keys_strategy: OnUnknownKeys,
+) -> Result<Value, ValueDeserializationError<Value>>
+where
+    Value: for<'de> Deserialize<'de>,
+{
+    use serde::de::IntoDeserializer as _;
+    let mut ignored_fields = Vec::new();
+    let value = serde_ignored::deserialize::<_, _, Value>(value.into_deserializer(), |path| {
+        ignored_fields.push(path.to_string());
+    })?;
+    apply_unknown_keys_strategy(value, ignored_fields, unknown_keys_strategy)
+}
+
+pub fn deserialize_value_from_reader<Value, Reader>(
+    reader: Reader,
+    unknown_keys_strategy: OnUnknownKeys,
+) -> Result<Value, ValueDeserializationError<Value>>
+where
+    Value: for<'de> Deserialize<'de>,
+    Reader: Read,
+{
+    let mut ignored_fields = Vec::new();
+    let value = serde_ignored::deserialize::<_, _, Value>(
+        serde_yaml::Deserializer::from_reader(reader),
+        |path| {
+            ignored_fields.push(path.to_string());
+        },
+    )?;
+    apply_unknown_keys_strategy(value, ignored_fields, unknown_keys_strategy)
+}
+
+fn apply_unknown_keys_strategy<Value>(
+    value: Value,
+    ignored_fields: Vec<String>,
+    strategy: OnUnknownKeys,
+) -> Result<Value, ValueDeserializationError<Value>> {
+    match (ignored_fields, strategy) {
+        (ignored_fields, _) if ignored_fields.is_empty() => Ok(value),
+        (ignored_fields, OnUnknownKeys::Warn) => {
+            warn!(
+                target: LOG_TARGET,
+                "The following unrecognized fields were found in the value: {ignored_fields:?}."
+            );
+            Ok(value)
+        }
+        (ignored_fields, OnUnknownKeys::Fail) => {
+            Err(ValueDeserializationError::UnrecognizedFields {
+                fields: ignored_fields,
+                value,
+            })
+        }
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum YamlIncludeError {
@@ -12,12 +109,23 @@ pub enum YamlIncludeError {
     InvalidInclude(String),
 }
 
+impl<Value> From<YamlIncludeError> for ValueDeserializationError<Value> {
+    fn from(e: YamlIncludeError) -> Self {
+        use YamlIncludeError as E;
+        match e {
+            E::Io(e) => Self::IoError(e),
+            E::Serde(e) => Self::SerdeError(e),
+            E::InvalidInclude(msg) => Self::IncludeError(msg),
+        }
+    }
+}
+
 /// Recursively resolves `!include <path>` tags in a YAML value.
 ///
 /// Paths are resolved relative to `base_dir`. Nested includes are supported
 /// (each included file's own includes resolve relative to that file's
 /// directory).
-pub fn resolve_includes(value: Value, base_dir: &Path) -> Result<Value, YamlIncludeError> {
+fn resolve_includes(value: Value, base_dir: &Path) -> Result<Value, YamlIncludeError> {
     match value {
         Value::Tagged(tagged) if tagged.tag == "include" => {
             let path_str = match &tagged.value {


### PR DESCRIPTION
## 1. What does this PR implement?

We do everything dynamically at the moment, so the specified patches and/or template file might include fields that are not valid for the deployment settings. At the very least, we check the generated deployment file is correct. There could be more static and dynamic checks we could run, but at the moment this is the only one I introduced.

I made the function that validates a deserializable type generic and moved it to `logos-blockchain-utils`, which explains the larger diff, but the core change are three lines added to the genesis binary in the tools folder.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.