### PR TITLE
chore(deployment): Move state dir env var from shell script to compose file

### DIFF
--- a/compose.run.yml
+++ b/compose.run.yml
@@ -60,6 +60,7 @@ services:
       - LOG_LEVEL=DEBUG
       - LOG_APPENDER=rolling-max-files
       - LOG_APPENDER_MAX_FILES=48
+      - STATE_PATH=/node-data/0/state
     ports:
       - "3000:3000/udp"
       - "3400:3400/udp"
@@ -83,6 +84,7 @@ services:
       - LOG_LEVEL=DEBUG
       - LOG_APPENDER=rolling-max-files
       - LOG_APPENDER_MAX_FILES=48
+      - STATE_PATH=/node-data/1/state
     ports:
       - "3001:3001/udp"
       - "3401:3401/udp"
@@ -106,6 +108,7 @@ services:
       - LOG_LEVEL=DEBUG
       - LOG_APPENDER=rolling-max-files
       - LOG_APPENDER_MAX_FILES=48
+      - STATE_PATH=/node-data/2/state
     ports:
       - "3002:3002/udp"
       - "3402:3402/udp"
@@ -129,6 +132,7 @@ services:
       - LOG_LEVEL=TRACE
       - LOG_APPENDER=rolling-max-files
       - LOG_APPENDER_MAX_FILES=48
+      - STATE_PATH=/node-data/3/state
     ports:
       - "3003:3003/udp"
       - "3403:3403/udp"

--- a/testnet/scripts/run_node.sh
+++ b/testnet/scripts/run_node.sh
@@ -7,7 +7,6 @@ export CFG_FILE_PATH="/node-data/${LB_HOST_IDX}/config.yaml" \
        CFG_HOST_IDENTIFIER="i-${LB_HOST_IDX}" \
        CFG_DEPLOYMENT_PATH="/node-data/cfgsync/deployment-settings.yaml" \
        LOG_BACKEND="file" \
-       LOG_DIR="/node-data/${LB_HOST_IDX}/" \
-       STATE_PATH="/node-data/${LB_HOST_IDX}/state"
+       LOG_DIR="/node-data/${LB_HOST_IDX}/"
 
 exec /usr/local/bin/logos-blockchain-node --deployment $CFG_DEPLOYMENT_PATH $CFG_FILE_PATH


### PR DESCRIPTION
Expose state directory environment variable to the compose.run.yaml file instead of setting it in the shell script.