### PR TITLE
chore: handle better deserialization issues in the utility function

### DIFF
--- a/c-bindings/src/api/lifecycle.rs
+++ b/c-bindings/src/api/lifecycle.rs
@@ -103,7 +103,7 @@ fn get_user_config(config_path: *const c_char) -> StatusResult<UserConfig> {
             log::error!("Could not convert the config path to string: {e}");
             OperationStatus::InitializationError
         })?;
-    deserialize_value_at_path::<UserConfig>(user_config_path.as_ref(), OnUnknownKeys::Warn).map_err(
+    deserialize_value_at_path::<UserConfig>(user_config_path.as_ref(), OnUnknownKeys::Fail).map_err(
         |e| {
             log::error!("Could not parse config file: {e}");
             OperationStatus::InitializationError
@@ -130,7 +130,7 @@ fn get_deployment_config(deployment_arg: *const c_char) -> StatusResult<Deployme
     match deployment_type {
         DeploymentType::WellKnown(well_known_deployment) => Ok(well_known_deployment.into()),
         DeploymentType::Custom(path) => {
-            deserialize_value_at_path::<DeploymentSettings>(path.as_ref(), OnUnknownKeys::Warn)
+            deserialize_value_at_path::<DeploymentSettings>(path.as_ref(), OnUnknownKeys::Fail)
                 .map_err(|e| {
                     log::error!("Could not parse deployment file: {e}");
                     OperationStatus::InitializationError

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -407,7 +407,7 @@ pub fn build_run_config(mut user_config: UserConfig, args: CliArgs) -> Result<Ru
         DeploymentType::Custom(custom_deployment_config_path) => {
             deserialize_value_at_path::<DeploymentSettings>(
                 custom_deployment_config_path,
-                OnUnknownKeys::Warn,
+                OnUnknownKeys::Fail,
             )?
         }
     };

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
 
     let run_config = {
         let user_config =
-            deserialize_value_at_path::<UserConfig>(cli_args.config_path(), OnUnknownKeys::Warn)
+            deserialize_value_at_path::<UserConfig>(cli_args.config_path(), OnUnknownKeys::Fail)
                 .inspect_err(|e| {
                     eprintln!("\nExiting... {e}.\n");
                 })?;

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -131,7 +131,7 @@ async fn post_blend_declaration(
     }: PostBlendDeclarationArgs,
 ) -> Result<()> {
     let user_config =
-        deserialize_value_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Warn)
+        deserialize_value_at_path::<UserConfig>(&user_config_path, OnUnknownKeys::Fail)
             .with_context(|| {
                 format!(
                     "Failed to read user config at '{}'",

--- a/utils/src/yaml.rs
+++ b/utils/src/yaml.rs
@@ -84,10 +84,14 @@ fn apply_unknown_keys_strategy<Value>(
     match (ignored_fields, strategy) {
         (ignored_fields, _) if ignored_fields.is_empty() => Ok(value),
         (ignored_fields, OnUnknownKeys::Warn) => {
-            warn!(
-                target: LOG_TARGET,
+            let message = format!(
                 "The following unrecognized fields were found in the value: {ignored_fields:?}."
             );
+            warn!(
+                target: LOG_TARGET,
+                message
+            );
+            eprintln!("{message}");
             Ok(value)
         }
         (ignored_fields, OnUnknownKeys::Fail) => {


### PR DESCRIPTION
## 1. What does this PR implement?

Built on top of https://github.com/logos-blockchain/logos-blockchain/pull/2859 cause it uses the generalized variant of the function to deserialize a YAML value. In general, in all places where we want to fail, we must use `OnUnknownKeys::Fail`, else the `Warn` variant will log a warning (now also print to stderr in case the logger is not initialized), but always returns `Ok`, which can be confusing.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.