### PR TITLE
feat(dumb-smart-mempool): loop block builder to add dependent txs

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -593,7 +593,7 @@ where
             .await
             .map_err(Error::FetchBlockTransactions)?;
 
-        let mut tx_stream: Pin<Box<_>> = Box::pin(txs_stream);
+        let tx_stream: Pin<Box<_>> = Box::pin(txs_stream);
 
         ledger_state = ledger_state
             .clone()
@@ -601,10 +601,7 @@ where
 
         // Collect all candidate transactions up front so the ones that fail can
         // be retried across multiple rounds.
-        let mut pending = Vec::new();
-        while let Some(tx) = tx_stream.next().await {
-            pending.push(tx);
-        }
+        let mut pending: Vec<_> = tx_stream.collect().await;
 
         let mut valid_txs = Vec::new();
 

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -645,7 +645,7 @@ where
 
         // Transactions that never became applicable are genuinely invalid against
         // this block's ledger state and can be evicted from the mempool.
-        let invalid_tx_hashes: Vec<_> = pending.iter().map(|tx| tx.hash()).collect();
+        let invalid_tx_hashes: Vec<_> = pending.iter().map(Transaction::hash).collect();
 
         if !invalid_tx_hashes.is_empty()
             && let Err(e) = relays

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -599,31 +599,53 @@ where
             .clone()
             .try_apply_header::<Groth16LeaderProof, HeaderId>(slot, &proof, ledger_config)?;
 
-        let mut valid_txs = Vec::new();
-        let mut invalid_tx_hashes = Vec::new();
-
+        // Collect all candidate transactions up front so the ones that fail can
+        // be retried across multiple rounds.
+        let mut pending = Vec::new();
         while let Some(tx) = tx_stream.next().await {
-            let tx_hash = tx.hash();
-            match ledger_state
-                .clone()
-                .try_apply_contents::<HeaderId, MainnetGasConstants>(
-                    ledger_config,
-                    iter::once(tx.clone()),
-                ) {
-                Ok((new_state, _events)) => {
-                    ledger_state = new_state;
-                    valid_txs.push(tx);
-                }
-                Err(err) => {
-                    tracing::debug!(
-                        "failed to apply tx {:?} during block assembly: {:?}",
-                        tx_hash,
-                        err
-                    );
-                    invalid_tx_hashes.push(tx_hash);
+            pending.push(tx);
+        }
+
+        let mut valid_txs = Vec::new();
+
+        // A transaction may only become valid once another transaction it depends
+        // on has already been applied. Repeatedly attempt to apply the pending
+        // transactions, retrying the full set of failures each round, while a
+        // round keeps adding new transactions to the block.
+        let mut applied_any = true;
+        while applied_any {
+            applied_any = false;
+            let mut still_pending = Vec::with_capacity(pending.len());
+
+            for tx in pending {
+                match ledger_state
+                    .clone()
+                    .try_apply_contents::<HeaderId, MainnetGasConstants>(
+                        ledger_config,
+                        iter::once(tx.clone()),
+                    ) {
+                    Ok((new_state, _events)) => {
+                        ledger_state = new_state;
+                        valid_txs.push(tx);
+                        applied_any = true;
+                    }
+                    Err(err) => {
+                        tracing::trace!(
+                            "tx {:?} not (yet) applicable during block assembly: {:?}",
+                            tx.hash(),
+                            err
+                        );
+                        still_pending.push(tx);
+                    }
                 }
             }
+
+            pending = still_pending;
         }
+
+        // Transactions that never became applicable are genuinely invalid against
+        // this block's ledger state and can be evicted from the mempool.
+        let invalid_tx_hashes: Vec<_> = pending.iter().map(|tx| tx.hash()).collect();
 
         if !invalid_tx_hashes.is_empty()
             && let Err(e) = relays


### PR DESCRIPTION
## 1. What does this PR implement?

A hacky first version of a smart mempool, we loop the block builder after every pass through the mempool tx set to try to include dependent txs as well.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ 

## 4. Is the specification accurate and complete?

NA

## 5. Does the implementation introduce changes in the specification?

NA

## Checklist

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
