### PR TITLE
test(sdp): tweak params for flaky activity e2e

### DIFF
--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -107,6 +107,7 @@ jobs:
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
           USE_LOCAL_HOST_NTP_TIME_CONFIG: true # Ensure tests use local NTP server for time sync
+          LOGOS_BLOCKCHAIN_NODE_BIN: ${{ github.workspace }}/target/release/logos-blockchain-node
         with:
           command: nextest
           args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --features mantle_sdp --test test_mantle_sdp_ops --test test_mantle_sdp_blend --no-fail-fast
@@ -129,6 +130,7 @@ jobs:
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
           USE_LOCAL_HOST_NTP_TIME_CONFIG: true # Ensure tests use local NTP server for time sync
+          LOGOS_BLOCKCHAIN_NODE_BIN: ${{ github.workspace }}/target/release/logos-blockchain-node
         with:
           command: nextest
           # - We don't test benches as they take 6h+, leading to a timeout

--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -107,7 +107,6 @@ jobs:
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
           USE_LOCAL_HOST_NTP_TIME_CONFIG: true # Ensure tests use local NTP server for time sync
-          LOGOS_BLOCKCHAIN_NODE_BIN: ${{ github.workspace }}/target/release/logos-blockchain-node
         with:
           command: nextest
           args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --features mantle_sdp --test test_mantle_sdp_ops --test test_mantle_sdp_blend --no-fail-fast
@@ -130,7 +129,6 @@ jobs:
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         env:
           USE_LOCAL_HOST_NTP_TIME_CONFIG: true # Ensure tests use local NTP server for time sync
-          LOGOS_BLOCKCHAIN_NODE_BIN: ${{ github.workspace }}/target/release/logos-blockchain-node
         with:
           command: nextest
           # - We don't test benches as they take 6h+, leading to a timeout

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -145,8 +145,9 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
         .scheduler
         .delayer
         .maximum_release_delay_in_rounds = 1.try_into().unwrap();
-    // Set num_blend_layers to NODE_COUNT to ensure that all nodes can collect
-    // a blend token from a single blend message.
+    // Set num_blend_layers to NODE_COUNT (instead of 1) to increase
+    // the probability that all nodes can collect a blend token from
+    // a single blend message.
     config.deployment.blend.common.num_blend_layers = (NODE_COUNT as u64).try_into().unwrap();
 
     config

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -107,12 +107,16 @@ const RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
 
 fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig {
     config.deployment.time.slot_duration = Duration::from_secs(1);
+
+    // Set the epoch length not too long to speed up the test,
+    // but also not too short because we want blend nodes to collect blend tokens
+    // every epoch to keep their declarations alive.
     config.deployment.cryptarchia.epoch_config = EpochConfig {
         epoch_stake_distribution_stabilization: 1.try_into().unwrap(),
         epoch_period_nonce_buffer: 1.try_into().unwrap(),
         epoch_period_nonce_stabilization: 1.try_into().unwrap(),
     };
-    config.deployment.cryptarchia.security_param = NonZero::new(2).unwrap();
+    config.deployment.cryptarchia.security_param = NonZero::new(4).unwrap();
     config.deployment.cryptarchia.slot_activation_coeff =
         NonNegativeRatio::new(1, 2.try_into().unwrap());
 
@@ -132,6 +136,18 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
         .expect("blend network params should exist");
     blend_params.inactivity_period = INACTIVITY_PERIOD;
     blend_params.retention_period = RETENTION_PERIOD;
+
+    // Shorten Blend delay to speed up the test
+    config
+        .deployment
+        .blend
+        .core
+        .scheduler
+        .delayer
+        .maximum_release_delay_in_rounds = 1.try_into().unwrap();
+    // Set num_blend_layers to NODE_COUNT to ensure that all nodes can collect a blend token
+    // from a single blend message.
+    config.deployment.blend.common.num_blend_layers = (NODE_COUNT as u64).try_into().unwrap();
 
     config
 }

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -145,8 +145,8 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
         .scheduler
         .delayer
         .maximum_release_delay_in_rounds = 1.try_into().unwrap();
-    // Set num_blend_layers to NODE_COUNT to ensure that all nodes can collect a blend token
-    // from a single blend message.
+    // Set num_blend_layers to NODE_COUNT to ensure that all nodes can collect
+    // a blend token from a single blend message.
     config.deployment.blend.common.num_blend_layers = (NODE_COUNT as u64).try_into().unwrap();
 
     config


### PR DESCRIPTION
## 1. What does this PR implement?

`sdp_blend_activity` was sometimes failing in macOS CI (slower than Linux) because it took much time until the tip reaches the target slot (because of blend hops and delays). 

This PR tweaks parameters to increase the epoch length, and shorten the blend hops and delay. I put detailed comments in the test explaining why these values were chosen.

I ran the test in macOS CI 3 times, and all passed successfully. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
