### PR TITLE
fix(mempool): reject oversized transactions

### DIFF
--- a/core/src/mantle/mock.rs
+++ b/core/src/mantle/mock.rs
@@ -8,7 +8,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{
     codec::SerializeOp as _,
-    mantle::{Transaction, TransactionHasher, TxHash},
+    mantle::{StorageSize, Transaction, TransactionHasher, TxHash},
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
@@ -44,6 +44,14 @@ impl<M: Serialize + DeserializeOwned + Clone> Transaction for MockTransaction<M>
 
     fn as_signing(&self) -> Vec<u8> {
         todo!()
+    }
+}
+
+impl<M: Serialize + DeserializeOwned + Clone> StorageSize for MockTransaction<M> {
+    fn storage_size(&self) -> usize {
+        self.to_bytes()
+            .expect("MockTransaction should be able to be serialized")
+            .len()
     }
 }
 

--- a/services/tx-service/src/backend/mod.rs
+++ b/services/tx-service/src/backend/mod.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 pub enum MempoolError {
     #[error("Item already in mempool")]
     ExistingItem,
+    #[error("Item is too large: {size} bytes exceeds maximum {max} bytes")]
+    ItemTooLarge { size: usize, max: usize },
     #[error("Storage operation failed: {0}")]
     StorageError(String),
     #[error(transparent)]

--- a/services/tx-service/src/tx/service.rs
+++ b/services/tx-service/src/tx/service.rs
@@ -13,7 +13,10 @@ use std::{
 };
 
 use futures::StreamExt as _;
-use lb_core::mantle::Transaction;
+use lb_core::{
+    block::MAX_BLOCK_SIZE,
+    mantle::{StorageSize, Transaction},
+};
 use lb_log_targets::mempool;
 use lb_network_service::{NetworkService, message::BackendNetworkMsg};
 use lb_services_utils::{
@@ -161,7 +164,7 @@ where
     Pool: MemPoolTrait<Storage = StorageAdapter> + RecoverableMempool + Send + Sync,
     StorageAdapter: MempoolStorageAdapter<RuntimeServiceId> + Clone + Send + Sync,
     <Pool as RecoverableMempool>::RecoveryState: Debug + Send + Sync,
-    Pool::Item: Transaction<Hash = Pool::Key> + Clone + Send + 'static,
+    Pool::Item: Transaction<Hash = Pool::Key> + StorageSize + Clone + Send + 'static,
     Pool::Settings: Clone + Sync + Send,
     NetworkAdapter:
         NetworkAdapterTrait<RuntimeServiceId, Payload = Pool::Item, Key = Pool::Key> + Send + Sync,
@@ -262,7 +265,7 @@ impl<Pool, NetworkAdapter, RecoveryBackend, StorageAdapter, RuntimeServiceId>
 where
     Pool: MemPoolTrait<Storage = StorageAdapter> + RecoverableMempool + Send + Sync,
     StorageAdapter: MempoolStorageAdapter<RuntimeServiceId> + Clone + Send + Sync,
-    Pool::Item: Transaction<Hash = Pool::Key> + Clone + Send + 'static,
+    Pool::Item: Transaction<Hash = Pool::Key> + StorageSize + Clone + Send + 'static,
     Pool::Settings: Clone,
     NetworkAdapter: NetworkAdapterTrait<RuntimeServiceId, Payload = Pool::Item> + Send + Sync,
     NetworkAdapter::Settings: Clone + Send + 'static,
@@ -372,6 +375,11 @@ where
         Pool::Settings: Send + Sync,
         NetworkAdapter::Settings: Send + Sync,
     {
+        if let Err(error) = Self::validate_item_for_mempool(&item) {
+            Self::handle_add_error(error, reply_channel);
+            return;
+        }
+
         let item_for_broadcast = item.clone();
 
         match pool.add_item(key, item).await {
@@ -504,6 +512,18 @@ where
         }
     }
 
+    fn validate_item_for_mempool(item: &Pool::Item) -> Result<(), MempoolError> {
+        let size = item.storage_size();
+        if size > MAX_BLOCK_SIZE {
+            return Err(MempoolError::ItemTooLarge {
+                size,
+                max: MAX_BLOCK_SIZE,
+            });
+        }
+
+        Ok(())
+    }
+
     async fn handle_network_item(
         pool: &mut Pool,
         key: Pool::Key,
@@ -513,21 +533,16 @@ where
         Pool::Settings: Send + Sync,
         NetworkAdapter::Settings: Send + Sync,
     {
+        if let Err(err) = Self::validate_item_for_mempool(&item) {
+            tracing::debug!(
+                target: LOG_TARGET,
+                "could not add network item to the pool due to: {err}"
+            );
+            return;
+        }
+
         if let Err(e) = pool.add_item(key, item).await {
-            match e {
-                MempoolError::ExistingItem => {
-                    tracing::trace!(
-                        target: LOG_TARGET,
-                        "network item already exists in the mempool"
-                    );
-                }
-                err => {
-                    tracing::debug!(
-                        target: LOG_TARGET,
-                        "could not add item to the pool due to: {err}"
-                    );
-                }
-            }
+            Self::handle_network_add_error(e);
             return;
         }
 
@@ -540,5 +555,22 @@ where
         );
 
         state_updater.update(Some(<Pool as RecoverableMempool>::save(pool).into()));
+    }
+
+    fn handle_network_add_error(error: MempoolError) {
+        match error {
+            MempoolError::ExistingItem => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    "network item already exists in the mempool"
+                );
+            }
+            err => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    "could not add item to the pool due to: {err}"
+                );
+            }
+        }
     }
 }

--- a/services/tx-service/tests/mock.rs
+++ b/services/tx-service/tests/mock.rs
@@ -9,6 +9,7 @@ use std::{
 use async_trait::async_trait;
 use futures::{Stream, StreamExt as _, stream};
 use lb_core::{
+    block::MAX_BLOCK_SIZE,
     codec::{DeserializeOp as _, SerializeOp as _},
     header::HeaderId,
     mantle::mock::{MockTransaction, MockTxId},
@@ -88,6 +89,77 @@ fn sample_removed_tx() -> MockTransaction<MockMessage> {
         version: 0,
         timestamp: 0,
     })
+}
+
+fn mock_pool_node_settings(
+    recovery_file_path: &Path,
+    predefined_messages: Vec<MockMessage>,
+) -> (MockPoolNodeServiceSettings, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let db_path = temp_dir.path().join("test_db");
+
+    (
+        MockPoolNodeServiceSettings {
+            network: NetworkConfig {
+                backend: MockConfig {
+                    predefined_messages,
+                    duration: tokio::time::Duration::from_millis(100),
+                    seed: 0,
+                    version: 1,
+                    weights: None,
+                },
+            },
+            storage: rocksdb::RocksBackendSettings {
+                db_path,
+                read_only: false,
+                column_family: None,
+            },
+            mockpool: TxMempoolSettings {
+                pool: (),
+                network_adapter: (),
+                recovery_path: recovery_file_path.to_path_buf(),
+            },
+            logging: TracingSettings::default(),
+            no_service: (),
+        },
+        temp_dir,
+    )
+}
+
+async fn add_tx(
+    mempool_outbound: &OutboundRelay<<MockMempoolService as ServiceData>::Message>,
+    tx: MockTransaction<MockMessage>,
+) -> Result<(), MempoolError> {
+    let (reply_channel, reply) = tokio::sync::oneshot::channel();
+    mempool_outbound
+        .send(MempoolMsg::Add {
+            key: tx.id(),
+            payload: tx,
+            reply_channel,
+        })
+        .await
+        .unwrap();
+
+    reply.await.expect("mempool should reply to local add")
+}
+
+async fn pending_txs(
+    mempool_outbound: &OutboundRelay<<MockMempoolService as ServiceData>::Message>,
+) -> Vec<MockTransaction<MockMessage>> {
+    let (reply_channel, reply) = tokio::sync::oneshot::channel();
+    mempool_outbound
+        .send(MempoolMsg::View {
+            ancestor_hint: [0; 32].into(),
+            reply_channel,
+        })
+        .await
+        .unwrap();
+
+    reply
+        .await
+        .expect("mempool should reply to view")
+        .collect::<Vec<_>>()
+        .await
 }
 
 #[derive(Clone, Default)]
@@ -323,7 +395,59 @@ async fn removed_items_remain_fetchable_after_recovery() {
 }
 
 #[test]
-#[expect(clippy::too_many_lines, reason = "self contained test")]
+fn local_submission_rejects_oversized_tx() {
+    let recovery_file_path = get_test_random_path();
+    run_with_recovery_teardown(&recovery_file_path, || {
+        let (settings, _temp_dir) = mock_pool_node_settings(&recovery_file_path, Vec::new());
+        let app = OverwatchRunner::<MockPoolNode>::run(settings, None)
+            .map_err(|e| eprintln!("Error encountered: {e}"))
+            .unwrap();
+
+        drop(
+            app.runtime()
+                .handle()
+                .block_on(app.handle().start_all_services()),
+        );
+
+        let mempool_outbound = app
+            .runtime()
+            .handle()
+            .block_on(async { app.handle().relay::<MockMempoolService>().await.unwrap() });
+
+        let oversized_tx = MockTransaction::new(MockMessage {
+            payload: "x".repeat(MAX_BLOCK_SIZE + 1),
+            content_topic: MOCK_TX_CONTENT_TOPIC,
+            version: 0,
+            timestamp: 0,
+        });
+
+        let error = app
+            .runtime()
+            .handle()
+            .block_on(add_tx(&mempool_outbound, oversized_tx))
+            .expect_err("oversized tx should be rejected");
+
+        assert!(matches!(
+            error,
+            MempoolError::ItemTooLarge {
+                size,
+                max: MAX_BLOCK_SIZE,
+            } if size > MAX_BLOCK_SIZE
+        ));
+
+        assert!(
+            app.runtime()
+                .handle()
+                .block_on(pending_txs(&mempool_outbound))
+                .is_empty()
+        );
+
+        drop(app.runtime().handle().block_on(app.handle().shutdown()));
+        app.blocking_wait_finished();
+    });
+}
+
+#[test]
 fn test_mock_mempool() {
     let recovery_file_path = get_test_random_path();
     run_with_recovery_teardown(&recovery_file_path, || {
@@ -347,32 +471,8 @@ fn test_mock_mempool() {
 
         let exp_txns: HashSet<MockMessage> = predefined_messages.iter().cloned().collect();
 
-        let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let db_path = temp_dir.path().join("test_db");
-
-        let settings = MockPoolNodeServiceSettings {
-            network: NetworkConfig {
-                backend: MockConfig {
-                    predefined_messages,
-                    duration: tokio::time::Duration::from_millis(100),
-                    seed: 0,
-                    version: 1,
-                    weights: None,
-                },
-            },
-            storage: rocksdb::RocksBackendSettings {
-                db_path,
-                read_only: false,
-                column_family: None,
-            },
-            mockpool: TxMempoolSettings {
-                pool: (),
-                network_adapter: (),
-                recovery_path: recovery_file_path.clone(),
-            },
-            logging: TracingSettings::default(),
-            no_service: (),
-        };
+        let (settings, _temp_dir) =
+            mock_pool_node_settings(&recovery_file_path, predefined_messages);
         let app = OverwatchRunner::<MockPoolNode>::run(settings, None)
             .map_err(|e| eprintln!("Error encountered: {e}"))
             .unwrap();


### PR DESCRIPTION
## 1. What does this PR implement?

Reject transactions larger than the maximum block body size at tx mempool admission.

This prevents individually unpublishable transactions from being stored in the mempool and later blocking block proposal selection.

The validation is applied to both local submissions and gossiped transactions. Oversized local submissions now return `MempoolError::ItemTooLarge`.

Added service-level coverage for oversized local submission rejection.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
