### PR TITLE
feat: new HTTP endpoint to join Blend as core node

### DIFF
--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -2,6 +2,7 @@ pub mod blend;
 pub mod locked_notes;
 
 use core::{
+    fmt::{self, Display, Formatter},
     ops::{Add, Sub},
     str::FromStr,
 };
@@ -157,6 +158,12 @@ impl FromStr for Locator {
             .map_err(|e| format!("Invalid multiaddr: {e}"))?;
         println!("Multiaddr: {multiaddr}");
         Self::try_from(multiaddr)
+    }
+}
+
+impl Display for Locator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -156,7 +156,6 @@ impl FromStr for Locator {
         let multiaddr = s
             .parse::<Multiaddr>()
             .map_err(|e| format!("Invalid multiaddr: {e}"))?;
-        println!("Multiaddr: {multiaddr}");
         Self::try_from(multiaddr)
     }
 }

--- a/nodes/api-common/src/bodies/blend.rs
+++ b/nodes/api-common/src/bodies/blend.rs
@@ -1,0 +1,8 @@
+use lb_core::{mantle::NoteId, sdp::Locator};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct JoinBlendRequestBody {
+    pub locator: Locator,
+    pub locked_note_id: NoteId,
+}

--- a/nodes/api-common/src/bodies/mod.rs
+++ b/nodes/api-common/src/bodies/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+pub mod blend;
 pub mod channel;
 pub mod wallet;
 

--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -6,6 +6,7 @@ pub const CRYPTARCHIA_HEADERS: &str = "/cryptarchia/headers";
 pub const CRYPTARCHIA_LIB_STREAM: &str = "/cryptarchia/lib-stream";
 pub const NETWORK_INFO: &str = "/network/info";
 pub const BLEND_NETWORK_INFO: &str = "/blend/info";
+pub const BLEND_JOIN_NETWORK: &str = "/blend/join";
 pub const MEMPOOL_ADD_TX: &str = "/mempool/add/tx";
 pub const CHANNEL: &str = "/channel/:id";
 pub const CHANNEL_DEPOSIT: &str = "/channel/deposit";

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -53,8 +53,8 @@ use crate::{
     BlendBroadcastSettings, BlendService, TracingService, WalletService,
     api::{
         handlers::{
-            channel, channel_deposit, leader_claim, post_activity, post_declaration,
-            post_set_declaration_id, post_withdrawal,
+            blend_join_network, channel, channel_deposit, leader_claim, post_activity,
+            post_declaration, post_set_declaration_id, post_withdrawal,
         },
         openapi::ApiDoc,
         tracing::reload_tracing_filter,
@@ -232,6 +232,12 @@ where
             .route(
                 paths::BLEND_NETWORK_INFO,
                 routing::get(blend_info::<BlendService, BlendBroadcastSettings, RuntimeServiceId>),
+            )
+            .route(
+                paths::BLEND_JOIN_NETWORK,
+                routing::post(
+                    blend_join_network::<BlendService, BlendBroadcastSettings, RuntimeServiceId>,
+                ),
             )
             .route(
                 paths::MEMPOOL_ADD_TX,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -32,6 +32,7 @@ use lb_core::{
 };
 use lb_http_api_common::{
     bodies::{
+        blend::JoinBlendRequestBody,
         channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
         wallet::{
             balance::WalletBalanceResponseBody,
@@ -596,12 +597,6 @@ where
     >(&handle))
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlendJoinNetworkRequestBody {
-    pub locator: lb_core::sdp::Locator,
-    pub locked_note_id: lb_core::mantle::NoteId,
-}
-
 #[utoipa::path(
     post,
     path = paths::BLEND_JOIN_NETWORK,
@@ -613,7 +608,7 @@ pub struct BlendJoinNetworkRequestBody {
 )]
 pub async fn blend_join_network<BlendService, BroadcastSettings, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
-    Json(req): Json<BlendJoinNetworkRequestBody>,
+    Json(req): Json<JoinBlendRequestBody>,
 ) -> Response
 where
     BlendService: ServiceData<

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -596,6 +596,41 @@ where
     >(&handle))
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlendJoinNetworkRequestBody {
+    pub locator: lb_core::sdp::Locator,
+    pub locked_note_id: lb_core::mantle::NoteId,
+}
+
+#[utoipa::path(
+    post,
+    path = paths::BLEND_JOIN_NETWORK,
+    request_body = BlendJoinNetworkRequestBody,
+    responses(
+        (status = 200, description = "Join the blend network", body = Option<lb_core::sdp::DeclarationId>),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
+pub async fn blend_join_network<BlendService, BroadcastSettings, RuntimeServiceId>(
+    State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+    Json(req): Json<BlendJoinNetworkRequestBody>,
+) -> Response
+where
+    BlendService: ServiceData<
+            Message = ProxyServiceMessage<
+                lb_blend_service::message::ServiceMessage<BroadcastSettings, PeerId>,
+            >,
+        > + 'static,
+    BroadcastSettings: Send + 'static,
+    RuntimeServiceId: Debug + Sync + Display + 'static + AsServiceId<BlendService>,
+{
+    make_request_and_return_response!(blend::blend_join_network::<
+        BlendService,
+        BroadcastSettings,
+        RuntimeServiceId,
+    >(&handle, req.locator, req.locked_note_id))
+}
+
 #[utoipa::path(
     post,
     path = paths::MEMPOOL_ADD_TX,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -17,6 +17,7 @@ use lb_api_service::http::{
     libp2p, mantle, mempool,
     storage::StorageAdapter,
 };
+use lb_blend_service::message::ProxyServiceMessage;
 use lb_chain_broadcast_service::BlockBroadcastService;
 use lb_chain_leader_service::api::ChainLeaderServiceData;
 use lb_chain_service::{ConsensusMsg, Slot, api::CryptarchiaServiceApi};
@@ -580,8 +581,11 @@ pub async fn blend_info<BlendService, BroadcastSettings, RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
 ) -> Response
 where
-    BlendService: ServiceData<Message = lb_blend_service::message::ServiceMessage<BroadcastSettings, PeerId>>
-        + 'static,
+    BlendService: ServiceData<
+            Message = ProxyServiceMessage<
+                lb_blend_service::message::ServiceMessage<BroadcastSettings, PeerId>,
+            >,
+        > + 'static,
     BroadcastSettings: Send + 'static,
     RuntimeServiceId: Debug + Sync + Display + 'static + AsServiceId<BlendService>,
 {

--- a/nodes/node/binary/src/generic_services/blend/mod.rs
+++ b/nodes/node/binary/src/generic_services/blend/mod.rs
@@ -67,6 +67,7 @@ pub type BlendEdgeService<RuntimeServiceId> = lb_blend_service::edge::BlendServi
 pub type BlendService<RuntimeServiceId> = lb_blend_service::BlendService<
     BlendCoreService<RuntimeServiceId>,
     BlendEdgeService<RuntimeServiceId>,
+    SdpService<RuntimeServiceId>,
     RuntimeServiceId,
 >;
 

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -542,7 +542,8 @@ impl CommonHttpClient {
         self.post(request_url, &body).await
     }
 
-    /// Post a request via an SDP declaration to join the blend network.
+    /// Post a request via an SDP declaration to join the blend network and
+    /// returns its declaration ID if successful.
     pub async fn join_blend_network(
         &self,
         base_url: &Url,

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -14,13 +14,17 @@ use lb_core::{
 use lb_groth16::fr_to_bytes;
 use lb_http_api_common::{
     MAX_BLOCKS_STREAM_BLOCKS, MAX_BLOCKS_STREAM_CHUNK_SIZE,
-    bodies::wallet::{
-        balance::WalletBalanceResponseBody,
-        transfer_funds::{WalletTransferFundsRequestBody, WalletTransferFundsResponseBody},
+    bodies::{
+        blend::JoinBlendRequestBody,
+        wallet::{
+            balance::WalletBalanceResponseBody,
+            transfer_funds::{WalletTransferFundsRequestBody, WalletTransferFundsResponseBody},
+        },
     },
     paths::{
-        BLOCK_EVENTS, BLOCKS, BLOCKS_DETAIL, BLOCKS_RANGE_STREAM, BLOCKS_STREAM, CHANNEL,
-        CRYPTARCHIA_INFO, CRYPTARCHIA_LIB_STREAM, MEMPOOL_ADD_TX, SDP_POST_DECLARATION,
+        BLEND_JOIN_NETWORK, BLOCK_EVENTS, BLOCKS, BLOCKS_DETAIL, BLOCKS_RANGE_STREAM,
+        BLOCKS_STREAM, CHANNEL, CRYPTARCHIA_INFO, CRYPTARCHIA_LIB_STREAM, MEMPOOL_ADD_TX,
+        SDP_POST_DECLARATION,
         wallet::{BALANCE, TRANSACTIONS_TRANSFER_FUNDS},
     },
     queries::BlocksStreamQuery,
@@ -533,6 +537,19 @@ impl CommonHttpClient {
     ) -> Result<WalletTransferFundsResponseBody, Error> {
         let request_url = base_url
             .join(TRANSACTIONS_TRANSFER_FUNDS.trim_start_matches('/'))
+            .map_err(Error::Url)?;
+
+        self.post(request_url, &body).await
+    }
+
+    /// Post a request via an SDP declaration to join the blend network.
+    pub async fn join_blend_network(
+        &self,
+        base_url: &Url,
+        body: JoinBlendRequestBody,
+    ) -> Result<DeclarationId, Error> {
+        let request_url = base_url
+            .join(BLEND_JOIN_NETWORK.trim_start_matches('/'))
             .map_err(Error::Url)?;
 
         self.post(request_url, &body).await

--- a/services/api/src/http/blend.rs
+++ b/services/api/src/http/blend.rs
@@ -26,3 +26,33 @@ where
         .await
         .map_err(|e| Box::new(e) as overwatch::DynError)
 }
+
+pub async fn blend_join_network<BlendService, BroadcastSettings, RuntimeServiceId>(
+    handle: &overwatch::overwatch::OverwatchHandle<RuntimeServiceId>,
+    locator: lb_core::sdp::Locator,
+    locked_note_id: lb_core::mantle::NoteId,
+) -> Result<lb_core::sdp::DeclarationId, overwatch::DynError>
+where
+    BlendService:
+        ServiceData<Message = ProxyServiceMessage<ServiceMessage<BroadcastSettings, PeerId>>>,
+    RuntimeServiceId: AsServiceId<BlendService> + Debug + Sync + Display + 'static,
+    BroadcastSettings: Send + 'static,
+{
+    let relay = handle.relay::<BlendService>().await?;
+    let (sender, receiver) = oneshot::channel();
+
+    relay
+        .send(ProxyServiceMessage::JoinAsCore {
+            locator,
+            locked_note_id,
+            reply: sender,
+        })
+        .await
+        .map_err(|(e, _)| e)?;
+
+    let result = receiver
+        .await
+        .map_err(|e| Box::new(e) as overwatch::DynError)??;
+
+    Ok(result)
+}

--- a/services/api/src/http/blend.rs
+++ b/services/api/src/http/blend.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use lb_blend_service::message::{NetworkInfo, ServiceMessage};
+use lb_blend_service::message::{NetworkInfo, ProxyServiceMessage, ServiceMessage};
 use lb_network_service::backends::libp2p::PeerId;
 use overwatch::services::{AsServiceId, ServiceData};
 use tokio::sync::oneshot;
@@ -9,7 +9,8 @@ pub async fn blend_info<BlendService, BroadcastSettings, RuntimeServiceId>(
     handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
 ) -> Result<Option<NetworkInfo<PeerId>>, overwatch::DynError>
 where
-    BlendService: ServiceData<Message = ServiceMessage<BroadcastSettings, PeerId>>,
+    BlendService:
+        ServiceData<Message = ProxyServiceMessage<ServiceMessage<BroadcastSettings, PeerId>>>,
     RuntimeServiceId: AsServiceId<BlendService> + Debug + Sync + Display + 'static,
     BroadcastSettings: Send + 'static,
 {
@@ -17,7 +18,7 @@ where
     let (sender, receiver) = oneshot::channel();
 
     relay
-        .send(ServiceMessage::GetNetworkInfo { reply: sender })
+        .send(ServiceMessage::GetNetworkInfo { reply: sender }.into())
         .await
         .map_err(|(e, _)| e)?;
 

--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -10,9 +10,17 @@ use futures::StreamExt as _;
 pub use lb_blend::message::{crypto::proofs::RealProofsVerifier, encap::ProofsVerifier};
 use lb_blend::scheduling::epoch::UninitializedEpochEventStream;
 use lb_chain_service::api::CryptarchiaServiceData;
-use lb_key_management_system_service::{api::KmsServiceApi, keys::PublicKeyEncoding};
+use lb_core::{
+    mantle::NoteId,
+    sdp::{DeclarationId, DeclarationMessage, Locator, ProviderId, ServiceType},
+};
+use lb_key_management_system_service::{
+    api::KmsServiceApi,
+    keys::{Ed25519PublicKey, PublicKeyEncoding, ZkPublicKey},
+};
 use lb_log_targets::blend;
 use lb_network_service::NetworkService;
+use lb_sdp_service::{SdpMessage, SdpServiceApi};
 use lb_services_utils::wait_until_services_are_ready;
 use lb_time_service::TimeService;
 use overwatch::{
@@ -40,6 +48,7 @@ use crate::{
         chain::BlendEpochState,
         node_id::{self, TryFrom as _},
     },
+    message::ProxyServiceMessage,
     settings::Settings,
 };
 
@@ -63,17 +72,17 @@ mod test_utils;
 
 const LOG_TARGET: &str = blend::service::ROOT;
 
-pub struct BlendService<CoreService, EdgeService, RuntimeServiceId>
+pub struct BlendService<CoreService, EdgeService, SdpService, RuntimeServiceId>
 where
     CoreService: ServiceData + CoreServiceComponents<RuntimeServiceId>,
     EdgeService: EdgeServiceComponents,
 {
     service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
-    _phantom: PhantomData<(CoreService, EdgeService)>,
+    _phantom: PhantomData<(CoreService, EdgeService, SdpService)>,
 }
 
-impl<CoreService, EdgeService, RuntimeServiceId> ServiceData
-    for BlendService<CoreService, EdgeService, RuntimeServiceId>
+impl<CoreService, EdgeService, SdpService, RuntimeServiceId> ServiceData
+    for BlendService<CoreService, EdgeService, SdpService, RuntimeServiceId>
 where
     CoreService: ServiceData + CoreServiceComponents<RuntimeServiceId>,
     EdgeService: EdgeServiceComponents,
@@ -84,12 +93,13 @@ where
     >;
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State>;
-    type Message = CoreService::Message;
+    type Message = ProxyServiceMessage<CoreService::Message>;
 }
 
+#[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
 #[async_trait]
-impl<CoreService, EdgeService, RuntimeServiceId> ServiceCore<RuntimeServiceId>
-    for BlendService<CoreService, EdgeService, RuntimeServiceId>
+impl<CoreService, EdgeService, SdpService, RuntimeServiceId> ServiceCore<RuntimeServiceId>
+    for BlendService<CoreService, EdgeService, SdpService, RuntimeServiceId>
 where
     CoreService: ServiceData<
             Message: MessageComponents<CoreService::NodeId, Payload: Into<Vec<u8>>>
@@ -117,6 +127,7 @@ where
             TimeBackend: lb_time_service::backends::TimeBackend + Send,
         > + Send
         + 'static,
+    SdpService: ServiceData<Message = SdpMessage> + Send,
     RuntimeServiceId: AsServiceId<Self>
         + AsServiceId<CoreService>
         + AsServiceId<EdgeService>
@@ -129,7 +140,8 @@ where
                 NetworkBackendOfService<CoreService, RuntimeServiceId>,
                 RuntimeServiceId,
             >,
-        > + Debug
+        > + AsServiceId<SdpService>
+        + Debug
         + Display
         + Clone
         + Send
@@ -166,13 +178,25 @@ where
         wait_until_services_are_ready!(
             &overwatch_handle,
             Some(Duration::from_mins(1)),
-            PreloadKmsService<_>
+            PreloadKmsService<_>,
+            SdpService
         )
         .await?;
+
+        let sdp_service_api =
+            SdpServiceApi::<SdpService>::from_overwatch_handle(overwatch_handle).await;
 
         let kms = KmsServiceApi::<PreloadKmsService<_>, RuntimeServiceId>::new(
             overwatch_handle.relay::<PreloadKmsService<_>>().await?,
         );
+
+        let PublicKeyEncoding::Zk(zk_public_key) = kms
+            .public_key(settings.core.zk.secret_key_kms_id.clone())
+            .await
+            .expect("ZK public key for provided ID should be stored in KMS.")
+        else {
+            panic!("Key with specified ID is not a ZK key.");
+        };
 
         let PublicKeyEncoding::Ed25519(non_ephemeral_signing_key_public) = kms
             .public_key(settings.common.non_ephemeral_signing_key_id)
@@ -249,13 +273,55 @@ where
                         .await?;
                 },
                 Some(message) = inbound_relay.next() => {
-                    if let Err(e) = instance.handle_inbound_message(message).await {
-                        error!(target: LOG_TARGET, "Failed to handle inbound message: {e:?}");
+                    match message {
+                        ProxyServiceMessage::JoinAsCore { locator, locked_note_id, reply } => {
+                            reply.send(
+                                submit_blend_sdp_declaration(
+                                    &sdp_service_api,
+                                    locator,
+                                    locked_note_id,
+                                    non_ephemeral_signing_key_public,
+                                    zk_public_key,
+                                )
+                                .await
+                            ).unwrap_or_else(|e| {
+                                debug!(target: LOG_TARGET, "Failed to send JoinAsCore reply: {e:?}");
+                            });
+                        },
+                        ProxyServiceMessage::Inner(inner_message) => {
+                            if let Err(e) = instance.handle_inbound_message(inner_message).await {
+                                error!(target: LOG_TARGET, "Failed to handle inbound message: {e:?}");
+                            }
+                        },
                     }
                 },
             }
         }
     }
+}
+
+async fn submit_blend_sdp_declaration<SdpService>(
+    sdp_service_api: &SdpServiceApi<SdpService>,
+    locator: Locator,
+    locked_note_id: NoteId,
+    non_ephemeral_signing_key_public: Ed25519PublicKey,
+    zk_id: ZkPublicKey,
+) -> Result<DeclarationId, lb_sdp_service::api::Error>
+where
+    SdpService: ServiceData<Message = SdpMessage>,
+{
+    tracing::info!(
+        target: LOG_TARGET,
+        "Submitting Blend service declaration to SDP with locator {locator:?} and locked note id {locked_note_id:?}",
+    );
+    let sdp_declaration = DeclarationMessage {
+        locators: [locator].into(),
+        locked_note_id,
+        provider_id: ProviderId(non_ephemeral_signing_key_public),
+        service_type: ServiceType::BlendNetwork,
+        zk_id,
+    };
+    sdp_service_api.post_declaration(sdp_declaration).await
 }
 
 type BroadcastSettings<CoreService, RuntimeServiceId> =

--- a/services/blend/src/message.rs
+++ b/services/blend/src/message.rs
@@ -1,6 +1,10 @@
 use core::fmt::{self, Debug, Formatter};
 
 use lb_blend::message::encap::validated::EncapsulatedMessageWithVerifiedPublicHeader;
+use lb_core::{
+    mantle::NoteId,
+    sdp::{DeclarationId, Locator},
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
@@ -19,6 +23,21 @@ pub struct CoreInfo<NodeId> {
     /// Negotiated peers for the old epoch, if an epoch transition is in
     /// progress.
     pub old_epoch_peers: Option<Vec<NodeId>>,
+}
+
+pub enum ProxyServiceMessage<InnerMessage> {
+    Inner(InnerMessage),
+    JoinAsCore {
+        locator: Locator,
+        locked_note_id: NoteId,
+        reply: oneshot::Sender<Result<DeclarationId, lb_sdp_service::api::Error>>,
+    },
+}
+
+impl<InnerMessage> From<InnerMessage> for ProxyServiceMessage<InnerMessage> {
+    fn from(value: InnerMessage) -> Self {
+        Self::Inner(value)
+    }
 }
 
 /// A message that is handled by [`BlendService`].

--- a/services/blend/src/service_components.rs
+++ b/services/blend/src/service_components.rs
@@ -11,8 +11,8 @@ pub trait ServiceComponents {
     type NodeId;
 }
 
-impl<CoreService, EdgeService, RuntimeServiceId> ServiceComponents
-    for BlendService<CoreService, EdgeService, RuntimeServiceId>
+impl<CoreService, EdgeService, SdpService, RuntimeServiceId> ServiceComponents
+    for BlendService<CoreService, EdgeService, SdpService, RuntimeServiceId>
 where
     CoreService: ServiceData + core::service_components::ServiceComponents<RuntimeServiceId>,
     EdgeService: ServiceData + edge::service_components::ServiceComponents,

--- a/services/chain/chain-leader/src/blend.rs
+++ b/services/chain/chain-leader/src/blend.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use lb_blend_service::message::{NetworkMessage, ServiceMessage};
+use lb_blend_service::message::{NetworkMessage, ProxyServiceMessage, ServiceMessage};
 use lb_chain_service_common::NetworkMessage as ChainNetworkMessage;
 use lb_core::{block::Proposal, codec::SerializeOp as _};
 use overwatch::services::{ServiceData, relay::OutboundRelay};
@@ -35,8 +35,11 @@ where
 
 impl<BlendService> BlendAdapter<BlendService>
 where
-    BlendService: ServiceData<Message = ServiceMessage<BlendService::BroadcastSettings, BlendService::NodeId>>
-        + lb_blend_service::ServiceComponents
+    BlendService: ServiceData<
+            Message = ProxyServiceMessage<
+                ServiceMessage<BlendService::BroadcastSettings, BlendService::NodeId>,
+            >,
+        > + lb_blend_service::ServiceComponents
         + Sync,
     <BlendService as ServiceData>::Message: Send,
     BlendService::BroadcastSettings: Clone + Sync,
@@ -44,12 +47,17 @@ where
     pub async fn publish_proposal(&self, proposal: Proposal) {
         if let Err((e, _)) = self
             .relay
-            .send(ServiceMessage::Blend(NetworkMessage {
-                message: ChainNetworkMessage::to_bytes(&ChainNetworkMessage::Proposal(proposal))
+            .send(
+                ServiceMessage::Blend(NetworkMessage {
+                    message: ChainNetworkMessage::to_bytes(&ChainNetworkMessage::Proposal(
+                        proposal,
+                    ))
                     .expect("NetworkMessage should be able to be serialized")
                     .to_vec(),
-                broadcast_settings: self.broadcast_settings.clone(),
-            }))
+                    broadcast_settings: self.broadcast_settings.clone(),
+                })
+                .into(),
+            )
             .await
         {
             error!(target: LOG_TARGET, "Failed to relay proposal to blend service: {e:?}");

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -229,9 +229,11 @@ impl<
     >
 where
     BlendService: ServiceData<
-            Message = lb_blend_service::message::ServiceMessage<
-                BlendService::BroadcastSettings,
-                BlendService::NodeId,
+            Message = lb_blend_service::message::ProxyServiceMessage<
+                lb_blend_service::message::ServiceMessage<
+                    BlendService::BroadcastSettings,
+                    BlendService::NodeId,
+                >,
             >,
         > + lb_blend_service::ServiceComponents<NodeId: Send + Sync>
         + Send
@@ -521,9 +523,11 @@ impl<
     >
 where
     BlendService: ServiceData<
-            Message = lb_blend_service::message::ServiceMessage<
-                BlendService::BroadcastSettings,
-                BlendService::NodeId,
+            Message = lb_blend_service::message::ProxyServiceMessage<
+                lb_blend_service::message::ServiceMessage<
+                    BlendService::BroadcastSettings,
+                    BlendService::NodeId,
+                >,
             >,
         > + lb_blend_service::ServiceComponents<NodeId: Send + Sync>
         + Send

--- a/tests/cucumber_tests/features/blend.feature
+++ b/tests/cucumber_tests/features/blend.feature
@@ -35,3 +35,19 @@ Feature: Blend
     Then all nodes have at least 10 blocks and converged to within 1 blocks in 360 seconds
     And all nodes agree on LIB in 300 seconds
     Then I stop all nodes
+
+  @blend_ci
+  Scenario: Join Blend via API declaration
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 1           | 2000         |
+    And I have a cluster with capacity of 1 nodes
+    And no nodes are declared as blend providers
+    And I start nodes with wallet resources:
+      | node_name | account_index | wallet_name | connected_to |
+      | NODE_1    | 1             | WALLET_1A   |              |
+    When all nodes have at least 2 blocks and converged to within 1 blocks in 180 seconds
+    And I send 1 transactions of 1000 LGO each from wallet "WALLET_1A" to blend core zk key of node "NODE_1"
+    Then I declare node "NODE_1" as blend core node via the API
+    And blend core SDP declaration for node "NODE_1" is included on node "NODE_1"
+    And I stop all nodes

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -40,7 +40,10 @@ use crate::{
                 create_and_submit_transaction_hashes, wait_for_transactions_inclusion,
             },
         },
-        utils::{blend_core_zk_pk_from_node_yaml, resolve_literal_or_env},
+        utils::{
+            blend_core_locator_from_node_yaml, blend_core_zk_pk_from_node_yaml,
+            resolve_literal_or_env,
+        },
         world::{
             CucumberWorld, GenesisTokens, ManualClusterKind, ManualClusterSpec, NodeSnapshot,
             PublicCryptarchiaEndpointPeer,
@@ -1168,6 +1171,76 @@ async fn step_run_blend_sdp_declaration_cli(
             ),
         });
     }
+
+    Ok(())
+}
+
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Required to be mutable by cucumber step function signature"
+)]
+#[then(expr = "I declare node {string} as blend core node via the API")]
+async fn step_run_blend_sdp_declaration_api(
+    world: &mut CucumberWorld,
+    step: &Step,
+    declarer_node_name: String,
+) -> StepResult {
+    let user_config_path = node_user_config_path(world, &declarer_node_name)?;
+    let locator = blend_core_locator_from_node_yaml(&user_config_path)?;
+    let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
+
+    let declarer_node_client = world
+        .nodes_info
+        .get(&declarer_node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node '{declarer_node_name}' not found in world state"),
+        })?
+        .started_node
+        .client
+        .clone();
+    let declarer_api_base_url = declarer_node_client.base_url().clone();
+
+    // Wait for the funded note locked on the Blend ZK key, querying the same
+    // node API that will process the join request.
+    let note_lookup_timeout = Duration::from_secs(30);
+    let note_lookup_started = Instant::now();
+    let mut last_lookup_error: Option<String>;
+    let locked_note_id = loop {
+        let Ok(wallet_balance) = CommonHttpClient::new(None)
+            .get_wallet_balance(declarer_api_base_url.clone(), blend_zk_pk, None)
+            .await
+        else {
+            continue;
+        };
+        if let Some(note_id) = wallet_balance.notes.keys().next().copied() {
+            break note_id;
+        }
+        last_lookup_error = Some("wallet has no notes yet".to_owned());
+
+        if note_lookup_started.elapsed() >= note_lookup_timeout {
+            return Err(StepError::Timeout {
+                message: format!(
+                    "Timed out waiting for a funded note on Blend ZK key of '{declarer_node_name}' via '{}' (last error: {})",
+                    declarer_api_base_url,
+                    last_lookup_error.unwrap_or_else(|| "unknown".to_owned())
+                ),
+            });
+        }
+
+        sleep(Duration::from_millis(250)).await;
+    };
+
+    let declaration_id = declarer_node_client
+        .join_blend_network(locator, locked_note_id)
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
+
+    info!(
+        target: TARGET,
+        "Node '{declarer_node_name}' joined blend core via API, declaration id: {declaration_id}"
+    );
 
     Ok(())
 }

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1094,6 +1094,7 @@ async fn step_run_blend_sdp_declaration_cli(
     declarer_node_name: String,
 ) -> StepResult {
     let user_config_path = node_user_config_path(world, &declarer_node_name)?;
+    let locator = blend_core_locator_from_node_yaml(&user_config_path)?;
     let blend_zk_pk = blend_zk_pk_for_node(world, &declarer_node_name)?;
 
     let declarer_api_base_url = world
@@ -1155,6 +1156,8 @@ async fn step_run_blend_sdp_declaration_cli(
         .arg("post-blend-declaration")
         .arg("--user-config-path")
         .arg(user_config_path)
+        .arg("--blend-addr")
+        .arg(format!("{locator}"))
         .arg("--locked-note-id")
         .arg(locked_note_id)
         .arg("--node-address")

--- a/tests/src/cucumber/utils.rs
+++ b/tests/src/cucumber/utils.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use hex::ToHex as _;
-use lb_core::codec::SerializeOp as _;
+use lb_core::{codec::SerializeOp as _, sdp::Locator};
 use lb_libp2p::{PeerId, identity, identity::ed25519};
 use lb_node::UserConfig;
 use lb_testing_framework::{CoreBuilderExt as _, ScenarioBuilder};
@@ -190,6 +190,26 @@ pub fn blend_core_zk_pk_from_node_yaml(path: &Path) -> Result<String, StepError>
     let config = user_config_from_node_yaml(path)?;
     let (zk_key_id, _) = config.blend_zk_key().map_err(StepError::UserConfigError)?;
     Ok(zk_key_id)
+}
+
+/// Reads a node YAML user config file and extracts the configured Blend core
+/// listening address as an SDP [`Locator`].
+pub fn blend_core_locator_from_node_yaml(path: &Path) -> Result<Locator, StepError> {
+    let config = user_config_from_node_yaml(path)?;
+    config
+        .blend
+        .core
+        .backend
+        .listening_address
+        .clone()
+        .try_into()
+        .map_err(|_| StepError::LogicalError {
+            message: format!(
+                "Blend listening address '{:?}' from '{}' is not a valid locator",
+                config.blend.core.backend.listening_address,
+                path.display()
+            ),
+        })
 }
 
 /// Extracts the child directory name that starts with a known prefix,

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -12,12 +12,13 @@ use lb_core::{
     sdp::{Declaration, DeclarationId, Locator},
 };
 use lb_http_api_common::{
-    bodies::wallet::transfer_funds::{
-        WalletTransferFundsRequestBody, WalletTransferFundsResponseBody,
+    bodies::{
+        blend::JoinBlendRequestBody,
+        wallet::transfer_funds::{WalletTransferFundsRequestBody, WalletTransferFundsResponseBody},
     },
     paths::{
-        BLEND_JOIN_NETWORK, BLEND_NETWORK_INFO, DIAL_PEER, MANTLE_METRICS, MANTLE_SDP_DECLARATIONS,
-        MEMPOOL_VIEW, NETWORK_INFO,
+        BLEND_NETWORK_INFO, DIAL_PEER, MANTLE_METRICS, MANTLE_SDP_DECLARATIONS, MEMPOOL_VIEW,
+        NETWORK_INFO,
     },
     queries::BlocksStreamQuery,
 };
@@ -77,26 +78,6 @@ impl NodeHttpClient {
 
         self.http_client
             .get::<(), Option<BlendNetworkInfo<PeerId>>>(request_url, None)
-            .await
-    }
-
-    /// Requests that the node join the Blend network as a core node by posting
-    /// an SDP declaration for its Blend ZK identity.
-    pub async fn join_blend_network(
-        &self,
-        locator: Locator,
-        locked_note_id: NoteId,
-    ) -> Result<DeclarationId, Error> {
-        let request_url = Self::join_path(&self.base_url, BLEND_JOIN_NETWORK)?;
-
-        self.http_client
-            .post::<_, DeclarationId>(
-                request_url,
-                &JoinBlendNetworkRequestBody {
-                    locator,
-                    locked_note_id,
-                },
-            )
             .await
     }
 
@@ -196,15 +177,25 @@ impl NodeHttpClient {
             .join(path.trim_start_matches('/'))
             .map_err(Error::Url)
     }
+
+    pub async fn join_blend_network(
+        &self,
+        locator: Locator,
+        locked_note_id: NoteId,
+    ) -> Result<DeclarationId, Error> {
+        self.http_client
+            .join_blend_network(
+                &self.base_url,
+                JoinBlendRequestBody {
+                    locator,
+                    locked_note_id,
+                },
+            )
+            .await
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct DialPeerRequestBody {
     addr: Multiaddr,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct JoinBlendNetworkRequestBody {
-    locator: Locator,
-    locked_note_id: NoteId,
 }

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -8,16 +8,16 @@ use lb_blend_service::message::NetworkInfo as BlendNetworkInfo;
 use lb_chain_service::ChainServiceInfo;
 use lb_core::{
     header::HeaderId,
-    mantle::{SignedMantleTx, TxHash},
-    sdp::Declaration,
+    mantle::{NoteId, SignedMantleTx, TxHash},
+    sdp::{Declaration, DeclarationId, Locator},
 };
 use lb_http_api_common::{
     bodies::wallet::transfer_funds::{
         WalletTransferFundsRequestBody, WalletTransferFundsResponseBody,
     },
     paths::{
-        BLEND_NETWORK_INFO, DIAL_PEER, MANTLE_METRICS, MANTLE_SDP_DECLARATIONS, MEMPOOL_VIEW,
-        NETWORK_INFO,
+        BLEND_JOIN_NETWORK, BLEND_NETWORK_INFO, DIAL_PEER, MANTLE_METRICS, MANTLE_SDP_DECLARATIONS,
+        MEMPOOL_VIEW, NETWORK_INFO,
     },
     queries::BlocksStreamQuery,
 };
@@ -77,6 +77,26 @@ impl NodeHttpClient {
 
         self.http_client
             .get::<(), Option<BlendNetworkInfo<PeerId>>>(request_url, None)
+            .await
+    }
+
+    /// Requests that the node join the Blend network as a core node by posting
+    /// an SDP declaration for its Blend ZK identity.
+    pub async fn join_blend_network(
+        &self,
+        locator: Locator,
+        locked_note_id: NoteId,
+    ) -> Result<DeclarationId, Error> {
+        let request_url = Self::join_path(&self.base_url, BLEND_JOIN_NETWORK)?;
+
+        self.http_client
+            .post::<_, DeclarationId>(
+                request_url,
+                &JoinBlendNetworkRequestBody {
+                    locator,
+                    locked_note_id,
+                },
+            )
             .await
     }
 
@@ -181,4 +201,10 @@ impl NodeHttpClient {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct DialPeerRequestBody {
     addr: Multiaddr,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct JoinBlendNetworkRequestBody {
+    locator: Locator,
+    locked_note_id: NoteId,
 }

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -145,7 +145,7 @@ async fn post_blend_declaration(
 
     validate_config_values(&client, node_address.clone(), &user_config, locked_note_id)
         .await
-        .with_context(|| "Failed to extract necessary values from user config")?;
+        .with_context(|| "Failed to validate values from user config")?;
 
     let declaration_id = client
         .join_blend_network(

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -56,17 +56,14 @@ impl CliCommand {
 
 #[derive(Debug, Subcommand)]
 enum SdpSubCommand {
-    /// Post a Blend SDP declaration using values extracted from the user
-    /// config.
+    /// Post a Blend SDP declaration using the specified locator address and ID
+    /// of a note to lock.
     ///
-    /// The command derives the following from `--user-config-path`:
-    /// - `provider_id` (from Blend non-ephemeral signing key)
-    /// - `zk_id` (from Blend core ZK key)
-    /// - `locator` (from Blend core listening address, unless overridden by
-    ///   `--blend-addr`)
     ///
-    /// It then validates that `--locked-note-id` exists for that ZK key before
-    /// submitting the declaration.
+    /// The command validates that:
+    /// - the SDP funding key has non-zero balance
+    /// - `--locked-note-id` exists for the Blend ZK key before submitting the
+    ///   declaration.
     PostBlendDeclaration(PostBlendDeclarationArgs),
 }
 
@@ -84,11 +81,10 @@ struct PostBlendDeclarationArgs {
     #[arg(long, value_name = "USER_CONFIG_YAML")]
     user_config_path: PathBuf,
 
-    /// Address of the Blend service to use in the declaration that overrides
-    /// the one present in the config file. This is useful for the case in which
-    /// a node is listening on the `0.0.0.0` address, and the declaration needs
-    /// to be posted with the externally reachable address, since `0.0.0.0` is
-    /// not a valid `Locator` value.
+    /// Address of the Blend service to include in the declaration.
+    ///
+    /// This must be externally reachable, because listening addresses such as
+    /// `0.0.0.0` are not valid `Locator` values for declarations.
     #[arg(long, value_name = "BLEND_ADDR")]
     blend_addr: Locator,
 
@@ -208,8 +204,8 @@ async fn verify_sdp_wallet_funding_pk_balance(
         .await
         .context("Failed to fetch wallet balance for SDP wallet funding pk.")?;
 
-    // TODO: Improve check to verify that the balance is not only non-zero, but also
-    // sufficient to cover the tx fees.
+    // TODO: Strengthen this preflight check to verify fee sufficiency, not only
+    // non-zero balance.
     if balance == 0 {
         bail!("The provided SDP wallet funding key does not have any balance");
     }

--- a/tools/blockchain-tools/src/bin/api.rs
+++ b/tools/blockchain-tools/src/bin/api.rs
@@ -3,11 +3,10 @@ use std::path::PathBuf;
 use anyhow::{Context as _, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use lb_common_http_client::{BasicAuthCredentials, CommonHttpClient};
-use lb_core::{
-    mantle::NoteId,
-    sdp::{DeclarationMessage, Locator, ProviderId, ServiceType},
+use lb_core::{mantle::NoteId, sdp::Locator};
+use lb_http_api_common::bodies::{
+    blend::JoinBlendRequestBody, wallet::balance::WalletBalanceResponseBody,
 };
-use lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody;
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_node::config::UserConfig;
 use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
@@ -91,7 +90,7 @@ struct PostBlendDeclarationArgs {
     /// to be posted with the externally reachable address, since `0.0.0.0` is
     /// not a valid `Locator` value.
     #[arg(long, value_name = "BLEND_ADDR")]
-    blend_addr: Option<Locator>,
+    blend_addr: Locator,
 
     /// Note ID to lock for the Blend declaration (HEX-encoded field element).
     #[arg(long, value_name = "NOTE_ID_HEX", value_parser = parse_hex_serde::<NoteId>)]
@@ -144,92 +143,41 @@ async fn post_blend_declaration(
         CommonHttpClient::new(credentials)
     };
 
-    let ExtractedUserConfigValues {
-        provider_id,
-        zk_id,
-        locked_note_id,
-        locator,
-    } = extract_values(
-        &client,
-        node_address.clone(),
-        &user_config,
-        locked_note_id,
-        blend_addr,
-    )
-    .await
-    .with_context(|| "Failed to extract necessary values from user config")?;
-
-    let declaration = DeclarationMessage {
-        locators: locator.into(),
-        locked_note_id,
-        provider_id,
-        service_type: ServiceType::BlendNetwork,
-        zk_id,
-    };
+    validate_config_values(&client, node_address.clone(), &user_config, locked_note_id)
+        .await
+        .with_context(|| "Failed to extract necessary values from user config")?;
 
     let declaration_id = client
-        .post_declaration(node_address, &declaration)
+        .join_blend_network(
+            &node_address,
+            JoinBlendRequestBody {
+                locator: blend_addr,
+                locked_note_id,
+            },
+        )
         .await
-        .context("Failed to post declaration")?;
+        .context("Failed to post Blend join network declaration")?;
 
     println!("Declaration posted successfully: {declaration_id}");
     Ok(())
 }
 
-struct ExtractedUserConfigValues {
-    provider_id: ProviderId,
-    zk_id: ZkPublicKey,
-    locked_note_id: NoteId,
-    locator: Locator,
-}
-
-async fn extract_values(
+async fn validate_config_values(
     client: &CommonHttpClient,
     node_address: Url,
     config: &UserConfig,
     locked_note_id: NoteId,
-    blend_address: Option<Locator>,
-) -> Result<ExtractedUserConfigValues> {
-    // Keep all config-derived declaration fields in one place so the CLI and
-    // node service remain aligned on identity/key source semantics.
-    let locator = if let Some(blend_address) = blend_address {
-        blend_address
-    } else {
-        extract_blend_locator(config)?
-    };
-
-    let provider_id = config
-        .blend_provider_id()
-        .map_err(|e| anyhow!(e))
-        .with_context(|| "Failed to extract provider ID from provided config.")?;
+) -> Result<()> {
+    let sdp_wallet_funding_pk = config.sdp.wallet.funding_pk;
+    verify_sdp_wallet_funding_pk_balance(client, node_address.clone(), sdp_wallet_funding_pk)
+        .await
+        .context("Failed to verify balance for SDP wallet funding key")?;
 
     let zk_id = extract_blend_zk_key(config)?;
 
     verify_locked_note_id_value(client, node_address, zk_id, locked_note_id).await?;
 
-    Ok(ExtractedUserConfigValues {
-        provider_id,
-        zk_id,
-        locked_note_id,
-        locator,
-    })
-}
-
-// Validate and return the Blend listening address from the provided config.
-fn extract_blend_locator(config: &UserConfig) -> Result<Locator> {
-    config
-        .blend
-        .core
-        .backend
-        .listening_address
-        .clone()
-        .try_into()
-        .map_err(|_| {
-            anyhow!(
-                "Blend listening address '{:?}' from config is not a valid locator",
-                config.blend.core.backend.listening_address
-            )
-        })
+    Ok(())
 }
 
 fn extract_blend_zk_key(config: &UserConfig) -> Result<ZkPublicKey> {
@@ -248,6 +196,25 @@ fn extract_blend_zk_key(config: &UserConfig) -> Result<ZkPublicKey> {
         );
     }
     Ok(zk_public_key)
+}
+
+async fn verify_sdp_wallet_funding_pk_balance(
+    client: &CommonHttpClient,
+    node_address: Url,
+    funding_pk: ZkPublicKey,
+) -> Result<()> {
+    let WalletBalanceResponseBody { balance, .. } = client
+        .get_wallet_balance(node_address, funding_pk, None)
+        .await
+        .context("Failed to fetch wallet balance for SDP wallet funding pk.")?;
+
+    // TODO: Improve check to verify that the balance is not only non-zero, but also
+    // sufficient to cover the tx fees.
+    if balance == 0 {
+        bail!("The provided SDP wallet funding key does not have any balance");
+    }
+
+    Ok(())
 }
 
 async fn verify_locked_note_id_value(


### PR DESCRIPTION
## 1. What does this PR implement?

Add a `/blend/join` POST endpoint to join Blend as a core node. The only inputs required are the multiaddr to be used as a locator (we don't perform any checks at the moment that it matches what's specified in the config file), and the ID of a note (with enough stake) to be locked. Everything else is computed internally by the Blend proxy service.

The new endpoint is also used in the existing CLI utility to join as a Blend node, that keeps the additional checks around balance sufficiency before sending the tx to the node.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.