### PR TITLE
chore(deployment): Bring back circuits download script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@
 # Ignore warnings about sensitive information as this is test data.
 
 ARG LB_NODE_VERSION=0.1.3
-# Cache directory used by the circuits. Not meant to be overridden.
-ARG LB_CACHE=/root/.cache/logos/blockchain
+ARG LB_CIRCUITS_VERSION=v0.5.1
 
 # ===========================
 # BUILD IMAGE
@@ -13,11 +12,13 @@ ARG LB_CACHE=/root/.cache/logos/blockchain
 FROM alpine:latest AS builder
 
 ARG LB_NODE_VERSION
+ARG LB_CIRCUITS_VERSION
 
 WORKDIR /logos-blockchain
 COPY . .
 
 RUN apk add --no-cache curl bash
+RUN scripts/setup-logos-blockchain-circuits.sh "$LB_CIRCUITS_VERSION" "linux-$(uname -m)"
 RUN scripts/setup-logos-blockchain-node.sh "$LB_NODE_VERSION" "linux-$(uname -m)"
 
 # ===========================
@@ -26,8 +27,6 @@ RUN scripts/setup-logos-blockchain-node.sh "$LB_NODE_VERSION" "linux-$(uname -m)
 
 FROM debian:trixie-slim
 
-ARG LB_CACHE
-
 LABEL maintainer="augustinas@status.im" \
     source="https://github.com/logos-blockchain/logos-blockchain" \
     description="Logos blockchain node image"
@@ -35,7 +34,8 @@ LABEL maintainer="augustinas@status.im" \
 # Copies the entire cache dir.
 # We only need the circuits, but this is currently much simpler than just copying the circuits subdir.
 # This might be addressed later, after the circuits directories structure is standardised.
-COPY --from=builder $LB_CACHE $LB_CACHE
+RUN mkdir -p /home/runner/.cache/logos/blockchain/
+COPY --from=builder /opt/circuits /home/runner/.cache/logos/blockchain/
 COPY --from=builder /usr/local/bin/logos-blockchain-node /usr/local/bin/logos-blockchain-node
 
 EXPOSE 3000 8080 9000 60000

--- a/scripts/setup-logos-blockchain-circuits.sh
+++ b/scripts/setup-logos-blockchain-circuits.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+VERSION="${1:-0.5.1}"
+PLATFORM="${2:-linux-x86_64}"
+OUT_PATH="${3:-/opt/circuits}"
+
+REPO="logos-blockchain/logos-blockchain-circuits"
+ARTIFACT_PREFIX="logos-blockchain-circuits"
+
+ARTIFACT_NAME="${ARTIFACT_PREFIX}-${VERSION}-${PLATFORM}"
+ARTIFACT_TAR_GZ="${ARTIFACT_NAME}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT_TAR_GZ}"
+TMP_FILE="/tmp/${ARTIFACT_TAR_GZ}"
+
+echo "Installing Logos Circuits $VERSION ($PLATFORM) to $OUT_PATH."
+echo ">> Downloading: $DOWNLOAD_URL"
+
+if ! curl -Lfo "$TMP_FILE" "$DOWNLOAD_URL"; then
+    echo "Download failed"
+    exit 1
+fi
+
+mkdir -p "$OUT_PATH"
+tar -xzf "$TMP_FILE" -C "$OUT_PATH"
+rm "$TMP_FILE"


### PR DESCRIPTION
## 1. What does this PR implement?

Download circuit artifacts as `logos-blockchain-node` still expects some of the binaries to be at a predetermined location.

## 2. Does the code have enough context to be clearly understood?

N/A

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
