### PR TITLE
fix(sdp): gate GC and note unlock to epoch transitions

### DIFF
--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -177,13 +177,16 @@ fn is_active(declaration: &Declaration, current_epoch: Epoch, config: &ServicePa
 impl<R: Rewards> ServiceState<R> {
     fn try_apply_header(
         mut self,
-        _last_epoch_state: &EpochState,
+        last_epoch_state: &EpochState,
         epoch_state: &EpochState,
         service_params: &ServiceParameters,
         _rewards_params: &R::Params,
     ) -> (Self, Vec<Utxo>) {
-        // Remove expired declarations based on retention_period
-        self.declarations = self
+        let reward_utxos = Vec::new();
+
+        if last_epoch_state.epoch() < epoch_state.epoch() {
+            // Remove expired declarations based on retention_period
+            self.declarations = self
             .declarations
             .iter()
             .filter(|(_id, declaration)| {
@@ -202,17 +205,17 @@ impl<R: Rewards> ServiceState<R> {
             .map(|(id, declaration)| (*id, declaration.clone()))
             .collect();
 
-        // Update rewards with current epoch state and distribute rewards
-        let reward_utxos = Vec::new();
-        // TODO: enable this after making the `rewards` module stable
-        // if last_epoch_state.epoch() < epoch_state.epoch() {
-        //     (self.rewards, reward_utxos) = self.rewards.update_epoch(
-        //         last_epoch_state,
-        //         epoch_state,
-        //         service_params,
-        //         rewards_params,
-        //     );
-        // }
+            // Update rewards with current epoch state and distribute rewards
+            // TODO: enable this after making the `rewards` module stable
+            // if last_epoch_state.epoch() < epoch_state.epoch() {
+            //     (self.rewards, reward_utxos) = self.rewards.update_epoch(
+            //         last_epoch_state,
+            //         epoch_state,
+            //         service_params,
+            //         rewards_params,
+            //     );
+            // }
+        }
 
         (self, reward_utxos)
     }
@@ -777,6 +780,18 @@ mod tests {
         }
         let declarations = ledger.get_declarations(ServiceType::BlendNetwork).unwrap();
         assert!(declarations.contains_key(&declaration_id));
+
+        // Before moving to epoch 7 where declaration will be removed,
+        // applying another header within the same epoch 6 must be a no-op
+        // (GC and unlock are gated to epoch transitions only).
+        let ledger_before = ledger.clone();
+        (ledger, _) = ledger
+            .try_apply_header(&config, &last_epoch_state, &last_epoch_state)
+            .unwrap();
+        assert_eq!(
+            ledger, ledger_before,
+            "within-epoch try_apply_header must not change ledger state"
+        );
 
         // Move forward to epoch 7 where declaration should be removed
         // because no activity message has been submitted since epoch 4


### PR DESCRIPTION
## 1. What does this PR implement?

The current SDP implementation runs GC and unlocking notes even if the epoch is not changing. Although those calls are no-op, it's a waste of computation because they traverses over all declarations. 

This PR gates them only to epoch transition, and improve an existing test.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
