### PR TITLE
fix(wallet): recover from stale wallet snapshots

### DIFF
--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -6,6 +6,7 @@ use lb_ledger::LedgerState;
 use lb_wallet::{Vouchers, WalletBlock, WalletError, WalletState};
 use overwatch::services::state::StateUpdater;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::{KeyId, WalletServiceError, WalletServiceSettings};
 
@@ -51,35 +52,52 @@ impl<'u> ServiceState<'u> {
         lib_ledger: &LedgerState,
         updater: &'u StateUpdater<Option<RecoveryState>>,
     ) -> Self {
+        let RecoveryState {
+            next_new_voucher_index,
+            vouchers,
+            lib_wallet_state,
+        } = state;
         let known_keys = settings
             .known_keys
             .iter()
-            .map(|(key_id, pk)| (*pk, key_id.clone()));
+            .map(|(key_id, pk)| (*pk, key_id.clone()))
+            .collect::<Vec<_>>();
 
-        // Initialize [`Wallet`] either from the persisted [`WalletState`]
-        // or from the current chain's LIB ledger state.
-        let (wallet, wallet_lib) = match state.lib_wallet_state {
-            Some((persisted_lib, wallet_state)) => (
-                Wallet::from_lib_wallet_state(
-                    known_keys,
-                    state.vouchers,
-                    persisted_lib,
-                    wallet_state,
-                ),
-                persisted_lib,
+        let (wallet, should_update_recovery) = match lib_wallet_state {
+            Some((persisted_lib, wallet_state)) if persisted_lib == lib => (
+                Wallet::from_lib_wallet_state(known_keys, vouchers, persisted_lib, wallet_state),
+                false,
             ),
+            Some((persisted_lib, _)) => {
+                warn!(
+                    ?persisted_lib,
+                    chain_lib = ?lib,
+                    "Ignoring wallet recovery state from stale LIB"
+                );
+
+                (
+                    Wallet::from_lib_ledger_state(known_keys, vouchers, lib, lib_ledger),
+                    true,
+                )
+            }
             None => (
-                Wallet::from_lib_ledger_state(known_keys, state.vouchers, lib, lib_ledger),
-                lib,
+                Wallet::from_lib_ledger_state(known_keys, vouchers, lib, lib_ledger),
+                false,
             ),
         };
 
-        Self {
-            next_new_voucher_index: state.next_new_voucher_index,
+        let service_state = Self {
+            next_new_voucher_index,
             wallet,
-            lib: wallet_lib,
+            lib,
             updater,
+        };
+
+        if should_update_recovery {
+            service_state.update_state();
         }
+
+        service_state
     }
 
     pub const fn lib(&self) -> HeaderId {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes wallet startup recovery when the persisted wallet snapshot belongs to a stale LIB.

On startup, the wallet service now compares the recovered wallet LIB with the current chain LIB. If they differ, it ignores the stale wallet snapshot, rebuilds wallet state from the current chain LIB ledger, and immediately persists the corrected recovery state so the same stale snapshot is not reused on the next restart.

Related to #2810.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
