### PR TITLE
fix: Blend panic and logs

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -14,6 +14,7 @@ ignore = [
   { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
   { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` can enter an unbounded DNSSEC NSEC3 validation loop and exhaust memory; pulled in through libp2p." },
   { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` DNS message compression can cause CPU exhaustion during encoding; pulled in through libp2p." },
+  { id = "RUSTSEC-2026-0173", reason = "`proc-macro-error2` is unmaintained." },
 ]
 unused-ignored-advisory = "deny"
 yanked = "deny"

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -963,12 +963,12 @@ where
         connection_id: ConnectionId,
         peer_id: PeerId,
         _: &Multiaddr,
-        _: &Multiaddr,
+        remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         // If the new peer makes the set of established connections too large, do not
         // try to upgrade the connection.
         if self.negotiated_peers.len() >= *self.peering_degree.end() {
-            tracing::trace!(target: LOG_TARGET, "Inbound connection {connection_id:?} with peer {peer_id:?} will not be upgraded since we are already at maximum peering capacity.");
+            tracing::trace!(target: LOG_TARGET, "Inbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} will not be upgraded since we are already at maximum peering capacity.");
             return Ok(Either::Right(DummyConnectionHandler));
         }
 
@@ -978,17 +978,17 @@ where
         // close one of the two connections depending on the comparison result of
         // local and remote peer IDs.
         if self.has_incoming_connection_with_peer(&peer_id) {
-            tracing::trace!(target: LOG_TARGET, "Inbound connection {connection_id:?} with peer {peer_id:?} will not be upgraded since there is already an inbound connection established or pending.");
+            tracing::trace!(target: LOG_TARGET, "Inbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} will not be upgraded since there is already an inbound connection established or pending.");
             return Ok(Either::Right(DummyConnectionHandler));
         }
 
         Ok(if !self.is_network_large_enough() {
-            tracing::debug!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with peer {peer_id:?} because membership size is too small.");
+            tracing::debug!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} because membership size is too small.");
             Either::Right(DummyConnectionHandler)
         } else if self.current_epoch_info.0.contains(&peer_id) {
             tracing::trace!(
                 target: LOG_TARGET,
-                "Upgrading inbound connection {connection_id:?} with core peer {peer_id:?}."
+                "Upgrading inbound connection {connection_id:?} with core peer {peer_id:?} with addr {remote_addr:?}."
             );
             self.connections_waiting_upgrade
                 .insert((peer_id, connection_id), Endpoint::Dialer);
@@ -998,7 +998,7 @@ where
                 (peer_id, connection_id),
             ))
         } else {
-            tracing::trace!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with edge peer {peer_id:?}.");
+            tracing::trace!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with edge peer {peer_id:?} with addr {remote_addr:?}.");
             Either::Right(DummyConnectionHandler)
         })
     }
@@ -1011,14 +1011,14 @@ where
         &mut self,
         connection_id: ConnectionId,
         peer_id: PeerId,
-        _: &Multiaddr,
+        remote_addr: &Multiaddr,
         _: Endpoint,
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         // If the new peer makes the set of established connections too large, do not
         // try to upgrade the connection.
         if self.negotiated_peers.len() >= *self.peering_degree.end() {
-            tracing::trace!(target: LOG_TARGET, "Outbound connection {connection_id:?} with peer {peer_id:?} will not be upgraded since we are already at maximum peering capacity.");
+            tracing::trace!(target: LOG_TARGET, "Outbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} will not be upgraded since we are already at maximum peering capacity.");
             return Ok(Either::Right(DummyConnectionHandler));
         }
 
@@ -1027,17 +1027,17 @@ where
         // Otherwise, we let the connection upgrade, and we will close one of the two
         // connections depending on the comparison result of local and remote peer IDs.
         if self.has_outgoing_connection_with_peer(&peer_id) {
-            tracing::trace!(target: LOG_TARGET, "Outbound connection {connection_id:?} with peer {peer_id:?} will not be upgraded since there is already an outbound connection established.");
+            tracing::trace!(target: LOG_TARGET, "Outbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} will not be upgraded since there is already an outbound connection established.");
             return Ok(Either::Right(DummyConnectionHandler));
         }
 
         Ok(if !self.is_network_large_enough() {
-            tracing::debug!(target: LOG_TARGET, "Denying outbound connection {connection_id:?} with peer {peer_id:?} because membership size is too small.");
+            tracing::debug!(target: LOG_TARGET, "Denying outbound connection {connection_id:?} with peer {peer_id:?} with addr {remote_addr:?} because membership size is too small.");
             Either::Right(DummyConnectionHandler)
         } else if self.current_epoch_info.0.contains(&peer_id) {
             tracing::trace!(
                 target: LOG_TARGET,
-                "Upgrading outbound connection {connection_id:?} with core peer {peer_id:?}."
+                "Upgrading outbound connection {connection_id:?} with core peer {peer_id:?} with addr {remote_addr:?}."
             );
             self.connections_waiting_upgrade
                 .insert((peer_id, connection_id), Endpoint::Listener);
@@ -1047,7 +1047,7 @@ where
                 (peer_id, connection_id),
             ))
         } else {
-            tracing::debug!(target: LOG_TARGET, "Denying outbound connection {connection_id:?} with edge peer {peer_id:?}.");
+            tracing::debug!(target: LOG_TARGET, "Denying outbound connection {connection_id:?} with edge peer {peer_id:?} with addr {remote_addr:?}.");
             Either::Right(DummyConnectionHandler)
         })
     }
@@ -1162,7 +1162,9 @@ where
                 ToBehaviour::HealthyPeer => {
                     self.handle_healthy_connection((peer_id, connection_id));
                 }
-                ToBehaviour::IOError(_) | ToBehaviour::DialUpgradeError(_) => {}
+                _ => {
+                    tracing::trace!(target: LOG_TARGET, "Unhandled connection handler event: {event:?} from peer {peer_id:?} on connection {connection_id:?}");
+                }
             },
         }
     }

--- a/blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/blend/network/src/core/with_edge/behaviour/mod.rs
@@ -184,25 +184,25 @@ impl NetworkBehaviour for Behaviour {
         connection_id: ConnectionId,
         peer: PeerId,
         _: &Multiaddr,
-        _: &Multiaddr,
+        remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         // If the new peer makes the set of incoming connections too large, do not try
         // to upgrade the connection.
         if self.upgraded_edge_peers.len() >= self.max_incoming_connections {
-            tracing::trace!(target: LOG_TARGET, "Connected peer {peer:?} on connection {connection_id:?} will not be upgraded since we are already at maximum incoming connection capacity.");
+            tracing::trace!(target: LOG_TARGET, "Connected peer {peer:?} with addr {remote_addr:?} on connection {connection_id:?} will not be upgraded since we are already at maximum incoming connection capacity.");
             return Ok(Either::Right(DummyConnectionHandler));
         }
 
         // Allow only inbound connections from edge nodes, if the Blend network is large
         // enough.
         Ok(if !self.is_network_large_enough() {
-            tracing::debug!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with peer {peer:?} because membership size is too small.");
+            tracing::debug!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with peer {peer:?} with addr {remote_addr:?} because membership size is too small.");
             Either::Right(DummyConnectionHandler)
         } else if self.current_membership.contains(&peer) {
-            tracing::trace!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with core peer {peer:?}.");
+            tracing::trace!(target: LOG_TARGET, "Denying inbound connection {connection_id:?} with core peer {peer:?} with addr {remote_addr:?}.");
             Either::Right(DummyConnectionHandler)
         } else {
-            tracing::debug!(target: LOG_TARGET, "Upgrading inbound connection {connection_id:?} with edge peer {peer:?}.");
+            tracing::debug!(target: LOG_TARGET, "Upgrading inbound connection {connection_id:?} with edge peer {peer:?} with addr {remote_addr:?}.");
             Either::Left(ConnectionHandler::new(
                 self.connection_timeout,
                 self.protocol_name.clone(),
@@ -247,7 +247,9 @@ impl NetworkBehaviour for Behaviour {
             Either::Left(ToBehaviour::SubstreamOpened) => {
                 self.handle_negotiated_connection((peer_id, connection_id));
             }
-            Either::Left(_) | Either::Right(_) => {}
+            Either::Left(_) | Either::Right(_) => {
+                tracing::trace!(target: LOG_TARGET, "Unhandled connection handler event: {event:?} from peer {peer_id:?} on connection {connection_id:?}");
+            }
         }
     }
 

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -381,7 +381,7 @@ where
                 }
             }
             _ => {
-                tracing::trace!(target: LOG_TARGET, "Received event from blend network that will be ignored.");
+                tracing::trace!(target: LOG_TARGET, "Received event from blend network that will be ignored: {event:?}.");
             }
         }
     }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -152,6 +152,8 @@ where
             })
             .build();
 
+        tracing::info!(target: LOG_TARGET, "Blend core swarm started with local peer id: {:?} and listening address: {listening_address:?}", swarm.local_peer_id());
+
         swarm.listen_on(listening_address).unwrap_or_else(|e| {
             panic!("Failed to listen on Blend network: {e:?}");
         });
@@ -270,6 +272,10 @@ where
         self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
     }
 
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "TODO: address this at some point."
+    )]
     fn handle_blend_core_behaviour_event(&mut self, blend_event: CoreToCoreEvent) {
         match blend_event {
             lb_blend::network::core::with_core::behaviour::Event::Message { message, sender, epoch } => {
@@ -312,7 +318,14 @@ where
                 }
             }
             lb_blend::network::core::with_core::behaviour::Event::OutboundConnectionUpgradeSucceeded(peer_id) => {
-                assert!(self.ongoing_dials.remove(&peer_id).is_some(), "Peer ID for a successfully upgraded connection must be present in storage");
+                // The peer is normally tracked in `ongoing_dials` (we dialed it),
+                // but it can legitimately be absent if its entry was cleared while
+                // this upgrade was in flight: e.g. an epoch rotation cleared the
+                // map (`StartNewEpoch`), or a sibling connection to the same peer
+                // resolved first (e.g., a different attempt was failed and we picked the same node again due to lack of alternatives).
+                if self.ongoing_dials.remove(&peer_id).is_none() {
+                    tracing::trace!(target: LOG_TARGET, "Outbound connection upgrade succeeded for peer {peer_id:?} that was no longer tracked in ongoing dials. Keeping the connection.");
+                }
             }
             lb_blend::network::core::with_core::behaviour::Event::InboundConnectionUpgradeFailed { peer, reason } => {
                 tracing::trace!(target: LOG_TARGET, "Inbound connection upgrade expectedly failed for {peer:?} with reason {reason:?}");

--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -107,6 +107,9 @@ where
                 cfg.with_idle_connection_timeout(Duration::from_secs(1))
             })
             .build();
+
+        tracing::info!(target: LOG_TARGET, "Blend edge swarm started with local peer id: {:?}.", swarm.local_peer_id());
+
         let stream_control = swarm.behaviour().new_control();
 
         let replication_factor: NonZeroUsize = settings.replication_factor.try_into().unwrap();


### PR DESCRIPTION
## 1. What does this PR implement?

A concurrency situation can trigger the (now removed) assert in the Blend code that results in panics. So the assert is replaced with a trace log. Also, we add more logs to be able to trace Blend connections better.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.