### PR TITLE
chore(cargo-deny): ignore proc-macro-error2 deprecation

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -14,6 +14,7 @@ ignore = [
   { id = "RUSTSEC-2025-0141", reason = "`bincode` is unmaintained but continuing to use it." },
   { id = "RUSTSEC-2026-0118", reason = "`hickory-proto` can enter an unbounded DNSSEC NSEC3 validation loop and exhaust memory; pulled in through libp2p." },
   { id = "RUSTSEC-2026-0119", reason = "`hickory-proto` DNS message compression can cause CPU exhaustion during encoding; pulled in through libp2p." },
+  { id = "RUSTSEC-2026-0173", reason = "`proc-macro-error2` is unmaintained; pulled in by `overwatch-derive` and `validator_derive` v0.20.0 (latest). No upstream fix available yet." },
 ]
 unused-ignored-advisory = "deny"
 yanked = "deny"


### PR DESCRIPTION
## 1. What does this PR implement?
Ignore proc-macro-error2 deprecation message.
While we've provided a fix for `Overwatch` ([PR](https://github.com/logos-co/Overwatch/pull/137)), we need to wait until `validator_derive` update. In the meantime, we ignore the `cargo-deny` warning.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
