### PR TITLE
feat(blend): do not pick new peers for failed message attempts

### DIFF
--- a/services/blend/src/edge/backends/libp2p/swarm.rs
+++ b/services/blend/src/edge/backends/libp2p/swarm.rs
@@ -39,10 +39,6 @@ pub struct DialAttempt {
     attempt_number: NonZeroU64,
     /// The message to send once the peer is successfully dialed.
     message: EncapsulatedMessageWithVerifiedPublicHeader,
-    /// Peers that have already been tried and failed for this message delivery.
-    /// When all available peers have been tried, this set is cleared to allow
-    /// retrying from scratch.
-    failed_peers: HashSet<PeerId>,
 }
 
 #[cfg(test)]
@@ -180,28 +176,17 @@ where
     }
 
     fn handle_send_message_command(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
-        self.dial_and_schedule_message(msg, HashSet::new());
+        self.dial_and_schedule_message(msg);
     }
 
     /// Schedule a dial with retries for a given message.
     ///
-    /// The peer to send the message to is chosen at random, excluding the peers
-    /// in `failed_peers`. If all available peers have already been tried, the
-    /// set is cleared and peers are chosen from scratch.
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "TODO: Address this at some point."
-    )]
-    fn dial_and_schedule_message(
-        &mut self,
-        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
-        mut failed_peers: HashSet<PeerId>,
-    ) {
-        if failed_peers.len() == self.membership.size() {
-            debug!(target: LOG_TARGET, "All peers have been tried for message with ID {:?}. Clearing failed peers memory and retrying from scratch.", msg.id());
-            failed_peers.clear();
-        }
-        let peers = self.choose_peers_except(&failed_peers);
+    /// A single set of `replication_factor` peers is chosen at random for the
+    /// message. Each chosen peer is then retried with exponential backoff (see
+    /// [`Self::schedule_retry`]); if a peer is still unreachable after all
+    /// attempts, the message is dropped for that peer.
+    fn dial_and_schedule_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
+        let peers = self.choose_peers();
         if peers.is_empty() {
             error!(target: LOG_TARGET, "No peers available to send the message to");
             return;
@@ -221,7 +206,6 @@ where
                 address,
                 attempt_number: 1.try_into().unwrap(),
                 message: msg.clone(),
-                failed_peers: failed_peers.clone(),
             });
 
             if let Err(e) = self.swarm.dial(opts) {
@@ -233,25 +217,24 @@ where
 
     /// Schedule a retry for a failed dial attempt with exponential backoff.
     ///
-    /// The dial attempt is removed from `pending_dials` and, if the maximum
-    /// number of attempts has not been reached, a delayed future is pushed
-    /// into `pending_retries`. When the future fires, the dial will be
-    /// re-attempted in `poll_next_and_match`.
-    ///
-    /// Returns `Some(DialAttempt)` if the maximum attempts have been exhausted,
-    /// `None` if a retry has been scheduled.
-    fn schedule_retry(
-        &mut self,
-        peer_id: PeerId,
-        connection_id: ConnectionId,
-    ) -> Option<DialAttempt> {
+    /// The dial attempt is removed from `pending_dials`. If the maximum number
+    /// of attempts has not been reached, a delayed future is pushed into
+    /// `pending_retries`; when it fires, the dial is re-attempted in
+    /// `poll_next_and_match`. Once all attempts are exhausted the message is
+    /// dropped: we do not fall back to a different peer.
+    fn schedule_retry(&mut self, peer_id: PeerId, connection_id: ConnectionId) {
         let dial_attempt = self
             .pending_dials
             .remove(&(peer_id, connection_id))
             .unwrap();
         let new_dial_attempt_number = dial_attempt.attempt_number.checked_add(1).unwrap();
         if new_dial_attempt_number > self.max_dial_attempts_per_connection {
-            return Some(dial_attempt);
+            error!(
+                target: LOG_TARGET,
+                "Giving up on message delivery: peer {peer_id:?} was not reachable after {} attempts. Dropping the message.",
+                self.max_dial_attempts_per_connection
+            );
+            return;
         }
         let delay = Duration::from_secs(1 << (new_dial_attempt_number.get() - 1));
         debug!(
@@ -269,13 +252,12 @@ where
                 },
             )
         }));
-        None
     }
 
-    fn choose_peers_except(&mut self, except: &HashSet<PeerId>) -> Vec<Node<PeerId>> {
+    fn choose_peers(&mut self) -> Vec<Node<PeerId>> {
         let peers_to_choose = self.membership.size().min(self.replication_factor.get());
         self.membership
-            .filter_and_choose_remote_nodes(&mut self.rng, peers_to_choose, except)
+            .filter_and_choose_remote_nodes(&mut self.rng, peers_to_choose, &HashSet::new())
             .cloned()
             .collect()
     }
@@ -368,11 +350,7 @@ where
         (peer_id, connection_id): (PeerId, ConnectionId),
     ) {
         error!(target: LOG_TARGET, "Failed to send message: {error} to peer {peer_id:?} on connection {connection_id:?}.");
-        // If the maximum attempt count was reached for this peer, try to schedule the
-        // message for a different peer, remembering all previously failed peers.
-        if let Some(dial_attempt) = self.schedule_retry(peer_id, connection_id) {
-            self.retry_with_different_peer(peer_id, dial_attempt);
-        }
+        self.schedule_retry(peer_id, connection_id);
     }
 
     fn handle_open_stream_failure(
@@ -381,11 +359,7 @@ where
         (peer_id, connection_id): (PeerId, ConnectionId),
     ) {
         error!(target: LOG_TARGET, "Failed to open stream to {peer_id}: {error}");
-        // If the maximum attempt count was reached for this peer, try to schedule the
-        // message for a different peer, remembering all previously failed peers.
-        if let Some(dial_attempt) = self.schedule_retry(peer_id, connection_id) {
-            self.retry_with_different_peer(peer_id, dial_attempt);
-        }
+        self.schedule_retry(peer_id, connection_id);
     }
 
     fn handle_outgoing_connection_error(
@@ -401,49 +375,12 @@ where
             return;
         };
 
-        // If the maximum attempt count was reached for this peer, try to schedule the
-        // message for a different peer, remembering all previously failed peers.
-        if let Some(dial_attempt) = self.schedule_retry(peer_id, connection_id) {
-            self.retry_with_different_peer(peer_id, dial_attempt);
-        }
-    }
-
-    /// After exhausting retries for a peer, add it to the failed peers set
-    /// and attempt the message with a different peer.
-    fn retry_with_different_peer(&mut self, failed_peer_id: PeerId, dial_attempt: DialAttempt) {
-        let DialAttempt {
-            message,
-            mut failed_peers,
-            ..
-        } = dial_attempt;
-        let is_peer_added = failed_peers.insert(failed_peer_id);
-        debug_assert!(
-            is_peer_added,
-            "Should only attempt a single batch of retries per peer."
-        );
-        self.dial_and_schedule_message(&message, failed_peers);
+        self.schedule_retry(peer_id, connection_id);
     }
 
     #[cfg(test)]
     pub fn send_message(&mut self, msg: &EncapsulatedMessageWithVerifiedPublicHeader) {
-        self.dial_and_schedule_message(msg, HashSet::new());
-    }
-
-    #[cfg(test)]
-    pub fn send_message_to_anyone_except(
-        &mut self,
-        peer_id: PeerId,
-        msg: &EncapsulatedMessageWithVerifiedPublicHeader,
-    ) {
-        self.dial_and_schedule_message(msg, HashSet::from([peer_id]));
-    }
-
-    #[cfg(test)]
-    pub fn failed_peers_for(&self, peer_id: &PeerId) -> Option<&HashSet<PeerId>> {
-        self.pending_dials
-            .iter()
-            .find(|((pid, _), _)| pid == peer_id)
-            .map(|(_, attempt)| &attempt.failed_peers)
+        self.dial_and_schedule_message(msg);
     }
 
     pub(super) async fn run(mut self) {

--- a/services/blend/src/edge/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/edge/backends/libp2p/tests/redials.rs
@@ -1,5 +1,4 @@
 use core::slice::from_ref;
-use std::collections::HashSet;
 
 use lb_blend::{
     message::crypto::key_ext::Ed25519SecretKeyExt as _,
@@ -9,32 +8,30 @@ use lb_key_management_system_service::keys::UnsecuredEd25519Key;
 use lb_libp2p::{Protocol, SwarmEvent};
 use libp2p::{Multiaddr, PeerId};
 use test_log::test;
-use tokio::{spawn, time};
+use tokio::time;
 
 use crate::{
-    core::backends::libp2p::core_swarm_test_utils::{
-        BlendBehaviourBuilder, SwarmBuilder as CoreSwarmBuilder, SwarmExt as _,
-        TestSwarm as CoreTestSwarm, new_nodes_with_empty_address,
-    },
     edge::backends::libp2p::tests::utils::{
         SwarmBuilder as EdgeSwarmBuilder, TestSwarm as EdgeTestSwarm,
     },
     test_utils::TestEncapsulatedMessage,
 };
 
+/// Verifies that a message whose chosen peer is unreachable is retried with
+/// exponential backoff and then dropped once all attempts are exhausted.
 #[test(tokio::test)]
-async fn edge_redial_same_peer() {
+async fn edge_drops_message_after_exhausting_attempts() {
     let random_peer_id = PeerId::random();
     let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
 
-    // Configure swarm with an unreachable member.
+    // Configure swarm with a single unreachable member.
     let EdgeTestSwarm { mut swarm, .. } =
         EdgeSwarmBuilder::new(Membership::new_without_local(from_ref(&Node {
             address: empty_multiaddr.clone(),
             id: random_peer_id,
             public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
         })))
-        .with_max_dial_attempts(3.try_into().unwrap())
+        .with_max_dial_attempts(3)
         .build();
     let message = TestEncapsulatedMessage::new(b"test-payload");
     swarm.send_message(&message);
@@ -55,9 +52,8 @@ async fn edge_redial_same_peer() {
     assert_eq!(*dial_attempt_1_record.message(), message.clone());
 
     // Poll through all 3 dial attempts (each fails with OutgoingConnectionError).
-    // Between errors, schedule_retry removes the entry from pending_dials and
-    // schedules a delayed retry, so we cannot check intermediate pending_dials
-    // state.
+    // The single chosen peer is retried with exponential backoff; we never fall
+    // back to a different peer.
     for _ in 0..3 {
         swarm
             .poll_next_until(|event| {
@@ -69,203 +65,11 @@ async fn edge_redial_same_peer() {
             .await;
     }
 
-    // All attempts exhausted. Since there is only one peer in the membership,
-    // the failed peers memory is cleared and the same peer is retried from scratch.
+    // All attempts exhausted: the message is dropped and nothing remains
+    // pending. We do not pick a new peer to retry with.
     assert!(
-        !swarm.pending_dials().is_empty(),
-        "Peer should be retried after failed peers memory is cleared"
-    );
-    assert_eq!(
-        swarm.failed_peers_for(&random_peer_id),
-        Some(&HashSet::new()),
-        "Failed peers memory should be empty after reset"
-    );
-}
-
-#[test(tokio::test)]
-async fn edge_redial_different_peer_after_redial_limit() {
-    let random_peer_id = PeerId::random();
-    let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
-
-    let (mut identities, peer_ids) = new_nodes_with_empty_address(1);
-    let CoreTestSwarm {
-        swarm: mut core_swarm,
-        incoming_message_receiver: mut core_swarm_incoming_message_receiver,
-        ..
-    } = CoreSwarmBuilder::new(identities.next().unwrap(), &peer_ids)
-        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
-    let (core_swarm_membership_entry, _) =
-        core_swarm.listen_and_return_membership_entry(None).await;
-
-    // We include both the core and the unreachable swarm in the membership.
-    let edge_membership = Membership::new_without_local(&[
-        core_swarm_membership_entry,
-        Node {
-            address: empty_multiaddr,
-            id: random_peer_id,
-            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
-        },
-    ]);
-    // We use max_dial_attempts=1 to avoid backoff delays in this test.
-    let EdgeTestSwarm {
-        swarm: mut edge_swarm,
-        ..
-    } = EdgeSwarmBuilder::new(edge_membership)
-        .with_max_dial_attempts(1)
-        .build();
-
-    let message = TestEncapsulatedMessage::new(b"test-payload");
-
-    // We instruct the swarm to try to dial the unreachable swarm first by excluding
-    // the core swarm from the initial set of recipients.
-    edge_swarm.send_message_to_anyone_except(*core_swarm.local_peer_id(), &message);
-
-    spawn(async move { core_swarm.run().await });
-    spawn(async move { edge_swarm.run().await });
-
-    // Verify the message is anyway received by the core swarm after the maximum
-    // number of dial attempts have been performed with the unreachable address.
-    let (received_message, received_message_epoch) =
-        core_swarm_incoming_message_receiver.recv().await.unwrap();
-    assert_eq!(received_message, message.into_inner().into());
-    assert_eq!(received_message_epoch, 1);
-}
-
-/// Verifies that when a peer fails all dial attempts, it is added to the failed
-/// peers set, preventing it from being chosen again on the next attempt.
-#[test(tokio::test)]
-async fn edge_remembers_failed_peers_across_retries() {
-    let unreachable_peer_1 = PeerId::random();
-    let unreachable_peer_2 = PeerId::random();
-    let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
-
-    let membership = Membership::new_without_local(&[
-        Node {
-            address: empty_multiaddr.clone(),
-            id: unreachable_peer_1,
-            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
-        },
-        Node {
-            address: empty_multiaddr.clone(),
-            id: unreachable_peer_2,
-            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
-        },
-    ]);
-
-    // Use max_dial_attempts=1 and replication_factor=1 so each peer fails
-    // immediately and only one peer is chosen at a time.
-    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(membership)
-        .with_max_dial_attempts(1)
-        .with_replication_factor(1)
-        .build();
-
-    let message = TestEncapsulatedMessage::new(b"test-payload");
-    swarm.send_message(&message);
-
-    // Determine which peer was chosen first.
-    let first_peer = swarm
-        .pending_dials()
-        .keys()
-        .next()
-        .expect("should have a pending dial")
-        .0;
-    let second_peer = if first_peer == unreachable_peer_1 {
-        unreachable_peer_2
-    } else {
-        unreachable_peer_1
-    };
-
-    // The first dial has no failed peers memory.
-    assert_eq!(swarm.failed_peers_for(&first_peer), Some(&HashSet::new()),);
-
-    // Let the first peer fail.
-    swarm
-        .poll_next_until(|event| {
-            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
-                return false;
-            };
-            *peer_id == Some(first_peer)
-        })
-        .await;
-
-    // The second peer should now be dialed, with the first peer in the failed set.
-    assert!(
-        swarm
-            .pending_dials()
-            .keys()
-            .any(|(pid, _)| *pid == second_peer),
-        "Second peer should be dialed after first peer failed"
-    );
-    assert_eq!(
-        swarm.failed_peers_for(&second_peer),
-        Some(&HashSet::from([first_peer])),
-    );
-}
-
-/// Verifies that when all peers have been tried and failed, the failed peers
-/// memory is cleared and peers are retried from scratch.
-#[test(tokio::test)]
-async fn edge_clears_failed_peers_memory_when_all_exhausted() {
-    let unreachable_peer_1 = PeerId::random();
-    let unreachable_peer_2 = PeerId::random();
-    let empty_multiaddr: Multiaddr = Protocol::Memory(0).into();
-
-    let membership = Membership::new_without_local(&[
-        Node {
-            address: empty_multiaddr.clone(),
-            id: unreachable_peer_1,
-            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
-        },
-        Node {
-            address: empty_multiaddr.clone(),
-            id: unreachable_peer_2,
-            public_key: UnsecuredEd25519Key::generate_with_blake_rng().public_key(),
-        },
-    ]);
-
-    let EdgeTestSwarm { mut swarm, .. } = EdgeSwarmBuilder::new(membership)
-        .with_max_dial_attempts(1)
-        .with_replication_factor(1)
-        .build();
-
-    let message = TestEncapsulatedMessage::new(b"test-payload");
-    swarm.send_message(&message);
-
-    // Fail the first peer.
-    let first_peer = swarm.pending_dials().keys().next().unwrap().0;
-    swarm
-        .poll_next_until(|event| {
-            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
-                return false;
-            };
-            *peer_id == Some(first_peer)
-        })
-        .await;
-
-    // Fail the second peer.
-    let second_peer = swarm.pending_dials().keys().next().unwrap().0;
-    assert_ne!(first_peer, second_peer);
-    swarm
-        .poll_next_until(|event| {
-            let SwarmEvent::OutgoingConnectionError { peer_id, .. } = event else {
-                return false;
-            };
-            *peer_id == Some(second_peer)
-        })
-        .await;
-
-    // Both peers have been tried. The memory should be cleared and a new dial
-    // should be attempted (one of the two peers picked again with an empty
-    // failed_peers set).
-    assert!(
-        !swarm.pending_dials().is_empty(),
-        "A new dial should be attempted after clearing failed peers memory"
-    );
-    let retried_peer = swarm.pending_dials().keys().next().unwrap().0;
-    assert_eq!(
-        swarm.failed_peers_for(&retried_peer),
-        Some(&HashSet::new()),
-        "Failed peers memory should be cleared after all peers have been tried"
+        swarm.pending_dials().is_empty(),
+        "Message should be dropped after exhausting all attempts for the chosen peer"
     );
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Based on internal discussions with @madxor, and also given we saw his node spamming our devnet with infinite retries for a single message attempt, we decided it's enough to stop trying to send a message if the message cannot be sent to the picked peer after the configured number of attempts. Since the redundancy is also configurable, we can increase that value to have more peers being randomly picked for each message instead. This simplifies the edge swarm code quite a bit and prevent infinite retry loops.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 @madxor 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.