### PR TITLE
fix(chain): use rpds in Cryptarchia for prepare-commit pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,6 +4451,7 @@ version = "0.1.2"
 dependencies = [
  "logos-blockchain-pol",
  "logos-blockchain-utils",
+ "rpds",
  "serde",
  "serde_with",
  "thiserror 2.0.18",

--- a/consensus/cryptarchia-engine/Cargo.toml
+++ b/consensus/cryptarchia-engine/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 lb-pol     = { workspace = true }
 lb-utils   = { features = ["time"], workspace = true }
+rpds       = { workspace = true }
 serde      = { workspace = true }
 serde_with = { features = ["macros"], workspace = true }
 thiserror  = { workspace = true }

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -3,11 +3,12 @@ pub mod time;
 
 use core::{fmt::Debug, hash::Hash};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     num::NonZero,
 };
 
 pub use config::*;
+use rpds::{HashTrieMapSync, HashTrieSetSync};
 use thiserror::Error;
 pub use time::{Epoch, EpochConfig, Slot};
 
@@ -135,9 +136,12 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub struct Branches<Id> {
-    branches: HashMap<Id, Branch<Id>>,
-    tips: HashSet<Id>,
+pub struct Branches<Id>
+where
+    Id: Eq + Hash,
+{
+    branches: HashTrieMapSync<Id, Branch<Id>>,
+    tips: HashTrieSetSync<Id>,
     lib: Id,
 }
 
@@ -179,8 +183,8 @@ where
     Id: Eq + Hash + Copy,
 {
     pub fn from_lib(lib: Id, slot: Slot, length: u64) -> Self {
-        let mut branches = HashMap::new();
-        branches.insert(
+        let mut branches = HashTrieMapSync::new_sync();
+        branches.insert_mut(
             lib,
             Branch {
                 id: lib,
@@ -189,7 +193,8 @@ where
                 length,
             },
         );
-        let tips = HashSet::from([lib]);
+        let mut tips = HashTrieSetSync::new_sync();
+        tips.insert_mut(lib);
         Self {
             branches,
             tips,
@@ -216,10 +221,10 @@ where
             .checked_add(1)
             .expect("New branch height overflows.");
 
-        self.tips.remove(&parent);
-        self.tips.insert(header);
+        self.tips.remove_mut(&parent);
+        self.tips.insert_mut(header);
 
-        self.branches.insert(
+        self.branches.insert_mut(
             header,
             Branch {
                 id: header,
@@ -305,12 +310,6 @@ where
             }
         }
         *current
-    }
-
-    /// Shrink internal data structures to release unused capacity.
-    fn shrink(&mut self) {
-        self.branches.shrink_to_fit();
-        self.tips.shrink_to_fit();
     }
 }
 
@@ -489,7 +488,7 @@ where
 
     /// Remove all blocks of a fork from `tip` to `lca`, excluding `lca`.
     fn prune_fork(&mut self, &ForkDivergenceInfo { lca, tip }: &ForkDivergenceInfo<Id>) -> Vec<Id> {
-        let tip_removed = self.branches.tips.remove(&tip.id);
+        let tip_removed = self.branches.tips.remove_mut(&tip.id);
         if !tip_removed {
             tracing::error!(target: LOG_TARGET, "Fork tip {tip:#?} not found in the set of tips.");
         }
@@ -497,11 +496,12 @@ where
         let mut current_tip = tip.id;
         let mut removed_blocks = vec![];
         while current_tip != lca.id {
-            let Some(branch) = self.branches.branches.remove(&current_tip) else {
+            let Some(branch) = self.branches.branches.get(&current_tip).copied() else {
                 // If tip is not in branch set, it means this tip was sharing part of its
                 // history with another fork that has already been removed.
                 break;
             };
+            self.branches.branches.remove_mut(&current_tip);
             removed_blocks.push(branch.id);
             current_tip = branch.parent;
         }
@@ -517,21 +517,11 @@ where
     fn prune_immutable_blocks(&mut self) -> impl Iterator<Item = (Slot, Id)> + '_ {
         let mut block = self.lib_branch().parent;
         std::iter::from_fn(move || {
-            self.branches.branches.remove(&block).map(|branch| {
-                block = branch.parent;
-                (branch.slot, branch.id)
-            })
+            let branch = self.branches.branches.get(&block).copied()?;
+            self.branches.branches.remove_mut(&block);
+            block = branch.parent;
+            Some((branch.slot, branch.id))
         })
-    }
-
-    /// Shrink internal data structures to release unused capacity.
-    ///
-    /// This should be called after a significant number of blocks have been
-    /// pruned by [`Self::prune_fork`] and [`Self::prune_immutable_blocks`] to
-    /// free up memory. This should not be called frequently since it is an
-    /// expensive operation.
-    fn shrink(&mut self) {
-        self.branches.shrink();
     }
 
     pub const fn branches(&self) -> &Branches<Id> {
@@ -564,7 +554,6 @@ where
         self.state = State::Online;
         // Update the LIB to the current local chain's tip
         let pruned_blocks = self.update_lib();
-        self.shrink();
         (self, pruned_blocks)
     }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -6,7 +6,7 @@ mod config;
 pub mod cryptarchia;
 pub mod mantle;
 
-use std::{collections::HashMap, hash::Hash};
+use std::hash::Hash;
 
 pub use config::Config;
 use cryptarchia::LedgerState as CryptarchiaLedger;
@@ -32,6 +32,7 @@ use lb_core::{
 use lb_cryptarchia_engine::Slot;
 use lb_groth16::{AdditiveGroup as _, Fr};
 use mantle::LedgerState as MantleLedger;
+use rpds::HashTrieMapSync;
 use thiserror::Error;
 
 use crate::mantle::helpers::MantleOperationVerificationHelper;
@@ -117,7 +118,7 @@ pub enum LedgerError<Id> {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ledger<Id: Eq + Hash> {
-    states: HashMap<Id, LedgerState>,
+    states: HashTrieMapSync<Id, LedgerState>,
     config: Config,
 }
 
@@ -127,7 +128,7 @@ where
 {
     pub fn new(id: Id, state: LedgerState, config: Config) -> Self {
         Self {
-            states: std::iter::once((id, state)).collect(),
+            states: HashTrieMapSync::new_sync().insert(id, state),
             config,
         }
     }
@@ -164,7 +165,7 @@ where
 
     /// Commits a new [`LedgerState`] created by [`Self::prepare_update`].
     pub fn commit_update(&mut self, id: Id, state: LedgerState) {
-        self.states.insert(id, state);
+        self.states.insert_mut(id, state);
     }
 
     pub fn state(&self, id: &Id) -> Option<&LedgerState> {
@@ -189,16 +190,7 @@ where
     ///
     /// `true` if the state was successfully removed, `false` otherwise.
     pub fn prune_state_at(&mut self, block: &Id) -> bool {
-        self.states.remove(block).is_some()
-    }
-
-    /// Shrinks the map of ledger states to free up memory that has been pruned
-    /// so far.
-    ///
-    /// This shouldn't be called frequently since the entire map is
-    /// reconstructed.
-    pub fn shrink(&mut self) {
-        self.states.shrink_to_fit();
+        self.states.remove_mut(block)
     }
 }
 

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -429,15 +429,6 @@ impl Cryptarchia {
         log_pruned_ledger_states(pruned_states_count);
     }
 
-    /// Shrinks the memory held by the ledger states.
-    ///
-    /// This should be called after a significant number of ledger states have
-    /// been pruned by [`Self::prune_ledger_states`] to free up memory. This
-    /// should not be called frequently since it is an expensive operation.
-    fn shrink_ledger_states(&mut self) {
-        self.ledger.shrink();
-    }
-
     fn online(self) -> (Self, PrunedBlocks<HeaderId>) {
         let (consensus, pruned_blocks) = self.consensus.online();
         let mut cryptarchia = Self {
@@ -447,10 +438,7 @@ impl Cryptarchia {
         };
 
         // Prune the ledger states of all the pruned blocks.
-        // Also, shrink the set of ledger states to free up memory,
-        // assuming that many blocks have been pruned during bootstrapping.
         cryptarchia.prune_ledger_states(pruned_blocks.all());
-        cryptarchia.shrink_ledger_states();
 
         (cryptarchia, pruned_blocks)
     }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -1045,12 +1045,12 @@ where
         let header = block.header();
         let prev_lib = cryptarchia.lib();
 
+        let mut candidate = cryptarchia.clone();
         let (pruned_blocks, reorged_blocks, events) =
-            cryptarchia.try_apply_block(&block, current_slot)?;
-        let new_lib = cryptarchia.lib();
+            candidate.try_apply_block(&block, current_slot)?;
+        let new_lib = candidate.lib();
 
         let tx_count = block.transactions().count();
-        metrics::emit_block_transactions_metric(tx_count);
 
         relays
             .storage_adapter()
@@ -1062,10 +1062,13 @@ where
             &pruned_blocks,
             Some(prev_lib),
             new_lib,
-            cryptarchia.consensus.lib_branch().slot(),
+            candidate.consensus.lib_branch().slot(),
             relays.storage_adapter(),
         )
         .await?;
+
+        *cryptarchia = candidate;
+        metrics::emit_block_transactions_metric(tx_count);
 
         let processed_block_event = {
             let tip = cryptarchia.tip_branch();

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -25,6 +25,7 @@ use lb_ledger::{
 };
 use lb_storage_service::{
     StorageMsg, StorageService,
+    api::{StorageApiRequest, chain::requests::ChainApiRequest},
     backends::{
         StorageBackend as _,
         rocksdb::{RocksBackend, RocksBackendSettings},
@@ -237,6 +238,135 @@ async fn get_block_ids() {
         stream.next().await.unwrap(),
         Err(Error::ParentIdNotFound(_))
     ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn process_block_does_not_mutate_state_when_storage_send_fails() {
+    let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
+    let (storage_tx, storage_rx) = mpsc::channel(10);
+    drop(storage_rx);
+    let (time_tx, _time_rx) = mpsc::channel(10);
+    let relays =
+        CryptarchiaConsensusRelays::<SignedMantleTx, RocksBackend, TestRuntimeServiceId>::new(
+            OutboundRelay::new(broadcast_tx),
+            OutboundRelay::new(storage_tx),
+            OutboundRelay::new(time_tx),
+        )
+        .await;
+    let (new_block_tx, mut new_block_rx) = broadcast::channel(10);
+    let (lib_tx, mut lib_rx) = broadcast::channel(10);
+
+    let (mut cryptarchia, block) = test_chain_with_next_block();
+    let initial_info = cryptarchia.info();
+    let block_slot = block.header().slot();
+
+    let result = CryptarchiaConsensus::<
+        _,
+        RocksBackend,
+        SystemTimeBackend,
+        TestRuntimeServiceId,
+    >::process_block(
+        &mut cryptarchia,
+        block,
+        block_slot,
+        &relays,
+        &new_block_tx,
+        &lib_tx,
+    )
+    .await;
+
+    match &result {
+        Err(Error::Storage(_)) => {}
+        Err(e) => panic!("expected storage error, got {e:?}"),
+        Ok(_) => panic!("expected storage error, got Ok"),
+    }
+    assert_eq!(cryptarchia.info(), initial_info);
+    assert!(new_block_rx.try_recv().is_err());
+    assert!(lib_rx.try_recv().is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() {
+    let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
+    let (storage_tx, mut storage_rx) = mpsc::channel(10);
+    let (time_tx, _time_rx) = mpsc::channel(10);
+    let relays =
+        CryptarchiaConsensusRelays::<SignedMantleTx, RocksBackend, TestRuntimeServiceId>::new(
+            OutboundRelay::new(broadcast_tx),
+            OutboundRelay::new(storage_tx),
+            OutboundRelay::new(time_tx),
+        )
+        .await;
+    let (new_block_tx, mut new_block_rx) = broadcast::channel(10);
+    let (lib_tx, mut lib_rx) = broadcast::channel(10);
+
+    let storage_task = tokio::spawn(async move {
+        let Some(StorageMsg::Api {
+            request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
+        }) = storage_rx.recv().await
+        else {
+            panic!("expected store block request");
+        };
+
+        response_tx
+            .send(Ok(()))
+            .expect("store block reply should be received");
+    });
+
+    let (mut cryptarchia, block) = test_chain_with_next_block();
+    let initial_info = cryptarchia.info();
+    let block_slot = block.header().slot();
+
+    let result = CryptarchiaConsensus::<
+        _,
+        RocksBackend,
+        SystemTimeBackend,
+        TestRuntimeServiceId,
+    >::process_block(
+        &mut cryptarchia,
+        block,
+        block_slot,
+        &relays,
+        &new_block_tx,
+        &lib_tx,
+    )
+    .await;
+    storage_task.await.unwrap();
+
+    match &result {
+        Err(Error::Storage(_)) => {}
+        Err(e) => panic!("expected storage error, got {e:?}"),
+        Ok(_) => panic!("expected storage error, got Ok"),
+    }
+    assert_eq!(cryptarchia.info(), initial_info);
+    assert!(new_block_rx.try_recv().is_err());
+    assert!(lib_rx.try_recv().is_err());
+}
+
+fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx>) {
+    let k = 3.try_into().unwrap();
+    let config = ledger_config(k);
+    let genesis_id = [0; 32].into();
+    let (zk_key, utxo) = utxo();
+    let cryptarchia = Cryptarchia::from_lib(
+        genesis_id,
+        LedgerState::from_utxos([utxo], &config),
+        genesis_id,
+        config,
+        lb_cryptarchia_engine::State::Online,
+        Slot::genesis(),
+        0,
+    );
+    let block = try_build_block(
+        &cryptarchia,
+        cryptarchia.tip(),
+        utxo,
+        &zk_key,
+        Slot::genesis() + 1,
+    )
+    .unwrap();
+
+    (cryptarchia, block)
 }
 
 #[must_use]

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -303,23 +303,36 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
     let (lib_tx, mut lib_rx) = broadcast::channel(10);
 
     let storage_task = tokio::spawn(async move {
-        let Some(msg) = storage_rx.recv().await else {
-            return Err("expected store block request, storage channel closed");
-        };
+        while let Some(msg) = storage_rx.recv().await {
+            match msg {
+                StorageMsg::Api {
+                    request:
+                        StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
+                } => {
+                    response_tx
+                        .send(Ok(()))
+                        .map_err(|_| "store block reply receiver dropped")?;
+                }
+                StorageMsg::Api {
+                    request:
+                        StorageApiRequest::Chain(ChainApiRequest::StoreImmutableBlockIds {
+                            response_tx,
+                            ..
+                        }),
+                } => {
+                    response_tx
+                        .send(Err(
+                            "StoreImmutableBlockIds is rejected by this test".to_owned()
+                        ))
+                        .map_err(|_| "immutable index reply receiver dropped")?;
 
-        let StorageMsg::Api {
-            request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
-        } = msg
-        else {
-            return Err("expected store block request");
-        };
+                    return Ok(());
+                }
+                _ => return Err("unexpected storage request"),
+            }
+        }
 
-        response_tx
-            .send(Ok(()))
-            .map_err(|_| "store block reply receiver dropped")?;
-
-        // Drop the receiver so the following immutable-index write fails at send time.
-        Ok(())
+        Err("expected immutable index write request, storage channel closed")
     });
 
     let (mut cryptarchia, block) = test_chain_with_next_block();
@@ -343,7 +356,7 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
     storage_task
         .await
         .expect("storage task should not panic")
-        .expect("storage task should handle initial StoreBlock request");
+        .expect("storage task should reject immutable index write");
 
     match &result {
         Err(Error::Storage(_)) => {}
@@ -369,14 +382,8 @@ fn test_chain_with_next_block() -> (Cryptarchia, Block<SignedMantleTx>) {
         Slot::genesis(),
         0,
     );
-    let block = try_build_block(
-        &cryptarchia,
-        cryptarchia.tip(),
-        utxo,
-        &zk_key,
-        Slot::genesis() + 1,
-    )
-    .unwrap();
+    let block =
+        try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, Slot::new(1)).unwrap();
 
     (cryptarchia, block)
 }

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -244,6 +244,8 @@ async fn get_block_ids() {
 async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
     let (storage_tx, storage_rx) = mpsc::channel(10);
+    // Close the storage relay before processing so the initial StoreBlock request
+    // fails.
     drop(storage_rx);
     let (time_tx, _time_rx) = mpsc::channel(10);
     let relays =
@@ -301,16 +303,23 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
     let (lib_tx, mut lib_rx) = broadcast::channel(10);
 
     let storage_task = tokio::spawn(async move {
-        let Some(StorageMsg::Api {
+        let Some(msg) = storage_rx.recv().await else {
+            return Err("expected store block request, storage channel closed");
+        };
+
+        let StorageMsg::Api {
             request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
-        }) = storage_rx.recv().await
+        } = msg
         else {
-            panic!("expected store block request");
+            return Err("expected store block request");
         };
 
         response_tx
             .send(Ok(()))
-            .expect("store block reply should be received");
+            .map_err(|_| "store block reply receiver dropped")?;
+
+        // Drop the receiver so the following immutable-index write fails at send time.
+        Ok(())
     });
 
     let (mut cryptarchia, block) = test_chain_with_next_block();
@@ -331,7 +340,10 @@ async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() 
         &lib_tx,
     )
     .await;
-    storage_task.await.unwrap();
+    storage_task
+        .await
+        .expect("storage task should not panic")
+        .expect("storage task should handle initial StoreBlock request");
 
     match &result {
         Err(Error::Storage(_)) => {}


### PR DESCRIPTION
## 1. What does this PR implement?

The parent PR #2813 is changing the way how chain service mutates `Cryptarchia`. It clones `Cryptarchia`, mutates it, persists artifacts to the storage, and replaces the original `Cryptarchia` with the cloned/mutated one only if the storage returned `Ok`. 

However, cloning `Cryptarchia` is not always cheap because it holds `HashMap<HeaderId, LedgerState>` which may be large especially when bootstrapping. Inside `LedgerState`, we use `rpds`s because we designed `LedgerState` to be cloned frequently. In contrast, we didn't design `Cryptarchia` to be cloned many times. (Yeah, we should have not make it `Clone`).

Now, because it's unavoidable to clone `Cryptarchia` in the PR #2813, I am replacing all `HashMap`s with `rpds` in this PR.

One concern is the insertion cost of rpds. However, the additional rpds structures we’re considering are likely negligible compared to the existing ones in LedgerState, which are updated on a per-tx (or per-UTXO) basis rather than per block.

Here are some simple benchmarks. Insertion/removal are definitely heavier. But, in absolute terms, the cose is still 200~800ns.
- Insert into a map of size N
  |N|HashMap|HashTrieMapSync|ratio|
  |-|-|-|-|
  |100|70 ns|87 ns|1.2x|
  |1000|153 ns|316 ns|2x|
  |10000|145 ns|479 ns|3x|
- Remove + insert into a set of size N
  |N|HashSet|HashTrieSetSync|ratio|
  |-|-|-|-|
  |100|110 ns|180 ns|1.6x|
  |1000|106 ns|234 ns|2.2x|
  |10000|125 ns|1.0 **us**|8x|
  

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
