### PR TITLE
feat(c-bindings): expose leader reward claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,6 +4129,7 @@ version = "0.1.2"
 dependencies = [
  "cbindgen",
  "logos-blockchain-api-service",
+ "logos-blockchain-chain-leader-service",
  "logos-blockchain-chain-service",
  "logos-blockchain-core",
  "logos-blockchain-groth16",

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -11,6 +11,7 @@ version     = { workspace = true }
 
 [dependencies]
 lb-api-service                = { workspace = true }
+lb-chain-leader-service       = { workspace = true }
 lb-chain-service              = { workspace = true }
 lb-core                       = { workspace = true }
 lb-groth16                    = { workspace = true }

--- a/c-bindings/src/api/leader.rs
+++ b/c-bindings/src/api/leader.rs
@@ -1,0 +1,104 @@
+use lb_chain_leader_service::api::ChainLeaderSerivceApi;
+use lb_node::{
+    RuntimeServiceId,
+    generic_services::{
+        ChainNetworkService, CryptarchiaLeaderService, CryptarchiaService, WalletService,
+    },
+};
+
+use crate::{
+    LogosBlockchainNode,
+    api::cryptarchia::{Hash, TxHash},
+    errors::OperationStatus,
+    logging,
+    result::{FfiStatusResult, StatusResult},
+    return_error_if_null_pointer, unwrap_or_return_error,
+};
+
+type LeaderService = CryptarchiaLeaderService<
+    CryptarchiaService<RuntimeServiceId>,
+    ChainNetworkService<RuntimeServiceId>,
+    WalletService<CryptarchiaService<RuntimeServiceId>, RuntimeServiceId>,
+    RuntimeServiceId,
+>;
+
+/// Claims available leader rewards.
+///
+/// This is a synchronous wrapper around [`ChainLeaderSerivceApi::claim`].
+///
+/// # Arguments
+///
+/// - `node`: A [`LogosBlockchainNode`] instance.
+///
+/// # Returns
+///
+/// A [`Result`] containing the submitted transaction hash on success, or an
+/// [`OperationStatus`] error on failure.
+pub(crate) fn leader_claim_sync(
+    node: &LogosBlockchainNode,
+) -> StatusResult<lb_core::mantle::TxHash> {
+    let runtime_handle = node.get_runtime_handle();
+
+    runtime_handle.block_on(async {
+        let relay = node
+            .get_overwatch_handle()
+            .relay::<LeaderService>()
+            .await
+            .map_err(|error| {
+                logging::error!(
+                    "leader_claim_sync",
+                    "Failed to get ChainLeader relay: {error}"
+                );
+                OperationStatus::RelayError
+            })?;
+
+        ChainLeaderSerivceApi::<LeaderService, RuntimeServiceId>::new(relay)
+            .claim()
+            .await
+            .map_err(|error| {
+                logging::error!(
+                    "leader_claim_sync",
+                    "Failed to claim leader rewards: {error}"
+                );
+                OperationStatus::ServiceError
+            })
+    })
+}
+
+pub type FfiLeaderClaimResult = FfiStatusResult<TxHash>;
+
+/// Claims available leader rewards and submits the claim transaction.
+///
+/// # Arguments
+///
+/// - `node`: A non-null pointer to a [`LogosBlockchainNode`] instance.
+///
+/// # Returns
+///
+/// Returns a [`FfiLeaderClaimResult`] containing the submitted transaction hash
+/// on success, or an [`OperationStatus`] error on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer. The caller
+/// must ensure that `node` is non-null and points to a valid
+/// [`LogosBlockchainNode`] instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn leader_claim(node: *const LogosBlockchainNode) -> FfiLeaderClaimResult {
+    return_error_if_null_pointer!("leader_claim", node);
+
+    let node = unsafe { &*node };
+    let tx_hash = unwrap_or_return_error!(leader_claim_sync(node));
+
+    let Ok(tx_hash_array): Result<Hash, _> =
+        tx_hash.as_signing_bytes().iter().as_slice().try_into()
+    else {
+        logging::error!(
+            "leader_claim",
+            "Failed to convert transaction hash to array."
+        );
+        return FfiLeaderClaimResult::err(OperationStatus::RuntimeError);
+    };
+
+    FfiLeaderClaimResult::ok(tx_hash_array)
+}

--- a/c-bindings/src/api/mod.rs
+++ b/c-bindings/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod blend;
 pub mod config;
 pub mod cryptarchia;
 pub mod keys;
+pub mod leader;
 pub mod lifecycle;
 pub(crate) mod memory;
 pub mod peer;


### PR DESCRIPTION
## 1. What does this PR implement?

Adds the node C binding for dashboard leader reward claiming.

This PR adds `leader_claim(node)` to `logos-blockchain-c`. The new binding calls the existing chain leader service API method, `ChainLeaderSerivceApi::claim()`, and returns the submitted claim transaction hash as `FfiStatusResult<TxHash>`.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
