### PR TITLE
feat(cli): Migrate from 0.1.2 cli command

### DIFF
--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -160,7 +160,9 @@ fn build_cryptarchia_config(
         CryptarchiaConfig::with_required_values(CryptarchiaConfigRequiredValues {
             funding_pk: cryptarchia_funding_key.to_public_key(),
         });
-    if let Some(initial_peers) = initial_peers {
+    if cryptarchia_args.ibd
+        && let Some(initial_peers) = initial_peers
+    {
         cryptarchia_config.network.bootstrap.ibd.peers = initial_peers
             .iter()
             .filter_map(|addr| match addr.iter().last() {

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/config.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/config.rs
@@ -66,7 +66,8 @@ pub struct OldSdpWallet {
     pub funding_pk: KeyId,
 }
 
-/// Holds the values of v0.1.2 configuration that should be transfered to a new config version.
+/// Holds the values of v0.1.2 configuration that should be transfered to a new
+/// config version.
 #[derive(Debug, Clone, Deserialize)]
 pub struct OldConfig {
     pub network: OldNetworkConfig,

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/config.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/config.rs
@@ -1,7 +1,6 @@
-use serde::{Deserialize, Deserializer};
-
 use lb_key_management_system_service::{backend::preload::KeyId, keys::Ed25519Key};
 use lb_libp2p::ed25519::SecretKey;
+use serde::{Deserialize, Deserializer};
 
 pub use crate::config::{kms::serde::Config as KmsConfig, wallet::serde::Config as WalletConfig};
 use crate::{

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/config.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/config.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Deserializer};
+
+use lb_key_management_system_service::{backend::preload::KeyId, keys::Ed25519Key};
+use lb_libp2p::ed25519::SecretKey;
+
+pub use crate::config::{kms::serde::Config as KmsConfig, wallet::serde::Config as WalletConfig};
+use crate::{
+    cli::config::keystore::{KeyTitle, Keystore},
+    config::parse_hex_ed25519_key,
+};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldNetworkConfig {
+    pub backend: OldNetworkBackend,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldNetworkBackend {
+    pub swarm: OldSwarmConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldSwarmConfig {
+    #[serde(deserialize_with = "deserialize_secret_key")]
+    pub node_key: SecretKey,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldBlendConfig {
+    pub non_ephemeral_signing_key_id: KeyId,
+    pub core: OldBlendCore,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldBlendCore {
+    pub zk: OldZkConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldZkConfig {
+    pub secret_key_kms_id: KeyId,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldCryptarchiaConfig {
+    pub leader: OldLeaderConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldLeaderConfig {
+    pub wallet: OldCryptarchiaWallet,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldCryptarchiaWallet {
+    pub funding_pk: KeyId,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldSdpConfig {
+    pub wallet: OldSdpWallet,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldSdpWallet {
+    pub funding_pk: KeyId,
+}
+
+/// Holds the values of v0.1.2 configuration that should be transfered to a new config version.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OldConfig {
+    pub network: OldNetworkConfig,
+    pub blend: OldBlendConfig,
+    pub cryptarchia: OldCryptarchiaConfig,
+    pub sdp: OldSdpConfig,
+    pub kms: KmsConfig,
+    pub wallet: WalletConfig,
+}
+
+impl OldConfig {
+    #[must_use]
+    pub fn into_keystore(self) -> Keystore {
+        let mut keystore = Keystore::default();
+        let mut old_kms = self.kms.backend.keys;
+
+        let network_secret_key = self.network.backend.swarm.node_key;
+        let network_secret_key = Ed25519Key::from_bytes(
+            network_secret_key
+                .as_ref()
+                .try_into()
+                .expect("SecretKey is guaranteed to be 32 bytes"),
+        );
+        keystore.set(KeyTitle::NETWORK_SWARM, network_secret_key.into());
+
+        if let Some(blend_signing) = old_kms.remove(&self.blend.non_ephemeral_signing_key_id) {
+            keystore.set(KeyTitle::BLEND_SIGNING, blend_signing);
+        }
+
+        if let Some(blend_zk) = old_kms.remove(&self.blend.core.zk.secret_key_kms_id) {
+            keystore.set(KeyTitle::BLEND_ZK, blend_zk);
+        }
+
+        if let Some(leader_funding) = old_kms.remove(&self.cryptarchia.leader.wallet.funding_pk) {
+            keystore.set(KeyTitle::LEADER_FUNDING, leader_funding);
+        }
+
+        if let Some(sdp_funding) = old_kms.remove(&self.sdp.wallet.funding_pk) {
+            keystore.set(KeyTitle::SDP_FUNDING, sdp_funding);
+        }
+
+        if let Some(voucher_master) = old_kms.remove(&self.wallet.voucher_master_key_id) {
+            keystore.set(KeyTitle::VAUCHER_MASTER, voucher_master);
+        }
+
+        keystore
+    }
+}
+
+fn deserialize_secret_key<'de, D>(deserializer: D) -> Result<SecretKey, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    parse_hex_ed25519_key(&s).map_err(serde::de::Error::custom)
+}

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
@@ -26,7 +26,7 @@ pub struct MigrateArgs {
     pub old_config: PathBuf,
 
     /// Path for the keystore file.
-    #[clap(long = "keystore")]
+    #[clap(long = "keystore", default_value = "keystore.yaml")]
     pub keystore: PathBuf,
 
     #[clap(flatten)]

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
@@ -1,0 +1,115 @@
+pub mod config;
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use color_eyre::eyre::Result;
+use thiserror::Error;
+
+use crate::{
+    ApiArgs, LogArgs, NetworkArgs,
+    cli::{
+        InitArgs,
+        config::{init::build_user_config, migrate_0_1_2::config::OldConfig},
+    },
+    config::{BlendArgs, CryptarchiaArgs, SdpArgs, StateArgs},
+};
+
+#[derive(Parser, Debug)]
+pub struct MigrateArgs {
+    /// Output file path for the generated config.
+    #[clap(long = "new-config", default_value = "user_config_new.yaml")]
+    pub new_config: PathBuf,
+
+    /// Output file path for the old config.
+    #[clap(long = "old-config", default_value = "user_config.yaml")]
+    pub old_config: PathBuf,
+
+    /// Path for the keystore file.
+    #[clap(long = "keystore")]
+    pub keystore: PathBuf,
+
+    #[clap(flatten)]
+    log: LogArgs,
+
+    #[clap(flatten)]
+    network: NetworkArgs,
+
+    #[clap(flatten)]
+    blend: BlendArgs,
+
+    #[clap(flatten)]
+    cryptarchia: CryptarchiaArgs,
+
+    #[clap(flatten)]
+    sdp: SdpArgs,
+
+    #[clap(flatten)]
+    api: ApiArgs,
+
+    #[clap(flatten)]
+    state: StateArgs,
+}
+
+impl From<MigrateArgs> for InitArgs {
+    fn from(migrate: MigrateArgs) -> Self {
+        Self {
+            output: migrate.new_config,
+            keystore: Some(migrate.keystore),
+            log: migrate.log,
+            network: migrate.network,
+            blend: migrate.blend,
+            cryptarchia: migrate.cryptarchia,
+            sdp: migrate.sdp,
+            api: migrate.api,
+            state: migrate.state,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum MigrateError {
+    #[error("Update command cancelled by user.")]
+    UserCancelled,
+
+    #[error("User configuration exists. Use `update` command.")]
+    UserFileExists,
+
+    #[error("Keystore file already exists. Cannot overwrite during migration.")]
+    KeystoreFileExists,
+
+    #[error("Old configuration file does not exist at the specified path.")]
+    OldConfigFileDoesNotExist,
+}
+
+pub fn run(args: MigrateArgs) -> Result<()> {
+    let user_config_path = args.new_config.clone();
+    let old_config_path = args.old_config.clone();
+    let keystore_path = args.keystore.clone();
+
+    if user_config_path.exists() {
+        return Err(MigrateError::UserFileExists.into());
+    }
+
+    if !old_config_path.exists() {
+        return Err(MigrateError::OldConfigFileDoesNotExist.into());
+    }
+
+    if keystore_path.exists() {
+        return Err(MigrateError::KeystoreFileExists.into());
+    }
+
+    let old_config_yaml = std::fs::read_to_string(&old_config_path)?;
+    let old_config: OldConfig = serde_yaml::from_str(&old_config_yaml)?;
+
+    let keystore = old_config.into_keystore();
+
+    let keystore_yaml = serde_yaml::to_string(&keystore)?;
+    std::fs::write(&keystore_path, &keystore_yaml)?;
+
+    let user_config = build_user_config(&keystore, args.into());
+    let user_config_yaml = serde_yaml::to_string(&user_config)?;
+    std::fs::write(&user_config_path, &user_config_yaml)?;
+
+    Ok(())
+}

--- a/nodes/node/binary/src/cli/config/mod.rs
+++ b/nodes/node/binary/src/cli/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod init;
 pub mod keystore;
 pub mod migrate;
+pub mod migrate_0_1_2;
 pub mod update;
 
 use std::io::Write as _;

--- a/nodes/node/binary/src/cli/config/update.rs
+++ b/nodes/node/binary/src/cli/config/update.rs
@@ -140,7 +140,9 @@ fn update_cryptarchia_config(
         .expect("Cryptarchia funding key set by default");
     cryptarchia_config.set_funding_pk(cryptarchia_funding_key.to_public_key());
 
-    if let Some(initial_peers) = initial_peers {
+    if cryptarchia_args.ibd
+        && let Some(initial_peers) = initial_peers
+    {
         cryptarchia_config.network.bootstrap.ibd.peers = initial_peers
             .iter()
             .filter_map(|addr| match addr.iter().last() {

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -14,7 +14,10 @@ use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use libp2p::Multiaddr;
 
 use crate::{
-    cli::keys::{AddKeyArgs, GenerateKeyArgs, RemoveKeyArgs},
+    cli::{
+        config::migrate_0_1_2,
+        keys::{AddKeyArgs, GenerateKeyArgs, RemoveKeyArgs},
+    },
     config::{
         ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
         LogArgs, NetworkArgs, RunConfig, SdpArgs, StateArgs, UserConfig, update_api, update_blend,
@@ -115,6 +118,9 @@ pub enum Command {
     UpdateConfig(Box<UpdateArgs>),
     /// Migrates a new user config with generated keys
     MigrateConfig(Box<MigrateArgs>),
+    /// Migrates 0.1.2 config to a new user config
+    #[command(name = "migrate-from-0.1.2")]
+    Migrate0_1_2(Box<migrate_0_1_2::MigrateArgs>),
     /// Generate a new key of type.
     GenerateKey(Box<GenerateKeyArgs>),
     /// Add a key of type to a keystore.

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -229,7 +229,7 @@ impl From<EmbeddedInitArgs> for InitArgs {
                 .expect("Valid multiaddr structure"),
         );
 
-        init_args.cryptarchia.disable_ibd_peers = !args.ibd;
+        init_args.cryptarchia.ibd = args.ibd;
         init_args.api.addr = Some(args.http_addr);
         init_args.state.path.clone_from(&args.state_path);
 

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -1,6 +1,5 @@
 use core::{convert::Infallible, str::FromStr};
 use std::{
-    collections::HashSet,
     net::{IpAddr, SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     time::Duration,
@@ -271,9 +270,10 @@ pub struct CryptarchiaArgs {
     )]
     pub cryptarchia_funding_pk: Option<ZkPublicKey>,
 
-    /// Overwrite IBD peer list with an empty list.
-    #[clap(long = "disable-ibd-peers", default_value_t = false)]
-    pub disable_ibd_peers: bool,
+    /// Enable Initial Block Download (IBD) using peers
+    /// passed via `--net-initial-peers`/`-p`.
+    #[clap(long = "ibd", default_value_t = false)]
+    pub ibd: bool,
 }
 
 #[derive(Parser, Debug, Default, Clone, Copy)]
@@ -544,18 +544,17 @@ pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
     }
 }
 
-pub fn update_cryptarchia(cryptarchia: &mut CryptarchiaConfig, cryptarchia_args: CryptarchiaArgs) {
+pub const fn update_cryptarchia(
+    cryptarchia: &mut CryptarchiaConfig,
+    cryptarchia_args: CryptarchiaArgs,
+) {
     let CryptarchiaArgs {
         cryptarchia_funding_pk: funding_pk,
-        disable_ibd_peers,
+        ..
     } = cryptarchia_args;
 
     if let Some(pk) = funding_pk {
         cryptarchia.set_funding_pk(pk);
-    }
-
-    if disable_ibd_peers {
-        cryptarchia.network.bootstrap.ibd.peers = HashSet::new();
     }
 }
 

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -26,6 +26,9 @@ async fn main() -> Result<()> {
             Command::MigrateConfig(migrate_args) => {
                 return logos_blockchain_node::cli::config::migrate::run(*migrate_args);
             }
+            Command::Migrate0_1_2(migrate_args) => {
+                return logos_blockchain_node::cli::config::migrate_0_1_2::run(*migrate_args);
+            }
             Command::GenerateKey(generate_args) => {
                 return logos_blockchain_node::cli::keys::run_generate_key(*generate_args);
             }


### PR DESCRIPTION
## 1. What does this PR implement?

The config of node v0.1.2 dont have a keystore, this change allows users to migrate to a new config format by running `logos-blockchain-node migrate-from-0.1.2`. This way users should be able to use the same keys between v0.1.2 and the next version.

## 2. Does the code have enough context to be clearly understood?

Convenience command

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
