### PR TITLE
feat(cli): restore opt-in --ibd flag for config generation

### DIFF
--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -160,7 +160,9 @@ fn build_cryptarchia_config(
         CryptarchiaConfig::with_required_values(CryptarchiaConfigRequiredValues {
             funding_pk: cryptarchia_funding_key.to_public_key(),
         });
-    if let Some(initial_peers) = initial_peers {
+    if cryptarchia_args.ibd
+        && let Some(initial_peers) = initial_peers
+    {
         cryptarchia_config.network.bootstrap.ibd.peers = initial_peers
             .iter()
             .filter_map(|addr| match addr.iter().last() {

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
@@ -26,7 +26,7 @@ pub struct MigrateArgs {
     pub old_config: PathBuf,
 
     /// Path for the keystore file.
-    #[clap(long = "keystore")]
+    #[clap(long = "keystore", default_value = "keystore.yaml")]
     pub keystore: PathBuf,
 
     #[clap(flatten)]

--- a/nodes/node/binary/src/cli/config/update.rs
+++ b/nodes/node/binary/src/cli/config/update.rs
@@ -140,7 +140,9 @@ fn update_cryptarchia_config(
         .expect("Cryptarchia funding key set by default");
     cryptarchia_config.set_funding_pk(cryptarchia_funding_key.to_public_key());
 
-    if let Some(initial_peers) = initial_peers {
+    if cryptarchia_args.ibd
+        && let Some(initial_peers) = initial_peers
+    {
         cryptarchia_config.network.bootstrap.ibd.peers = initial_peers
             .iter()
             .filter_map(|addr| match addr.iter().last() {

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -14,7 +14,10 @@ use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
 use libp2p::Multiaddr;
 
 use crate::{
-    cli::keys::{AddKeyArgs, GenerateKeyArgs, RemoveKeyArgs},
+    cli::{
+        config::migrate_0_1_2,
+        keys::{AddKeyArgs, GenerateKeyArgs, RemoveKeyArgs},
+    },
     config::{
         ApiArgs, BlendArgs, CryptarchiaArgs, DeploymentArgs, DeploymentSettings, DeploymentType,
         LogArgs, NetworkArgs, RunConfig, SdpArgs, StateArgs, UserConfig, update_api, update_blend,
@@ -115,6 +118,9 @@ pub enum Command {
     UpdateConfig(Box<UpdateArgs>),
     /// Migrates a new user config with generated keys
     MigrateConfig(Box<MigrateArgs>),
+    /// Migrates 0.1.2 config to a new user config
+    #[command(name = "migrate-from-0.1.2")]
+    Migrate0_1_2(Box<migrate_0_1_2::MigrateArgs>),
     /// Generate a new key of type.
     GenerateKey(Box<GenerateKeyArgs>),
     /// Add a key of type to a keystore.

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -229,7 +229,7 @@ impl From<EmbeddedInitArgs> for InitArgs {
                 .expect("Valid multiaddr structure"),
         );
 
-        init_args.cryptarchia.disable_ibd_peers = !args.ibd;
+        init_args.cryptarchia.ibd = args.ibd;
         init_args.api.addr = Some(args.http_addr);
         init_args.state.path.clone_from(&args.state_path);
 

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -1,6 +1,5 @@
 use core::{convert::Infallible, str::FromStr};
 use std::{
-    collections::HashSet,
     net::{IpAddr, SocketAddr, ToSocketAddrs as _},
     path::PathBuf,
     time::Duration,
@@ -271,9 +270,10 @@ pub struct CryptarchiaArgs {
     )]
     pub cryptarchia_funding_pk: Option<ZkPublicKey>,
 
-    /// Overwrite IBD peer list with an empty list.
-    #[clap(long = "disable-ibd-peers", default_value_t = false)]
-    pub disable_ibd_peers: bool,
+    /// Enable Initial Block Download (IBD) using peers
+    /// passed via `--net-initial-peers`/`-p`.
+    #[clap(long = "ibd", default_value_t = false)]
+    pub ibd: bool,
 }
 
 #[derive(Parser, Debug, Default, Clone, Copy)]
@@ -544,18 +544,17 @@ pub fn update_blend(blend: &mut BlendConfig, blend_args: BlendArgs) {
     }
 }
 
-pub fn update_cryptarchia(cryptarchia: &mut CryptarchiaConfig, cryptarchia_args: CryptarchiaArgs) {
+pub const fn update_cryptarchia(
+    cryptarchia: &mut CryptarchiaConfig,
+    cryptarchia_args: CryptarchiaArgs,
+) {
     let CryptarchiaArgs {
         cryptarchia_funding_pk: funding_pk,
-        disable_ibd_peers,
+        ..
     } = cryptarchia_args;
 
     if let Some(pk) = funding_pk {
         cryptarchia.set_funding_pk(pk);
-    }
-
-    if disable_ibd_peers {
-        cryptarchia.network.bootstrap.ibd.peers = HashSet::new();
     }
 }
 

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -26,6 +26,9 @@ async fn main() -> Result<()> {
             Command::MigrateConfig(migrate_args) => {
                 return logos_blockchain_node::cli::config::migrate::run(*migrate_args);
             }
+            Command::Migrate0_1_2(migrate_args) => {
+                return logos_blockchain_node::cli::config::migrate_0_1_2::run(*migrate_args);
+            }
             Command::GenerateKey(generate_args) => {
                 return logos_blockchain_node::cli::keys::run_generate_key(*generate_args);
             }


### PR DESCRIPTION
## 1. What does this PR implement?

Restores the opt-in `--ibd` flag (removed in #2801) for config generation, replacing the inverted `--disable-ibd-peers` flag on `CryptarchiaArgs`. IBD peers are now only populated from `--net-initial-peers`/`-p` when `--ibd` is passed:

* `init-config` / `migrate-config`: IBD peer list is empty by default; `--ibd` populates it from the initial peers that include a `PeerId`.
* `migrate-from-0.1.2`: IBD is disabled by default when migrating from a 0.1.2 config, and enabled only if the migrate invocation includes `--ibd`.
* `update-config`: existing IBD peers in the config are left untouched unless `--ibd` is passed together with new initial peers (previously every update silently re-populated them).
* The embedded (c-bindings) `EmbeddedInitArgs.ibd` mapping is updated accordingly; its default remains IBD-off.

Note: with `--disable-ibd-peers` gone, `update-config` no longer has a flag to clear IBD peers from an existing config. If that is still needed it can be added as a separate explicit flag.

Based on #2912 (`cli-migrate-0.1.2`) so the migration command picks up the new default; targets that branch.

## 2. Does the code have enough context to be clearly understood?

CLI behavior change only; no protocol changes. The flag semantics match the pre-#2801 `--ibd` flag introduced in #2734.

## 3. Who are the specification authors and who is accountable for this PR?

N/A (CLI convenience change). Accountable: @davidrusu.

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)