### PR TITLE
feat(wallet): add pending voucher tracking to prevent race conditions

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -21,7 +21,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         AuthenticatedMantleTx, SignedMantleTx, StorageSize, Transaction, TxHash, TxSelect,
-        gas::MainnetGasConstants, ops::leader_claim::LeaderClaimOp,
+        gas::MainnetGasConstants,
     },
     proofs::leader_proof::{Groth16LeaderProof, LeaderPrivate},
 };
@@ -55,7 +55,6 @@ use crate::{
     leadership::{SlotContext, build_proof_for, fetch_slot_context, search_for_winning_slots},
     mempool::{MempoolAdapter as _, adapter::MempoolAdapter},
     relays::CryptarchiaConsensusRelays,
-    wallet::{LeaderWalletError, fund_and_sign_leader_claim_tx},
 };
 
 /// The per-subscriber stream of per-epoch winning slots. Each item
@@ -106,14 +105,10 @@ pub enum Error {
     BlockCreation(#[from] BlockError),
     #[error("Wallet API error: {0}")]
     Wallet(#[from] Box<WalletApiError>),
-    #[error("Leader wallet error: {0}")]
-    LeaderWallet(#[from] LeaderWalletError),
     #[error("Mempool error: {0}")]
     Mempool(#[source] DynError),
     #[error("Chain service error: {0}")]
     ChainService(#[from] lb_chain_service::api::ApiError),
-    #[error("No claimable voucher found")]
-    NoClaimableVoucher,
     #[error("Ledger state not found for {0:?}")]
     LedgerStateNotFound(HeaderId),
 }
@@ -773,28 +768,17 @@ where
     ) -> Result<TxHash, Error> {
         let (tip, ledger_state) = Self::get_tip_ledger_state(cryptarchia).await?;
 
-        let voucher_nullifier = wallet
-            .get_claimable_voucher(Some(tip))
-            .await?
-            .response
-            .ok_or(Error::NoClaimableVoucher)?
-            .nullifier;
-        let pks = wallet.get_known_addresses().await?;
-
-        // TODO: let the user chose where to receive the rewards
         let reward_amount = ledger_state.mantle_ledger().leader_reward_amount();
-        let signed_tx = fund_and_sign_leader_claim_tx(
-            LeaderClaimOp {
-                rewards_root: ledger_state.mantle_ledger().vouchers_snapshot_root(),
-                voucher_nullifier,
-                pk: pks[0],
-            },
-            reward_amount,
-            tip,
-            wallet,
-            config,
-        )
-        .await?;
+        let signed_tx = wallet
+            .build_leader_claim_tx(
+                tip,
+                ledger_state.mantle_ledger().vouchers_snapshot_root(),
+                reward_amount,
+                config.funding_pk,
+                config.max_tx_fee,
+            )
+            .await?
+            .response;
         let tx_hash = signed_tx.hash();
 
         mempool.post_tx(signed_tx).await.map_err(Error::Mempool)?;

--- a/services/chain/chain-leader/src/wallet.rs
+++ b/services/chain/chain-leader/src/wallet.rs
@@ -1,90 +1,13 @@
-use std::fmt::{Debug, Display};
-
-use lb_core::{
-    header::HeaderId,
-    mantle::{
-        Note, Op, SignedMantleTx, Value,
-        gas::{GasCost, GasOverflow, MainnetGasConstants},
-        ops::leader_claim::LeaderClaimOp,
-        tx_builder::{MantleTxBuilder, TxBuilderError},
-    },
-};
+use lb_core::mantle::gas::GasCost;
 use lb_key_management_system_service::keys::ZkPublicKey;
-use lb_wallet_service::api::{WalletApi, WalletApiError, WalletServiceData};
-use overwatch::services::AsServiceId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LeaderWalletConfig {
-    // Hard cap on the transaction fee for LEADER_CLAIM
+    // Hard cap on the transaction fee for LEADER_CLAIM.
     pub max_tx_fee: GasCost,
 
     // The key to use for paying transaction fees for LEADER_CLAIM.
     // Change notes will be returned to this same funding pk.
     pub funding_pk: ZkPublicKey,
-}
-
-pub async fn fund_and_sign_leader_claim_tx<Wallet, RuntimeServiceId>(
-    op: LeaderClaimOp,
-    reward_amount: Value,
-    tip: HeaderId,
-    wallet: &WalletApi<Wallet, RuntimeServiceId>,
-    config: &LeaderWalletConfig,
-) -> Result<SignedMantleTx, LeaderWalletError>
-where
-    Wallet: WalletServiceData,
-    RuntimeServiceId: Debug + Send + Sync + Display + 'static + AsServiceId<Wallet>,
-{
-    let tx_context = wallet
-        .get_tx_context(Some(tip))
-        .await
-        .map_err(|error| LeaderWalletError::WalletApi(Box::new(error)))?;
-    let tx_builder = MantleTxBuilder::new(tx_context)
-        .push_op(Op::LeaderClaim(op))
-        .map_err(LeaderWalletError::TxBuilder)?
-        .add_ledger_output(Note::new(reward_amount, config.funding_pk))
-        .map_err(LeaderWalletError::TxBuilder)?;
-    let funded_tx_builder = wallet
-        .fund_tx(
-            Some(tip),
-            tx_builder,
-            config.funding_pk,
-            vec![config.funding_pk],
-        )
-        .await
-        .map_err(|e| LeaderWalletError::WalletApi(Box::new(e)))?
-        .response;
-
-    let tx_fee = funded_tx_builder.gas_cost::<MainnetGasConstants>()?;
-    tracing::debug!(
-        net_balance = funded_tx_builder.net_balance(),
-        gas_cost = ?tx_fee,
-        reward_amount,
-        n_inputs = funded_tx_builder.ledger_inputs().len(),
-        "leader claim tx builder state after funding"
-    );
-    if tx_fee > config.max_tx_fee {
-        return Err(LeaderWalletError::TxFeeExceedsMaxFee {
-            tx_fee,
-            max_fee: config.max_tx_fee,
-        });
-    }
-
-    Ok(wallet
-        .sign_tx(Some(tip), funded_tx_builder)
-        .await
-        .map_err(|e| LeaderWalletError::WalletApi(Box::new(e)))?
-        .response)
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum LeaderWalletError {
-    #[error(transparent)]
-    WalletApi(#[from] Box<WalletApiError>),
-    #[error("Transaction fee exceeded the configured max fee. tx_fee={tx_fee} > max_fee={max_fee}")]
-    TxFeeExceedsMaxFee { max_fee: GasCost, tx_fee: GasCost },
-    #[error(transparent)]
-    GasOverflow(#[from] GasOverflow),
-    #[error(transparent)]
-    TxBuilder(#[from] TxBuilderError),
 }

--- a/services/wallet/src/api.rs
+++ b/services/wallet/src/api.rs
@@ -2,7 +2,8 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         Note, SignedMantleTx, TxHash, Value,
-        ops::leader_claim::VoucherCm,
+        gas::GasCost,
+        ops::leader_claim::{RewardsRoot, VoucherCm},
         tx::MantleTxContext,
         tx_builder::{MantleTxBuilder, TxBuilderError},
     },
@@ -21,8 +22,8 @@ use overwatch::{
 use tokio::sync::oneshot::{self, error::RecvError};
 
 use crate::{
-    ClaimableVoucherInfo, TipResponse, UtxoWithKeyId, VoucherCommitmentAndNullifier, WalletMsg,
-    WalletServiceError, WalletServiceSettings,
+    ClaimableVoucherInfo, TipResponse, UtxoWithKeyId, WalletMsg, WalletServiceError,
+    WalletServiceSettings,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -148,6 +149,30 @@ where
         Ok(rx.await??)
     }
 
+    pub async fn build_leader_claim_tx(
+        &self,
+        tip: HeaderId,
+        rewards_root: RewardsRoot,
+        reward_amount: Value,
+        funding_pk: ZkPublicKey,
+        max_tx_fee: GasCost,
+    ) -> Result<TipResponse<SignedMantleTx>, WalletApiError> {
+        let (resp_tx, rx) = oneshot::channel();
+
+        self.relay
+            .send(WalletMsg::BuildLeaderClaimTx {
+                tip,
+                rewards_root,
+                reward_amount,
+                funding_pk,
+                max_tx_fee,
+                resp_tx,
+            })
+            .await?;
+
+        Ok(rx.await??)
+    }
+
     pub async fn get_tx_context(
         &self,
         block_id: Option<HeaderId>,
@@ -249,17 +274,6 @@ where
             .send(WalletMsg::GenerateNewVoucherSecret { resp_tx })
             .await?;
         Ok(rx.await?)
-    }
-
-    pub async fn get_claimable_voucher(
-        &self,
-        tip: Option<HeaderId>,
-    ) -> Result<TipResponse<Option<VoucherCommitmentAndNullifier>>, WalletApiError> {
-        let (resp_tx, rx) = oneshot::channel();
-        self.relay
-            .send(WalletMsg::GetClaimableVoucher { tip, resp_tx })
-            .await?;
-        Ok(rx.await??)
     }
 
     pub async fn get_claimable_vouchers(

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -200,7 +200,7 @@ pub struct UtxoWithKeyId {
     pub key_id: KeyId,
 }
 
-struct BuiltLeaderClaimTx {
+struct LeaderClaimTx {
     signed_tx: SignedMantleTx,
     voucher_nullifier: VoucherNullifier,
 }
@@ -1087,8 +1087,8 @@ where
         ledger: LedgerState,
         state: &mut ServiceState<'_>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
-    ) -> Result<BuiltLeaderClaimTx, WalletServiceError> {
-        let voucher_nullifier = Self::reserve_claimable_voucher(state, request.tip)
+    ) -> Result<LeaderClaimTx, WalletServiceError> {
+        let voucher_nullifier = Self::reserve_claimable_voucher(state, request.tip)?
             .ok_or(WalletServiceError::NoClaimableVoucher)?;
 
         let result =
@@ -1099,7 +1099,7 @@ where
             state.release_claim_reservation(voucher_nullifier);
         }
 
-        result.map(|signed_tx| BuiltLeaderClaimTx {
+        result.map(|signed_tx| LeaderClaimTx {
             signed_tx,
             voucher_nullifier,
         })
@@ -1108,8 +1108,13 @@ where
     fn reserve_claimable_voucher(
         state: &mut ServiceState<'_>,
         tip: HeaderId,
-    ) -> Option<VoucherNullifier> {
-        match state.find_available_claimable_voucher(tip) {
+    ) -> Result<Option<VoucherNullifier>, WalletServiceError> {
+        let claimable_vouchers = state.claimable_vouchers(tip)?;
+
+        match (
+            claimable_vouchers.available.into_iter().next(),
+            claimable_vouchers.pending.len(),
+        ) {
             (Some(voucher), _) => {
                 state.reserve_claim(voucher.nullifier);
 
@@ -1120,16 +1125,16 @@ where
                     "Found and reserved claimable voucher"
                 );
 
-                Some(voucher.nullifier)
+                Ok(Some(voucher.nullifier))
             }
             (None, pending_count) if pending_count > 0 => {
                 debug!(
                     target: LOG_TARGET,
                     "No available vouchers: {pending_count} are pending"
                 );
-                None
+                Ok(None)
             }
-            (None, _) => None,
+            (None, _) => Ok(None),
         }
     }
 
@@ -1146,38 +1151,21 @@ where
                 return;
             }
         };
-        let response = Self::find_claimable_vouchers(state, tip).map(|vouchers| TipResponse {
+        let response = state.claimable_vouchers(tip).map(|vouchers| TipResponse {
             tip,
-            response: vouchers,
+            response: vouchers
+                .available
+                .into_iter()
+                .map(|voucher| ClaimableVoucherInfo {
+                    commitment: voucher.commitment,
+                    nullifier: voucher.nullifier,
+                })
+                .collect(),
         });
 
         if resp_tx.send(response).is_err() {
             debug!(target: LOG_TARGET, "Failed to respond to GetClaimableVouchers");
         }
-    }
-
-    fn find_claimable_vouchers(
-        state: &ServiceState<'_>,
-        tip: HeaderId,
-    ) -> Result<Vec<ClaimableVoucherInfo>, WalletServiceError> {
-        let wallet = state.wallet();
-
-        wallet
-            .voucher_commitments_and_nullifiers()
-            .filter(|voucher| !state.is_claim_reserved(&voucher.nullifier))
-            .filter_map(|voucher| {
-                wallet
-                    .voucher_path_snapshot(tip, &voucher.commitment)
-                    .map_err(WalletServiceError::from)
-                    .transpose()
-                    .map(|path| {
-                        path.map(|_| ClaimableVoucherInfo {
-                            commitment: voucher.commitment,
-                            nullifier: voucher.nullifier,
-                        })
-                    })
-            })
-            .collect()
     }
 
     async fn build_reserved_leader_claim_tx(
@@ -1341,11 +1329,11 @@ where
             state.release_claim_reservation(*nullifier);
         }
 
-        let lib_blocks_count = lib_update.pruned_blocks.immutable_blocks.len() as u64;
+        let new_immutable_blocks_count = lib_update.pruned_blocks.immutable_blocks.len() as u64;
         state.advance_lib(
             lib_update.new_lib,
             lib_update.pruned_blocks.all(),
-            lib_blocks_count,
+            new_immutable_blocks_count,
             claimed_nullifiers,
         );
     }

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -16,8 +16,8 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{
-        AuthenticatedMantleTx, Note, NoteId, Op, OpProof, SignedMantleTx, Transaction as _, TxHash,
-        Utxo, Value,
+        AuthenticatedMantleTx, NoteId, Op, OpProof, SignedMantleTx, Transaction as _, TxHash, Utxo,
+        Value,
         gas::{GasCost, GasOverflow, MainnetGasConstants},
         ledger::Inputs,
         ops::{
@@ -1175,13 +1175,12 @@ where
         state: &ServiceState<'_>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
     ) -> Result<SignedMantleTx, WalletServiceError> {
-        let tx_builder = MantleTxBuilder::new(ledger.tx_context())
-            .push_op(Op::LeaderClaim(LeaderClaimOp {
+        let tx_builder =
+            MantleTxBuilder::new(ledger.tx_context()).push_op(Op::LeaderClaim(LeaderClaimOp {
                 rewards_root: request.rewards_root,
                 voucher_nullifier,
                 pk: request.funding_pk,
-            }))?
-            .add_ledger_output(Note::new(request.reward_amount, request.funding_pk))?;
+            }))?;
 
         let funded_tx_builder = state.wallet().fund_tx::<MainnetGasConstants>(
             request.tip,

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod api;
 mod states;
 
-use std::{collections::HashMap, path::PathBuf, time::Duration};
+use std::{collections::HashMap, num::NonZeroU64, path::PathBuf, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -382,6 +382,7 @@ where
         let mut lib_receiver = cryptarchia_api.subscribe_lib_updates().await?;
 
         let (epoch_config, consensus_config) = cryptarchia_api.get_epoch_config().await?;
+        let security_param = NonZeroU64::from(consensus_config.security_param()).get();
         let epoch_config = EpochConfig {
             epoch_config,
             consensus_config,
@@ -402,6 +403,7 @@ where
             lib,
             &lib_ledger,
             &service_resources_handle.state_updater,
+            security_param,
         );
         let voucher_master_key_id = settings.voucher_master_key_id;
 
@@ -1358,9 +1360,11 @@ where
             state.release_claim_reservation(*nullifier);
         }
 
+        let lib_blocks_count = lib_update.pruned_blocks.immutable_blocks.len() as u64;
         state.advance_lib(
             lib_update.new_lib,
             lib_update.pruned_blocks.all(),
+            lib_blocks_count,
             claimed_nullifiers,
         );
     }

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -640,7 +640,7 @@ where
                 .await;
             }
             WalletMsg::GetClaimableVouchers { tip, resp_tx } => {
-                Self::get_claimable_vouchers(tip, resp_tx, state.wallet(), cryptarchia).await;
+                Self::get_claimable_vouchers(tip, resp_tx, state, cryptarchia).await;
             }
             WalletMsg::GetKnownAddresses { resp_tx } => {
                 Self::get_known_addresses(state.wallet(), resp_tx);
@@ -1136,7 +1136,7 @@ where
     async fn get_claimable_vouchers(
         tip: Option<HeaderId>,
         resp_tx: Sender<Result<TipResponse<Vec<ClaimableVoucherInfo>>, WalletServiceError>>,
-        wallet: &Wallet,
+        state: &ServiceState<'_>,
         cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
     ) {
         let tip = match Self::msg_tip_or_latest(tip, cryptarchia).await {
@@ -1146,7 +1146,7 @@ where
                 return;
             }
         };
-        let response = Self::find_claimable_vouchers(wallet, tip).map(|vouchers| TipResponse {
+        let response = Self::find_claimable_vouchers(state, tip).map(|vouchers| TipResponse {
             tip,
             response: vouchers,
         });
@@ -1157,11 +1157,14 @@ where
     }
 
     fn find_claimable_vouchers(
-        wallet: &Wallet,
+        state: &ServiceState<'_>,
         tip: HeaderId,
     ) -> Result<Vec<ClaimableVoucherInfo>, WalletServiceError> {
+        let wallet = state.wallet();
+
         wallet
             .voucher_commitments_and_nullifiers()
+            .filter(|voucher| !state.is_claim_reserved(&voucher.nullifier))
             .filter_map(|voucher| {
                 wallet
                     .voucher_path_snapshot(tip, &voucher.commitment)

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -16,8 +16,9 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{
-        AuthenticatedMantleTx, NoteId, Op, OpProof, SignedMantleTx, Transaction as _, TxHash, Utxo,
-        gas::MainnetGasConstants,
+        AuthenticatedMantleTx, Note, NoteId, Op, OpProof, SignedMantleTx, Transaction as _, TxHash,
+        Utxo, Value,
+        gas::{GasCost, GasOverflow, MainnetGasConstants},
         ledger::Inputs,
         ops::{
             channel::{ChannelId, config::ChannelConfigOp, inscribe::InscriptionOp},
@@ -105,11 +106,23 @@ pub enum WalletServiceError {
     #[error(transparent)]
     TxBuilder(#[from] TxBuilderError),
 
+    #[error(transparent)]
+    GasOverflow(#[from] GasOverflow),
+
+    #[error("Transaction fee exceeded the configured max fee. tx_fee={tx_fee} > max_fee={max_fee}")]
+    TxFeeExceedsMaxFee { max_fee: GasCost, tx_fee: GasCost },
+
     #[error("PoC generation failed: {0:?}")]
     PoCGenerationFailed(#[from] lb_core::proofs::leader_claim_proof::Error),
 
+    #[error("No claimable voucher found")]
+    NoClaimableVoucher,
+
     #[error("Voucher not found for the nullifier")]
     VoucherNotFound(VoucherNullifier),
+
+    #[error("Claim reservation not found for voucher nullifier {0:?}")]
+    ClaimReservationNotFound(VoucherNullifier),
 
     #[error("Merkle path not found for voucher_cm: {0:?}")]
     VoucherMerklePathNotFound(VoucherCm),
@@ -134,6 +147,14 @@ pub enum WalletMsg {
         change_pk: ZkPublicKey,
         funding_pks: Vec<ZkPublicKey>,
         resp_tx: Sender<Result<TipResponse<MantleTxBuilder>, WalletServiceError>>,
+    },
+    BuildLeaderClaimTx {
+        tip: HeaderId,
+        rewards_root: RewardsRoot,
+        reward_amount: Value,
+        funding_pk: ZkPublicKey,
+        max_tx_fee: GasCost,
+        resp_tx: Sender<Result<TipResponse<SignedMantleTx>, WalletServiceError>>,
     },
     SignTx {
         tip: Option<HeaderId>,
@@ -187,10 +208,17 @@ pub struct UtxoWithKeyId {
     pub key_id: KeyId,
 }
 
-#[derive(Debug)]
-pub struct VoucherCommitmentAndNullifier {
-    pub commitment: VoucherCm,
-    pub nullifier: VoucherNullifier,
+struct BuiltLeaderClaimTx {
+    signed_tx: SignedMantleTx,
+    voucher_nullifier: VoucherNullifier,
+}
+
+struct LeaderClaimTxRequest {
+    tip: HeaderId,
+    rewards_root: RewardsRoot,
+    reward_amount: Value,
+    funding_pk: ZkPublicKey,
+    max_tx_fee: GasCost,
 }
 
 #[derive(Debug)]
@@ -212,6 +240,7 @@ impl WalletMsg {
             | Self::GetClaimableVoucher { tip, .. }
             | Self::GetClaimableVouchers { tip, .. }
             | Self::GetTxContext { block_id: tip, .. } => *tip,
+            Self::BuildLeaderClaimTx { tip, .. } => Some(*tip),
             Self::SignTxWithEd25519 { .. }
             | Self::SignTxWithZk { .. }
             | Self::GenerateNewVoucherSecret { .. }
@@ -431,6 +460,16 @@ where
         }
     }
 
+    async fn ledger_state_at(
+        tip: HeaderId,
+        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+    ) -> Result<LedgerState, WalletServiceError> {
+        cryptarchia
+            .get_ledger_state(tip)
+            .await?
+            .ok_or(WalletServiceError::LedgerStateNotFound(tip))
+    }
+
     #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
     #[expect(
         clippy::cognitive_complexity,
@@ -498,6 +537,51 @@ where
                     debug!(target: LOG_TARGET, "Failed to respond to FundTx");
                 }
             }
+            WalletMsg::BuildLeaderClaimTx {
+                tip,
+                rewards_root,
+                reward_amount,
+                funding_pk,
+                max_tx_fee,
+                resp_tx,
+            } => {
+                let ledger = match Self::ledger_state_at(tip, cryptarchia).await {
+                    Ok(ledger) => ledger,
+                    Err(err) => {
+                        Self::send_err(resp_tx, err);
+                        return;
+                    }
+                };
+                let request = LeaderClaimTxRequest {
+                    tip,
+                    rewards_root,
+                    reward_amount,
+                    funding_pk,
+                    max_tx_fee,
+                };
+                let response = Self::build_leader_claim_tx(request, ledger, state, kms).await;
+
+                match response {
+                    Ok(built_tx) => {
+                        let voucher_nullifier = built_tx.voucher_nullifier;
+                        if resp_tx
+                            .send(Ok(TipResponse {
+                                tip,
+                                response: built_tx.signed_tx,
+                            }))
+                            .is_err()
+                        {
+                            state.release_claim_reservation(voucher_nullifier);
+                            debug!(target: LOG_TARGET, "Failed to respond to BuildLeaderClaimTx");
+                        }
+                    }
+                    Err(err) => {
+                        if resp_tx.send(Err(err)).is_err() {
+                            debug!(target: LOG_TARGET, "Failed to respond to BuildLeaderClaimTx");
+                        }
+                    }
+                }
+            }
             WalletMsg::SignTx {
                 tip,
                 tx_builder,
@@ -511,14 +595,10 @@ where
                     }
                 };
 
-                let ledger = match cryptarchia.get_ledger_state(tip).await {
-                    Ok(Some(ledger)) => ledger,
-                    Ok(None) => {
-                        Self::send_err(resp_tx, WalletServiceError::LedgerStateNotFound(tip));
-                        return;
-                    }
+                let ledger = match Self::ledger_state_at(tip, cryptarchia).await {
+                    Ok(ledger) => ledger,
                     Err(err) => {
-                        Self::send_err(resp_tx, WalletServiceError::from(err));
+                        Self::send_err(resp_tx, err);
                         return;
                     }
                 };
@@ -922,10 +1002,12 @@ where
             }
         };
 
-        // Get the ledger state at the specified tip
-        let Ok(Some(ledger_state)) = cryptarchia.get_ledger_state(tip).await else {
-            Self::send_err(resp_tx, WalletServiceError::LedgerStateNotFound(tip));
-            return;
+        let ledger_state = match Self::ledger_state_at(tip, cryptarchia).await {
+            Ok(ledger_state) => ledger_state,
+            Err(err) => {
+                Self::send_err(resp_tx, err);
+                return;
+            }
         };
 
         let wallet_state = match wallet.wallet_state_at(tip) {
@@ -1010,45 +1092,62 @@ where
             .into()
     }
 
-    async fn get_claimable_voucher(
-        tip: Option<HeaderId>,
-        resp_tx: Sender<
-            Result<TipResponse<Option<VoucherCommitmentAndNullifier>>, WalletServiceError>,
-        >,
-        wallet: &Wallet,
-        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
-    ) {
-        let tip = match Self::msg_tip_or_latest(tip, cryptarchia).await {
-            Ok(tip) => tip,
-            Err(err) => {
-                Self::send_err(resp_tx, err);
-                return;
-            }
-        };
+    async fn build_leader_claim_tx(
+        request: LeaderClaimTxRequest,
+        ledger: LedgerState,
+        state: &mut ServiceState<'_>,
+        kms: &KmsServiceApi<Kms, RuntimeServiceId>,
+    ) -> Result<BuiltLeaderClaimTx, WalletServiceError> {
+        let voucher_nullifier = Self::reserve_claimable_voucher(state, request.tip)
+            .ok_or(WalletServiceError::NoClaimableVoucher)?;
 
-        let voucher = Self::find_claimable_voucher(wallet, tip);
-        if resp_tx
-            .send(Ok(TipResponse {
-                tip,
-                response: voucher,
-            }))
-            .is_err()
-        {
-            debug!(target: LOG_TARGET, "Failed to respond to GetClaimableVoucher");
+        let result =
+            Self::build_reserved_leader_claim_tx(request, voucher_nullifier, ledger, state, kms)
+                .await;
+
+        if result.is_err() {
+            state.release_claim_reservation(voucher_nullifier);
         }
+
+        result.map(|signed_tx| BuiltLeaderClaimTx {
+            signed_tx,
+            voucher_nullifier,
+        })
     }
 
-    fn find_claimable_voucher(
-        wallet: &Wallet,
+    fn reserve_claimable_voucher(
+        state: &mut ServiceState<'_>,
         tip: HeaderId,
-    ) -> Option<VoucherCommitmentAndNullifier> {
-        for (nf, cm) in wallet.voucher_commitments_and_nullifiers() {
-            if let Ok(Some(_)) = wallet.voucher_path_snapshot(tip, cm) {
-                return Some(VoucherCommitmentAndNullifier {
-                    commitment: *cm,
-                    nullifier: *nf,
-                });
-            }
+    ) -> Option<VoucherNullifier> {
+        let vouchers: Vec<_> = state
+            .wallet()
+            .voucher_commitments_and_nullifiers()
+            .map(|(nf, cm)| (*nf, *cm))
+            .collect();
+
+        let (available_voucher, pending_count) =
+            Self::find_available_voucher(&vouchers, state, tip);
+
+        if let Some((nf, cm)) = available_voucher {
+            state.reserve_claim(nf);
+
+            debug!(
+                target: LOG_TARGET,
+                ?nf,
+                ?cm,
+                "Found and reserved claimable voucher"
+            );
+
+            return Some(nf);
+        }
+
+        if pending_count > 0 {
+            debug!(
+                target: LOG_TARGET,
+                "No available vouchers: {}/{} are pending",
+                pending_count,
+                vouchers.len()
+            );
         }
         None
     }
@@ -1095,6 +1194,84 @@ where
                     })
             })
             .collect()
+    }
+
+    async fn build_reserved_leader_claim_tx(
+        request: LeaderClaimTxRequest,
+        voucher_nullifier: VoucherNullifier,
+        ledger: LedgerState,
+        state: &mut ServiceState<'_>,
+        kms: &KmsServiceApi<Kms, RuntimeServiceId>,
+    ) -> Result<SignedMantleTx, WalletServiceError> {
+        let tx_builder = MantleTxBuilder::new(ledger.tx_context())
+            .push_op(Op::LeaderClaim(LeaderClaimOp {
+                rewards_root: request.rewards_root,
+                voucher_nullifier,
+                pk: request.funding_pk,
+            }))?
+            .add_ledger_output(Note::new(request.reward_amount, request.funding_pk))?;
+
+        let excluded_notes = state.pending_claim_funding_notes();
+        let funded_tx_builder = state.wallet().fund_tx_excluding::<MainnetGasConstants>(
+            request.tip,
+            &tx_builder,
+            request.funding_pk,
+            [request.funding_pk],
+            excluded_notes,
+        )?;
+
+        let funding_notes = funded_tx_builder
+            .ledger_inputs()
+            .iter()
+            .map(Utxo::id)
+            .collect::<Vec<_>>();
+
+        state.reserve_claim_funding_notes(voucher_nullifier, funding_notes)?;
+
+        let tx_fee = funded_tx_builder.gas_cost::<MainnetGasConstants>()?;
+        debug!(
+            target: LOG_TARGET,
+            net_balance = funded_tx_builder.net_balance(),
+            gas_cost = ?tx_fee,
+            reward_amount = request.reward_amount,
+            n_inputs = funded_tx_builder.ledger_inputs().len(),
+            "leader claim tx builder state after funding"
+        );
+
+        if tx_fee > request.max_tx_fee {
+            return Err(WalletServiceError::TxFeeExceedsMaxFee {
+                max_fee: request.max_tx_fee,
+                tx_fee,
+            });
+        }
+
+        Self::sign_tx(funded_tx_builder, request.tip, ledger, kms, state.wallet()).await
+    }
+
+    fn find_available_voucher(
+        vouchers: &[(VoucherNullifier, VoucherCm)],
+        state: &mut ServiceState<'_>,
+        tip: HeaderId,
+    ) -> (Option<(VoucherNullifier, VoucherCm)>, usize) {
+        let mut pending_count = 0;
+
+        for &(nf, cm) in vouchers {
+            if state.is_claim_pending(&nf) {
+                pending_count += 1;
+                trace!(
+                    target: LOG_TARGET,
+                    ?nf,
+                    "Skipping pending voucher"
+                );
+                continue;
+            }
+
+            if let Ok(Some(_)) = state.wallet().voucher_path_snapshot(tip, &cm) {
+                return (Some((nf, cm)), pending_count);
+            }
+        }
+
+        (None, pending_count)
     }
 
     async fn backfill_if_not_in_sync(
@@ -1206,21 +1383,27 @@ where
     ) {
         log_lib_update(lib_update);
 
+        let claimed_nullifiers = Self::collect_claimed_nullifiers_from_blocks(
+            lib_update.pruned_blocks.immutable_blocks.values(),
+            storage_adapter,
+        )
+        .await;
+
+        for nullifier in &claimed_nullifiers {
+            state.release_claim_reservation(*nullifier);
+        }
+
         state.advance_lib(
             lib_update.new_lib,
             lib_update.pruned_blocks.all(),
-            Self::collect_claimed_nullifiers_from_blocks(
-                lib_update.pruned_blocks.immutable_blocks.values(),
-                storage_adapter,
-            )
-            .await,
+            claimed_nullifiers,
         );
     }
 
     async fn collect_claimed_nullifiers_from_blocks(
         blocks: impl Iterator<Item = &HeaderId>,
         storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> impl IntoIterator<Item = VoucherNullifier> {
+    ) -> Vec<VoucherNullifier> {
         let immutable_blocks: Vec<Block<Tx>> = futures::stream::iter(blocks)
             .filter_map(async |header_id| storage_adapter.get_block(header_id).await)
             .collect::<Vec<_>>()
@@ -1241,7 +1424,7 @@ where
                 }
             })
             .collect();
-        claimed_nullifiers.into_iter()
+        claimed_nullifiers
     }
 
     #[expect(
@@ -1346,14 +1529,10 @@ where
             }
         };
 
-        let ledger_state = match cryptarchia.get_ledger_state(block_id).await {
-            Ok(Some(ledger_state)) => ledger_state,
-            Ok(None) => {
-                Self::send_err(resp_tx, WalletServiceError::LedgerStateNotFound(block_id));
-                return;
-            }
+        let ledger_state = match Self::ledger_state_at(block_id, cryptarchia).await {
+            Ok(ledger_state) => ledger_state,
             Err(err) => {
-                Self::send_err(resp_tx, WalletServiceError::from(err));
+                Self::send_err(resp_tx, err);
                 return;
             }
         };

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -121,9 +121,6 @@ pub enum WalletServiceError {
     #[error("Voucher not found for the nullifier")]
     VoucherNotFound(VoucherNullifier),
 
-    #[error("Claim reservation not found for voucher nullifier {0:?}")]
-    ClaimReservationNotFound(VoucherNullifier),
-
     #[error("Merkle path not found for voucher_cm: {0:?}")]
     VoucherMerklePathNotFound(VoucherCm),
 
@@ -177,11 +174,6 @@ pub enum WalletMsg {
     },
     GenerateNewVoucherSecret {
         resp_tx: Sender<VoucherCm>,
-    },
-    GetClaimableVoucher {
-        tip: Option<HeaderId>,
-        resp_tx:
-            Sender<Result<TipResponse<Option<VoucherCommitmentAndNullifier>>, WalletServiceError>>,
     },
     GetClaimableVouchers {
         tip: Option<HeaderId>,
@@ -237,7 +229,6 @@ impl WalletMsg {
             | Self::FundTx { tip, .. }
             | Self::SignTx { tip, .. }
             | Self::GetLeaderAgedNotes { tip, .. }
-            | Self::GetClaimableVoucher { tip, .. }
             | Self::GetClaimableVouchers { tip, .. }
             | Self::GetTxContext { block_id: tip, .. } => *tip,
             Self::BuildLeaderClaimTx { tip, .. } => Some(*tip),
@@ -647,9 +638,6 @@ where
                     resp_tx,
                 )
                 .await;
-            }
-            WalletMsg::GetClaimableVoucher { tip, resp_tx } => {
-                Self::get_claimable_voucher(tip, resp_tx, state.wallet(), cryptarchia).await;
             }
             WalletMsg::GetClaimableVouchers { tip, resp_tx } => {
                 Self::get_claimable_vouchers(tip, resp_tx, state.wallet(), cryptarchia).await;
@@ -1174,15 +1162,15 @@ where
     ) -> Result<Vec<ClaimableVoucherInfo>, WalletServiceError> {
         wallet
             .voucher_commitments_and_nullifiers()
-            .filter_map(|(nf, cm)| {
+            .filter_map(|voucher| {
                 wallet
-                    .voucher_path_snapshot(tip, cm)
+                    .voucher_path_snapshot(tip, &voucher.commitment)
                     .map_err(WalletServiceError::from)
                     .transpose()
                     .map(|path| {
                         path.map(|_| ClaimableVoucherInfo {
-                            commitment: *cm,
-                            nullifier: *nf,
+                            commitment: voucher.commitment,
+                            nullifier: voucher.nullifier,
                         })
                     })
             })
@@ -1193,7 +1181,7 @@ where
         request: LeaderClaimTxRequest,
         voucher_nullifier: VoucherNullifier,
         ledger: LedgerState,
-        state: &mut ServiceState<'_>,
+        state: &ServiceState<'_>,
         kms: &KmsServiceApi<Kms, RuntimeServiceId>,
     ) -> Result<SignedMantleTx, WalletServiceError> {
         let tx_builder = MantleTxBuilder::new(ledger.tx_context())
@@ -1204,22 +1192,12 @@ where
             }))?
             .add_ledger_output(Note::new(request.reward_amount, request.funding_pk))?;
 
-        let excluded_notes = state.pending_claim_funding_notes();
-        let funded_tx_builder = state.wallet().fund_tx_excluding::<MainnetGasConstants>(
+        let funded_tx_builder = state.wallet().fund_tx::<MainnetGasConstants>(
             request.tip,
             &tx_builder,
             request.funding_pk,
             [request.funding_pk],
-            excluded_notes,
         )?;
-
-        let funding_notes = funded_tx_builder
-            .ledger_inputs()
-            .iter()
-            .map(Utxo::id)
-            .collect::<Vec<_>>();
-
-        state.reserve_claim_funding_notes(voucher_nullifier, funding_notes)?;
 
         let tx_fee = funded_tx_builder.gas_cost::<MainnetGasConstants>()?;
         debug!(

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -1119,37 +1119,28 @@ where
         state: &mut ServiceState<'_>,
         tip: HeaderId,
     ) -> Option<VoucherNullifier> {
-        let vouchers: Vec<_> = state
-            .wallet()
-            .voucher_commitments_and_nullifiers()
-            .map(|(nf, cm)| (*nf, *cm))
-            .collect();
+        match state.find_available_claimable_voucher(tip) {
+            (Some(voucher), _) => {
+                state.reserve_claim(voucher.nullifier);
 
-        let (available_voucher, pending_count) =
-            Self::find_available_voucher(&vouchers, state, tip);
+                debug!(
+                    target: LOG_TARGET,
+                    nf = ?voucher.nullifier,
+                    cm = ?voucher.commitment,
+                    "Found and reserved claimable voucher"
+                );
 
-        if let Some((nf, cm)) = available_voucher {
-            state.reserve_claim(nf);
-
-            debug!(
-                target: LOG_TARGET,
-                ?nf,
-                ?cm,
-                "Found and reserved claimable voucher"
-            );
-
-            return Some(nf);
+                Some(voucher.nullifier)
+            }
+            (None, pending_count) if pending_count > 0 => {
+                debug!(
+                    target: LOG_TARGET,
+                    "No available vouchers: {pending_count} are pending"
+                );
+                None
+            }
+            (None, _) => None,
         }
-
-        if pending_count > 0 {
-            debug!(
-                target: LOG_TARGET,
-                "No available vouchers: {}/{} are pending",
-                pending_count,
-                vouchers.len()
-            );
-        }
-        None
     }
 
     async fn get_claimable_vouchers(
@@ -1246,32 +1237,6 @@ where
         }
 
         Self::sign_tx(funded_tx_builder, request.tip, ledger, kms, state.wallet()).await
-    }
-
-    fn find_available_voucher(
-        vouchers: &[(VoucherNullifier, VoucherCm)],
-        state: &mut ServiceState<'_>,
-        tip: HeaderId,
-    ) -> (Option<(VoucherNullifier, VoucherCm)>, usize) {
-        let mut pending_count = 0;
-
-        for &(nf, cm) in vouchers {
-            if state.is_claim_pending(&nf) {
-                pending_count += 1;
-                trace!(
-                    target: LOG_TARGET,
-                    ?nf,
-                    "Skipping pending voucher"
-                );
-                continue;
-            }
-
-            if let Ok(Some(_)) = state.wallet().voucher_path_snapshot(tip, &cm) {
-                return (Some((nf, cm)), pending_count);
-            }
-        }
-
-        (None, pending_count)
     }
 
     async fn backfill_if_not_in_sync(

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -12,7 +12,7 @@ use lb_core::{
 };
 use lb_ledger::LedgerState;
 use lb_log_targets::wallet;
-use lb_wallet::{Vouchers, WalletBlock, WalletError, WalletState};
+use lb_wallet::{KnownVoucher, Vouchers, WalletBlock, WalletError, WalletState};
 use overwatch::services::state::StateUpdater;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -134,6 +134,8 @@ pub struct RecoveryState {
     /// [`WalletState`] at the last known LIB.
     /// `None` on fresh start; populated after the first LIB update.
     lib_wallet_state: Option<(HeaderId, WalletState)>,
+    // After restart we cannot know whether a reserved claim was submitted,
+    // accepted, or dropped, so recovering it could block usable vouchers/notes.
     #[serde(skip)]
     pending_claims: PendingClaims,
 }
@@ -240,16 +242,38 @@ impl<'u> ServiceState<'u> {
         &self.wallet
     }
 
+    pub fn find_available_claimable_voucher(
+        &mut self,
+        tip: HeaderId,
+    ) -> (Option<KnownVoucher>, usize) {
+        let wallet_state = &self.wallet;
+        let pending_claims = &mut self.pending_claims;
+        let mut pending_count = 0;
+
+        let available_voucher = wallet_state
+            .voucher_commitments_and_nullifiers()
+            .find(|voucher| {
+                if pending_claims.is_reserved(&voucher.nullifier) {
+                    pending_count += 1;
+
+                    return false;
+                }
+
+                matches!(
+                    wallet_state.voucher_path_snapshot(tip, &voucher.commitment),
+                    Ok(Some(_))
+                )
+            });
+
+        (available_voucher, pending_count)
+    }
+
     pub fn reserve_claim(&mut self, nullifier: VoucherNullifier) {
         self.pending_claims.reserve(nullifier);
     }
 
     pub fn release_claim_reservation(&mut self, nullifier: VoucherNullifier) {
         self.pending_claims.release(nullifier);
-    }
-
-    pub fn is_claim_pending(&mut self, nullifier: &VoucherNullifier) -> bool {
-        self.pending_claims.is_reserved(nullifier)
     }
 
     pub fn reserve_claim_funding_notes(

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -1,11 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use lb_core::{
     header::HeaderId,
-    mantle::{
-        NoteId,
-        ops::leader_claim::{VoucherCm, VoucherNullifier},
-    },
+    mantle::ops::leader_claim::{VoucherCm, VoucherNullifier},
 };
 use lb_ledger::LedgerState;
 use lb_log_targets::wallet;
@@ -22,7 +19,6 @@ pub type Wallet = lb_wallet::Wallet<KeyId, VoucherId>;
 
 #[derive(Debug, Clone)]
 struct PendingClaim {
-    funding_notes: HashSet<NoteId>,
     lib_blocks_elapsed: u64,
 }
 
@@ -41,7 +37,6 @@ impl PendingClaims {
         self.claims.insert(
             nullifier,
             PendingClaim {
-                funding_notes: HashSet::new(),
                 lib_blocks_elapsed: 0,
             },
         );
@@ -59,33 +54,6 @@ impl PendingClaims {
 
     fn is_reserved(&self, nullifier: &VoucherNullifier) -> bool {
         self.claims.contains_key(nullifier)
-    }
-
-    fn reserve_funding_notes(
-        &mut self,
-        nullifier: VoucherNullifier,
-        funding_notes: impl IntoIterator<Item = NoteId>,
-    ) -> Result<(), WalletServiceError> {
-        let Some(claim) = self.claims.get_mut(&nullifier) else {
-            return Err(WalletServiceError::ClaimReservationNotFound(nullifier));
-        };
-
-        claim.funding_notes = funding_notes.into_iter().collect();
-        debug!(
-            target: wallet::SERVICE,
-            ?nullifier,
-            funding_notes = claim.funding_notes.len(),
-            "Reserved claim funding notes"
-        );
-
-        Ok(())
-    }
-
-    fn funding_notes(&self) -> Vec<NoteId> {
-        self.claims
-            .values()
-            .flat_map(|claim| claim.funding_notes.iter().copied())
-            .collect()
     }
 
     fn advance_lib(&mut self, lib_blocks: u64, expiry_blocks: u64) {
@@ -276,19 +244,6 @@ impl<'u> ServiceState<'u> {
 
     pub fn release_claim_reservation(&mut self, nullifier: VoucherNullifier) {
         self.pending_claims.release(nullifier);
-    }
-
-    pub fn reserve_claim_funding_notes(
-        &mut self,
-        nullifier: VoucherNullifier,
-        funding_notes: impl IntoIterator<Item = NoteId>,
-    ) -> Result<(), WalletServiceError> {
-        self.pending_claims
-            .reserve_funding_notes(nullifier, funding_notes)
-    }
-
-    pub fn pending_claim_funding_notes(&self) -> Vec<NoteId> {
-        self.pending_claims.funding_notes()
     }
 
     fn update_state(&self) {

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -246,6 +246,10 @@ impl<'u> ServiceState<'u> {
         self.pending_claims.release(nullifier);
     }
 
+    pub fn is_claim_reserved(&self, nullifier: &VoucherNullifier) -> bool {
+        self.pending_claims.is_reserved(nullifier)
+    }
+
     fn update_state(&self) {
         let lib_wallet_state = self
             .wallet()

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -1,17 +1,131 @@
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
+
 use lb_core::{
     header::HeaderId,
-    mantle::ops::leader_claim::{VoucherCm, VoucherNullifier},
+    mantle::{
+        NoteId,
+        ops::leader_claim::{VoucherCm, VoucherNullifier},
+    },
 };
 use lb_ledger::LedgerState;
+use lb_log_targets::wallet;
 use lb_wallet::{Vouchers, WalletBlock, WalletError, WalletState};
 use overwatch::services::state::StateUpdater;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use crate::{KeyId, WalletServiceError, WalletServiceSettings};
 
 type VoucherIndex = u64;
 type VoucherId = (KeyId, VoucherIndex);
 pub type Wallet = lb_wallet::Wallet<KeyId, VoucherId>;
+
+const VOUCHER_PENDING_TIMEOUT: Duration = Duration::from_mins(1);
+
+#[derive(Debug, Clone)]
+struct PendingClaim {
+    funding_notes: HashSet<NoteId>,
+    reserved_at: Instant,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PendingClaims {
+    claims: HashMap<VoucherNullifier, PendingClaim>,
+}
+
+impl PendingClaims {
+    fn reserve(&mut self, nullifier: VoucherNullifier) {
+        self.prune_expired();
+        debug!(
+            target: wallet::SERVICE,
+            ?nullifier,
+            "Reserved claim voucher"
+        );
+        self.claims.insert(
+            nullifier,
+            PendingClaim {
+                funding_notes: HashSet::new(),
+                reserved_at: Instant::now(),
+            },
+        );
+    }
+
+    fn release(&mut self, nullifier: VoucherNullifier) {
+        if self.claims.remove(&nullifier).is_some() {
+            debug!(
+                target: wallet::SERVICE,
+                ?nullifier,
+                "Released pending claim reservation"
+            );
+        }
+    }
+
+    fn is_reserved(&mut self, nullifier: &VoucherNullifier) -> bool {
+        self.prune_expired();
+        self.claims.contains_key(nullifier)
+    }
+
+    fn reserve_funding_notes(
+        &mut self,
+        nullifier: VoucherNullifier,
+        funding_notes: impl IntoIterator<Item = NoteId>,
+    ) -> Result<(), WalletServiceError> {
+        self.prune_expired();
+        let Some(claim) = self.claims.get_mut(&nullifier) else {
+            return Err(WalletServiceError::ClaimReservationNotFound(nullifier));
+        };
+
+        claim.funding_notes = funding_notes.into_iter().collect();
+        debug!(
+            target: wallet::SERVICE,
+            ?nullifier,
+            funding_notes = claim.funding_notes.len(),
+            "Reserved claim funding notes"
+        );
+
+        Ok(())
+    }
+
+    fn funding_notes(&mut self) -> Vec<NoteId> {
+        self.prune_expired();
+
+        self.claims
+            .values()
+            .flat_map(|claim| claim.funding_notes.iter().copied())
+            .collect()
+    }
+
+    fn prune_expired(&mut self) {
+        let now = Instant::now();
+        let before_count = self.claims.len();
+
+        self.claims.retain(|nullifier, claim| {
+            let expired = now.duration_since(claim.reserved_at) >= VOUCHER_PENDING_TIMEOUT;
+
+            if expired {
+                debug!(
+                    target: wallet::SERVICE,
+                    ?nullifier,
+                    "Removing expired pending claim reservation (timeout: {:?})",
+                    VOUCHER_PENDING_TIMEOUT
+                );
+            }
+
+            !expired
+        });
+
+        if before_count != self.claims.len() {
+            debug!(
+                target: wallet::SERVICE,
+                "Cleaned {} expired pending claim reservation(s)",
+                before_count - self.claims.len()
+            );
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecoveryState {
@@ -20,6 +134,8 @@ pub struct RecoveryState {
     /// [`WalletState`] at the last known LIB.
     /// `None` on fresh start; populated after the first LIB update.
     lib_wallet_state: Option<(HeaderId, WalletState)>,
+    #[serde(skip)]
+    pending_claims: PendingClaims,
 }
 
 impl overwatch::services::state::ServiceState for RecoveryState {
@@ -31,6 +147,7 @@ impl overwatch::services::state::ServiceState for RecoveryState {
             next_new_voucher_index: 0,
             vouchers: Vouchers::default(),
             lib_wallet_state: None,
+            pending_claims: PendingClaims::default(),
         })
     }
 }
@@ -41,6 +158,7 @@ pub struct ServiceState<'u> {
     wallet: Wallet,
     lib: HeaderId,
     updater: &'u StateUpdater<Option<RecoveryState>>,
+    pending_claims: PendingClaims,
 }
 
 impl<'u> ServiceState<'u> {
@@ -51,6 +169,12 @@ impl<'u> ServiceState<'u> {
         lib_ledger: &LedgerState,
         updater: &'u StateUpdater<Option<RecoveryState>>,
     ) -> Self {
+        let RecoveryState {
+            next_new_voucher_index,
+            vouchers,
+            lib_wallet_state,
+            pending_claims,
+        } = state;
         let known_keys = settings
             .known_keys
             .iter()
@@ -58,27 +182,23 @@ impl<'u> ServiceState<'u> {
 
         // Initialize [`Wallet`] either from the persisted [`WalletState`]
         // or from the current chain's LIB ledger state.
-        let (wallet, wallet_lib) = match state.lib_wallet_state {
+        let (wallet, wallet_lib) = match lib_wallet_state {
             Some((persisted_lib, wallet_state)) => (
-                Wallet::from_lib_wallet_state(
-                    known_keys,
-                    state.vouchers,
-                    persisted_lib,
-                    wallet_state,
-                ),
+                Wallet::from_lib_wallet_state(known_keys, vouchers, persisted_lib, wallet_state),
                 persisted_lib,
             ),
             None => (
-                Wallet::from_lib_ledger_state(known_keys, state.vouchers, lib, lib_ledger),
+                Wallet::from_lib_ledger_state(known_keys, vouchers, lib, lib_ledger),
                 lib,
             ),
         };
 
         Self {
-            next_new_voucher_index: state.next_new_voucher_index,
+            next_new_voucher_index,
             wallet,
             lib: wallet_lib,
             updater,
+            pending_claims,
         }
     }
 
@@ -120,6 +240,31 @@ impl<'u> ServiceState<'u> {
         &self.wallet
     }
 
+    pub fn reserve_claim(&mut self, nullifier: VoucherNullifier) {
+        self.pending_claims.reserve(nullifier);
+    }
+
+    pub fn release_claim_reservation(&mut self, nullifier: VoucherNullifier) {
+        self.pending_claims.release(nullifier);
+    }
+
+    pub fn is_claim_pending(&mut self, nullifier: &VoucherNullifier) -> bool {
+        self.pending_claims.is_reserved(nullifier)
+    }
+
+    pub fn reserve_claim_funding_notes(
+        &mut self,
+        nullifier: VoucherNullifier,
+        funding_notes: impl IntoIterator<Item = NoteId>,
+    ) -> Result<(), WalletServiceError> {
+        self.pending_claims
+            .reserve_funding_notes(nullifier, funding_notes)
+    }
+
+    pub fn pending_claim_funding_notes(&mut self) -> Vec<NoteId> {
+        self.pending_claims.funding_notes()
+    }
+
     fn update_state(&self) {
         let lib_wallet_state = self
             .wallet()
@@ -130,6 +275,7 @@ impl<'u> ServiceState<'u> {
             next_new_voucher_index: self.next_new_voucher_index,
             vouchers: self.wallet.vouchers().clone(),
             lib_wallet_state: Some((self.lib, lib_wallet_state)),
+            pending_claims: self.pending_claims.clone(),
         }));
     }
 }

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::{Duration, Instant},
-};
+use std::collections::{HashMap, HashSet};
 
 use lb_core::{
     header::HeaderId,
@@ -23,12 +20,10 @@ type VoucherIndex = u64;
 type VoucherId = (KeyId, VoucherIndex);
 pub type Wallet = lb_wallet::Wallet<KeyId, VoucherId>;
 
-const VOUCHER_PENDING_TIMEOUT: Duration = Duration::from_mins(1);
-
 #[derive(Debug, Clone)]
 struct PendingClaim {
     funding_notes: HashSet<NoteId>,
-    reserved_at: Instant,
+    lib_blocks_elapsed: u64,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -38,7 +33,6 @@ struct PendingClaims {
 
 impl PendingClaims {
     fn reserve(&mut self, nullifier: VoucherNullifier) {
-        self.prune_expired();
         debug!(
             target: wallet::SERVICE,
             ?nullifier,
@@ -48,7 +42,7 @@ impl PendingClaims {
             nullifier,
             PendingClaim {
                 funding_notes: HashSet::new(),
-                reserved_at: Instant::now(),
+                lib_blocks_elapsed: 0,
             },
         );
     }
@@ -63,8 +57,7 @@ impl PendingClaims {
         }
     }
 
-    fn is_reserved(&mut self, nullifier: &VoucherNullifier) -> bool {
-        self.prune_expired();
+    fn is_reserved(&self, nullifier: &VoucherNullifier) -> bool {
         self.claims.contains_key(nullifier)
     }
 
@@ -73,7 +66,6 @@ impl PendingClaims {
         nullifier: VoucherNullifier,
         funding_notes: impl IntoIterator<Item = NoteId>,
     ) -> Result<(), WalletServiceError> {
-        self.prune_expired();
         let Some(claim) = self.claims.get_mut(&nullifier) else {
             return Err(WalletServiceError::ClaimReservationNotFound(nullifier));
         };
@@ -89,28 +81,32 @@ impl PendingClaims {
         Ok(())
     }
 
-    fn funding_notes(&mut self) -> Vec<NoteId> {
-        self.prune_expired();
-
+    fn funding_notes(&self) -> Vec<NoteId> {
         self.claims
             .values()
             .flat_map(|claim| claim.funding_notes.iter().copied())
             .collect()
     }
 
-    fn prune_expired(&mut self) {
-        let now = Instant::now();
+    fn advance_lib(&mut self, lib_blocks: u64, expiry_blocks: u64) {
+        if lib_blocks == 0 {
+            return;
+        }
+
         let before_count = self.claims.len();
 
         self.claims.retain(|nullifier, claim| {
-            let expired = now.duration_since(claim.reserved_at) >= VOUCHER_PENDING_TIMEOUT;
+            claim.lib_blocks_elapsed = claim.lib_blocks_elapsed.saturating_add(lib_blocks);
+
+            let expired = claim.lib_blocks_elapsed >= expiry_blocks;
 
             if expired {
                 debug!(
                     target: wallet::SERVICE,
                     ?nullifier,
-                    "Removing expired pending claim reservation (timeout: {:?})",
-                    VOUCHER_PENDING_TIMEOUT
+                    lib_blocks_elapsed = claim.lib_blocks_elapsed,
+                    expiry_blocks,
+                    "Removing pending claim reservation after LIB progress"
                 );
             }
 
@@ -120,7 +116,7 @@ impl PendingClaims {
         if before_count != self.claims.len() {
             debug!(
                 target: wallet::SERVICE,
-                "Cleaned {} expired pending claim reservation(s)",
+                "Cleaned {} pending claim reservation(s) after LIB progress",
                 before_count - self.claims.len()
             );
         }
@@ -161,6 +157,7 @@ pub struct ServiceState<'u> {
     lib: HeaderId,
     updater: &'u StateUpdater<Option<RecoveryState>>,
     pending_claims: PendingClaims,
+    security_param: u64,
 }
 
 impl<'u> ServiceState<'u> {
@@ -170,6 +167,7 @@ impl<'u> ServiceState<'u> {
         lib: HeaderId,
         lib_ledger: &LedgerState,
         updater: &'u StateUpdater<Option<RecoveryState>>,
+        security_param: u64,
     ) -> Self {
         let RecoveryState {
             next_new_voucher_index,
@@ -201,6 +199,7 @@ impl<'u> ServiceState<'u> {
             lib: wallet_lib,
             updater,
             pending_claims,
+            security_param,
         }
     }
 
@@ -230,11 +229,14 @@ impl<'u> ServiceState<'u> {
         &mut self,
         new_lib: HeaderId,
         pruned_blocks: impl IntoIterator<Item = HeaderId>,
+        lib_blocks_count: u64,
         pruned_nullifiers: impl IntoIterator<Item = VoucherNullifier>,
     ) {
         self.lib = new_lib;
         self.wallet.prune_states(pruned_blocks);
         self.wallet.prune_vouchers(pruned_nullifiers);
+        self.pending_claims
+            .advance_lib(lib_blocks_count, self.security_param);
         self.update_state();
     }
 
@@ -285,7 +287,7 @@ impl<'u> ServiceState<'u> {
             .reserve_funding_notes(nullifier, funding_notes)
     }
 
-    pub fn pending_claim_funding_notes(&mut self) -> Vec<NoteId> {
+    pub fn pending_claim_funding_notes(&self) -> Vec<NoteId> {
         self.pending_claims.funding_notes()
     }
 
@@ -301,5 +303,36 @@ impl<'u> ServiceState<'u> {
             lib_wallet_state: Some((self.lib, lib_wallet_state)),
             pending_claims: self.pending_claims.clone(),
         }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXPIRY_BLOCKS: u64 = 4;
+
+    #[test]
+    fn pending_claim_does_not_expire_without_lib_progress() {
+        let nullifier = VoucherNullifier::default();
+        let mut pending_claims = PendingClaims::default();
+
+        pending_claims.reserve(nullifier);
+        pending_claims.advance_lib(0, EXPIRY_BLOCKS);
+
+        assert!(pending_claims.is_reserved(&nullifier));
+    }
+
+    #[test]
+    fn pending_claim_expires_after_enough_lib_progress() {
+        let nullifier = VoucherNullifier::default();
+        let mut pending_claims = PendingClaims::default();
+
+        pending_claims.reserve(nullifier);
+        pending_claims.advance_lib(EXPIRY_BLOCKS - 1, EXPIRY_BLOCKS);
+        assert!(pending_claims.is_reserved(&nullifier));
+
+        pending_claims.advance_lib(1, EXPIRY_BLOCKS);
+        assert!(!pending_claims.is_reserved(&nullifier));
     }
 }

--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -6,7 +6,7 @@ use lb_core::{
 };
 use lb_ledger::LedgerState;
 use lb_log_targets::wallet;
-use lb_wallet::{KnownVoucher, Vouchers, WalletBlock, WalletError, WalletState};
+use lb_wallet::{Voucher, Vouchers, WalletBlock, WalletError, WalletState};
 use overwatch::services::state::StateUpdater;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -17,12 +17,17 @@ type VoucherIndex = u64;
 type VoucherId = (KeyId, VoucherIndex);
 pub type Wallet = lb_wallet::Wallet<KeyId, VoucherId>;
 
-#[derive(Debug, Clone)]
-struct PendingClaim {
-    lib_blocks_elapsed: u64,
+pub struct ClaimableVouchers {
+    pub available: Vec<Voucher>,
+    pub pending: Vec<Voucher>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PendingClaim {
+    immutable_blocks_since_reservation: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct PendingClaims {
     claims: HashMap<VoucherNullifier, PendingClaim>,
 }
@@ -37,7 +42,7 @@ impl PendingClaims {
         self.claims.insert(
             nullifier,
             PendingClaim {
-                lib_blocks_elapsed: 0,
+                immutable_blocks_since_reservation: 0,
             },
         );
     }
@@ -56,24 +61,36 @@ impl PendingClaims {
         self.claims.contains_key(nullifier)
     }
 
-    fn advance_lib(&mut self, lib_blocks: u64, expiry_blocks: u64) {
-        if lib_blocks == 0 {
+    /// Evict reservations whose LIB-progress age reached the configured limit.
+    ///
+    /// Each LIB update adds `new_immutable_blocks_count` to every reservation's
+    /// `immutable_blocks_since_reservation` counter. A reservation expires once
+    /// that counter reaches `max_immutable_blocks_since_reservation`.
+    fn evict_expired(
+        &mut self,
+        new_immutable_blocks_count: u64,
+        max_immutable_blocks_since_reservation: u64,
+    ) {
+        if new_immutable_blocks_count == 0 {
             return;
         }
 
         let before_count = self.claims.len();
 
         self.claims.retain(|nullifier, claim| {
-            claim.lib_blocks_elapsed = claim.lib_blocks_elapsed.saturating_add(lib_blocks);
+            claim.immutable_blocks_since_reservation = claim
+                .immutable_blocks_since_reservation
+                .saturating_add(new_immutable_blocks_count);
 
-            let expired = claim.lib_blocks_elapsed >= expiry_blocks;
+            let expired =
+                claim.immutable_blocks_since_reservation >= max_immutable_blocks_since_reservation;
 
             if expired {
                 debug!(
                     target: wallet::SERVICE,
                     ?nullifier,
-                    lib_blocks_elapsed = claim.lib_blocks_elapsed,
-                    expiry_blocks,
+                    immutable_blocks_since_reservation = claim.immutable_blocks_since_reservation,
+                    max_immutable_blocks_since_reservation,
                     "Removing pending claim reservation after LIB progress"
                 );
             }
@@ -98,9 +115,9 @@ pub struct RecoveryState {
     /// [`WalletState`] at the last known LIB.
     /// `None` on fresh start; populated after the first LIB update.
     lib_wallet_state: Option<(HeaderId, WalletState)>,
-    // After restart we cannot know whether a reserved claim was submitted,
-    // accepted, or dropped, so recovering it could block usable vouchers/notes.
-    #[serde(skip)]
+    /// Voucher reservations for claim transactions that were built/submitted
+    /// but have not reached LIB yet. Stale reservations are bounded by
+    /// LIB-progress expiry after recovery.
     pending_claims: PendingClaims,
 }
 
@@ -197,14 +214,14 @@ impl<'u> ServiceState<'u> {
         &mut self,
         new_lib: HeaderId,
         pruned_blocks: impl IntoIterator<Item = HeaderId>,
-        lib_blocks_count: u64,
+        new_immutable_blocks_count: u64,
         pruned_nullifiers: impl IntoIterator<Item = VoucherNullifier>,
     ) {
         self.lib = new_lib;
         self.wallet.prune_states(pruned_blocks);
         self.wallet.prune_vouchers(pruned_nullifiers);
         self.pending_claims
-            .advance_lib(lib_blocks_count, self.security_param);
+            .evict_expired(new_immutable_blocks_count, self.security_param);
         self.update_state();
     }
 
@@ -212,30 +229,29 @@ impl<'u> ServiceState<'u> {
         &self.wallet
     }
 
-    pub fn find_available_claimable_voucher(
-        &mut self,
+    pub fn claimable_vouchers(
+        &self,
         tip: HeaderId,
-    ) -> (Option<KnownVoucher>, usize) {
-        let wallet_state = &self.wallet;
-        let pending_claims = &mut self.pending_claims;
-        let mut pending_count = 0;
+    ) -> Result<ClaimableVouchers, WalletServiceError> {
+        let mut available = Vec::new();
+        let mut pending = Vec::new();
 
-        let available_voucher = wallet_state
-            .voucher_commitments_and_nullifiers()
-            .find(|voucher| {
-                if pending_claims.is_reserved(&voucher.nullifier) {
-                    pending_count += 1;
+        for voucher in self.wallet.voucher_commitments_and_nullifiers() {
+            if self.pending_claims.is_reserved(&voucher.nullifier) {
+                pending.push(voucher);
+                continue;
+            }
 
-                    return false;
-                }
+            if self
+                .wallet
+                .voucher_path_snapshot(tip, &voucher.commitment)?
+                .is_some()
+            {
+                available.push(voucher);
+            }
+        }
 
-                matches!(
-                    wallet_state.voucher_path_snapshot(tip, &voucher.commitment),
-                    Ok(Some(_))
-                )
-            });
-
-        (available_voucher, pending_count)
+        Ok(ClaimableVouchers { available, pending })
     }
 
     pub fn reserve_claim(&mut self, nullifier: VoucherNullifier) {
@@ -244,10 +260,6 @@ impl<'u> ServiceState<'u> {
 
     pub fn release_claim_reservation(&mut self, nullifier: VoucherNullifier) {
         self.pending_claims.release(nullifier);
-    }
-
-    pub fn is_claim_reserved(&self, nullifier: &VoucherNullifier) -> bool {
-        self.pending_claims.is_reserved(nullifier)
     }
 
     fn update_state(&self) {
@@ -277,7 +289,7 @@ mod tests {
         let mut pending_claims = PendingClaims::default();
 
         pending_claims.reserve(nullifier);
-        pending_claims.advance_lib(0, EXPIRY_BLOCKS);
+        pending_claims.evict_expired(0, EXPIRY_BLOCKS);
 
         assert!(pending_claims.is_reserved(&nullifier));
     }
@@ -288,10 +300,10 @@ mod tests {
         let mut pending_claims = PendingClaims::default();
 
         pending_claims.reserve(nullifier);
-        pending_claims.advance_lib(EXPIRY_BLOCKS - 1, EXPIRY_BLOCKS);
+        pending_claims.evict_expired(EXPIRY_BLOCKS - 1, EXPIRY_BLOCKS);
         assert!(pending_claims.is_reserved(&nullifier));
 
-        pending_claims.advance_lib(1, EXPIRY_BLOCKS);
+        pending_claims.evict_expired(1, EXPIRY_BLOCKS);
         assert!(!pending_claims.is_reserved(&nullifier));
     }
 }

--- a/tests/src/tests/mantle/leader.rs
+++ b/tests/src/tests/mantle/leader.rs
@@ -121,6 +121,7 @@ async fn claim_leader_rewards(node: &NodeHttpClient, duration: Duration) -> TxHa
 }
 
 #[tokio::test]
+#[ignore = "Blocked on zero-fee transaction funding fix in https://github.com/logos-blockchain/logos-blockchain/pull/2970"]
 async fn concurrent_leader_claims() {
     let (_base, nodes, leader_funding_pk) = setup_test_nodes("concurrent_leader_claims").await;
     let node = &nodes[0];

--- a/tests/src/tests/mantle/leader.rs
+++ b/tests/src/tests/mantle/leader.rs
@@ -41,10 +41,17 @@ async fn leader_claim() {
     let node = &nodes[0];
     let mut block_stream = node.client.blocks_stream().await.unwrap();
 
+    // Wait for two epoch transitions.
+    // 0->1: vouchers (blocks) are collected but not added to MMR
+    // 1->2: vouchers are added to MMR and become claimable
     // Submit a tx with a LeaderClaim operation
-    wait_for_claimable_vouchers(&node.client, Duration::from_secs(30)).await;
+    wait_for_claimable_vouchers(&node.client, Duration::from_mins(5)).await;
 
     let tx_hash = claim_leader_rewards(&node.client, Duration::from_secs(30)).await;
+
+    // Wait for the claim tx to be included in the chain
+    // TODO: Check if wallet balance is increased by improving wallet
+    // to track reward UTXOs in the wallet: https://github.com/logos-blockchain/logos-blockchain/issues/2627
     wait_for_tx_inclusion(&mut block_stream, tx_hash).await;
 }
 

--- a/tests/src/tests/mantle/leader.rs
+++ b/tests/src/tests/mantle/leader.rs
@@ -2,11 +2,11 @@ use std::{collections::HashSet, num::NonZero, path::PathBuf, time::Duration};
 
 use futures::StreamExt as _;
 use lb_api_service::http::consensus::leader::LeaderClaimResponseBody;
-use lb_chain_service::{ChainServiceMode, State};
 use lb_common_http_client::ProcessedBlockEvent;
 use lb_groth16::fr_to_bytes;
-use lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody;
-use lb_http_api_common::bodies::wallet::claimable_vouchers::WalletClaimableVouchersResponseBody;
+use lb_http_api_common::bodies::wallet::{
+    balance::WalletBalanceResponseBody, claimable_vouchers::WalletClaimableVouchersResponseBody,
+};
 use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_node::{
     Transaction as _, TxHash,

--- a/tests/src/tests/mantle/leader.rs
+++ b/tests/src/tests/mantle/leader.rs
@@ -1,28 +1,30 @@
-use std::{
-    num::NonZero,
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::Duration,
-};
+use std::{collections::HashSet, num::NonZero, path::PathBuf, time::Duration};
 
 use futures::StreamExt as _;
 use lb_api_service::http::consensus::leader::LeaderClaimResponseBody;
 use lb_chain_service::{ChainServiceMode, State};
+use lb_common_http_client::ProcessedBlockEvent;
+use lb_groth16::fr_to_bytes;
+use lb_http_api_common::bodies::wallet::balance::WalletBalanceResponseBody;
 use lb_http_api_common::bodies::wallet::claimable_vouchers::WalletClaimableVouchersResponseBody;
+use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_node::{
     Transaction as _, TxHash,
     config::{RunConfig, cryptarchia::deployment::EpochConfig},
 };
-use lb_testing_framework::{DeploymentBuilder, NodeHttpClient, TopologyConfig as TfTopologyConfig};
+use lb_testing_framework::{
+    DeploymentBuilder, LbcEnv, NodeHttpClient, TopologyConfig as TfTopologyConfig,
+    configs::wallet::{WalletAccount, WalletConfig},
+};
 use lb_utils::math::NonNegativeRatio;
 use logos_blockchain_tests::{
-    common::manual_cluster::{ManualNodeLayout, api_url, start_local_manual_cluster_with_layout},
+    common::manual_cluster::{
+        LocalManualClusterHarnessBase, ManualNodeLayout, api_url,
+        start_local_manual_cluster_with_layout,
+    },
     cucumber::defaults::E2E_ARTIFACTS_DIR,
 };
-use testing_framework_core::scenario::DynError;
+use testing_framework_core::scenario::{DynError, StartedNode};
 use tokio::time::{sleep, timeout};
 
 const NODE_COUNT: usize = 1;
@@ -35,74 +37,18 @@ const NODE_COUNT: usize = 1;
 /// 4. Verify the claim tx is successfully included in the chain.
 #[tokio::test]
 async fn leader_claim() {
-    // TODO: This is an workaround to get values from the updated configs
-    // during the cluster setup. Refactor the testing framework for better UX.
-    let slots_per_epoch = Arc::new(AtomicU64::new(0));
-    let (_base, nodes) = start_local_manual_cluster_with_layout(
-        "leader-claim",
-        "mantle-leader",
-        DeploymentBuilder::new(
-            TfTopologyConfig::with_node_numbers(NODE_COUNT)
-                .with_test_context(Some("leader_claim".to_owned())),
-        ),
-        NODE_COUNT,
-        ManualNodeLayout::SelectNodeSeed(0),
-        {
-            let slots_per_epoch = Arc::clone(&slots_per_epoch);
-            move |config| Ok::<_, DynError>(test_config(config, &slots_per_epoch))
-        },
-        Some(PathBuf::from(E2E_ARTIFACTS_DIR)),
-    )
-    .await;
-    let slots_per_epoch = slots_per_epoch.load(Ordering::Relaxed);
-
+    let (_base, nodes, _leader_funding_pk) = setup_test_nodes("leader_claim").await;
     let node = &nodes[0];
-
-    // Wait for two epoch transitions.
-    // 0->1: vouchers (blocks) are collected but not added to MMR
-    // 1->2: vouchers are added to MMR and become claimable
-    let target_slot = 2 * slots_per_epoch;
-    wait_for_nodes_slot(
-        nodes
-            .iter()
-            .map(|node| &node.client)
-            .collect::<Vec<_>>()
-            .as_slice(),
-        target_slot,
-        Duration::from_mins(5),
-    )
-    .await;
-
-    // Subscribes to process blocks to check if our tx is included in the end
     let mut block_stream = node.client.blocks_stream().await.unwrap();
 
     // Submit a tx with a LeaderClaim operation
     wait_for_claimable_vouchers(&node.client, Duration::from_secs(30)).await;
 
     let tx_hash = claim_leader_rewards(&node.client, Duration::from_secs(30)).await;
-
-    // Wait for the claim tx to be included in the chain
-    // TODO: Check if wallet balance is increased by improving wallet
-    // to track reward UTXOs in the wallet: https://github.com/logos-blockchain/logos-blockchain/issues/2627
-    timeout(Duration::from_mins(1), {
-        async {
-            while let Some(block) = block_stream.next().await {
-                if block
-                    .block
-                    .transactions
-                    .iter()
-                    .any(|tx| tx.hash() == tx_hash)
-                {
-                    break;
-                }
-            }
-        }
-    })
-    .await
-    .unwrap_or_else(|_| panic!("Timed out waiting for tx to be included in the chain"));
+    wait_for_tx_inclusion(&mut block_stream, tx_hash).await;
 }
 
-fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig {
+fn test_config(mut config: RunConfig, leader_funding_pk: ZkPublicKey) -> RunConfig {
     config.deployment.time.slot_duration = Duration::from_secs(1);
     config.deployment.cryptarchia.epoch_config = EpochConfig {
         epoch_stake_distribution_stabilization: 1.try_into().unwrap(),
@@ -112,11 +58,7 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
     config.deployment.cryptarchia.security_param = NonZero::new(2).unwrap();
     config.deployment.cryptarchia.slot_activation_coeff =
         NonNegativeRatio::new(1, 2.try_into().unwrap());
-
-    slots_per_epoch.store(
-        config.deployment.cryptarchia.slots_per_epoch(),
-        Ordering::Relaxed,
-    );
+    config.user.cryptarchia.leader.wallet.funding_pk = leader_funding_pk;
 
     config
 }
@@ -160,56 +102,162 @@ async fn wait_for_claimable_vouchers(node: &NodeHttpClient, duration: Duration) 
 async fn claim_leader_rewards(node: &NodeHttpClient, duration: Duration) -> TxHash {
     timeout(duration, async {
         loop {
-            let response = reqwest::Client::new()
-                .post(api_url(node, "leader/claim"))
-                .send()
-                .await
-                .expect("leader claim request should not fail");
-
-            let status = response.status();
-            if status.is_success() {
-                let body: LeaderClaimResponseBody = response
-                    .json()
-                    .await
-                    .expect("leader claim response should be valid JSON");
-                return body.tx_hash;
+            match try_claim_leader_rewards_once(node).await {
+                Ok(Some(body)) => return body.tx_hash,
+                Ok(None) => sleep(Duration::from_millis(500)).await,
+                Err(err) => panic!("{err}"),
             }
-
-            let body = response.text().await.unwrap_or_default();
-            if status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
-                && body.contains("No claimable voucher found")
-            {
-                sleep(Duration::from_millis(500)).await;
-                continue;
-            }
-
-            panic!("leader claim should succeed, got status: {status} body: {body}");
         }
     })
     .await
     .unwrap_or_else(|_| panic!("leader claim should become available within {duration:?}"))
 }
 
-async fn wait_for_nodes_slot(nodes: &[&NodeHttpClient], target_slot: u64, duration: Duration) {
+#[tokio::test]
+async fn concurrent_leader_claims() {
+    let (_base, nodes, leader_funding_pk) = setup_test_nodes("concurrent_leader_claims").await;
+    let node = &nodes[0];
+    let mut block_stream = node.client.blocks_stream().await.unwrap();
+
+    wait_for_wallet_notes(&node.client, leader_funding_pk, 2, Duration::from_mins(2)).await;
+    let successful_tx_hashes =
+        submit_concurrent_leader_claims(&node.client, 2, Duration::from_mins(1)).await;
+    assert_unique_tx_hashes(&successful_tx_hashes);
+
+    wait_for_tx_inclusions(&mut block_stream, &successful_tx_hashes).await;
+}
+
+async fn submit_concurrent_leader_claims(
+    node: &NodeHttpClient,
+    min_successful_claims: usize,
+    duration: Duration,
+) -> Vec<TxHash> {
     timeout(duration, async {
         loop {
-            let mut all_ready = true;
+            let (tx1, tx2, tx3) = tokio::join!(
+                try_claim_leader_rewards_once(node),
+                try_claim_leader_rewards_once(node),
+                try_claim_leader_rewards_once(node)
+            );
+            let tx_hashes = <[_; 3]>::from((tx1, tx2, tx3))
+                .into_iter()
+                .filter_map(|result| {
+                    result.expect(
+                        "leader claim request should either reserve a voucher or report none",
+                    )
+                })
+                .map(|body| body.tx_hash)
+                .collect::<Vec<_>>();
 
-            for node in nodes {
-                let info = node
-                    .consensus_info()
-                    .await
-                    .expect("fetching consensus info should succeed");
-
-                if info.cryptarchia_info.slot < target_slot.into()
-                    || !matches!(info.mode, ChainServiceMode::Started(State::Online))
-                {
-                    all_ready = false;
-                    break;
-                }
+            if tx_hashes.len() >= min_successful_claims {
+                return tx_hashes;
             }
 
-            if all_ready {
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("leader claim should become available within {duration:?}"))
+}
+
+async fn setup_test_nodes(
+    test_context: &str,
+) -> (
+    LocalManualClusterHarnessBase,
+    Vec<StartedNode<LbcEnv>>,
+    ZkPublicKey,
+) {
+    let (wallet_config, leader_funding_pk) = leader_funding_wallet_config();
+    let (base, nodes) = start_local_manual_cluster_with_layout(
+        "leader-claim",
+        "mantle-leader",
+        DeploymentBuilder::new(
+            TfTopologyConfig::with_node_numbers(NODE_COUNT)
+                .with_allow_multiple_genesis_tokens(true)
+                .with_test_context(Some(test_context.to_owned())),
+        )
+        .with_wallet_config(wallet_config),
+        NODE_COUNT,
+        ManualNodeLayout::SelectNodeSeed(0),
+        move |config| Ok::<_, DynError>(test_config(config, leader_funding_pk)),
+        Some(PathBuf::from(E2E_ARTIFACTS_DIR)),
+    )
+    .await;
+
+    (base, nodes, leader_funding_pk)
+}
+
+fn leader_funding_wallet_config() -> (WalletConfig, ZkPublicKey) {
+    let account = WalletAccount::deterministic(42, 100_000, false)
+        .expect("leader funding account should be valid");
+    let funding_pk = account.public_key();
+    let accounts = (0..3)
+        .map(|idx| {
+            WalletAccount::new(
+                format!("leader-funding-{idx}"),
+                account.secret_key.clone(),
+                100_000,
+                false,
+            )
+            .expect("leader funding account should be valid")
+        })
+        .collect();
+
+    (WalletConfig::new(accounts), funding_pk)
+}
+
+async fn wait_for_tx_inclusion(
+    block_stream: &mut (impl futures::Stream<Item = ProcessedBlockEvent> + Unpin),
+    tx_hash: TxHash,
+) {
+    wait_for_tx_inclusions(block_stream, &[tx_hash]).await;
+}
+
+async fn wait_for_tx_inclusions(
+    block_stream: &mut (impl futures::Stream<Item = ProcessedBlockEvent> + Unpin),
+    tx_hashes: &[TxHash],
+) {
+    let mut remaining_tx_hashes = tx_hashes.iter().copied().collect::<HashSet<_>>();
+
+    timeout(Duration::from_mins(1), async {
+        while let Some(block) = block_stream.next().await {
+            for tx in &block.block.transactions {
+                remaining_tx_hashes.remove(&tx.hash());
+            }
+
+            if remaining_tx_hashes.is_empty() {
+                return;
+            }
+        }
+
+        panic!("block stream closed before txs were included; remaining={remaining_tx_hashes:?}");
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!("Timed out waiting for txs to be included; remaining={remaining_tx_hashes:?}")
+    });
+}
+
+fn assert_unique_tx_hashes(tx_hashes: &[TxHash]) {
+    let unique = tx_hashes.iter().collect::<HashSet<_>>();
+    assert_eq!(
+        unique.len(),
+        tx_hashes.len(),
+        "Concurrent claims should not return duplicate tx hashes"
+    );
+}
+
+async fn wait_for_wallet_notes(
+    node: &NodeHttpClient,
+    pk: ZkPublicKey,
+    min_notes: usize,
+    duration: Duration,
+) {
+    timeout(duration, async {
+        loop {
+            let balance = get_wallet_balance(node, pk).await;
+
+            if balance.notes.len() >= min_notes {
                 return;
             }
 
@@ -217,5 +265,59 @@ async fn wait_for_nodes_slot(nodes: &[&NodeHttpClient], target_slot: u64, durati
         }
     })
     .await
-    .unwrap_or_else(|_| panic!("nodes should reach slot {target_slot}"));
+    .unwrap_or_else(|_| panic!("wallet should have at least {min_notes} funding notes"));
+}
+
+async fn get_wallet_balance(node: &NodeHttpClient, pk: ZkPublicKey) -> WalletBalanceResponseBody {
+    let pk_hex = hex::encode(fr_to_bytes(&pk.into()));
+    let response = reqwest::Client::new()
+        .get(api_url(node, &format!("wallet/{pk_hex}/balance")))
+        .send()
+        .await
+        .expect("balance request should not fail");
+
+    assert!(
+        response.status().is_success(),
+        "balance request should succeed, got status: {}",
+        response.status()
+    );
+
+    response
+        .json()
+        .await
+        .expect("balance response should be valid JSON")
+}
+
+async fn try_claim_leader_rewards_once(
+    node: &NodeHttpClient,
+) -> Result<Option<LeaderClaimResponseBody>, String> {
+    let response = reqwest::Client::new()
+        .post(api_url(node, "leader/claim"))
+        .send()
+        .await
+        .map_err(|err| format!("leader claim request should not fail: {err}"))?;
+
+    let status = response.status();
+    if response.status().is_success() {
+        return response
+            .json()
+            .await
+            .map(Some)
+            .map_err(|err| format!("leader claim response should be valid JSON: {err}"));
+    }
+
+    let body = response.text().await.unwrap_or_default();
+    if is_claim_temporarily_unavailable(status, &body) {
+        return Ok(None);
+    }
+
+    Err(format!(
+        "leader claim should succeed, got status: {status} body: {body}"
+    ))
+}
+
+fn is_claim_temporarily_unavailable(status: reqwest::StatusCode, body: &str) -> bool {
+    status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        && (body.contains("No claimable voucher found")
+            || body.contains("Wallet does not have enough funds"))
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -32,7 +32,7 @@ use lb_mmr::{MerkleMountainRange, MerklePath};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-pub use crate::voucher::Vouchers;
+pub use crate::voucher::{KnownVoucher, Vouchers};
 
 const LOG_TARGET: &str = wallet::CORE;
 
@@ -460,9 +460,7 @@ where
         self.known_vouchers.get_by_nullifier(nf)
     }
 
-    pub fn voucher_commitments_and_nullifiers(
-        &self,
-    ) -> impl Iterator<Item = (&VoucherNullifier, &VoucherCm)> {
+    pub fn voucher_commitments_and_nullifiers(&self) -> impl Iterator<Item = KnownVoucher> + '_ {
         self.known_vouchers.commitments_and_nullifiers()
     }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -167,23 +167,12 @@ impl WalletState {
         change_pk: ZkPublicKey,
         pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
     ) -> Result<MantleTxBuilder, WalletError> {
-        self.fund_tx_excluding::<G>(tx_builder, change_pk, pks, std::iter::empty::<NoteId>())
-    }
-
-    pub fn fund_tx_excluding<G: GasConstants>(
-        &self,
-        tx_builder: &MantleTxBuilder,
-        change_pk: ZkPublicKey,
-        pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
-        excluded_notes: impl IntoIterator<Item = NoteId>,
-    ) -> Result<MantleTxBuilder, WalletError> {
         // Get all UTXOs owned by the provided PKs, excluding the following notes:
         // - Notes that are being consumed/locked by the tx
         // - Notes that are already locked in Ledger
         let consumed_or_locked = tx_builder
             .consumed_or_locked_notes()
             .chain(self.locked_notes.iter().copied())
-            .chain(excluded_notes)
             .collect::<HashSet<_>>();
         let mut utxos = self
             .utxos_owned_by_pks(pks)
@@ -530,22 +519,6 @@ where
     ) -> Result<MantleTxBuilder, WalletError> {
         self.wallet_state_at(tip)?
             .fund_tx::<G>(tx_builder, change_pk, funding_pks)
-    }
-
-    pub fn fund_tx_excluding<G: GasConstants>(
-        &self,
-        tip: HeaderId,
-        tx_builder: &MantleTxBuilder,
-        change_pk: ZkPublicKey,
-        funding_pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
-        excluded_notes: impl IntoIterator<Item = NoteId>,
-    ) -> Result<MantleTxBuilder, WalletError> {
-        self.wallet_state_at(tip)?.fund_tx_excluding::<G>(
-            tx_builder,
-            change_pk,
-            funding_pks,
-            excluded_notes,
-        )
     }
 
     pub fn wallet_state_at(&self, tip: HeaderId) -> Result<WalletState, WalletError> {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -167,12 +167,23 @@ impl WalletState {
         change_pk: ZkPublicKey,
         pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
     ) -> Result<MantleTxBuilder, WalletError> {
+        self.fund_tx_excluding::<G>(tx_builder, change_pk, pks, std::iter::empty::<NoteId>())
+    }
+
+    pub fn fund_tx_excluding<G: GasConstants>(
+        &self,
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
+        excluded_notes: impl IntoIterator<Item = NoteId>,
+    ) -> Result<MantleTxBuilder, WalletError> {
         // Get all UTXOs owned by the provided PKs, excluding the following notes:
         // - Notes that are being consumed/locked by the tx
         // - Notes that are already locked in Ledger
         let consumed_or_locked = tx_builder
             .consumed_or_locked_notes()
             .chain(self.locked_notes.iter().copied())
+            .chain(excluded_notes)
             .collect::<HashSet<_>>();
         let mut utxos = self
             .utxos_owned_by_pks(pks)
@@ -521,6 +532,22 @@ where
     ) -> Result<MantleTxBuilder, WalletError> {
         self.wallet_state_at(tip)?
             .fund_tx::<G>(tx_builder, change_pk, funding_pks)
+    }
+
+    pub fn fund_tx_excluding<G: GasConstants>(
+        &self,
+        tip: HeaderId,
+        tx_builder: &MantleTxBuilder,
+        change_pk: ZkPublicKey,
+        funding_pks: impl IntoIterator<Item = impl Borrow<ZkPublicKey>>,
+        excluded_notes: impl IntoIterator<Item = NoteId>,
+    ) -> Result<MantleTxBuilder, WalletError> {
+        self.wallet_state_at(tip)?.fund_tx_excluding::<G>(
+            tx_builder,
+            change_pk,
+            funding_pks,
+            excluded_notes,
+        )
     }
 
     pub fn wallet_state_at(&self, tip: HeaderId) -> Result<WalletState, WalletError> {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -32,7 +32,7 @@ use lb_mmr::{MerkleMountainRange, MerklePath};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-pub use crate::voucher::{KnownVoucher, Vouchers};
+pub use crate::voucher::{Voucher, Vouchers};
 
 const LOG_TARGET: &str = wallet::CORE;
 
@@ -449,7 +449,7 @@ where
         self.known_vouchers.get_by_nullifier(nf)
     }
 
-    pub fn voucher_commitments_and_nullifiers(&self) -> impl Iterator<Item = KnownVoucher> + '_ {
+    pub fn voucher_commitments_and_nullifiers(&self) -> impl Iterator<Item = Voucher> + '_ {
         self.known_vouchers.commitments_and_nullifiers()
     }
 

--- a/wallet/src/voucher.rs
+++ b/wallet/src/voucher.rs
@@ -3,6 +3,12 @@ use std::collections::HashMap;
 use lb_core::mantle::ops::leader_claim::{VoucherCm, VoucherNullifier};
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Copy, Debug)]
+pub struct KnownVoucher {
+    pub nullifier: VoucherNullifier,
+    pub commitment: VoucherCm,
+}
+
 /// Holds voucher indices for
 /// - generating new vouchers
 /// - looking up existing voucher IDs by commitment or nullifier
@@ -46,10 +52,13 @@ impl<Id> Vouchers<Id> {
         self.vouchers.remove(&cm)
     }
 
-    pub(crate) fn commitments_and_nullifiers(
-        &self,
-    ) -> impl Iterator<Item = (&VoucherNullifier, &VoucherCm)> {
-        self.voucher_nullifiers.iter()
+    pub(crate) fn commitments_and_nullifiers(&self) -> impl Iterator<Item = KnownVoucher> + '_ {
+        self.voucher_nullifiers
+            .iter()
+            .map(|(&nullifier, &commitment)| KnownVoucher {
+                nullifier,
+                commitment,
+            })
     }
 
     #[must_use]

--- a/wallet/src/voucher.rs
+++ b/wallet/src/voucher.rs
@@ -4,7 +4,7 @@ use lb_core::mantle::ops::leader_claim::{VoucherCm, VoucherNullifier};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug)]
-pub struct KnownVoucher {
+pub struct Voucher {
     pub nullifier: VoucherNullifier,
     pub commitment: VoucherCm,
 }
@@ -52,10 +52,10 @@ impl<Id> Vouchers<Id> {
         self.vouchers.remove(&cm)
     }
 
-    pub(crate) fn commitments_and_nullifiers(&self) -> impl Iterator<Item = KnownVoucher> + '_ {
+    pub(crate) fn commitments_and_nullifiers(&self) -> impl Iterator<Item = Voucher> + '_ {
         self.voucher_nullifiers
             .iter()
-            .map(|(&nullifier, &commitment)| KnownVoucher {
+            .map(|(&nullifier, &commitment)| Voucher {
                 nullifier,
                 commitment,
             })


### PR DESCRIPTION
## 1. What does this PR implement?

This PR moves leader-claim transaction construction into the wallet service because the wallet is the component with the local context needed to build these transactions correctly.

Previously, chain-leader selected a voucher and then asked the wallet to fund/sign the transaction, which split claim construction across services. That becomes brittle once a node can have multiple claimable vouchers, because voucher selection needs to account for claim transactions that are already being built.

With this change, chain-leader only asks the wallet for a ready claim transaction. The wallet handles voucher selection, funding, signing, and short-lived pending-claim tracking in one place, so concurrent claim requests do not reuse the same voucher.

Funding-note reservation is intentionally not included in this PR. For the current testnet leader-claim flow we expect 0 gas fees, so claim transactions should not need funding notes in the normal path. The broader funding-note concurrency issue still exists for other wallet-funded operations and should be handled separately.

The focused e2e test currently fails because concurrent claim txs can still race on funding notes. There is already a fix for the zero-fee path in https://github.com/logos-blockchain/logos-blockchain/pull/2970, so once that lands this should be pass.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
