### PR TITLE
fix(cryptarchia): use strict_add for Epoch and Slot

### DIFF
--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -917,7 +917,7 @@ pub mod tests {
 
         let slot = Slot::genesis();
 
-        assert_eq!(slot + 10u64, Slot::from(10));
+        assert_eq!(slot.strict_add(10.into()), Slot::from(10));
 
         let id_100 = hash(&100u64);
 
@@ -1197,7 +1197,7 @@ pub mod tests {
             .receive_block(
                 hash(&100u64),
                 cryptarchia.lib(),
-                cryptarchia.lib_branch().slot + 1,
+                cryptarchia.lib_branch().slot.strict_add(1.into()),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&7u64));
@@ -1233,7 +1233,7 @@ pub mod tests {
             .receive_block(
                 hash(&102u64),
                 cryptarchia.tip(),
-                cryptarchia.tip_branch().slot + 1,
+                cryptarchia.tip_branch().slot.strict_add(1.into()),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&8u64));

--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -1,13 +1,8 @@
 use core::{
     cmp::Ordering,
     fmt::{self, Display, Formatter},
-    ops::AddAssign,
 };
-use std::{
-    num::NonZero,
-    ops::{Add, Sub},
-    time::Duration,
-};
+use std::{num::NonZero, time::Duration};
 
 use lb_utils::bounded_duration::{MinimalBoundedDuration, SECOND};
 use time::OffsetDateTime;
@@ -45,14 +40,14 @@ impl Epoch {
         self.0
     }
 
+    /// Strict epoch addition, panicking if overflow occurred.
+    ///
+    /// # Panics
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
     #[must_use]
-    pub const fn saturating_add(self, rhs: Self) -> Self {
-        Self(self.0.saturating_add(rhs.0))
-    }
-
-    #[must_use]
-    pub const fn saturating_sub(self, rhs: Self) -> Self {
-        Self(self.0.saturating_sub(rhs.0))
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        Self(self.0.strict_add(rhs.0))
     }
 }
 
@@ -133,25 +128,19 @@ impl Slot {
         }
     }
 
+    /// Strict slot addition, panicking if overflow occurred.
+    ///
+    /// # Panics
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[must_use]
+    pub const fn strict_add(self, rhs: Self) -> Self {
+        Self(self.0.strict_add(rhs.0))
+    }
+
     #[must_use]
     pub const fn saturating_sub(self, rhs: Self) -> Self {
         Self(self.0.saturating_sub(rhs.0))
-    }
-}
-
-impl Add for Slot {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0 + rhs.0)
-    }
-}
-
-impl Sub for Slot {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.saturating_sub(rhs)
     }
 }
 
@@ -184,44 +173,6 @@ impl From<u64> for Slot {
 impl From<Slot> for u64 {
     fn from(slot: Slot) -> Self {
         slot.0
-    }
-}
-
-impl Add<u64> for Slot {
-    type Output = Self;
-
-    fn add(self, rhs: u64) -> Self::Output {
-        Self(self.0 + rhs)
-    }
-}
-
-impl Add<u32> for Epoch {
-    type Output = Self;
-
-    fn add(self, rhs: u32) -> Self::Output {
-        Self(self.0 + rhs)
-    }
-}
-
-impl AddAssign<u32> for Epoch {
-    fn add_assign(&mut self, rhs: u32) {
-        self.0 += rhs;
-    }
-}
-
-impl Add for Epoch {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0 + rhs.0)
-    }
-}
-
-impl Sub for Epoch {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0 - rhs.0)
     }
 }
 
@@ -312,8 +263,8 @@ impl SlotTimer {
     #[must_use]
     pub fn slot_interval(&self, now: OffsetDateTime) -> Interval {
         let slot_duration = self.config.slot_duration;
-        let next_slot_start =
-            self.config.genesis_time + slot_duration * u64::from(self.current_slot(now) + 1) as u32;
+        let next_slot_start = self.config.genesis_time
+            + slot_duration * u64::from(self.current_slot(now).strict_add(1.into())) as u32;
         let delay = next_slot_start - now;
         let mut interval = tokio::time::interval_at(
             tokio::time::Instant::now()

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -191,8 +191,9 @@ impl ChannelState {
     // Returns the new sequencer index and its starting slot
     #[must_use]
     pub fn round_robin(&self, block_slot: Slot) -> (u16, Slot) {
-        let elapsed_slot_since_last_tip = (block_slot - self.tip_slot).into_inner();
-        let tip_sequencer_duration = (block_slot - self.tip_sequencer_starting_slot).into_inner();
+        let elapsed_slot_since_last_tip = (block_slot.saturating_sub(self.tip_slot)).into_inner();
+        let tip_sequencer_duration =
+            (block_slot.saturating_sub(self.tip_sequencer_starting_slot)).into_inner();
         let posting_timeframe = u64::from(self.posting_timeframe.0);
         let posting_timeout = u64::from(self.posting_timeout.0);
         let num_sequencers = self.accredited_keys.len() as u64; // bounded by ChannelKeyIndex::MAX
@@ -213,10 +214,14 @@ impl ChannelState {
         // Starting slot mirrors the same priority.
         let starting_slot = sequencers_timed_out
             .filter(|_| is_timed_out)
-            .map(|sequencers_timed_out| self.tip_slot + sequencers_timed_out * posting_timeout)
+            .map(|sequencers_timed_out| {
+                self.tip_slot
+                    .strict_add((sequencers_timed_out * posting_timeout).into())
+            })
             .or_else(|| {
                 timeframe_elapsed.map(|timeframe_elapsed| {
-                    self.tip_sequencer_starting_slot + timeframe_elapsed * posting_timeframe
+                    self.tip_sequencer_starting_slot
+                        .strict_add((timeframe_elapsed * posting_timeframe).into())
                 })
             })
             .unwrap_or(self.tip_sequencer_starting_slot);

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -110,7 +110,7 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
         // withdrawal because SDP uses the snapshot from `SNAPSHOT_FINALIZATION_DELAY`
         // epochs ago.
         // The note will be unlocked once the withdrawn epoch set here is reached.
-        declaration.withdrawn = Some(ctx.epoch + sdp::SNAPSHOT_FINALIZATION_DELAY);
+        declaration.withdrawn = Some(ctx.epoch.strict_add(sdp::SNAPSHOT_FINALIZATION_DELAY));
         declaration.nonce = self.nonce;
 
         debug!(

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -3,7 +3,6 @@ pub mod locked_notes;
 
 use core::{
     fmt::{self, Display, Formatter},
-    ops::{Add, Sub},
     str::FromStr,
 };
 use std::{collections::HashMap, hash::Hash};
@@ -46,51 +45,7 @@ pub struct ServiceParameters {
     pub epoch: Epoch,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NumberOfEpochs(Epoch);
-
-impl NumberOfEpochs {
-    #[must_use]
-    pub const fn new(epoch: Epoch) -> Self {
-        Self(epoch)
-    }
-}
-
-impl From<u32> for NumberOfEpochs {
-    fn from(value: u32) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<NumberOfEpochs> for u32 {
-    fn from(this: NumberOfEpochs) -> Self {
-        this.0.into_inner()
-    }
-}
-
-impl Add for NumberOfEpochs {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0 + rhs.0)
-    }
-}
-
-impl Add<NumberOfEpochs> for Epoch {
-    type Output = Self;
-
-    fn add(self, rhs: NumberOfEpochs) -> Self::Output {
-        self + rhs.0
-    }
-}
-
-impl Sub<NumberOfEpochs> for Epoch {
-    type Output = Self;
-
-    fn sub(self, rhs: NumberOfEpochs) -> Self::Output {
-        self - rhs.0
-    }
-}
+pub type NumberOfEpochs = Epoch;
 
 // TODO: Check spec for max limit once we migrate the SDP Declare op to use the
 // `NomEncode` and `NomDecode` traits.
@@ -258,7 +213,7 @@ impl Declaration {
             locators: declaration_msg.locators.clone(),
             zk_id: declaration_msg.zk_id,
             created: epoch,
-            active: epoch + SNAPSHOT_FINALIZATION_DELAY,
+            active: epoch.strict_add(SNAPSHOT_FINALIZATION_DELAY),
             withdrawn: None,
             nonce: 0,
         }

--- a/ledger/src/cryptarchia/block_density.rs
+++ b/ledger/src/cryptarchia/block_density.rs
@@ -24,8 +24,7 @@ impl BlockDensity {
     /// the block density for epoch 2 will be computed during [200, 259],
     /// which is the Stake Distribution Snapshot + Buffer phases of epoch 2.
     fn compute_period_range(epoch: Epoch, config: &Config) -> RangeInclusive<Slot> {
-        let snapshot_slot_for_next_epoch =
-            config.total_stake_snapshot(epoch.saturating_add(1.into()));
+        let snapshot_slot_for_next_epoch = config.total_stake_snapshot(epoch.strict_add(1.into()));
         let start = snapshot_slot_for_next_epoch
             .saturating_sub(config.total_stake_inference_period().into());
         let end = snapshot_slot_for_next_epoch.saturating_sub(1.into());

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -240,7 +240,7 @@ impl LedgerState {
                 next_epoch_state,
                 ..self
             })
-        } else if new_epoch == current_epoch + 1 {
+        } else if new_epoch == current_epoch.strict_add(1.into()) {
             // case 2)
 
             // infer new total stake
@@ -272,7 +272,7 @@ impl LedgerState {
                 ..next_epoch_state
             };
             let next_epoch_state = EpochState {
-                epoch: new_epoch + 1,
+                epoch: new_epoch.strict_add(1.into()),
                 nonce: self.nonce,
                 utxos: self.utxos.clone(),
                 total_stake,
@@ -345,7 +345,7 @@ impl LedgerState {
                 sdp: sdp.clone(),
             };
             let next_epoch_state = EpochState {
-                epoch: new_epoch + 1,
+                epoch: new_epoch.strict_add(1.into()),
                 nonce: self.nonce,
                 utxos: self.utxos.clone(),
                 total_stake,
@@ -1384,13 +1384,13 @@ pub mod tests {
         let ledger_state = ledger.state(&genesis).unwrap().clone();
         let ledger_config = ledger.config();
 
-        let slot = Slot::genesis() + 10;
+        let slot = Slot::genesis().strict_add(10.into());
         let ledger_state2 = ledger_state
             .cryptarchia_ledger
             .update_epoch_state::<HeaderId>(slot, &SdpLedger::new(0.into()), ledger_config)
             .expect("Ledger needs to move forward");
 
-        let slot2 = Slot::genesis() + 1;
+        let slot2 = Slot::genesis().strict_add(1.into());
         let update_epoch_err = ledger_state2
             .update_epoch_state::<HeaderId>(slot2, &SdpLedger::new(0.into()), ledger_config)
             .err();
@@ -1408,7 +1408,7 @@ pub mod tests {
         let utxo = utxo();
         let (ledger, genesis) = ledger(&[utxo], config());
         let ledger_state = ledger.state(&genesis).unwrap().clone().cryptarchia_ledger;
-        let slot = Slot::genesis() + 1;
+        let slot = Slot::genesis().strict_add(1.into());
         let proof = DummyProof {
             public: LeaderPublic {
                 aged_root: Fr::from(0u8), // Invalid aged root
@@ -1433,7 +1433,7 @@ pub mod tests {
         let utxo = utxo();
         let (ledger, genesis) = ledger(&[utxo], config());
         let ledger_state = ledger.state(&genesis).unwrap().clone().cryptarchia_ledger;
-        let slot = Slot::genesis() + 1;
+        let slot = Slot::genesis().strict_add(1.into());
         let proof = DummyProof {
             public: LeaderPublic {
                 aged_root: ledger_state.aged_utxos().root(),

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -256,9 +256,12 @@ impl<R: Rewards> ServiceState<R> {
     ) -> bool {
         let withdrawn = declaration
             .withdrawn
-            .is_some_and(|withdrawn| withdrawn + config.retention_period < current_epoch);
-        let inactive =
-            declaration.active + config.inactivity_period + config.retention_period < current_epoch;
+            .is_some_and(|withdrawn| withdrawn.strict_add(config.retention_period) < current_epoch);
+        let inactive = declaration
+            .active
+            .strict_add(config.inactivity_period)
+            .strict_add(config.retention_period)
+            < current_epoch;
         withdrawn || inactive
     }
 
@@ -925,7 +928,9 @@ mod tests {
             .get(&ServiceType::BlendNetwork)
             .unwrap()
             .retention_period;
-        let target_epoch = withdrawn_epoch + retention_period + Epoch::new(1);
+        let target_epoch = withdrawn_epoch
+            .strict_add(retention_period)
+            .strict_add(Epoch::new(1));
         for epoch in (withdrawn_epoch.into_inner() + 1)..target_epoch.into_inner() {
             let new_epoch_state = next_epoch_state(epoch.into(), last_epoch_state.clone());
             (sdp_ledger, _) = sdp_ledger

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -109,7 +109,7 @@ fn next_blocks_stream_cursor(
     } else if boundary_slot >= slot_to {
         None
     } else {
-        Some(boundary_slot + 1)
+        Some(boundary_slot.strict_add(1.into()))
     }
 }
 

--- a/services/api/src/http/mantle.rs
+++ b/services/api/src/http/mantle.rs
@@ -422,7 +422,7 @@ where
 
     let mut blocks = Vec::with_capacity(limit.min(1024));
     let mut current_id = chain_info.tip;
-    let gated_slot_from = slot_from.max(chain_info.lib_slot + 1);
+    let gated_slot_from = slot_from.max(chain_info.lib_slot.strict_add(1.into()));
     if gated_slot_from > slot_to {
         return Ok(Vec::new());
     }
@@ -588,7 +588,7 @@ where
     let has_immutable_range = slot_from <= immutable_slot_to;
     // Mutable window starts strictly above LIB; LIB itself is served via immutable
     // index.
-    let mutable_slot_from = (chain_info.lib_slot + 1).max(slot_from);
+    let mutable_slot_from = (chain_info.lib_slot.strict_add(1.into())).max(slot_from);
     let has_mutable_range = !immutable_only && mutable_slot_from <= slot_to;
 
     let fetch_mutable = |remaining: usize, descending: bool| {

--- a/services/blend/src/core/state.rs
+++ b/services/blend/src/core/state.rs
@@ -164,8 +164,7 @@ mod service {
 
             // Check if `old_epoch_token_collector` has the correct epoch number.
             if let Some(old_epoch_token_collector) = &old_epoch_token_collector {
-                let provided_current_epoch =
-                    old_epoch_token_collector.epoch().saturating_add(1.into());
+                let provided_current_epoch = old_epoch_token_collector.epoch().strict_add(1.into());
                 if provided_current_epoch != last_seen_epoch {
                     return Err(error::EpochMismatch {
                         last_seen: last_seen_epoch,

--- a/services/blend/src/core/tests/mod.rs
+++ b/services/blend/src/core/tests/mod.rs
@@ -127,7 +127,7 @@ async fn test_handle_incoming_blend_message() {
 
     // Creates a new processor/scheduler/token_collector with the new epoch
     // number.
-    epoch += 1;
+    epoch = epoch.strict_add(1.into());
     let public_info = new_epoch_info(epoch, membership.clone(), &settings);
     let mut new_processor = new_crypto_processor(
         EpochCryptographicProcessorSettings {
@@ -225,7 +225,7 @@ async fn test_handle_incoming_blend_message() {
 
     // Check that a message built with a future epoch cannot be
     // decapsulated by either processor, and thus not scheduled.
-    epoch += 1;
+    epoch = epoch.strict_add(1.into());
     let mut future_processor = new_crypto_processor(
         EpochCryptographicProcessorSettings {
             non_ephemeral_encryption_key: settings.non_ephemeral_signing_key.derive_x25519(),
@@ -505,7 +505,7 @@ async fn test_handle_epoch_transition_expired() {
     // Create token collector and collect a token.
     let mut token_collector = EpochBlendingTokenCollector::new(&reward_epoch_info(&public_info))
         .rotate_epoch(&reward_epoch_info(&new_epoch_info(
-            epoch + 1,
+            epoch.strict_add(1.into()),
             membership.clone(),
             &settings,
         )))
@@ -592,7 +592,7 @@ async fn test_handle_epoch_event() {
         EpochEvent::NewEpoch(
             CoreEpochInfo {
                 public: CoreEpochPublicInfo {
-                    epoch: epoch + 1,
+                    epoch: epoch.strict_add(1.into()),
                     ..public_info.clone()
                 },
                 core_poq_generator: Some(()),
@@ -620,7 +620,7 @@ async fn test_handle_epoch_event() {
     else {
         panic!("expected Transitioning output");
     };
-    assert_eq!(new_crypto_processor.epoch(), epoch + 1);
+    assert_eq!(new_crypto_processor.epoch(), epoch.strict_add(1.into()));
     assert_eq!(old_crypto_processor.epoch(), epoch);
     assert_eq!(
         new_scheduler.release_delayer().unreleased_messages().len(),
@@ -630,7 +630,7 @@ async fn test_handle_epoch_event() {
         old_scheduler.release_delayer().unreleased_messages().len(),
         0
     );
-    assert_eq!(new_epoch_info.epoch, epoch + 1);
+    assert_eq!(new_epoch_info.epoch, epoch.strict_add(1.into()));
     assert!(
         new_recovery_checkpoint
             .clone()
@@ -661,8 +661,8 @@ async fn test_handle_epoch_event() {
     else {
         panic!("expected TransitionCompleted output");
     };
-    assert_eq!(current_crypto_processor.epoch(), epoch + 1);
-    assert_eq!(current_epoch_info.epoch, epoch + 1);
+    assert_eq!(current_crypto_processor.epoch(), epoch.strict_add(1.into()));
+    assert_eq!(current_epoch_info.epoch, epoch.strict_add(1.into()));
     assert!(
         new_recovery_checkpoint
             .clone()
@@ -683,7 +683,7 @@ async fn test_handle_epoch_event() {
             CoreEpochInfo {
                 public: CoreEpochPublicInfo {
                     membership: new_membership(minimal_network_size - 1).0,
-                    epoch: epoch + 2,
+                    epoch: epoch.strict_add(2.into()),
                     ..current_epoch_info.clone()
                 },
                 core_poq_generator: Some(()),
@@ -707,7 +707,7 @@ async fn test_handle_epoch_event() {
     else {
         panic!("expected Retiring output");
     };
-    assert_eq!(old_crypto_processor.epoch(), epoch + 1);
+    assert_eq!(old_crypto_processor.epoch(), epoch.strict_add(1.into()));
 }
 
 /// On an epoch change where the membership actually changes (and the local node
@@ -755,7 +755,7 @@ async fn test_handle_epoch_event_membership_change_rewires_backend_and_generator
 
     // The new epoch has a *different* (larger) membership; `new_membership`
     // always includes the local node, so the node stays part of the core.
-    let new_epoch = epoch + 1;
+    let new_epoch = epoch.strict_add(1.into());
     let new_membership = new_membership(minimal_network_size + 1).0;
     assert_ne!(
         new_membership.size(),
@@ -858,7 +858,7 @@ async fn transition_to_new_epoch_with_secret(secret_epoch: Epoch) -> Vec<Epoch> 
         EpochEvent::NewEpoch(
             CoreEpochInfo {
                 public: CoreEpochPublicInfo {
-                    epoch: epoch + 1,
+                    epoch: epoch.strict_add(1.into()),
                     ..public_info.clone()
                 },
                 core_poq_generator: Some(()),
@@ -942,7 +942,7 @@ async fn test_handle_epoch_event_empty_epoch_retires() {
     let (sdp_relay, _sdp_relay_receiver) = sdp_relay();
 
     // Handle a NewEpoch(Empty) event - empty membership triggers Retiring.
-    let empty_epoch = epoch + 1;
+    let empty_epoch = epoch.strict_add(1.into());
     let output = handle_epoch_event(
         EpochEvent::NewEpoch((empty_epoch, ZkHash::from(1)).into()),
         &settings,
@@ -1011,7 +1011,7 @@ async fn test_handle_epoch_event_non_empty_without_local_core_path_retires() {
         EpochEvent::NewEpoch(
             CoreEpochInfo {
                 public: CoreEpochPublicInfo {
-                    epoch: epoch + 1,
+                    epoch: epoch.strict_add(1.into()),
                     ..public_info.clone()
                 },
                 core_poq_generator: None,

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -82,7 +82,7 @@ fn cryptarchia_switch_to_online() {
         assert!(reorged_blocks.is_empty());
 
         block_ids.push(block.header().id());
-        slot = block.header().slot() + 1;
+        slot = block.header().slot().strict_add(1.into());
     }
 
     // Now, the chain is [G, B1, B2, B3].
@@ -142,7 +142,7 @@ async fn get_block_ids() {
     );
 
     // Add 2 blocks (not finalized yet since k=3)
-    let mut slot = Slot::genesis() + 1;
+    let mut slot = Slot::genesis().strict_add(1.into());
     let mut block_ids = vec![genesis_id];
     for _ in 0..2 {
         let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
@@ -159,7 +159,7 @@ async fn get_block_ids() {
         .await
         .unwrap();
         block_ids.push(block.header().id());
-        slot = block.header().slot() + 1;
+        slot = block.header().slot().strict_add(1.into());
     }
 
     // get_block_ids when all blocks are in memory.
@@ -206,7 +206,7 @@ async fn get_block_ids() {
         .await
         .unwrap();
         block_ids.push(block.header().id());
-        slot = block.header().slot() + 1;
+        slot = block.header().slot().strict_add(1.into());
     }
 
     // All blocks are loaded from memory + storage.

--- a/services/time/src/backends/common.rs
+++ b/services/time/src/backends/common.rs
@@ -24,8 +24,9 @@ pub fn slot_timer(
         Pin::new(Box::new(
             IntervalStream::new(SlotTimer::new(slot_config).slot_interval(datetime))
                 .zip(futures::stream::iter(std::iter::successors(
-                    Some(current_slot + 1), // +1 because `slot_interval` ticks from the next slot
-                    |&slot| Some(slot + 1),
+                    Some(current_slot.strict_add(1.into())), /* +1 because `slot_interval` ticks
+                                                              * from the next slot */
+                    |&slot| Some(slot.strict_add(1.into())),
                 )))
                 .map(move |(_, slot)| new_slot_tick(slot, epoch_config, base_period_length)),
         )),
@@ -61,12 +62,12 @@ mod tests {
         // The first tick will be the next slot after the timer was created.
         let tick = timer.next().await;
         // Slots should increment by 1 for each tick.
-        expected_slot = expected_slot + 1;
+        expected_slot = expected_slot.strict_add(1.into());
         assert_eq!(tick.unwrap().slot, expected_slot);
 
         // Slots should increment by 1 for each tick.
         let tick = timer.next().await;
-        expected_slot = expected_slot + 1;
+        expected_slot = expected_slot.strict_add(1.into());
         assert_eq!(tick.unwrap().slot, expected_slot);
     }
 

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -70,8 +70,10 @@ async fn sdp_blend_activity() {
     // Wait past the point where declarations would be removed if no activity
     // proofs were submitted.
     let initial_active_epoch = declarations.values().next().unwrap().active;
-    let survival_epochs =
-        initial_active_epoch + INACTIVITY_PERIOD + RETENTION_PERIOD + Epoch::new(2); // +1 margin
+    let survival_epochs = initial_active_epoch
+        .strict_add(INACTIVITY_PERIOD)
+        .strict_add(RETENTION_PERIOD)
+        .strict_add(Epoch::new(2)); // +1 margin
     let survival_slots = Slot::new(u64::from(u32::from(survival_epochs)) * slots_per_epoch);
     wait_for_nodes_tip_slot(
         &[&node0.client, &node1.client],
@@ -102,8 +104,8 @@ async fn sdp_blend_activity() {
     }
 }
 
-const INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
-const RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
+const INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
+const RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
 
 fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig {
     config.deployment.time.slot_duration = Duration::from_secs(1);

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -213,7 +213,7 @@ async fn sdp_ops_e2e() {
     // Wait for the snapshot finalization delay and the retention period to pass.
     wait_for_tip_slot(
         &node0,
-        (u64::from((withdraw_epoch + RETENTION_PERIOD + Epoch::new(1)).into_inner())
+        (u64::from((withdraw_epoch.strict_add(RETENTION_PERIOD).strict_add(Epoch::new(1))).into_inner())
             * slots_per_epoch)
             .into(),
         Duration::from_mins(3),

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -48,7 +48,7 @@ use num_bigint::BigUint;
 use testing_framework_core::scenario::{DynError, StartNodeOptions};
 use tokio::time::{sleep, timeout};
 
-const RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
+const RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
 
 /// High-level SDP flow covered by this E2E:
 /// - submit a `Declare` transaction backed by an unused genesis note and wait

--- a/tools/config/src/deployment.rs
+++ b/tools/config/src/deployment.rs
@@ -53,8 +53,8 @@ const EPOCH_STAKE_DISTRIBUTION_STABILIZATION: u8 = 3;
 const EPOCH_PERIOD_NONCE_BUFFER: u8 = 3;
 const EPOCH_PERIOD_NONCE_STABILIZATION: u8 = 4;
 
-const SDP_INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
-const SDP_RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(Epoch::new(1));
+const SDP_INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
+const SDP_RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
 const SDP_EPOCH: Epoch = Epoch::new(0);
 const MIN_STAKE_THRESHOLD: u64 = 1;
 const MIN_STAKE_TIMESTAMP: u64 = 0;

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -76,7 +76,7 @@ where
         last_slot: Option<Slot>,
     ) -> Result<impl Stream<Item = (ZoneMessage, Slot)> + '_, Error> {
         let lib_slot = self.node.consensus_info().await?.cryptarchia_info.lib_slot;
-        let start_slot = last_slot.map_or_else(Slot::genesis, |s| s + 1);
+        let start_slot = last_slot.map_or_else(Slot::genesis, |s| s.strict_add(1.into()));
 
         #[expect(
             closure_returning_async_block,
@@ -101,7 +101,7 @@ where
                 .zone_messages_in_blocks(current_slot, end_slot, self.channel_id)
                 .await
             {
-                Ok(messages) => Some((messages, end_slot + 1)),
+                Ok(messages) => Some((messages, end_slot.strict_add(1.into()))),
                 Err(e) => {
                     warn!(target: TARGET,
                         ?current_slot, ?end_slot, err = ?e,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes the finding `5` in the audit https://github.com/logos-blockchain/logos-blockchain/pull/2922. 
> Unchecked Epoch - Epoch / Epoch - NumberOfEpochs subtraction panics/wraps

In this PR, I removed `Sub` impls from `Epoch` and `Slot` because they're not used anywhere.

Also, I replaced `Add` impls with `strict_add` which panics when overflow. In almost all cases, we don't want epochs and slots to silently saturate. 
I chose `strict_add` rather than `checked_add + expect`, because it's shorter and it also prints the caller info when it panics (even in release build):
```
thread 'main' (6709414) panicked at src/main.rs:3:22:
attempt to add with overflow
```

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Not directly related to the spec.

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
