### PR TITLE
fix(serde): Use fixed size non len prefix for arrays and use nom encoding for non human readable SignedMantleTx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5168,6 +5168,7 @@ name = "logos-blockchain-utils"
 version = "0.1.2"
 dependencies = [
  "async-trait",
+ "bincode",
  "blake2",
  "cipher",
  "const-hex",

--- a/blend/message/src/reward/epoch.rs
+++ b/blend/message/src/reward/epoch.rs
@@ -218,7 +218,7 @@ mod tests {
             ),
             EpochRandomness::from(Fr::ZERO),
         );
-        assert_eq!(maybe_distance, Some(8.into()));
+        assert_eq!(maybe_distance, Some(6.into()));
 
         let maybe_distance = evaluation.evaluate(
             &BlendingToken::new(

--- a/blend/message/src/reward/token.rs
+++ b/blend/message/src/reward/token.rs
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_blending_token_hamming_distance() {
         let token = blending_token(1, 1, 2);
-        assert_eq!(token.hamming_distance(1, Fr::ONE.into()), 6.into());
+        assert_eq!(token.hamming_distance(1, Fr::ONE.into()), 5.into());
     }
 
     fn blending_token(

--- a/core/src/block/deser.rs
+++ b/core/src/block/deser.rs
@@ -69,4 +69,36 @@ mod tests {
         assert_eq!(block.header().id(), restored.header().id());
         assert_eq!(block.signature(), restored.signature());
     }
+
+    #[test]
+    fn test_bincode_fixed_size_fields_have_no_length_prefix() {
+        const VERSION: usize = 4; // u32 enum variant tag
+        const PARENT_BLOCK: usize = 32;
+        const SLOT: usize = 8;
+        const BLOCK_ROOT: usize = 32;
+        const POL_PROOF: usize = 128;
+        const ENTROPY_CONTRIBUTION: usize = 32;
+        const LEADER_KEY: usize = 32;
+        const VOUCHER_CM: usize = 32;
+        const SIGNATURE: usize = 64;
+        const TX_COUNT: usize = 8; // u64 Vec length (genuinely variable)
+        const EXPECTED: usize = VERSION
+            + PARENT_BLOCK
+            + SLOT
+            + BLOCK_ROOT
+            + POL_PROOF
+            + ENTROPY_CONTRIBUTION
+            + LEADER_KEY
+            + VOUCHER_CM
+            + SIGNATURE
+            + TX_COUNT;
+
+        let block = make_empty_block();
+        let bytes = bincode::serialize(&block).expect("bincode serialization should succeed");
+        assert_eq!(
+            bytes.len(),
+            EXPECTED,
+            "empty block encoding must contain no length prefixes for fixed-size fields"
+        );
+    }
 }

--- a/core/src/block/deser.rs
+++ b/core/src/block/deser.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_bincode_fixed_size_fields_have_no_length_prefix() {
-        const VERSION: usize = 4; // u32 enum variant tag
+        const VERSION: usize = 1;
         const PARENT_BLOCK: usize = 32;
         const SLOT: usize = 8;
         const BLOCK_ROOT: usize = 32;

--- a/core/src/header/mod.rs
+++ b/core/src/header/mod.rs
@@ -4,7 +4,7 @@ use blake2::Digest as _;
 use lb_cryptarchia_engine::Slot;
 use lb_groth16::fr_to_bytes;
 use lb_key_management_system_keys::keys::{Ed25519Key, Ed25519Signature};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const BEDROCK_VERSION: u8 = 1;
 
@@ -43,7 +43,7 @@ impl Debug for Nonce {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
 #[repr(u8)]
 pub enum Version {
     Bedrock = BEDROCK_VERSION,
@@ -53,6 +53,61 @@ impl Version {
     #[must_use]
     pub const fn as_byte(self) -> u8 {
         self as u8
+    }
+}
+
+impl TryFrom<u8> for Version {
+    type Error = std::io::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            BEDROCK_VERSION => Ok(Self::Bedrock),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid version [{value}]"),
+            )),
+        }
+    }
+}
+
+impl TryFrom<&str> for Version {
+    type Error = std::io::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "bedrock" => Ok(Self::Bedrock),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid version [{value}]"),
+            )),
+        }
+    }
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(format!("{self:?}").as_str())
+        } else {
+            serializer.serialize_u8(self.as_byte())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            Self::try_from(s.as_str()).map_err(serde::de::Error::custom)
+        } else {
+            Self::try_from(<u8>::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+        }
     }
 }
 

--- a/core/src/mantle/tx.rs
+++ b/core/src/mantle/tx.rs
@@ -14,7 +14,10 @@ use crate::{
     mantle::{
         AuthenticatedMantleTx, StorageSize, Transaction, TransactionHasher, Value,
         channel::Channels,
-        encoding::{Ops, decode_mantle_tx, encode_mantle_tx, encode_signed_mantle_tx},
+        encoding::{
+            Ops, decode_mantle_tx, decode_signed_mantle_tx, encode_mantle_tx,
+            encode_signed_mantle_tx,
+        },
         gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow, GasPrice},
         genesis_tx::{GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE},
         ops::{
@@ -301,7 +304,7 @@ impl From<SignedMantleTx> for MantleTx {
 // confirmation.
 // TODO: Split entity into a system that allows for verification in different
 // stages.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignedMantleTx {
     pub mantle_tx: MantleTx,
     // TODO: make this more efficient
@@ -643,19 +646,48 @@ impl StorageSize for SignedMantleTx {
     }
 }
 
+impl Serialize for SignedMantleTx {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            #[derive(Serialize)]
+            pub struct SignedMantleTxHelper<'a> {
+                pub mantle_tx: &'a MantleTx,
+                pub ops_proofs: &'a [OpProof],
+            }
+            SignedMantleTxHelper {
+                mantle_tx: &self.mantle_tx,
+                ops_proofs: &self.ops_proofs,
+            }
+            .serialize(serializer)
+        } else {
+            encode_signed_mantle_tx(self).serialize(serializer)
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for SignedMantleTx {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        struct SignedMantleTxHelper {
-            mantle_tx: MantleTx,
-            ops_proofs: Vec<OpProof>,
-        }
+        if deserializer.is_human_readable() {
+            #[derive(Deserialize)]
+            struct SignedMantleTxHelper {
+                mantle_tx: MantleTx,
+                ops_proofs: Vec<OpProof>,
+            }
 
-        let helper = SignedMantleTxHelper::deserialize(deserializer)?;
-        Self::new(helper.mantle_tx, helper.ops_proofs).map_err(serde::de::Error::custom)
+            let helper = SignedMantleTxHelper::deserialize(deserializer)?;
+            Self::new(helper.mantle_tx, helper.ops_proofs).map_err(serde::de::Error::custom)
+        } else {
+            let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
+            decode_signed_mantle_tx(bytes.as_slice())
+                .map(|(_, tx)| tx)
+                .map_err(serde::de::Error::custom)
+        }
     }
 }
 

--- a/core/src/proofs/leader_claim_proof.rs
+++ b/core/src/proofs/leader_claim_proof.rs
@@ -141,23 +141,22 @@ impl From<LeaderClaimPrivate> for lb_poc::PoCWitnessInputsData {
 }
 
 mod proof_serde {
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserializer, Serializer};
 
+    // Hex string for human-readable formats; a fixed-size 128-byte array
+    // (no length prefix) for binary formats like bincode.
     pub fn serialize<S>(item: &lb_poc::PoCProof, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_bytes(&item.to_bytes())
+        lb_utils::serde::serialize_bytes_array(item.to_bytes(), serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<lb_poc::PoCProof, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let proof_bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-        let proof_array: [u8; 128] = proof_bytes
-            .try_into()
-            .map_err(|_| serde::de::Error::custom("Expected exactly 128 bytes"))?;
+        let proof_array = lb_utils::serde::deserialize_bytes_array::<128, D>(deserializer)?;
         Ok(lb_poc::PoCProof::from_bytes(&proof_array))
     }
 }

--- a/core/src/proofs/leader_proof.rs
+++ b/core/src/proofs/leader_proof.rs
@@ -281,36 +281,22 @@ impl From<LeaderPrivate> for lb_pol::PolWitnessInputsData {
 }
 
 mod proof_serde {
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserializer, Serializer};
 
+    // Hex string for human-readable formats; a fixed-size 128-byte array
+    // (no length prefix) for binary formats like bincode.
     pub fn serialize<S>(item: &lb_pol::PoLProof, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let bytes = item.to_bytes();
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&hex::encode(bytes))
-        } else {
-            serializer.serialize_bytes(&bytes)
-        }
+        lb_utils::serde::serialize_bytes_array(item.to_bytes(), serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<lb_pol::PoLProof, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let proof_array: [u8; 128] = if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            hex::decode(s)
-                .map_err(serde::de::Error::custom)?
-                .try_into()
-                .map_err(|_| serde::de::Error::custom("Expected exactly 128 bytes"))?
-        } else {
-            let proof_bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-            proof_bytes
-                .try_into()
-                .map_err(|_| serde::de::Error::custom("Expected exactly 128 bytes"))?
-        };
+        let proof_array = lb_utils::serde::deserialize_bytes_array::<128, D>(deserializer)?;
         Ok(lb_pol::PoLProof::from_bytes(&proof_array))
     }
 }

--- a/kms/keys/src/keys/zk/signature.rs
+++ b/kms/keys/src/keys/zk/signature.rs
@@ -48,7 +48,14 @@ macro_rules! declare_serde_generic_array {
                 if serializer.is_human_readable() {
                     serializer.serialize_str(&hex::encode(bytes))
                 } else {
-                    serializer.serialize_bytes(bytes)
+                    // Serialized as a fixed-size tuple so binary formats like
+                    // bincode do not emit a length prefix.
+                    use serde::ser::SerializeTuple as _;
+                    let mut tuple = serializer.serialize_tuple($size::USIZE)?;
+                    for byte in bytes {
+                        tuple.serialize_element(byte)?;
+                    }
+                    tuple.end()
                 }
             }
 
@@ -79,18 +86,35 @@ macro_rules! declare_serde_generic_array {
                     GenericArray::try_from_iter(bytes)
                         .map_err(|e| serde::de::Error::custom(e.to_string()))
                 } else {
-                    let bytes = <Vec<u8>>::deserialize(deserializer)?;
+                    struct ArrayVisitor;
 
-                    if bytes.len() != $size::USIZE {
-                        return Err(serde::de::Error::custom(format!(
-                            "expected {} bytes, got {}",
-                            $size::USIZE,
-                            bytes.len()
-                        )));
+                    impl<'de> serde::de::Visitor<'de> for ArrayVisitor {
+                        type Value = GenericArray<u8, $size>;
+
+                        fn expecting(
+                            &self,
+                            formatter: &mut core::fmt::Formatter,
+                        ) -> core::fmt::Result {
+                            write!(formatter, "an array of {} bytes", $size::USIZE)
+                        }
+
+                        fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                            self,
+                            mut seq: A,
+                        ) -> Result<Self::Value, A::Error> {
+                            let mut output = GenericArray::<u8, $size>::default();
+                            for (i, byte) in output.iter_mut().enumerate() {
+                                *byte = seq
+                                    .next_element()?
+                                    .ok_or_else(|| serde::de::Error::invalid_length(i, &self))?;
+                            }
+                            Ok(output)
+                        }
                     }
 
-                    GenericArray::try_from_iter(bytes)
-                        .map_err(|e| serde::de::Error::custom(e.to_string()))
+                    // Mirrors `serialize`: a fixed-size tuple read back
+                    // without a length prefix.
+                    deserializer.deserialize_tuple($size::USIZE, ArrayVisitor)
                 }
             }
         }

--- a/ledger/src/mantle/sdp/rewards/blend/mod.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/mod.rs
@@ -412,9 +412,9 @@ mod tests {
                 provider2,
                 &ActivityMetadata::Blend(Box::new(blend::ActivityProof {
                     epoch: 0.into(),
-                    proof_of_quota: new_proof_of_quota_unchecked(2),
-                    signing_key: new_signing_key(2),
-                    proof_of_selection: new_proof_of_selection_unchecked(2),
+                    proof_of_quota: new_proof_of_quota_unchecked(4),
+                    signing_key: new_signing_key(4),
+                    proof_of_selection: new_proof_of_selection_unchecked(4),
                 })),
                 &params,
             )
@@ -669,9 +669,9 @@ mod tests {
                 provider1,
                 &ActivityMetadata::Blend(Box::new(blend::ActivityProof {
                     epoch: 0.into(),
-                    proof_of_quota: new_proof_of_quota_unchecked(2),
-                    signing_key: new_signing_key(2),
-                    proof_of_selection: new_proof_of_selection_unchecked(2),
+                    proof_of_quota: new_proof_of_quota_unchecked(4),
+                    signing_key: new_signing_key(4),
+                    proof_of_selection: new_proof_of_selection_unchecked(4),
                 })),
                 &params,
             )

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -38,6 +38,7 @@ time  = ["dep:humantime", "dep:serde_with", "dep:time"]
 tokio = ["dep:futures", "dep:tokio"]
 
 [dev-dependencies]
+bincode     = { workspace = true }
 nistrs      = { workspace = true }
 rand_chacha = { workspace = true }
 serde_json  = { features = ["alloc"], workspace = true }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -33,7 +33,18 @@ pub mod serde {
         if serializer.is_human_readable() {
             serialize_human_readable_bytes_array(src, serializer)
         } else {
-            serializer.serialize_bytes(&src)
+            // Serialized as a fixed-size tuple so binary formats like bincode
+            // do not emit a length prefix for compile-time-sized data. The
+            // tuple is built explicitly because serde only implements
+            // `Serialize` for arrays up to 32 elements; `src.serialize()`
+            // would silently coerce larger arrays to the length-prefixed
+            // slice encoding.
+            use serde::ser::SerializeTuple as _;
+            let mut tuple = serializer.serialize_tuple(N)?;
+            for byte in &src {
+                tuple.serialize_element(byte)?;
+            }
+            tuple.end()
         }
     }
 
@@ -57,18 +68,34 @@ pub mod serde {
     >(
         deserializer: D,
     ) -> Result<[u8; N], D::Error> {
-        use serde::Deserialize as _;
-        let bytes = <&[u8]>::deserialize(deserializer)?;
-        if bytes.len() == N {
-            let mut output = [0u8; N];
-            output.copy_from_slice(bytes);
-            Ok(output)
-        } else {
-            Err(<D::Error as serde::de::Error>::invalid_length(
-                bytes.len(),
-                &format!("{N}").as_str(),
-            ))
+        struct ArrayVisitor<const N: usize>;
+
+        impl<'de, const N: usize> serde::de::Visitor<'de> for ArrayVisitor<N> {
+            type Value = [u8; N];
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(formatter, "an array of {N} bytes")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut output = [0u8; N];
+                for (i, byte) in output.iter_mut().enumerate() {
+                    *byte = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &self))?;
+                }
+                Ok(output)
+            }
         }
+
+        // Mirrors `serialize_bytes_array`: fixed-size data is encoded as a
+        // tuple of bytes, which binary formats read back without a length
+        // prefix. serde only provides `Deserialize` for arrays up to 32
+        // elements, so larger sizes need this explicit tuple visitor.
+        deserializer.deserialize_tuple(N, ArrayVisitor::<N>)
     }
 
     pub fn deserialize_bytes_array<'de, const N: usize, D: serde::Deserializer<'de>>(
@@ -78,6 +105,56 @@ pub mod serde {
             deserialize_human_readable_bytes_array(deserializer)
         } else {
             deserialize_human_unreadable_bytes_array(deserializer)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        /// 64 bytes exceeds serde's built-in 32-element array support, so this
+        /// exercises the explicit tuple path on both ends.
+        struct Bytes64([u8; 64]);
+
+        impl serde::Serialize for Bytes64 {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                super::serialize_bytes_array(self.0, serializer)
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for Bytes64 {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                super::deserialize_bytes_array(deserializer).map(Self)
+            }
+        }
+
+        #[test]
+        fn bincode_encoding_has_no_length_prefix() {
+            let bytes = bincode::serialize(&Bytes64([7u8; 64])).unwrap();
+            assert_eq!(
+                bytes,
+                vec![7u8; 64],
+                "fixed-size byte arrays must encode as exactly N bytes"
+            );
+        }
+
+        #[test]
+        fn bincode_roundtrips() {
+            let original: [u8; 64] = core::array::from_fn(|i| i as u8);
+            let bytes = bincode::serialize(&Bytes64(original)).unwrap();
+            let decoded: Bytes64 = bincode::deserialize(&bytes).unwrap();
+            assert_eq!(decoded.0, original);
+        }
+
+        #[test]
+        fn bincode_rejects_truncated_input() {
+            assert!(bincode::deserialize::<Bytes64>(&[7u8; 63]).is_err());
+        }
+
+        #[test]
+        fn json_is_hex_string() {
+            let json = serde_json::to_string(&Bytes64([0xABu8; 64])).unwrap();
+            assert_eq!(json, format!("\"{}\"", "ab".repeat(64)));
+            let decoded: Bytes64 = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded.0, [0xABu8; 64]);
         }
     }
 


### PR DESCRIPTION
## 1. What does this PR implement?

### Remove bincode length prefixes for fixed-size data
  
  Bincode (fixint) was emitting a redundant 8-byte length prefix for every
  fixed-size field serialized via `serialize_bytes` — signatures, public keys,
  and Groth16 proofs whose sizes are compile-time constants.

  ### Changes
  - **`lb_utils::serde`**: `serialize_bytes_array` / `deserialize_bytes_array`
    now encode `[u8; N]` as a fixed-size tuple (exactly N bytes, no prefix).
    An explicit tuple visitor is required since serde only implements array
    `Deserialize` for N ≤ 32. Fixes `Ed25519PublicKey` (32B) and
    `Ed25519Signature` (64B) everywhere.
  - **`ZkSignature`** (kms/keys): pi_a/pi_b/pi_c encoded as tuples — saves
    24 bytes of prefixes per zk signature.
  - **PoL / PoC proofs** (128B): delegate to the shared helpers. PoC also
    gains the previously missing human-readable (hex) branch.

  ### Tests
  - New regression tests pin the exact encodings: a 64-byte array encodes to
    exactly 64 bytes, and an empty block to exactly 372 bytes.
  - Regenerated 4 hash-dependent test vectors: blend reward hamming distances
    are computed over the bincode bytes of `BlendingToken`, so expected
    distances/seeds changed.

  ### Breaking
  - ⚠️  Wire/storage format change: blocks and proposals are not byte-compatible
    with previous versions (re-sync or migration required).
  - Consensus IDs (`TxHash`, `HeaderId`, `ContentId`) are unaffected — none are
    derived from bincode bytes. Blend reward hamming distances **do** change.

## 2. Does the code have enough context to be clearly understood?

> [!IMPORTANT]  
> Add a link to the specification document, pointing at the specific section.  
> Any implementation detail that could be considered idiosyncratic and not direct from the specification, should be  
> explained.  
> Always consider what someone new would need to know for the code to make sense, and add this context to it.

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur @youngjoon-lee @danielSanchezQ 

## 4. Is the specification accurate and complete?
Yes, specification is complete. This is fixing an implementation mistake on serialization.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
