### PR TITLE
fix: zone sdk slot clock mut bug

### DIFF
--- a/zone-sdk/src/sequencer/slot_clock.rs
+++ b/zone-sdk/src/sequencer/slot_clock.rs
@@ -31,9 +31,6 @@ impl SlotClock {
     }
 
     pub(super) fn observe_slot(&mut self, observed_slot: Slot) {
-        self.chain_start_time = SystemTime::now()
-            .checked_sub(duration_mul(self.slot_duration, slot_to_u64(observed_slot)))
-            .unwrap_or(self.chain_start_time);
         self.last_observed_slot = observed_slot;
         self.last_observed_at = Instant::now();
     }

--- a/zone-sdk/src/sequencer/slot_clock.rs
+++ b/zone-sdk/src/sequencer/slot_clock.rs
@@ -64,11 +64,6 @@ const fn slots_from_duration(elapsed: Duration, slot_duration: Duration) -> u64 
     }
 }
 
-fn duration_mul(duration: Duration, n: u64) -> Duration {
-    let nanos = duration.as_nanos().saturating_mul(u128::from(n));
-    Duration::from_nanos(nanos.min(u128::from(u64::MAX)) as u64)
-}
-
 pub(super) const fn slot_to_u64(slot: Slot) -> u64 {
     slot.into_inner()
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Fixed a bug in the Zone SDK where `SlotClock::chain_start_time` was mutated every time a block was processed to align with the time the block was processed.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
