### PR TITLE
feat: add more descriptive zone sdk events for user feedback

### DIFF
--- a/deployment/tui-zone/src/lib.rs
+++ b/deployment/tui-zone/src/lib.rs
@@ -137,7 +137,7 @@ fn handle_event(
             }
             state.save_checkpoint(checkpoint);
         }
-        Event::TxStatusChanged { .. } | Event::TurnNotification { .. } => {}
+        Event::MempoolPending(_) | Event::TurnNotification { .. } => {}
     }
 }
 

--- a/deployment/tui-zone/src/lib.rs
+++ b/deployment/tui-zone/src/lib.rs
@@ -137,7 +137,7 @@ fn handle_event(
             }
             state.save_checkpoint(checkpoint);
         }
-        Event::TurnNotification { .. } => {}
+        Event::TxStatusChanged { .. } | Event::TurnNotification { .. } => {}
     }
 }
 

--- a/tests/cucumber_tests/features/zone.feature
+++ b/tests/cucumber_tests/features/zone.feature
@@ -128,6 +128,11 @@ Feature: Zone SDK
       | MSG_1 | a1   |
       | MSG_2 | a2   |
       | MSG_3 | a3   |
+    And sequencer "SEQ_A" emits the full transaction lifecycle for zone messages in 30 seconds:
+      | alias |
+      | MSG_1 |
+      | MSG_2 |
+      | MSG_3 |
     Then the zone indexer returns messages in any order in 360 seconds:
       | alias |
       | MSG_1 |
@@ -269,6 +274,10 @@ Feature: Zone SDK
       | alias  |
       | MSG_B1 |
       | MSG_B2 |
+    And sequencer "SEQ_B" observed mempool pending events for zone messages:
+      | alias  |
+      | MSG_B1 |
+      | MSG_B2 |
     Then sequencer "SEQ_B" has 3 pending publish txs in 180 seconds
     Then sequencer "SEQ_B" has 1 pending publish txs in 180 seconds
     And the zone indexer returns messages in any order in 360 seconds:
@@ -315,6 +324,11 @@ Feature: Zone SDK
       | own_key_index | turn_to_write | pending_transactions | time_out |
       | 1             | NOT_OUR_TURN  | 3                    | 120      |
     And sequencer "SEQ_B" emits published events for queued zone messages on its turn in 180 seconds:
+      | alias  |
+      | MSG_C1 |
+      | MSG_C2 |
+      | MSG_C3 |
+    And sequencer "SEQ_B" observed mempool pending events for zone messages:
       | alias  |
       | MSG_C1 |
       | MSG_C2 |

--- a/tests/cucumber_tests/features/zone.feature
+++ b/tests/cucumber_tests/features/zone.feature
@@ -19,6 +19,11 @@ Feature: Zone SDK
       | MSG_3 | Third message  |
     Then all zone messages are safe in 120 seconds
     And all zone messages are finalized in 180 seconds
+    And sequencer "SEQ_A" emits the full transaction lifecycle for zone messages in 30 seconds:
+      | alias |
+      | MSG_1 |
+      | MSG_2 |
+      | MSG_3 |
     And the zone indexer returns messages in this order:
       | alias |
       | MSG_1 |

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -103,6 +103,7 @@ struct StartedSequencerRuntime {
     ready_rx: tokio::sync::watch::Receiver<bool>,
     channel_view_rx: tokio::sync::watch::Receiver<lb_zone_sdk::sequencer::SequencerChannelView>,
     turn_to_write_rx: tokio::sync::watch::Receiver<lb_zone_sdk::sequencer::TurnNotification>,
+    tx_status_rx: broadcast::Receiver<lb_zone_sdk::sequencer::TxStatusUpdate>,
     discarded_payloads: Option<DiscardedPayloads>,
 }
 
@@ -786,6 +787,7 @@ async fn start_named_sequencer_with_config(
         runtime.ready_rx,
         runtime.channel_view_rx,
         runtime.turn_to_write_rx,
+        runtime.tx_status_rx,
         runtime.discarded_payloads,
     );
 
@@ -852,6 +854,7 @@ fn from_policy_runtime(
         ready_rx: rt.ready_rx,
         channel_view_rx: rt.channel_view_rx,
         turn_to_write_rx: rt.turn_to_write_rx,
+        tx_status_rx: rt.tx_status_rx,
         discarded_payloads,
     }
 }

--- a/tests/src/cucumber/steps/manual_zone/runner.rs
+++ b/tests/src/cucumber/steps/manual_zone/runner.rs
@@ -26,8 +26,8 @@ use lb_key_management_system_service::keys::Ed25519Signature;
 pub use lb_zone_sdk::sequencer::{
     AtomicWithdrawInfo, ChannelUpdate, DepositInfo, Error, Event, FinalizedOp, FinalizedTx,
     InscriptionId, InscriptionInfo, OrphanedTx, PendingTx, PublishResult, SequencerChannelView,
-    SequencerCheckpoint, SequencerConfig, TurnNotification, TxSource, TxStatus, WithdrawArg,
-    WithdrawInfo,
+    SequencerCheckpoint, SequencerConfig, TurnNotification, TxSource, TxStatus, TxStatusUpdate,
+    WithdrawArg, WithdrawInfo,
 };
 use lb_zone_sdk::{adapter, sequencer::ZoneSequencer};
 use tokio::{
@@ -233,6 +233,7 @@ pub struct Runtime<Node> {
     pub ready_rx: watch::Receiver<bool>,
     pub channel_view_rx: watch::Receiver<SequencerChannelView>,
     pub turn_to_write_rx: watch::Receiver<TurnNotification>,
+    pub tx_status_rx: broadcast::Receiver<TxStatusUpdate>,
 }
 
 /// Drive loop body. Owns the sequencer until both the block stream
@@ -285,6 +286,7 @@ where
     let ready_rx = sequencer.subscribe_ready();
     let channel_view_rx = sequencer.subscribe_channel_view();
     let turn_to_write_rx = sequencer.subscribe_turn_to_write();
+    let tx_status_rx = sequencer.subscribe_tx_status();
     let event_rx = sequencer.subscribe_events();
 
     let task = tokio::spawn(run(sequencer, policy, cmd_rx));
@@ -300,6 +302,7 @@ where
         ready_rx,
         channel_view_rx,
         turn_to_write_rx,
+        tx_status_rx,
     }
 }
 

--- a/tests/src/cucumber/steps/manual_zone/runner.rs
+++ b/tests/src/cucumber/steps/manual_zone/runner.rs
@@ -26,7 +26,8 @@ use lb_key_management_system_service::keys::Ed25519Signature;
 pub use lb_zone_sdk::sequencer::{
     AtomicWithdrawInfo, ChannelUpdate, DepositInfo, Error, Event, FinalizedOp, FinalizedTx,
     InscriptionId, InscriptionInfo, OrphanedTx, PendingTx, PublishResult, SequencerChannelView,
-    SequencerCheckpoint, SequencerConfig, TurnNotification, WithdrawArg, WithdrawInfo,
+    SequencerCheckpoint, SequencerConfig, TurnNotification, TxSource, TxStatus, WithdrawArg,
+    WithdrawInfo,
 };
 use lb_zone_sdk::{adapter, sequencer::ZoneSequencer};
 use tokio::{

--- a/tests/src/cucumber/steps/manual_zone/steps.rs
+++ b/tests/src/cucumber/steps/manual_zone/steps.rs
@@ -22,6 +22,7 @@ use super::{
         wait_until_sorted_conflict_settles,
     },
     errors::{log_step_error, zone_step_error},
+    runner::{TxSource, TxStatus},
     support::{
         PublishDeadline, balance_update_payload, collect_indexed_messages,
         collect_indexed_messages_exactly_once, ensure_zone_transactions_included,
@@ -29,7 +30,8 @@ use super::{
         wait_for_adopted_payloads, wait_for_channel_view, wait_for_deposit,
         wait_for_exact_indexed_payload_count, wait_for_finalized_deposit_via_sequencer,
         wait_for_finalized_withdraw_via_sequencer, wait_for_lib_advance,
-        wait_for_transactions_finalized, wait_for_turn_to_write, wait_for_withdraw,
+        wait_for_transactions_finalized, wait_for_turn_to_write, wait_for_tx_status_lifecycle,
+        wait_for_withdraw,
     },
     tables::{
         ConcurrentZoneMessageRow, GeneratedZoneMessageBatch, concurrent_zone_message_rows,
@@ -1071,6 +1073,34 @@ async fn step_all_zone_messages_are_finalized(
     wait_for_transactions_finalized(
         node_url,
         &inscription_ids,
+        Duration::from_secs(timeout_seconds),
+    )
+    .await
+    .map_err(|error| zone_step_error(step, &error))
+}
+
+#[cucumber::then(
+    expr = "sequencer {string} emits the full transaction lifecycle for zone messages in {int} seconds:"
+)]
+async fn step_sequencer_emits_full_transaction_lifecycle(
+    world: &mut CucumberWorld,
+    step: &Step,
+    sequencer_alias: String,
+    timeout_seconds: u64,
+) -> StepResult {
+    let aliases = single_column_table(step, "alias", "zone message aliases")?;
+    let tx_hashes = log_step_error(step, world.zone.message_tx_hashes_for_aliases(&aliases))?;
+    let events = log_step_error(step, world.zone.sequencer_events_mut(&sequencer_alias))?;
+
+    wait_for_tx_status_lifecycle(
+        events,
+        &tx_hashes,
+        &[
+            TxStatus::AcceptedLocally,
+            TxStatus::PendingMempool,
+            TxStatus::OnChain(TxSource::Local),
+            TxStatus::Finalized(TxSource::Local),
+        ],
         Duration::from_secs(timeout_seconds),
     )
     .await

--- a/tests/src/cucumber/steps/manual_zone/steps.rs
+++ b/tests/src/cucumber/steps/manual_zone/steps.rs
@@ -26,12 +26,14 @@ use super::{
     support::{
         PublishDeadline, balance_update_payload, collect_indexed_messages,
         collect_indexed_messages_exactly_once, ensure_zone_transactions_included,
-        parse_balance_payload, publish_message_with_retry, wait_for_adopted_payload,
-        wait_for_adopted_payloads, wait_for_channel_view, wait_for_deposit,
-        wait_for_exact_indexed_payload_count, wait_for_finalized_deposit_via_sequencer,
-        wait_for_finalized_withdraw_via_sequencer, wait_for_lib_advance,
-        wait_for_transactions_finalized, wait_for_turn_to_write, wait_for_tx_status_lifecycle,
-        wait_for_withdraw,
+        parse_balance_payload, publish_message_with_retry,
+        wait_for_adopted_payload_and_collect_mempool_pending,
+        wait_for_adopted_payloads_and_collect_mempool_pending, wait_for_channel_view,
+        wait_for_deposit, wait_for_exact_indexed_payload_count,
+        wait_for_finalized_deposit_via_sequencer_and_collect_mempool_pending,
+        wait_for_finalized_withdraw_via_sequencer_and_collect_mempool_pending,
+        wait_for_lib_advance, wait_for_transactions_finalized, wait_for_turn_to_write,
+        wait_for_tx_status_lifecycle, wait_for_withdraw,
     },
     tables::{
         ConcurrentZoneMessageRow, GeneratedZoneMessageBatch, concurrent_zone_message_rows,
@@ -953,11 +955,15 @@ async fn step_sequencer_emits_published_events_for_queued_zone_messages_on_turn(
     .await
     .map_err(|error| zone_step_error(step, &error))?;
 
-    let published = {
+    let (published, mempool_pending) = {
         let events = log_step_error(step, world.zone.sequencer_events_mut(&sequencer_alias))?;
-        wait_for_adopted_payloads(events, &payloads, Duration::from_secs(timeout_seconds))
-            .await
-            .map_err(|error| zone_step_error(step, &error))?
+        wait_for_adopted_payloads_and_collect_mempool_pending(
+            events,
+            &payloads,
+            Duration::from_secs(timeout_seconds),
+        )
+        .await
+        .map_err(|error| zone_step_error(step, &error))?
     };
 
     for ((message_alias, payload), published) in aliases.into_iter().zip(payloads).zip(published) {
@@ -969,15 +975,51 @@ async fn step_sequencer_emits_published_events_for_queued_zone_messages_on_turn(
             &published,
         );
     }
+    world
+        .zone
+        .record_mempool_pending(sequencer_alias.clone(), mempool_pending);
 
     Ok(())
 }
 
-#[cucumber::then(expr = "sequencer {string} has {int} pending publish txs in {int} seconds")]
+#[cucumber::then(expr = "sequencer {string} observed mempool pending events for zone messages:")]
+#[expect(
+    clippy::unused_async,
+    reason = "Cucumber step functions are async even when assertion is synchronous"
+)]
 #[expect(
     clippy::needless_pass_by_ref_mut,
     reason = "Cucumber step functions require `&mut World` as the first parameter"
 )]
+async fn step_sequencer_emitted_mempool_pending_events_for_zone_messages(
+    world: &mut CucumberWorld,
+    step: &Step,
+    sequencer_alias: String,
+) -> StepResult {
+    let aliases = single_column_table(step, "alias", "zone message aliases")?;
+    let tx_hashes = log_step_error(step, world.zone.message_tx_hashes_for_aliases(&aliases))?;
+
+    for (alias, tx_hash) in aliases.iter().zip(tx_hashes.iter()) {
+        if !world
+            .zone
+            .has_observed_mempool_pending(&sequencer_alias, tx_hash)
+        {
+            return Err(StepError::LogicalError {
+                message: format!(
+                    "Sequencer '{sequencer_alias}' did not emit mempool pending event for zone message '{alias}'"
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Cucumber step functions require `&mut World` as the first parameter"
+)]
+#[cucumber::then(expr = "sequencer {string} has {int} pending publish txs in {int} seconds")]
 async fn step_sequencer_has_pending_publish_txs(
     world: &mut CucumberWorld,
     step: &Step,
@@ -1009,14 +1051,21 @@ async fn step_sequencer_publishes_immediately_while_in_turn(
     timeout_seconds: u64,
 ) -> StepResult {
     let payload = message_payload(world, &message_alias)?;
-    let published = {
+    let (published, mempool_pending) = {
         let events = log_step_error(step, world.zone.sequencer_events_mut(&sequencer_alias))?;
-        wait_for_adopted_payload(events, &payload, Duration::from_secs(timeout_seconds))
-            .await
-            .map_err(|error| zone_step_error(step, &error))?
+        wait_for_adopted_payload_and_collect_mempool_pending(
+            events,
+            &payload,
+            Duration::from_secs(timeout_seconds),
+        )
+        .await
+        .map_err(|error| zone_step_error(step, &error))?
     };
 
     remember_published_zone_message(world, &sequencer_alias, message_alias, payload, &published);
+    world
+        .zone
+        .record_mempool_pending(sequencer_alias.clone(), mempool_pending);
 
     Ok(())
 }
@@ -1080,6 +1129,9 @@ async fn step_all_zone_messages_are_finalized(
 }
 
 #[cucumber::then(
+    expr = "sequencer {string} emits the full transaction lifecycle for zone messages in {int} seconds:"
+)]
+#[cucumber::when(
     expr = "sequencer {string} emits the full transaction lifecycle for zone messages in {int} seconds:"
 )]
 async fn step_sequencer_emits_full_transaction_lifecycle(
@@ -1293,14 +1345,18 @@ async fn step_zone_sequencer_finalizes_deposit(
         .clone();
     let events = log_step_error(step, world.zone.sequencer_events_mut(&sequencer_alias))?;
 
-    wait_for_finalized_deposit_via_sequencer(
+    let mempool_pending = wait_for_finalized_deposit_via_sequencer_and_collect_mempool_pending(
         events,
         &deposit,
         amount,
         Duration::from_secs(timeout_seconds),
     )
     .await
-    .map_err(|error| zone_step_error(step, &error))
+    .map_err(|error| zone_step_error(step, &error))?;
+    world
+        .zone
+        .record_mempool_pending(sequencer_alias.clone(), mempool_pending);
+    Ok(())
 }
 
 #[cucumber::then(expr = "sequencer {string} finalizes withdraw {string} in {int} seconds")]
@@ -1317,13 +1373,17 @@ async fn step_zone_sequencer_finalizes_withdraw(
         .clone();
     let events = log_step_error(step, world.zone.sequencer_events_mut(&sequencer_alias))?;
 
-    wait_for_finalized_withdraw_via_sequencer(
+    let mempool_pending = wait_for_finalized_withdraw_via_sequencer_and_collect_mempool_pending(
         events,
         &withdraw,
         Duration::from_secs(timeout_seconds),
     )
     .await
-    .map_err(|error| zone_step_error(step, &error))
+    .map_err(|error| zone_step_error(step, &error))?;
+    world
+        .zone
+        .record_mempool_pending(sequencer_alias.clone(), mempool_pending);
+    Ok(())
 }
 
 #[cucumber::then(

--- a/tests/src/cucumber/steps/manual_zone/steps.rs
+++ b/tests/src/cucumber/steps/manual_zone/steps.rs
@@ -1090,10 +1090,13 @@ async fn step_sequencer_emits_full_transaction_lifecycle(
 ) -> StepResult {
     let aliases = single_column_table(step, "alias", "zone message aliases")?;
     let tx_hashes = log_step_error(step, world.zone.message_tx_hashes_for_aliases(&aliases))?;
-    let events = log_step_error(step, world.zone.sequencer_events_mut(&sequencer_alias))?;
+    let mut tx_status_rx = log_step_error(
+        step,
+        world.zone.take_sequencer_tx_status_rx(&sequencer_alias),
+    )?;
 
     wait_for_tx_status_lifecycle(
-        events,
+        &mut tx_status_rx,
         &tx_hashes,
         &[
             TxStatus::AcceptedLocally,

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -51,7 +51,7 @@ use tracing::warn;
 use super::runner::{
     self, ChannelUpdate, Event, FinalizedOp, InscriptionId, InscriptionInfo, OrphanedTx, PendingTx,
     PublishResult, SequencerChannelView, SequencerCheckpoint, SequencerClient, SequencerConfig,
-    TurnNotification, TxStatus, WithdrawArg,
+    TurnNotification, TxStatus, TxStatusUpdate, WithdrawArg,
 };
 use crate::common::{
     chain::wait_for_transactions_inclusion, mantle_inscription::make_inscription,
@@ -172,6 +172,7 @@ pub struct PolicyRuntime {
     pub ready_rx: tokio::sync::watch::Receiver<bool>,
     pub channel_view_rx: tokio::sync::watch::Receiver<SequencerChannelView>,
     pub turn_to_write_rx: tokio::sync::watch::Receiver<TurnNotification>,
+    pub tx_status_rx: tokio::sync::broadcast::Receiver<TxStatusUpdate>,
 }
 
 fn to_policy_runtime(rt: runner::Runtime<ZoneNodeHttpClient>) -> PolicyRuntime {
@@ -183,6 +184,7 @@ fn to_policy_runtime(rt: runner::Runtime<ZoneNodeHttpClient>) -> PolicyRuntime {
         ready_rx: rt.ready_rx,
         channel_view_rx: rt.channel_view_rx,
         turn_to_write_rx: rt.turn_to_write_rx,
+        tx_status_rx: rt.tx_status_rx,
     }
 }
 
@@ -632,7 +634,7 @@ pub async fn wait_for_adopted_payloads(
 }
 
 pub async fn wait_for_tx_status_lifecycle(
-    events: &mut tokio::sync::broadcast::Receiver<Event>,
+    tx_status_rx: &mut tokio::sync::broadcast::Receiver<TxStatusUpdate>,
     tx_hashes: &[InscriptionId],
     statuses: &[TxStatus],
     duration: Duration,
@@ -644,20 +646,20 @@ pub async fn wait_for_tx_status_lifecycle(
 
     timeout(duration, async {
         while !remaining.is_empty() {
-            let event = match events.recv().await {
-                Ok(event) => event,
+            let update = match tx_status_rx.recv().await {
+                Ok(update) => update,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!("event subscriber lagged by {n}, recovering");
+                    warn!("tx-status subscriber lagged by {n}, recovering");
                     continue;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     return Err(ZoneTestError::SequencerStopped);
                 }
             };
-            let Event::TxStatusChanged { tx_hash, status } = event else {
-                continue;
-            };
-            remaining.remove(&(tx_hash, status));
+            remaining.remove(&(update.tx_hash, update.status));
+            if remaining.is_empty() {
+                return Ok(());
+            }
         }
         Ok(())
     })

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -548,14 +548,16 @@ pub async fn publish_message_with_retry(
 }
 
 /// Waits until the sequencer's event stream surfaces the payload in
-/// [`ChannelUpdate::adopted`] — i.e. the inscription was published and
+/// [`ChannelUpdate::adopted`] while collecting any mempool-pending events
+/// passed on the same event stream — i.e. the inscription was published and
 /// landed on the canonical chain. This is the end-to-end signal a real
 /// SDK consumer would observe.
-pub async fn wait_for_adopted_payload(
+pub async fn wait_for_adopted_payload_and_collect_mempool_pending(
     events: &mut tokio::sync::broadcast::Receiver<Event>,
     data: &[u8],
     duration: Duration,
-) -> Result<PublishResult, ZoneTestError> {
+) -> Result<(PublishResult, HashSet<InscriptionId>), ZoneTestError> {
+    let mut mempool_pending = HashSet::new();
     timeout(duration, async {
         loop {
             let event = match events.recv().await {
@@ -568,14 +570,21 @@ pub async fn wait_for_adopted_payload(
                     return Err(ZoneTestError::SequencerStopped);
                 }
             };
+            if let Event::MempoolPending(tx_hash) = event {
+                mempool_pending.insert(tx_hash);
+                continue;
+            }
             let Event::BlocksProcessed { channel_update, .. } = event else {
                 continue;
             };
             for info in channel_update.adopted {
                 if info.payload.as_slice() == data {
-                    return Ok(PublishResult {
-                        tx: PendingTx::Inscription(info),
-                    });
+                    return Ok((
+                        PublishResult {
+                            tx: PendingTx::Inscription(info),
+                        },
+                        mempool_pending,
+                    ));
                 }
             }
         }
@@ -585,16 +594,18 @@ pub async fn wait_for_adopted_payload(
 }
 
 /// Waits for every payload in `data` to appear in
-/// [`ChannelUpdate::adopted`].
-pub async fn wait_for_adopted_payloads(
+/// [`ChannelUpdate::adopted`], while collecting any mempool-pending events
+/// passed on the same event stream.
+pub async fn wait_for_adopted_payloads_and_collect_mempool_pending(
     events: &mut tokio::sync::broadcast::Receiver<Event>,
     data: &[Inscription],
     duration: Duration,
-) -> Result<Vec<PublishResult>, ZoneTestError> {
+) -> Result<(Vec<PublishResult>, HashSet<InscriptionId>), ZoneTestError> {
     timeout(duration, async {
         let mut results: Vec<Option<PublishResult>> =
             std::iter::repeat_with(|| None).take(data.len()).collect();
         let mut remaining = data.len();
+        let mut mempool_pending = HashSet::new();
 
         while remaining > 0 {
             let event = match events.recv().await {
@@ -607,6 +618,10 @@ pub async fn wait_for_adopted_payloads(
                     return Err(ZoneTestError::SequencerStopped);
                 }
             };
+            if let Event::MempoolPending(tx_hash) = event {
+                mempool_pending.insert(tx_hash);
+                continue;
+            }
             let Event::BlocksProcessed { channel_update, .. } = event else {
                 continue;
             };
@@ -627,7 +642,7 @@ pub async fn wait_for_adopted_payloads(
             }
         }
 
-        Ok(results.into_iter().flatten().collect())
+        Ok((results.into_iter().flatten().collect(), mempool_pending))
     })
     .await
     .map_err(|_| ZoneTestError::PublishTimeout)?
@@ -962,32 +977,38 @@ pub async fn wait_for_withdraw(
 
 /// Waits until the sequencer's event stream surfaces the expected deposit
 /// in [`Event::BlocksProcessed::finalized`] (matched by `inputs`, `amount`,
-/// and `metadata`). Drains the events channel as it goes — call this
-/// after any earlier event consumers in the scenario have moved past the
-/// relevant publish events.
-pub async fn wait_for_finalized_deposit_via_sequencer(
+/// and `metadata`) while collecting any mempool-pending events. Drains the
+/// events channel as it goes — call this after any earlier event consumers in
+/// the scenario have moved past the relevant publish events.
+pub async fn wait_for_finalized_deposit_via_sequencer_and_collect_mempool_pending(
     events: &mut tokio::sync::broadcast::Receiver<Event>,
     expected: &DepositOp,
     expected_amount: Value,
     duration: Duration,
-) -> Result<(), ZoneTestError> {
-    poll_sequencer_finalized_until(events, duration, ZoneTestError::IndexerTimeout, |op| {
-        matches!(op, FinalizedOp::Deposit(d)
+) -> Result<HashSet<InscriptionId>, ZoneTestError> {
+    poll_sequencer_finalized_until_and_collect_mempool_pending(
+        events,
+        duration,
+        ZoneTestError::IndexerTimeout,
+        |op| {
+            matches!(op, FinalizedOp::Deposit(d)
             if d.inputs == expected.inputs
                 && d.amount == expected_amount
                 && d.metadata == expected.metadata)
-    })
+        },
+    )
     .await
 }
 
 /// Waits until the sequencer's event stream surfaces the expected withdraw
-/// (matched by `outputs`). Drains the events channel as it goes.
-pub async fn wait_for_finalized_withdraw_via_sequencer(
+/// (matched by `outputs`) while collecting any mempool-pending events. Drains
+/// the events channel as it goes.
+pub async fn wait_for_finalized_withdraw_via_sequencer_and_collect_mempool_pending(
     events: &mut tokio::sync::broadcast::Receiver<Event>,
     expected: &ChannelWithdrawOp,
     duration: Duration,
-) -> Result<(), ZoneTestError> {
-    poll_sequencer_finalized_until(
+) -> Result<HashSet<InscriptionId>, ZoneTestError> {
+    poll_sequencer_finalized_until_and_collect_mempool_pending(
         events,
         duration,
         ZoneTestError::WithdrawTimeout,
@@ -996,13 +1017,14 @@ pub async fn wait_for_finalized_withdraw_via_sequencer(
     .await
 }
 
-async fn poll_sequencer_finalized_until(
+async fn poll_sequencer_finalized_until_and_collect_mempool_pending(
     events: &mut tokio::sync::broadcast::Receiver<Event>,
     duration: Duration,
     timeout_error: ZoneTestError,
     mut predicate: impl FnMut(&FinalizedOp) -> bool,
-) -> Result<(), ZoneTestError> {
+) -> Result<HashSet<InscriptionId>, ZoneTestError> {
     timeout(duration, async {
+        let mut mempool_pending = HashSet::new();
         loop {
             let event = match events.recv().await {
                 Ok(event) => event,
@@ -1014,12 +1036,16 @@ async fn poll_sequencer_finalized_until(
                     return Err(ZoneTestError::SequencerStopped);
                 }
             };
+            if let Event::MempoolPending(tx_hash) = event {
+                mempool_pending.insert(tx_hash);
+                continue;
+            }
             let Event::BlocksProcessed { finalized, .. } = event else {
                 continue;
             };
             for tx in finalized {
                 if tx.ops.iter().any(&mut predicate) {
-                    return Ok(());
+                    return Ok(mempool_pending);
                 }
             }
         }

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -51,7 +51,7 @@ use tracing::warn;
 use super::runner::{
     self, ChannelUpdate, Event, FinalizedOp, InscriptionId, InscriptionInfo, OrphanedTx, PendingTx,
     PublishResult, SequencerChannelView, SequencerCheckpoint, SequencerClient, SequencerConfig,
-    TurnNotification, WithdrawArg,
+    TurnNotification, TxStatus, WithdrawArg,
 };
 use crate::common::{
     chain::wait_for_transactions_inclusion, mantle_inscription::make_inscription,
@@ -629,6 +629,40 @@ pub async fn wait_for_adopted_payloads(
     })
     .await
     .map_err(|_| ZoneTestError::PublishTimeout)?
+}
+
+pub async fn wait_for_tx_status_lifecycle(
+    events: &mut tokio::sync::broadcast::Receiver<Event>,
+    tx_hashes: &[InscriptionId],
+    statuses: &[TxStatus],
+    duration: Duration,
+) -> Result<(), ZoneTestError> {
+    let mut remaining: HashSet<(InscriptionId, TxStatus)> = tx_hashes
+        .iter()
+        .flat_map(|tx_hash| statuses.iter().map(move |status| (*tx_hash, *status)))
+        .collect();
+
+    timeout(duration, async {
+        while !remaining.is_empty() {
+            let event = match events.recv().await {
+                Ok(event) => event,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!("event subscriber lagged by {n}, recovering");
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err(ZoneTestError::SequencerStopped);
+                }
+            };
+            let Event::TxStatusChanged { tx_hash, status } = event else {
+                continue;
+            };
+            remaining.remove(&(tx_hash, status));
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|_| ZoneTestError::IndexerTimeout)?
 }
 
 /// Waits until the subscribed channel view satisfies the supplied predicate.

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -190,6 +190,7 @@ pub struct ZoneState {
     saved_checkpoints: HashMap<String, SequencerCheckpoint>,
     latest_checkpoints: HashMap<String, SequencerCheckpoint>,
     sequencer_startups: HashMap<String, ZoneSequencerStartup>,
+    observed_mempool_pending: HashMap<String, HashSet<InscriptionId>>,
     sorted_total_payloads: Option<usize>,
     sorted_expected_by_sequencer: Option<HashMap<String, Vec<Inscription>>>,
 }
@@ -457,6 +458,28 @@ impl ZoneState {
                     })
             })
             .collect()
+    }
+
+    pub fn record_mempool_pending(
+        &mut self,
+        sequencer_alias: impl Into<String>,
+        tx_hashes: impl IntoIterator<Item = InscriptionId>,
+    ) {
+        self.observed_mempool_pending
+            .entry(sequencer_alias.into())
+            .or_default()
+            .extend(tx_hashes);
+    }
+
+    #[must_use]
+    pub fn has_observed_mempool_pending(
+        &self,
+        sequencer_alias: &str,
+        tx_hash: &InscriptionId,
+    ) -> bool {
+        self.observed_mempool_pending
+            .get(sequencer_alias)
+            .is_some_and(|observed| observed.contains(tx_hash))
     }
 
     pub fn published_message_payloads(&self) -> Result<Vec<Inscription>, StepError> {

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -49,7 +49,9 @@ use crate::{
         },
         error::{StepError, StepResult},
         fee_reserve::ScenarioFeeState,
-        steps::manual_zone::runner::{Event, InscriptionId, SequencerCheckpoint, SequencerClient},
+        steps::manual_zone::runner::{
+            Event, InscriptionId, SequencerCheckpoint, SequencerClient, TxStatusUpdate,
+        },
         utils::{make_builder, shared_host_bin_path},
         wallet::feed::{CucumberWalletBlockFeed, CucumberWalletBlockFeedError},
     },
@@ -157,6 +159,7 @@ pub struct ZoneSequencerRuntime {
     ready_rx: tokio::sync::watch::Receiver<bool>,
     channel_view_rx: tokio::sync::watch::Receiver<lb_zone_sdk::sequencer::SequencerChannelView>,
     turn_to_write_rx: tokio::sync::watch::Receiver<lb_zone_sdk::sequencer::TurnNotification>,
+    tx_status_rx: Option<tokio::sync::broadcast::Receiver<TxStatusUpdate>>,
     discarded_payloads: Option<ZoneDiscardedPayloads>,
 }
 
@@ -526,6 +529,24 @@ impl ZoneState {
             .map(|runtime| runtime.checkpoint_rx.clone())
     }
 
+    pub fn take_sequencer_tx_status_rx(
+        &mut self,
+        sequencer_alias: &str,
+    ) -> Result<tokio::sync::broadcast::Receiver<TxStatusUpdate>, StepError> {
+        self.runtimes
+            .get_mut(sequencer_alias)
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Zone sequencer '{sequencer_alias}' is not running"),
+            })?
+            .tx_status_rx
+            .take()
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!(
+                    "Zone sequencer '{sequencer_alias}' tx-status receiver was already consumed"
+                ),
+            })
+    }
+
     pub fn resolve_checkpoint(
         &self,
         alias: impl AsRef<str>,
@@ -555,6 +576,7 @@ impl ZoneState {
         ready_rx: tokio::sync::watch::Receiver<bool>,
         channel_view_rx: tokio::sync::watch::Receiver<lb_zone_sdk::sequencer::SequencerChannelView>,
         turn_to_write_rx: tokio::sync::watch::Receiver<lb_zone_sdk::sequencer::TurnNotification>,
+        tx_status_rx: tokio::sync::broadcast::Receiver<TxStatusUpdate>,
         discarded_payloads: Option<ZoneDiscardedPayloads>,
     ) {
         if let Some(runtime) = self.runtimes.remove(&alias) {
@@ -571,6 +593,7 @@ impl ZoneState {
                 ready_rx,
                 channel_view_rx,
                 turn_to_write_rx,
+                tx_status_rx: Some(tx_status_rx),
                 discarded_payloads,
             },
         );

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -437,6 +437,25 @@ impl ZoneState {
             .collect()
     }
 
+    pub fn message_tx_hashes_for_aliases(
+        &self,
+        aliases: &[String],
+    ) -> Result<Vec<InscriptionId>, StepError> {
+        aliases
+            .iter()
+            .map(|alias| {
+                self.published_messages
+                    .get(alias)
+                    .and_then(|message| message.inscription_id)
+                    .ok_or(StepError::LogicalError {
+                        message: format!(
+                            "Zone message alias '{alias}' does not have a tracked tx hash"
+                        ),
+                    })
+            })
+            .collect()
+    }
+
     pub fn published_message_payloads(&self) -> Result<Vec<Inscription>, StepError> {
         self.message_payloads_for_aliases(&self.published_order)
     }

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -14,7 +14,7 @@ use super::{
     state::{ChannelUpdateInfo, TxState},
     types::{
         ChannelUpdate, Error, Event, FinalizedTx, SequencerChannelView, SequencerCheckpoint,
-        TurnNotification,
+        TurnNotification, TxSource, TxStatus,
     },
     zone_sequencer::{ZoneSequencer, build_checkpoint},
 };
@@ -109,6 +109,8 @@ where
         // arrives.
         self.publish_channel_view();
 
+        self.queue_block_status_events(&channel_update, &finalized);
+
         let block_event = self
             .publish_checkpoint()
             .map(|checkpoint| Event::BlocksProcessed {
@@ -124,7 +126,10 @@ where
             return Some(self.emit_now(Event::Ready));
         }
 
-        block_event
+        if let Some(ev) = block_event {
+            self.buffered_events.push_back(ev);
+        }
+        self.buffered_events.pop_front()
     }
 
     /// If not yet ready and startup backfill is complete, mark ready. Returns
@@ -478,6 +483,35 @@ where
             },
         };
         (channel_update, result.finalized_items)
+    }
+
+    fn queue_block_status_events(
+        &mut self,
+        channel_update: &ChannelUpdate,
+        finalized: &[FinalizedTx],
+    ) {
+        for tx in &channel_update.orphaned {
+            let tx_hash = tx.tx_hash();
+            let source = self
+                .state
+                .as_ref()
+                .map_or(TxSource::Other, |state| state.tx_source(&tx_hash));
+            self.queue_tx_status(tx_hash, TxStatus::Orphaned(source));
+        }
+        for info in &channel_update.adopted {
+            let source = self
+                .state
+                .as_ref()
+                .map_or(TxSource::Other, |state| state.tx_source(&info.tx_hash));
+            self.queue_tx_status(info.tx_hash, TxStatus::OnChain(source));
+        }
+        for tx in finalized {
+            let source = self
+                .state
+                .as_ref()
+                .map_or(TxSource::Other, |state| state.tx_source(&tx.tx_hash));
+            self.queue_tx_status(tx.tx_hash, TxStatus::Finalized(source));
+        }
     }
 
     fn log_channel_update(update: &ChannelUpdateInfo) {

--- a/zone-sdk/src/sequencer/backfill.rs
+++ b/zone-sdk/src/sequencer/backfill.rs
@@ -14,7 +14,7 @@ use super::{
     block_fetch::fetch_and_process_blocks,
     slot_clock::SlotClock,
     state::TxState,
-    types::{ChannelUpdate, Error, Event, FinalizedOp},
+    types::{ChannelUpdate, Error, Event, FinalizedOp, TxSource, TxStatus},
     zone_sequencer::ZoneSequencer,
 };
 use crate::adapter;
@@ -106,14 +106,23 @@ where
             return Some(None);
         };
 
-        Some(Some(Event::BlocksProcessed {
+        for tx in &batch.items {
+            let source = self
+                .state
+                .as_ref()
+                .map_or(TxSource::Other, |state| state.tx_source(&tx.tx_hash));
+            self.queue_tx_status(tx.tx_hash, TxStatus::Finalized(source));
+        }
+
+        self.buffered_events.push_back(Event::BlocksProcessed {
             checkpoint,
             channel_update: ChannelUpdate {
                 orphaned: Vec::new(),
                 adopted: Vec::new(),
             },
             finalized: batch.items,
-        }))
+        });
+        Some(self.buffered_events.pop_front())
     }
 
     /// Ensure the blocks stream is connected. Returns `false` if not yet

--- a/zone-sdk/src/sequencer/backfill.rs
+++ b/zone-sdk/src/sequencer/backfill.rs
@@ -153,6 +153,10 @@ where
     /// `current_tip` stays None so the first live block event emits everything
     /// from LIB up to the new tip as `adopted`. On reconnect this is a no-op
     /// once both `state` and `slot_clock` are initialized.
+    #[expect(
+        clippy::cognitive_complexity,
+        reason = "TODO: address this in a dedicated refactor"
+    )]
     async fn init_state_if_needed(&mut self) -> bool {
         if self.state.is_some() && self.slot_clock.is_some() {
             return true;

--- a/zone-sdk/src/sequencer/backfill.rs
+++ b/zone-sdk/src/sequencer/backfill.rs
@@ -153,10 +153,6 @@ where
     /// `current_tip` stays None so the first live block event emits everything
     /// from LIB up to the new tip as `adopted`. On reconnect this is a no-op
     /// once both `state` and `slot_clock` are initialized.
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "TODO: address this in a dedicated refactor"
-    )]
     async fn init_state_if_needed(&mut self) -> bool {
         if self.state.is_some() && self.slot_clock.is_some() {
             return true;

--- a/zone-sdk/src/sequencer/handle.rs
+++ b/zone-sdk/src/sequencer/handle.rs
@@ -23,7 +23,7 @@ use super::{
     },
     types::{
         AtomicWithdrawInfo, Error, InscriptionInfo, PendingTx, PublishResult, SequencerCheckpoint,
-        WithdrawArg, WithdrawInfo,
+        TxStatus, WithdrawArg, WithdrawInfo,
     },
     zone_sequencer::ZoneSequencer,
 };
@@ -118,6 +118,8 @@ where
         let state = self.sequencer.state.as_mut().unwrap();
         state.submit_inscription(signed_tx.clone(), parent, new_msg_id, data);
         self.sequencer.last_msg_id = new_msg_id;
+        self.sequencer
+            .queue_tx_status(id, TxStatus::AcceptedLocally);
 
         // Queue the post into the in-flight batch pool only if it's our
         // turn — otherwise the tx sits in `state.pending` as `!posted` and
@@ -195,6 +197,8 @@ where
         state.submit_other(tx.clone());
         let parent_msg = self.sequencer.last_msg_id;
         self.sequencer.last_msg_id = msg_id;
+        self.sequencer
+            .queue_tx_status(id, TxStatus::AcceptedLocally);
 
         info!(target: TARGET,
             "Submitted tx including inscription {:?}",
@@ -280,6 +284,8 @@ where
         // Safe to unwrap — ensure_ready() guarantees state is initialized.
         let state = self.sequencer.state.as_mut().unwrap();
         state.submit_other(signed_tx.clone());
+        self.sequencer
+            .queue_tx_status(tx_hash, TxStatus::AcceptedLocally);
 
         info!(target: TARGET, "Submitted channel_config transaction {}", hex::encode(tx_hash.0));
 
@@ -410,6 +416,8 @@ where
             withdraw_infos.clone(),
         );
         self.sequencer.last_msg_id = msg_id;
+        self.sequencer
+            .queue_tx_status(tx_hash, TxStatus::AcceptedLocally);
 
         // Queue the post only if it's our turn — see `publish` for the
         // turn-gate rationale.

--- a/zone-sdk/src/sequencer/mod.rs
+++ b/zone-sdk/src/sequencer/mod.rs
@@ -62,7 +62,7 @@ pub use handle::SequencerHandle;
 pub use types::{
     AtomicWithdrawInfo, ChannelUpdate, DepositInfo, Error, Event, FinalizedOp, FinalizedTx,
     InscriptionId, InscriptionInfo, OrphanedTx, PendingTx, PublishResult, SequencerChannelView,
-    SequencerCheckpoint, SequencerConfig, TurnNotification, TxSource, TxStatus, WithdrawArg,
-    WithdrawInfo,
+    SequencerCheckpoint, SequencerConfig, TurnNotification, TxSource, TxStatus, TxStatusUpdate,
+    WithdrawArg, WithdrawInfo,
 };
 pub use zone_sequencer::ZoneSequencer;

--- a/zone-sdk/src/sequencer/mod.rs
+++ b/zone-sdk/src/sequencer/mod.rs
@@ -62,6 +62,7 @@ pub use handle::SequencerHandle;
 pub use types::{
     AtomicWithdrawInfo, ChannelUpdate, DepositInfo, Error, Event, FinalizedOp, FinalizedTx,
     InscriptionId, InscriptionInfo, OrphanedTx, PendingTx, PublishResult, SequencerChannelView,
-    SequencerCheckpoint, SequencerConfig, TurnNotification, WithdrawArg, WithdrawInfo,
+    SequencerCheckpoint, SequencerConfig, TurnNotification, TxSource, TxStatus, WithdrawArg,
+    WithdrawInfo,
 };
 pub use zone_sequencer::ZoneSequencer;

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use lb_core::{
     header::HeaderId,
@@ -10,7 +10,7 @@ use lb_core::{
 };
 use rpds::HashTrieSetSync;
 
-use super::types::{AtomicWithdrawInfo, InscriptionInfo, PendingTx, WithdrawInfo};
+use super::types::{AtomicWithdrawInfo, InscriptionInfo, PendingTx, TxSource, WithdrawInfo};
 
 /// Result of channel update detection — the linear block-level delta
 /// between two canonical chains.
@@ -54,6 +54,9 @@ pub struct TxState {
     pending_by_parent: HashMap<MsgId, Vec<TxHash>>,
     /// Non-inscription pending txs (e.g. `set_keys`).
     pending_other: HashMap<TxHash, SignedMantleTx>,
+    /// Tx hashes accepted locally by this sequencer runtime or restored from
+    /// its checkpoint.
+    local_txs: HashSet<TxHash>,
     /// Per-block cumulative safe sets.
     block_states: BTreeMap<HeaderId, HashTrieSetSync<TxHash>>,
     /// Block parent relationships for pruning.
@@ -75,6 +78,7 @@ impl TxState {
             pending: HashMap::new(),
             pending_by_parent: HashMap::new(),
             pending_other: HashMap::new(),
+            local_txs: HashSet::new(),
             block_states,
             parent_map: HashMap::new(),
             current_lib: lib,
@@ -122,6 +126,7 @@ impl TxState {
         withdraws: Option<Vec<WithdrawInfo>>,
     ) {
         let tx_hash = signed_tx.mantle_tx.hash();
+        self.local_txs.insert(tx_hash);
         self.pending_by_parent
             .entry(parent_msg)
             .or_default()
@@ -143,6 +148,7 @@ impl TxState {
     /// Submit a non-inscription tx for tracking (e.g. `set_keys`).
     pub fn submit_other(&mut self, signed_tx: SignedMantleTx) {
         let tx_hash = signed_tx.mantle_tx.hash();
+        self.local_txs.insert(tx_hash);
         self.pending_other.insert(tx_hash, signed_tx);
     }
 
@@ -326,18 +332,18 @@ impl TxState {
             return Vec::new();
         }
         let channel_tip = self.channel_tip_at(tip);
-        let on_branch: std::collections::HashSet<TxHash> = self
+        let on_branch: HashSet<TxHash> = self
             .collect_pending_suffix(channel_tip)
             .iter()
             .map(|i| i.tx_hash)
             .collect();
-        let safe: std::collections::HashSet<TxHash> = self
+        let safe: HashSet<TxHash> = self
             .block_states
             .get(&tip)
             .map(|s| s.iter().copied().collect())
             .unwrap_or_default();
 
-        let eligible: std::collections::HashSet<TxHash> = self
+        let eligible: HashSet<TxHash> = self
             .pending
             .keys()
             .filter(|h| !on_branch.contains(h) && !safe.contains(h))
@@ -350,7 +356,7 @@ impl TxState {
         // Find root parents: parent_msg values for eligible entries whose
         // parent is NOT the `this_msg` of another eligible entry. Sort for
         // determinism across HashMap iteration order.
-        let eligible_this_msgs: std::collections::HashSet<MsgId> = eligible
+        let eligible_this_msgs: HashSet<MsgId> = eligible
             .iter()
             .filter_map(|h| self.pending.get(h).map(|p| p.this_msg))
             .collect();
@@ -371,7 +377,7 @@ impl TxState {
         // BFS from each root parent via pending_by_parent; collect only
         // eligible entries in parent-first order.
         let mut ordered = Vec::with_capacity(eligible.len());
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::new();
         for root in root_parents {
             for info in self.collect_pending_suffix(root) {
                 if eligible.contains(&info.tx_hash) && seen.insert(info.tx_hash) {
@@ -418,6 +424,15 @@ impl TxState {
     #[must_use]
     pub fn pending_inscription(&self, tx_hash: &TxHash) -> Option<&PendingInscription> {
         self.pending.get(tx_hash)
+    }
+
+    #[must_use]
+    pub fn tx_source(&self, tx_hash: &TxHash) -> TxSource {
+        if self.local_txs.contains(tx_hash) {
+            TxSource::Local
+        } else {
+            TxSource::Other
+        }
     }
 
     /// Mark a pending inscription as posted. Returns true only for the first
@@ -551,10 +566,8 @@ impl TxState {
         let new_branch = self.collect_inscriptions_on_branch(new_tip);
         let old_branch = self.collect_inscriptions_on_branch(old_tip);
 
-        let new_chain: std::collections::HashSet<MsgId> =
-            new_branch.iter().map(|i| i.this_msg).collect();
-        let old_chain: std::collections::HashSet<MsgId> =
-            old_branch.iter().map(|i| i.this_msg).collect();
+        let new_chain: HashSet<MsgId> = new_branch.iter().map(|i| i.this_msg).collect();
+        let old_chain: HashSet<MsgId> = old_branch.iter().map(|i| i.this_msg).collect();
 
         let adopted: Vec<InscriptionInfo> = new_branch
             .iter()

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use lb_core::{
     header::HeaderId,
@@ -54,9 +54,9 @@ pub struct TxState {
     pending_by_parent: HashMap<MsgId, Vec<TxHash>>,
     /// Non-inscription pending txs (e.g. `set_keys`).
     pending_other: HashMap<TxHash, SignedMantleTx>,
-    /// Tx hashes accepted locally by this sequencer runtime or restored from
-    /// its checkpoint.
-    local_txs: HashSet<TxHash>,
+    /// Bounded insertion-ordered tx hashes accepted locally by this sequencer
+    /// runtime or restored from its checkpoint.
+    local_txs: VecDeque<TxHash>,
     /// Per-block cumulative safe sets.
     block_states: BTreeMap<HeaderId, HashTrieSetSync<TxHash>>,
     /// Block parent relationships for pruning.
@@ -78,7 +78,7 @@ impl TxState {
             pending: HashMap::new(),
             pending_by_parent: HashMap::new(),
             pending_other: HashMap::new(),
-            local_txs: HashSet::new(),
+            local_txs: VecDeque::new(),
             block_states,
             parent_map: HashMap::new(),
             current_lib: lib,
@@ -126,7 +126,7 @@ impl TxState {
         withdraws: Option<Vec<WithdrawInfo>>,
     ) {
         let tx_hash = signed_tx.mantle_tx.hash();
-        self.local_txs.insert(tx_hash);
+        self.track_local_tx(tx_hash);
         self.pending_by_parent
             .entry(parent_msg)
             .or_default()
@@ -148,8 +148,24 @@ impl TxState {
     /// Submit a non-inscription tx for tracking (e.g. `set_keys`).
     pub fn submit_other(&mut self, signed_tx: SignedMantleTx) {
         let tx_hash = signed_tx.mantle_tx.hash();
-        self.local_txs.insert(tx_hash);
+        self.track_local_tx(tx_hash);
         self.pending_other.insert(tx_hash, signed_tx);
+    }
+
+    fn track_local_tx(&mut self, tx_hash: TxHash) {
+        if !self.local_txs.contains(&tx_hash) {
+            self.local_txs.push_back(tx_hash);
+        }
+    }
+
+    pub fn prune_local_tx_tracking(&mut self, max_tracked: usize) {
+        while self.local_txs.len() > max_tracked {
+            self.local_txs.pop_front();
+        }
+    }
+
+    pub fn remove_local_tx(&mut self, tx_hash: &TxHash) {
+        self.local_txs.retain(|tracked| tracked != tx_hash);
     }
 
     /// Process a new block. Finalization is handled by backfill ground
@@ -597,7 +613,7 @@ impl TxState {
     /// Returns inscriptions in BFS order (parents before children).
     pub(crate) fn collect_pending_suffix(&self, from_msg: MsgId) -> Vec<InscriptionInfo> {
         let mut suffix = Vec::new();
-        let mut queue = std::collections::VecDeque::new();
+        let mut queue = VecDeque::new();
         queue.push_back(from_msg);
 
         while let Some(current) = queue.pop_front() {

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -83,6 +83,16 @@ pub enum OrphanedTx {
     AtomicWithdraw(AtomicWithdrawInfo),
 }
 
+impl OrphanedTx {
+    #[must_use]
+    pub const fn tx_hash(&self) -> TxHash {
+        match self {
+            Self::Inscription(i) => i.tx_hash,
+            Self::AtomicWithdraw(a) => a.tx_hash,
+        }
+    }
+}
+
 /// Configuration for the zone sequencer.
 #[derive(Clone)]
 pub struct SequencerConfig {
@@ -183,11 +193,44 @@ pub enum Event {
     /// catch-up surfaces via [`ChannelUpdate::orphaned`] on the next
     /// `BlocksProcessed` once the stream resumes.
     Ready,
+    /// Transaction lifecycle status update.
+    TxStatusChanged {
+        /// Transaction hash whose lifecycle advanced.
+        tx_hash: TxHash,
+        /// New transaction status.
+        status: TxStatus,
+    },
     /// Turn-to-write status update for this sequencer.
     ///
     /// Emitted on the same change boundary as the `turn_to_write` watch
     /// channel (excluding `current_slot`-only updates).
     TurnNotification { notification: TurnNotification },
+}
+
+/// Local lifecycle status for a transaction submitted through the sequencer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TxStatus {
+    /// Accepted by the SDK and tracked locally.
+    AcceptedLocally,
+    /// Accepted by the node post API and expected to be in the mempool.
+    PendingMempool,
+    /// Observed in the canonical non-finalized chain.
+    OnChain(TxSource),
+    /// Previously tracked tx was invalidated by a canonical chain update.
+    Orphaned(TxSource),
+    /// Observed in finalized chain history.
+    Finalized(TxSource),
+}
+
+/// Whether an observed transaction originated from this sequencer runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TxSource {
+    /// The tx was accepted locally by this sequencer or restored from its
+    /// checkpoint.
+    Local,
+    /// The tx was observed on chain but is not known as local to this
+    /// sequencer.
+    Other,
 }
 
 /// Channel state delta from one [`Event::BlocksProcessed`].

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -18,6 +18,7 @@ use lb_core::{
 const DEFAULT_RESUBMIT_INTERVAL: Duration = Duration::from_secs(30);
 const DEFAULT_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 const DEFAULT_PUBLISH_CHANNEL_CAPACITY: usize = 256;
+const DEFAULT_MAX_LOCAL_TX_TRACKING: usize = 1_000;
 
 /// Inscription identifier.
 pub type InscriptionId = TxHash;
@@ -101,6 +102,7 @@ pub struct SequencerConfig {
     pub publish_channel_capacity: usize,
     pub min_slots_remaining_in_turn: u64,
     pub max_pending_publish_depth: usize,
+    pub max_local_tx_tracking: usize,
 }
 
 impl Default for SequencerConfig {
@@ -111,6 +113,7 @@ impl Default for SequencerConfig {
             publish_channel_capacity: DEFAULT_PUBLISH_CHANNEL_CAPACITY,
             min_slots_remaining_in_turn: 1,
             max_pending_publish_depth: 10,
+            max_local_tx_tracking: DEFAULT_MAX_LOCAL_TX_TRACKING,
         }
     }
 }
@@ -193,13 +196,9 @@ pub enum Event {
     /// catch-up surfaces via [`ChannelUpdate::orphaned`] on the next
     /// `BlocksProcessed` once the stream resumes.
     Ready,
-    /// Transaction lifecycle status update.
-    TxStatusChanged {
-        /// Transaction hash whose lifecycle advanced.
-        tx_hash: TxHash,
-        /// New transaction status.
-        status: TxStatus,
-    },
+    /// Transaction was accepted by the node post API and is expected to be in
+    /// the mempool.
+    MempoolPending(TxHash),
     /// Turn-to-write status update for this sequencer.
     ///
     /// Emitted on the same change boundary as the `turn_to_write` watch
@@ -220,6 +219,13 @@ pub enum TxStatus {
     Orphaned(TxSource),
     /// Observed in finalized chain history.
     Finalized(TxSource),
+}
+
+/// Status update for a single transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TxStatusUpdate {
+    pub tx_hash: TxHash,
+    pub status: TxStatus,
 }
 
 /// Whether an observed transaction originated from this sequencer runtime.

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -18,7 +18,7 @@ use lb_core::{
 const DEFAULT_RESUBMIT_INTERVAL: Duration = Duration::from_secs(30);
 const DEFAULT_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 const DEFAULT_PUBLISH_CHANNEL_CAPACITY: usize = 256;
-const DEFAULT_MAX_LOCAL_TX_TRACKING: usize = 1_000;
+const DEFAULT_MAX_LOCAL_TX_TRACKING: usize = 10_000;
 
 /// Inscription identifier.
 pub type InscriptionId = TxHash;
@@ -206,7 +206,19 @@ pub enum Event {
     TurnNotification { notification: TurnNotification },
 }
 
-/// Local lifecycle status for a transaction submitted through the sequencer.
+/// Tx-hash lifecycle status for a transaction observed by the sequencer.
+///
+/// This enum tracks the lifecycle of a specific transaction hash, not a
+/// publish intent. Republishing after an orphan or any other retry produces a
+/// new tx hash and therefore a new lifecycle.
+///
+/// Typical flows:
+/// - Plain success: `AcceptedLocally -> PendingMempool -> OnChain(_) ->
+///   Finalized(_)`
+/// - Reorg on the same hash: `... -> OnChain(_) -> Orphaned(_) -> OnChain(_) ->
+///   Finalized(_)`
+/// - Republish after orphan: original hash reaches `Orphaned(_)`; the
+///   republished tx starts over at `AcceptedLocally` under its new hash.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TxStatus {
     /// Accepted by the SDK and tracked locally.
@@ -215,7 +227,11 @@ pub enum TxStatus {
     PendingMempool,
     /// Observed in the canonical non-finalized chain.
     OnChain(TxSource),
-    /// Previously tracked tx was invalidated by a canonical chain update.
+    /// Previously tracked tx was invalidated on the current canonical branch.
+    ///
+    /// This is branch-local, not a permanent tombstone: the same hash can
+    /// later resurface as [`TxStatus::OnChain`] or [`TxStatus::Finalized`]
+    /// after a deeper reorg.
     Orphaned(TxSource),
     /// Observed in finalized chain history.
     Finalized(TxSource),
@@ -228,14 +244,18 @@ pub struct TxStatusUpdate {
     pub status: TxStatus,
 }
 
-/// Whether an observed transaction originated from this sequencer runtime.
+/// Whether an observed transaction is still attributable to this sequencer
+/// runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TxSource {
     /// The tx was accepted locally by this sequencer or restored from its
     /// checkpoint.
     Local,
-    /// The tx was observed on chain but is not known as local to this
-    /// sequencer.
+    /// The tx was observed on chain but is not currently known as local to
+    /// this sequencer.
+    ///
+    /// This includes both genuinely external txs and txs that were previously
+    /// local but have since been evicted from the bounded local-tracking set.
     Other,
 }
 

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -28,7 +28,7 @@ use super::{
     state::TxState,
     types::{
         Event, SequencerChannelView, SequencerCheckpoint, SequencerConfig, TurnNotification,
-        TxStatus, WithdrawInfo,
+        TxSource, TxStatus, TxStatusUpdate, WithdrawInfo,
     },
 };
 use crate::{adapter, adapter::BoxStream};
@@ -116,6 +116,7 @@ pub struct ZoneSequencer<Node> {
     pub(super) channel_view_tx: watch::Sender<SequencerChannelView>,
     pub(super) turn_to_write_tx: watch::Sender<TurnNotification>,
     pub(super) checkpoint_tx: watch::Sender<Option<SequencerCheckpoint>>,
+    pub(super) tx_status_tx: broadcast::Sender<TxStatusUpdate>,
 }
 
 impl<Node> ZoneSequencer<Node>
@@ -170,6 +171,7 @@ where
             for (_hash, tx) in pending_txs {
                 restore_pending_tx(&mut tx_state, tx, channel_id);
             }
+            tx_state.prune_local_tx_tracking(config.max_local_tx_tracking);
             (Some(tx_state), lib_slot, last_msg_id, false)
         } else {
             info!(target: TARGET, "Starting fresh (no checkpoint)");
@@ -191,6 +193,7 @@ where
             .as_ref()
             .map(|s| build_checkpoint(s, last_msg_id, lib_slot));
         let (checkpoint_tx, _) = watch::channel(initial_checkpoint);
+        let (tx_status_tx, _) = broadcast::channel(256);
 
         Self {
             channel_id,
@@ -219,6 +222,7 @@ where
             channel_view_tx,
             turn_to_write_tx,
             checkpoint_tx,
+            tx_status_tx,
         }
     }
 
@@ -294,6 +298,12 @@ where
         let mut rx = self.checkpoint_tx.subscribe();
         rx.mark_changed();
         rx
+    }
+
+    /// Subscribe to tx-status changes.
+    #[must_use]
+    pub fn subscribe_tx_status(&self) -> broadcast::Receiver<TxStatusUpdate> {
+        self.tx_status_tx.subscribe()
     }
 
     /// Subscribe to the broadcast channel of events.
@@ -382,8 +392,26 @@ where
     }
 
     pub(super) fn queue_tx_status(&mut self, tx_hash: TxHash, status: TxStatus) {
-        self.buffered_events
-            .push_back(Event::TxStatusChanged { tx_hash, status });
+        let update = TxStatusUpdate { tx_hash, status };
+        drop(self.tx_status_tx.send(update));
+        if matches!(status, TxStatus::PendingMempool) {
+            self.buffered_events
+                .push_back(Event::MempoolPending(tx_hash));
+        }
+        if let Some(state) = self.state.as_mut() {
+            match status {
+                TxStatus::AcceptedLocally => {
+                    state.prune_local_tx_tracking(self.config.max_local_tx_tracking);
+                }
+                TxStatus::Orphaned(TxSource::Local) | TxStatus::Finalized(TxSource::Local) => {
+                    state.remove_local_tx(&tx_hash);
+                }
+                TxStatus::PendingMempool
+                | TxStatus::OnChain(_)
+                | TxStatus::Orphaned(TxSource::Other)
+                | TxStatus::Finalized(TxSource::Other) => {}
+            }
+        }
     }
 
     /// Push a single-tx publish post into `in_flight`. Used by

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -28,7 +28,7 @@ use super::{
     state::TxState,
     types::{
         Event, SequencerChannelView, SequencerCheckpoint, SequencerConfig, TurnNotification,
-        WithdrawInfo,
+        TxStatus, WithdrawInfo,
     },
 };
 use crate::{adapter, adapter::BoxStream};
@@ -364,11 +364,14 @@ where
             Some(results) = self.in_flight.next() => {
                 for (tx_hash, success) in results {
                     self.posting.remove(&tx_hash);
-                    if success && let Some(state) = self.state.as_mut() {
-                        state.mark_pending_inscription_posted(&tx_hash);
+                    if success {
+                        if let Some(state) = self.state.as_mut() {
+                            state.mark_pending_inscription_posted(&tx_hash);
+                        }
+                        self.queue_tx_status(tx_hash, TxStatus::PendingMempool);
                     }
                 }
-                None
+                self.buffered_events.pop_front().map(|event| self.emit_now(event))
             }
         }
     }
@@ -376,6 +379,11 @@ where
     pub(super) fn emit_now(&self, event: Event) -> Event {
         drop(self.event_tx.send(event.clone()));
         event
+    }
+
+    pub(super) fn queue_tx_status(&mut self, tx_hash: TxHash, status: TxStatus) {
+        self.buffered_events
+            .push_back(Event::TxStatusChanged { tx_hash, status });
     }
 
     /// Push a single-tx publish post into `in_flight`. Used by

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -301,6 +301,11 @@ where
     }
 
     /// Subscribe to tx-status changes.
+    ///
+    /// These updates are broadcast as soon as the sequencer classifies a tx.
+    /// When a block causes `OnChain`, `Orphaned`, or `Finalized`, the matching
+    /// [`super::Event::BlocksProcessed`] is queued separately and may be
+    /// observed later by consumers listening to both streams.
     #[must_use]
     pub fn subscribe_tx_status(&self) -> broadcast::Receiver<TxStatusUpdate> {
         self.tx_status_tx.subscribe()
@@ -374,11 +379,10 @@ where
             Some(results) = self.in_flight.next() => {
                 for (tx_hash, success) in results {
                     self.posting.remove(&tx_hash);
-                    if success {
-                        if let Some(state) = self.state.as_mut() {
-                            state.mark_pending_inscription_posted(&tx_hash);
-                        }
-                        self.queue_tx_status(tx_hash, TxStatus::PendingMempool);
+                    if success
+                        && let Some(state) = self.state.as_mut()
+                        && state.mark_pending_inscription_posted(&tx_hash) {
+                            self.queue_tx_status(tx_hash, TxStatus::PendingMempool);
                     }
                 }
                 self.buffered_events.pop_front().map(|event| self.emit_now(event))
@@ -403,12 +407,12 @@ where
                 TxStatus::AcceptedLocally => {
                     state.prune_local_tx_tracking(self.config.max_local_tx_tracking);
                 }
-                TxStatus::Orphaned(TxSource::Local) | TxStatus::Finalized(TxSource::Local) => {
+                TxStatus::Finalized(TxSource::Local) => {
                     state.remove_local_tx(&tx_hash);
                 }
                 TxStatus::PendingMempool
                 | TxStatus::OnChain(_)
-                | TxStatus::Orphaned(TxSource::Other)
+                | TxStatus::Orphaned(_)
                 | TxStatus::Finalized(TxSource::Other) => {}
             }
         }


### PR DESCRIPTION
## 1. What does this PR implement?

Adds zone-sdk transaction lifecycle events with source tagging:
- Introduces `TxStatusChanged`, `TxStatus`, and `TxSource`.
- Emits local accept, mempool pending, on-chain, orphaned, and finalized states.
- Tracks local transaction identity separately from pending state to preserve `Local` classification after cleanup.
- Adds cucumber coverage for the full local transaction lifecycle.
- Keeps existing `BlocksProcessed` behavior intact.

Closes #2900.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
