### PR TITLE
feat(c-bindings): Expose cli utilities to c-bindings

### DIFF
--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -1,14 +1,30 @@
 use std::{
     ffi::{CStr, c_char},
+    net::Ipv4Addr,
+    path::PathBuf,
     slice,
     str::FromStr as _,
 };
 
-use lb_node::cli::{EmbeddedInitArgs, InitArgs};
+use lb_node::cli::{EmbeddedInitArgs, InitArgs, MigrateArgs, ParticipateArgs, UpdateArgs};
 use multiaddr::Multiaddr;
 use tokio::runtime::Runtime;
 
-use crate::{OperationStatus, api::types::config::Deployment, logging};
+use crate::{
+    OperationStatus, api::types::config::Deployment, logging, return_error_if_null_pointer,
+};
+
+/// Converts a non-null C string pointer into a [`PathBuf`].
+///
+/// # Safety
+///
+/// The pointer must be non-null and point to a valid NUL-terminated C string.
+pub(crate) unsafe fn cstr_to_path(pointer: *const c_char) -> PathBuf {
+    unsafe { CStr::from_ptr(pointer) }
+        .to_string_lossy()
+        .to_string()
+        .into()
+}
 
 #[repr(C)]
 pub struct GenerateConfigArgs {
@@ -125,4 +141,312 @@ pub fn generate_config_sync(args: EmbeddedInitArgs) -> OperationStatus {
 pub unsafe extern "C" fn generate_user_config(args: GenerateConfigArgs) -> OperationStatus {
     let init_args = EmbeddedInitArgs::from(args);
     generate_config_sync(init_args)
+}
+
+/// Updates an existing user config file with keys from a keystore file,
+/// equivalent to the `update-config` CLI command. Runs non-interactively
+/// (existing files are overwritten without confirmation).
+///
+/// # Arguments
+///
+/// - `user_config_path`: Path to the user config YAML file.
+/// - `keystore_path`: Path to the keystore YAML file.
+///
+/// # Returns
+///
+/// An [`OperationStatus`] indicating the result of the operation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid NUL-terminated C strings.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn update_user_config(
+    user_config_path: *const c_char,
+    keystore_path: *const c_char,
+) -> OperationStatus {
+    return_error_if_null_pointer!("update_user_config", user_config_path);
+    return_error_if_null_pointer!("update_user_config", keystore_path);
+
+    let args = UpdateArgs::new(
+        unsafe { cstr_to_path(user_config_path) },
+        unsafe { cstr_to_path(keystore_path) },
+        true,
+    );
+
+    match lb_node::cli::config::update::run(args) {
+        Ok(()) => OperationStatus::Ok,
+        Err(error) => {
+            logging::error!("update_user_config", "Error updating config: {error:?}");
+            OperationStatus::ConfigurationError
+        }
+    }
+}
+
+/// Generates a new user config file from an existing keystore file,
+/// equivalent to the `migrate-config` CLI command.
+///
+/// # Arguments
+///
+/// - `output_path`: Output path for the generated user config YAML file. Must
+///   not exist yet.
+/// - `keystore_path`: Path to the existing keystore YAML file.
+///
+/// # Returns
+///
+/// An [`OperationStatus`] indicating the result of the operation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid NUL-terminated C strings.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn migrate_user_config(
+    output_path: *const c_char,
+    keystore_path: *const c_char,
+) -> OperationStatus {
+    return_error_if_null_pointer!("migrate_user_config", output_path);
+    return_error_if_null_pointer!("migrate_user_config", keystore_path);
+
+    let args = MigrateArgs::new(unsafe { cstr_to_path(output_path) }, unsafe {
+        cstr_to_path(keystore_path)
+    });
+
+    match lb_node::cli::config::migrate::run(args) {
+        Ok(()) => OperationStatus::Ok,
+        Err(error) => {
+            logging::error!("migrate_user_config", "Error migrating config: {error:?}");
+            OperationStatus::ConfigurationError
+        }
+    }
+}
+
+/// Migrates a 0.1.2 config file to a new user config and keystore, equivalent
+/// to the `migrate-from-0.1.2` CLI command.
+///
+/// # Arguments
+///
+/// - `new_config_path`: Output path for the generated user config YAML file.
+///   Must not exist yet.
+/// - `old_config_path`: Path to the existing 0.1.2 config YAML file.
+/// - `keystore_path`: Output path for the generated keystore YAML file. Must
+///   not exist yet.
+///
+/// # Returns
+///
+/// An [`OperationStatus`] indicating the result of the operation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid NUL-terminated C strings.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn migrate_user_config_0_1_2(
+    new_config_path: *const c_char,
+    old_config_path: *const c_char,
+    keystore_path: *const c_char,
+) -> OperationStatus {
+    return_error_if_null_pointer!("migrate_user_config_0_1_2", new_config_path);
+    return_error_if_null_pointer!("migrate_user_config_0_1_2", old_config_path);
+    return_error_if_null_pointer!("migrate_user_config_0_1_2", keystore_path);
+
+    let args = lb_node::cli::config::migrate_0_1_2::MigrateArgs::new(
+        unsafe { cstr_to_path(new_config_path) },
+        unsafe { cstr_to_path(old_config_path) },
+        unsafe { cstr_to_path(keystore_path) },
+    );
+
+    match lb_node::cli::config::migrate_0_1_2::run(args) {
+        Ok(()) => OperationStatus::Ok,
+        Err(error) => {
+            logging::error!(
+                "migrate_user_config_0_1_2",
+                "Error migrating config: {error:?}"
+            );
+            OperationStatus::ConfigurationError
+        }
+    }
+}
+
+/// Generates `participation_data.yaml` from a user config and keystore,
+/// equivalent to the `participate` CLI command.
+///
+/// # Arguments
+///
+/// - `config_path`: Path to the user config YAML file.
+/// - `keystore_path`: Path to the keystore YAML file.
+/// - `output_dir`: Output directory for `participation_data.yaml`.
+/// - `external_address`: Optional (nullable) public IPv4 address of the node,
+///   required when the blend listening address is unspecified (0.0.0.0).
+///
+/// # Returns
+///
+/// An [`OperationStatus`] indicating the result of the operation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all non-null pointers are valid NUL-terminated C strings.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn participate(
+    config_path: *const c_char,
+    keystore_path: *const c_char,
+    output_dir: *const c_char,
+    external_address: *const c_char,
+) -> OperationStatus {
+    return_error_if_null_pointer!("participate", config_path);
+    return_error_if_null_pointer!("participate", keystore_path);
+    return_error_if_null_pointer!("participate", output_dir);
+
+    let external_address = if external_address.is_null() {
+        None
+    } else {
+        let address = unsafe { CStr::from_ptr(external_address) }.to_string_lossy();
+        match address.parse::<Ipv4Addr>() {
+            Ok(address) => Some(address),
+            Err(error) => {
+                logging::error!(
+                    "participate",
+                    "Invalid external address '{address}': {error}"
+                );
+                return OperationStatus::ValidationError;
+            }
+        }
+    };
+
+    let args = ParticipateArgs {
+        config: unsafe { cstr_to_path(config_path) },
+        keystore: unsafe { cstr_to_path(keystore_path) },
+        output: unsafe { cstr_to_path(output_dir) },
+        external_address,
+    };
+
+    match lb_node::cli::participate::run(&args) {
+        Ok(()) => OperationStatus::Ok,
+        Err(error) => {
+            logging::error!(
+                "participate",
+                "Error generating participation data: {error:?}"
+            );
+            OperationStatus::ConfigurationError
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{ffi::CString, path::Path};
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::api::{
+        free_cstring,
+        keys::{KeyType, add_key, generate_key, remove_key},
+        peer::get_peer_id,
+    };
+
+    fn cstring(path: &Path) -> CString {
+        CString::new(path.to_string_lossy().as_bytes()).expect("Path should not contain NUL")
+    }
+
+    #[test]
+    fn test_config_and_key_commands_roundtrip() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config_path = temp_dir.path().join("user_config.yaml");
+        let keystore_path = temp_dir.path().join("keystore.yaml");
+
+        // init-config
+        let status = generate_config_sync(EmbeddedInitArgs {
+            output: config_path.clone(),
+            kms_file: Some(keystore_path.clone()),
+            ..Default::default()
+        });
+        assert!(status.is_ok(), "Failed to generate config: {status:?}");
+        assert!(config_path.exists());
+        assert!(keystore_path.exists());
+
+        let config_c = cstring(&config_path);
+        let keystore_c = cstring(&keystore_path);
+
+        // update-config
+        let status = unsafe { update_user_config(config_c.as_ptr(), keystore_c.as_ptr()) };
+        assert!(status.is_ok(), "Failed to update config: {status:?}");
+
+        // generate-key
+        let generated_title = CString::new("GeneratedKey").expect("Valid CString");
+        let result = unsafe {
+            generate_key(
+                config_c.as_ptr(),
+                keystore_c.as_ptr(),
+                KeyType::Zk,
+                generated_title.as_ptr(),
+            )
+        };
+        assert!(result.is_ok(), "Failed to generate key: {:?}", result.error);
+        let key_id = unsafe { CStr::from_ptr(result.value) }
+            .to_str()
+            .expect("Key id should be valid UTF-8")
+            .to_owned();
+        assert!(!key_id.is_empty());
+        assert!(unsafe { free_cstring(result.value) }.is_ok());
+
+        // add-key
+        let key_hex = CString::new("11".repeat(32)).expect("Valid CString");
+        let added_title = CString::new("AddedKey").expect("Valid CString");
+        let status = unsafe {
+            add_key(
+                config_c.as_ptr(),
+                keystore_c.as_ptr(),
+                KeyType::Ed25519,
+                key_hex.as_ptr(),
+                added_title.as_ptr(),
+            )
+        };
+        assert!(status.is_ok(), "Failed to add key: {status:?}");
+
+        // remove-key
+        let status =
+            unsafe { remove_key(config_c.as_ptr(), keystore_c.as_ptr(), added_title.as_ptr()) };
+        assert!(status.is_ok(), "Failed to remove key: {status:?}");
+
+        // get-peer-id
+        let result = unsafe { get_peer_id(config_c.as_ptr()) };
+        assert!(result.is_ok(), "Failed to get peer id: {:?}", result.error);
+        let peer_id = unsafe { CStr::from_ptr(result.value) }
+            .to_str()
+            .expect("Peer id should be valid UTF-8")
+            .to_owned();
+        assert!(!peer_id.is_empty());
+        assert!(unsafe { free_cstring(result.value) }.is_ok());
+
+        // participate
+        let output_dir = temp_dir.path().join("participation");
+        let output_c = cstring(&output_dir);
+        let external_address = CString::new("203.0.113.7").expect("Valid CString");
+        let status = unsafe {
+            participate(
+                config_c.as_ptr(),
+                keystore_c.as_ptr(),
+                output_c.as_ptr(),
+                external_address.as_ptr(),
+            )
+        };
+        assert!(
+            status.is_ok(),
+            "Failed to generate participation data: {status:?}"
+        );
+        assert!(output_dir.join("participation_data.yaml").exists());
+
+        // migrate-config
+        let migrated_path = temp_dir.path().join("migrated_config.yaml");
+        let migrated_c = cstring(&migrated_path);
+        let status = unsafe { migrate_user_config(migrated_c.as_ptr(), keystore_c.as_ptr()) };
+        assert!(status.is_ok(), "Failed to migrate config: {status:?}");
+        assert!(migrated_path.exists());
+    }
 }

--- a/c-bindings/src/api/keys.rs
+++ b/c-bindings/src/api/keys.rs
@@ -1,6 +1,6 @@
 use std::ffi::{CStr, CString, c_char};
 
-use lb_key_management_system_keys::keys::{UnsecuredEd25519Key, UnsecuredZkKey};
+use lb_key_management_system_keys::keys::{Ed25519Key, Key, UnsecuredEd25519Key, ZkKey};
 use lb_node::cli::keys::{
     AddKeyArgs, GenerateKeyArgs, KeyType as NodeKeyType, RemoveKeyArgs, run_add_key, run_remove_key,
 };
@@ -140,8 +140,8 @@ pub unsafe extern "C" fn add_key(
 
     let key_hex = unsafe { CStr::from_ptr(key_hex) }.to_string_lossy();
 
-    let (ed25519_key, zk_key) = match parse_key_hex(key_type, &key_hex) {
-        Ok(keys) => keys,
+    let key = match parse_key_hex(key_type, &key_hex) {
+        Ok(key) => key,
         Err(error) => {
             logging::error!("add_key", "Invalid key: {error}");
             return OperationStatus::ValidationError;
@@ -152,8 +152,7 @@ pub unsafe extern "C" fn add_key(
         unsafe { cstr_to_path(user_config_path) },
         unsafe { cstr_to_path(keystore_path) },
         unsafe { key_title_from_ptr(key_title) },
-        ed25519_key,
-        zk_key,
+        &key,
         true,
     );
 
@@ -166,12 +165,8 @@ pub unsafe extern "C" fn add_key(
     }
 }
 
-/// Parses a hex-encoded secret key into the optional key pair expected by
-/// [`AddKeyArgs`].
-fn parse_key_hex(
-    key_type: KeyType,
-    key_hex: &str,
-) -> Result<(Option<UnsecuredEd25519Key>, Option<UnsecuredZkKey>), String> {
+/// Parses a hex-encoded secret key of the given type into a [`Key`].
+fn parse_key_hex(key_type: KeyType, key_hex: &str) -> Result<Key, String> {
     match key_type {
         KeyType::Ed25519 => {
             let secret_key = lb_node::config::parse_hex_ed25519_key(key_hex)?;
@@ -179,11 +174,11 @@ fn parse_key_hex(
                 .as_ref()
                 .try_into()
                 .map_err(|_| "Invalid ed25519 secret key length".to_owned())?;
-            Ok((Some(UnsecuredEd25519Key::from_bytes(&bytes)), None))
+            Ok(Ed25519Key::from(UnsecuredEd25519Key::from_bytes(&bytes)).into())
         }
         KeyType::Zk => {
             let zk_key = lb_node::config::parse_hex_zk_key(key_hex)?;
-            Ok((None, Some(zk_key)))
+            Ok(ZkKey::from(zk_key).into())
         }
     }
 }

--- a/c-bindings/src/api/keys.rs
+++ b/c-bindings/src/api/keys.rs
@@ -1,0 +1,237 @@
+use std::ffi::{CStr, CString, c_char};
+
+use lb_key_management_system_keys::keys::{UnsecuredEd25519Key, UnsecuredZkKey};
+use lb_node::cli::keys::{
+    AddKeyArgs, GenerateKeyArgs, KeyType as NodeKeyType, RemoveKeyArgs, run_add_key, run_remove_key,
+};
+
+use crate::{
+    OperationStatus, api::config::cstr_to_path, logging, result::FfiStatusResult,
+    return_error_if_null_pointer,
+};
+
+/// Type of key to generate or add to a keystore.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum KeyType {
+    Ed25519 = 0x0,
+    Zk = 0x1,
+}
+
+impl From<KeyType> for NodeKeyType {
+    fn from(value: KeyType) -> Self {
+        match value {
+            KeyType::Ed25519 => Self::Ed25519,
+            KeyType::Zk => Self::Zk,
+        }
+    }
+}
+
+/// Converts a nullable C string pointer into an optional key title.
+unsafe fn key_title_from_ptr(key_title: *const c_char) -> Option<String> {
+    if key_title.is_null() {
+        None
+    } else {
+        Some(
+            unsafe { CStr::from_ptr(key_title) }
+                .to_string_lossy()
+                .to_string(),
+        )
+    }
+}
+
+/// Result type for [`generate_key`]. On success, `value` is a pointer to a
+/// NUL-terminated C string containing the new key's id.
+pub type FfiGenerateKeyResult = FfiStatusResult<*mut c_char>;
+
+/// Generates a new key and persists it to the keystore and user config files,
+/// equivalent to the `generate-key` CLI command. Runs non-interactively.
+///
+/// # Arguments
+///
+/// - `user_config_path`: Path to the user config YAML file.
+/// - `keystore_path`: Path to the keystore YAML file.
+/// - `key_type`: The [`KeyType`] of key to generate.
+/// - `key_title`: Optional (nullable) title for the new key. When null, a title
+///   is auto-generated.
+///
+/// # Returns
+///
+/// A [`FfiGenerateKeyResult`] containing a pointer to an allocated C string
+/// (the new key's id) on success, or an [`OperationStatus`] error on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all non-null pointers are valid NUL-terminated C strings.
+///
+/// # Memory Management
+///
+/// This function allocates memory for the output C string. The caller must
+/// free this memory using the [`free_cstring`](super::free_cstring) function.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn generate_key(
+    user_config_path: *const c_char,
+    keystore_path: *const c_char,
+    key_type: KeyType,
+    key_title: *const c_char,
+) -> FfiGenerateKeyResult {
+    return_error_if_null_pointer!("generate_key", user_config_path);
+    return_error_if_null_pointer!("generate_key", keystore_path);
+
+    let args = GenerateKeyArgs::new(
+        unsafe { cstr_to_path(user_config_path) },
+        unsafe { cstr_to_path(keystore_path) },
+        key_type.into(),
+        unsafe { key_title_from_ptr(key_title) },
+        true,
+    );
+
+    let key_id = match lb_node::cli::keys::generate_key(args) {
+        Ok(key_id) => key_id,
+        Err(error) => {
+            logging::error!("generate_key", "Error generating key: {error:?}");
+            return FfiGenerateKeyResult::err(OperationStatus::ConfigurationError);
+        }
+    };
+
+    match CString::new(key_id) {
+        Ok(key_id) => FfiGenerateKeyResult::ok(key_id.into_raw()),
+        Err(error) => {
+            logging::error!("generate_key", "Failed to create CString: {error}");
+            FfiGenerateKeyResult::err(OperationStatus::RuntimeError)
+        }
+    }
+}
+
+/// Adds an existing key to the keystore and user config files, equivalent to
+/// the `add-key` CLI command. Runs non-interactively.
+///
+/// # Arguments
+///
+/// - `user_config_path`: Path to the user config YAML file.
+/// - `keystore_path`: Path to the keystore YAML file.
+/// - `key_type`: The [`KeyType`] of the provided key.
+/// - `key_hex`: The secret key as a hex-encoded C string.
+/// - `key_title`: Optional (nullable) title for the key. When null, a title is
+///   auto-generated.
+///
+/// # Returns
+///
+/// An [`OperationStatus`] indicating the result of the operation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all non-null pointers are valid NUL-terminated C strings.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn add_key(
+    user_config_path: *const c_char,
+    keystore_path: *const c_char,
+    key_type: KeyType,
+    key_hex: *const c_char,
+    key_title: *const c_char,
+) -> OperationStatus {
+    return_error_if_null_pointer!("add_key", user_config_path);
+    return_error_if_null_pointer!("add_key", keystore_path);
+    return_error_if_null_pointer!("add_key", key_hex);
+
+    let key_hex = unsafe { CStr::from_ptr(key_hex) }.to_string_lossy();
+
+    let (ed25519_key, zk_key) = match parse_key_hex(key_type, &key_hex) {
+        Ok(keys) => keys,
+        Err(error) => {
+            logging::error!("add_key", "Invalid key: {error}");
+            return OperationStatus::ValidationError;
+        }
+    };
+
+    let args = AddKeyArgs::new(
+        unsafe { cstr_to_path(user_config_path) },
+        unsafe { cstr_to_path(keystore_path) },
+        unsafe { key_title_from_ptr(key_title) },
+        ed25519_key,
+        zk_key,
+        true,
+    );
+
+    match run_add_key(args) {
+        Ok(()) => OperationStatus::Ok,
+        Err(error) => {
+            logging::error!("add_key", "Error adding key: {error:?}");
+            OperationStatus::ConfigurationError
+        }
+    }
+}
+
+/// Parses a hex-encoded secret key into the optional key pair expected by
+/// [`AddKeyArgs`].
+fn parse_key_hex(
+    key_type: KeyType,
+    key_hex: &str,
+) -> Result<(Option<UnsecuredEd25519Key>, Option<UnsecuredZkKey>), String> {
+    match key_type {
+        KeyType::Ed25519 => {
+            let secret_key = lb_node::config::parse_hex_ed25519_key(key_hex)?;
+            let bytes: [u8; 32] = secret_key
+                .as_ref()
+                .try_into()
+                .map_err(|_| "Invalid ed25519 secret key length".to_owned())?;
+            Ok((Some(UnsecuredEd25519Key::from_bytes(&bytes)), None))
+        }
+        KeyType::Zk => {
+            let zk_key = lb_node::config::parse_hex_zk_key(key_hex)?;
+            Ok((None, Some(zk_key)))
+        }
+    }
+}
+
+/// Removes a key with the given title from the keystore and user config
+/// files, equivalent to the `remove-key` CLI command. Runs non-interactively.
+///
+/// # Arguments
+///
+/// - `user_config_path`: Path to the user config YAML file.
+/// - `keystore_path`: Path to the keystore YAML file.
+/// - `key_title`: Title of the key to remove.
+///
+/// # Returns
+///
+/// An [`OperationStatus`] indicating the result of the operation.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid NUL-terminated C strings.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn remove_key(
+    user_config_path: *const c_char,
+    keystore_path: *const c_char,
+    key_title: *const c_char,
+) -> OperationStatus {
+    return_error_if_null_pointer!("remove_key", user_config_path);
+    return_error_if_null_pointer!("remove_key", keystore_path);
+    return_error_if_null_pointer!("remove_key", key_title);
+
+    let key_title = unsafe { CStr::from_ptr(key_title) }
+        .to_string_lossy()
+        .to_string();
+
+    let args = RemoveKeyArgs::new(
+        unsafe { cstr_to_path(user_config_path) },
+        unsafe { cstr_to_path(keystore_path) },
+        key_title,
+        true,
+    );
+
+    match run_remove_key(args) {
+        Ok(()) => OperationStatus::Ok,
+        Err(error) => {
+            logging::error!("remove_key", "Error removing key: {error:?}");
+            OperationStatus::ConfigurationError
+        }
+    }
+}

--- a/c-bindings/src/api/mod.rs
+++ b/c-bindings/src/api/mod.rs
@@ -1,8 +1,10 @@
 pub mod blend;
 pub mod config;
 pub mod cryptarchia;
+pub mod keys;
 pub mod lifecycle;
 pub(crate) mod memory;
+pub mod peer;
 pub mod sdp;
 pub mod storage;
 pub mod subscriptions;

--- a/c-bindings/src/api/peer.rs
+++ b/c-bindings/src/api/peer.rs
@@ -1,0 +1,56 @@
+use std::ffi::{CString, c_char};
+
+use crate::{
+    OperationStatus, api::config::cstr_to_path, logging, result::FfiStatusResult,
+    return_error_if_null_pointer,
+};
+
+/// Result type for [`get_peer_id`]. On success, `value` is a pointer to a
+/// NUL-terminated C string containing the base58-encoded libp2p `PeerId`.
+pub type FfiGetPeerIdResult = FfiStatusResult<*mut c_char>;
+
+/// Derives the libp2p `PeerId` from the node key in a user config file,
+/// equivalent to the `get-peer-id` CLI command.
+///
+/// # Arguments
+///
+/// - `config_path`: Path to the user config YAML file.
+///
+/// # Returns
+///
+/// A [`FfiGetPeerIdResult`] containing a pointer to an allocated C string
+/// (the base58-encoded `PeerId`) on success, or an [`OperationStatus`] error
+/// on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that `config_path` is a valid NUL-terminated C string.
+///
+/// # Memory Management
+///
+/// This function allocates memory for the output C string. The caller must
+/// free this memory using the [`free_cstring`](super::free_cstring) function.
+#[must_use]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_peer_id(config_path: *const c_char) -> FfiGetPeerIdResult {
+    return_error_if_null_pointer!("get_peer_id", config_path);
+
+    let config_path = unsafe { cstr_to_path(config_path) };
+
+    let peer_id = match lb_node::cli::get_peer_id::peer_id_from_config(&config_path) {
+        Ok(peer_id) => peer_id,
+        Err(error) => {
+            logging::error!("get_peer_id", "Error deriving peer id: {error:?}");
+            return FfiGetPeerIdResult::err(OperationStatus::ConfigurationError);
+        }
+    };
+
+    match CString::new(peer_id.to_string()) {
+        Ok(peer_id) => FfiGetPeerIdResult::ok(peer_id.into_raw()),
+        Err(error) => {
+            logging::error!("get_peer_id", "Failed to create CString: {error}");
+            FfiGetPeerIdResult::err(OperationStatus::RuntimeError)
+        }
+    }
+}

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
@@ -51,6 +51,26 @@ pub struct MigrateArgs {
     state: StateArgs,
 }
 
+impl MigrateArgs {
+    /// Creates arguments programmatically (e.g. from the c-bindings crate),
+    /// leaving all config overrides at their defaults.
+    #[must_use]
+    pub fn new(new_config: PathBuf, old_config: PathBuf, keystore: PathBuf) -> Self {
+        Self {
+            new_config,
+            old_config,
+            keystore,
+            log: LogArgs::default(),
+            network: NetworkArgs::default(),
+            blend: BlendArgs::default(),
+            cryptarchia: CryptarchiaArgs::default(),
+            sdp: SdpArgs::default(),
+            api: ApiArgs::default(),
+            state: StateArgs::default(),
+        }
+    }
+}
+
 impl From<MigrateArgs> for InitArgs {
     fn from(migrate: MigrateArgs) -> Self {
         Self {

--- a/nodes/node/binary/src/cli/get_peer_id.rs
+++ b/nodes/node/binary/src/cli/get_peer_id.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use color_eyre::eyre::Result;
 use lb_libp2p::ed25519;
 use lb_utils::yaml::{OnUnknownKeys, deserialize_value_at_path};
@@ -6,12 +8,19 @@ use libp2p::PeerId;
 use super::GetPeerIdArgs;
 use crate::UserConfig;
 
-pub fn run(args: &GetPeerIdArgs) -> Result<()> {
-    let user_config = deserialize_value_at_path::<UserConfig>(&args.config, OnUnknownKeys::Warn)?;
+/// Derives the libp2p `PeerId` from the node key in the user config at
+/// `config_path`.
+pub fn peer_id_from_config(config_path: &Path) -> Result<PeerId> {
+    let user_config = deserialize_value_at_path::<UserConfig>(config_path, OnUnknownKeys::Warn)?;
 
     let node_key = user_config.network.backend.swarm.node_key;
     let keypair = libp2p::identity::Keypair::from(ed25519::Keypair::from(node_key));
-    let peer_id = PeerId::from(keypair.public());
+
+    Ok(PeerId::from(keypair.public()))
+}
+
+pub fn run(args: &GetPeerIdArgs) -> Result<()> {
+    let peer_id = peer_id_from_config(&args.config)?;
 
     println!("{peer_id}");
 

--- a/nodes/node/binary/src/cli/keys.rs
+++ b/nodes/node/binary/src/cli/keys.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, ValueEnum};
 use color_eyre::eyre::Result;
-use lb_key_management_system_service::keys::{
-    Ed25519Key, Key, UnsecuredEd25519Key, UnsecuredZkKey, ZkKey,
+use lb_key_management_system_service::{
+    backend::preload::KeyId,
+    keys::{Ed25519Key, Key, UnsecuredEd25519Key, UnsecuredZkKey, ZkKey},
 };
 use thiserror::Error;
 
@@ -60,6 +61,27 @@ pub struct GenerateKeyArgs {
     key_type: KeyType,
 }
 
+impl GenerateKeyArgs {
+    /// Creates arguments programmatically (e.g. from the c-bindings crate).
+    /// `auto_approve` skips interactive prompts.
+    #[must_use]
+    pub const fn new(
+        user_config: PathBuf,
+        keystore: PathBuf,
+        key_type: KeyType,
+        key_title: Option<String>,
+        auto_approve: bool,
+    ) -> Self {
+        Self {
+            user_config,
+            keystore,
+            yes: auto_approve,
+            key_title,
+            key_type,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct AddKeyArgs {
     /// Path for the user config file.
@@ -88,6 +110,29 @@ pub struct AddKeyArgs {
         value_parser = parse_hex_ed25519_key
     )]
     pub ed25519_key: Option<UnsecuredEd25519Key>,
+}
+
+impl AddKeyArgs {
+    /// Creates arguments programmatically (e.g. from the c-bindings crate).
+    /// `auto_approve` skips interactive prompts.
+    #[must_use]
+    pub const fn new(
+        user_config: PathBuf,
+        keystore: PathBuf,
+        key_title: Option<String>,
+        ed25519_key: Option<UnsecuredEd25519Key>,
+        zk_key: Option<UnsecuredZkKey>,
+        auto_approve: bool,
+    ) -> Self {
+        Self {
+            user_config,
+            keystore,
+            yes: auto_approve,
+            key_title,
+            zk_key,
+            ed25519_key,
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -122,15 +167,29 @@ pub struct RemoveKeyArgs {
     pub key_title: String,
 }
 
-pub fn run_generate_key(args: GenerateKeyArgs) -> Result<()> {
-    let GenerateKeyArgs {
-        user_config: user_config_path,
-        keystore: keystore_path,
-        key_title,
-        key_type,
-        yes: auto_approve,
-    } = args;
+impl RemoveKeyArgs {
+    /// Creates arguments programmatically (e.g. from the c-bindings crate).
+    /// `auto_approve` skips interactive prompts.
+    #[must_use]
+    pub const fn new(
+        user_config: PathBuf,
+        keystore: PathBuf,
+        key_title: String,
+        auto_approve: bool,
+    ) -> Self {
+        Self {
+            user_config,
+            keystore,
+            yes: auto_approve,
+            key_title,
+        }
+    }
+}
 
+fn load_user_config_and_keystore(
+    user_config_path: &Path,
+    keystore_path: &Path,
+) -> Result<(UserConfig, Keystore)> {
     if !user_config_path.exists() {
         return Err(KeysError::UserFileDoesNotExist.into());
     }
@@ -139,39 +198,98 @@ pub fn run_generate_key(args: GenerateKeyArgs) -> Result<()> {
         return Err(KeysError::KeystoreFileDoesNotExist.into());
     }
 
-    let user_config_yaml = std::fs::read_to_string(&user_config_path)?;
-    let mut user_config: UserConfig = serde_yaml::from_str(&user_config_yaml)?;
+    let user_config_yaml = std::fs::read_to_string(user_config_path)?;
+    let user_config = serde_yaml::from_str(&user_config_yaml)?;
 
-    let keystore_yaml = std::fs::read_to_string(&keystore_path)?;
-    let mut keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;
+    let keystore_yaml = std::fs::read_to_string(keystore_path)?;
+    let keystore = serde_yaml::from_str(&keystore_yaml)?;
+
+    Ok((user_config, keystore))
+}
+
+fn persist_user_config_and_keystore(
+    user_config: &mut UserConfig,
+    keystore: &Keystore,
+    user_config_path: &Path,
+    keystore_path: &Path,
+) -> Result<()> {
+    update_user_config(user_config, keystore, UpdateArgs::default());
+
+    let user_config_yaml = serde_yaml::to_string(user_config)?;
+    std::fs::write(user_config_path, &user_config_yaml)?;
+
+    let keystore_yaml = serde_yaml::to_string(keystore)?;
+    std::fs::write(keystore_path, &keystore_yaml)?;
+
+    Ok(())
+}
+
+fn generate_key_into_keystore(
+    keystore: &mut Keystore,
+    key_title: String,
+    key_type: &KeyType,
+) -> (KeyId, Key) {
+    match key_type {
+        KeyType::Ed25519 => {
+            let (id, secret_key) = keystore.generate_ed25519(key_title);
+            (id, Ed25519Key::from(secret_key).into())
+        }
+        KeyType::Zk => {
+            let (id, secret_key) = keystore.generate_zk(key_title);
+            (id, ZkKey::from(secret_key).into())
+        }
+    }
+}
+
+/// Generates a new key, persists it to the keystore and user config, and
+/// returns the new key's [`KeyId`]. Non-interactive.
+pub fn generate_key(args: GenerateKeyArgs) -> Result<KeyId> {
+    let GenerateKeyArgs {
+        user_config: user_config_path,
+        keystore: keystore_path,
+        key_title,
+        key_type,
+        ..
+    } = args;
+
+    let (mut user_config, mut keystore) =
+        load_user_config_and_keystore(&user_config_path, &keystore_path)?;
 
     let user_key_title = key_title
         .as_ref()
         .map_or_else(|| next_user_key_title(&keystore), Clone::clone);
 
-    let (key_id, key): (_, Key) = match key_type {
-        KeyType::Ed25519 => {
-            let (id, secret_key) = keystore.generate_ed25519(user_key_title);
-            (id, Ed25519Key::from(secret_key).into())
-        }
-        KeyType::Zk => {
-            let (id, secret_key) = keystore.generate_zk(user_key_title);
-            (id, ZkKey::from(secret_key).into())
-        }
-    };
+    let (key_id, _) = generate_key_into_keystore(&mut keystore, user_key_title, &key_type);
 
-    if !auto_approve && confirm_overwrite("Write key to keystore?")? {
-        update_user_config(&mut user_config, &keystore, UpdateArgs::default());
+    persist_user_config_and_keystore(
+        &mut user_config,
+        &keystore,
+        &user_config_path,
+        &keystore_path,
+    )?;
 
-        let user_config_yaml = serde_yaml::to_string(&user_config)?;
-        std::fs::write(&user_config_path, &user_config_yaml)?;
+    Ok(key_id)
+}
 
-        let keystore_yaml = serde_yaml::to_string(&keystore)?;
-        std::fs::write(&keystore_path, &keystore_yaml)?;
-    } else {
+pub fn run_generate_key(args: GenerateKeyArgs) -> Result<()> {
+    if args.yes || confirm_overwrite("Write key to keystore?")? {
+        let key_id = generate_key(args)?;
         println!("KeyID: {key_id}");
-        println!("Key: {key:?}");
+        return Ok(());
     }
+
+    // Declined: generate and show the key without persisting it.
+    let (_, mut keystore) = load_user_config_and_keystore(&args.user_config, &args.keystore)?;
+
+    let user_key_title = args
+        .key_title
+        .as_ref()
+        .map_or_else(|| next_user_key_title(&keystore), Clone::clone);
+
+    let (key_id, key) = generate_key_into_keystore(&mut keystore, user_key_title, &args.key_type);
+
+    println!("KeyID: {key_id}");
+    println!("Key: {key:?}");
 
     Ok(())
 }
@@ -186,19 +304,8 @@ pub fn run_add_key(args: AddKeyArgs) -> Result<()> {
         ed25519_key,
     } = args;
 
-    if !user_config_path.exists() {
-        return Err(KeysError::UserFileDoesNotExist.into());
-    }
-
-    if !keystore_path.exists() {
-        return Err(KeysError::KeystoreFileDoesNotExist.into());
-    }
-
-    let user_config_yaml = std::fs::read_to_string(&user_config_path)?;
-    let mut user_config: UserConfig = serde_yaml::from_str(&user_config_yaml)?;
-
-    let keystore_yaml = std::fs::read_to_string(&keystore_path)?;
-    let mut keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;
+    let (mut user_config, mut keystore) =
+        load_user_config_and_keystore(&user_config_path, &keystore_path)?;
 
     let user_key_title = key_title
         .as_ref()
@@ -228,13 +335,12 @@ pub fn run_add_key(args: AddKeyArgs) -> Result<()> {
     keystore.set(user_key_title.clone(), key);
 
     if auto_approve || confirm_overwrite(&format!("Add key '{user_key_title}' to keystore?"))? {
-        update_user_config(&mut user_config, &keystore, UpdateArgs::default());
-
-        let user_config_yaml = serde_yaml::to_string(&user_config)?;
-        std::fs::write(&user_config_path, &user_config_yaml)?;
-
-        let keystore_yaml = serde_yaml::to_string(&keystore)?;
-        std::fs::write(&keystore_path, &keystore_yaml)?;
+        persist_user_config_and_keystore(
+            &mut user_config,
+            &keystore,
+            &user_config_path,
+            &keystore_path,
+        )?;
 
         println!("Successfully added key '{user_key_title}' to files.");
     } else {
@@ -252,19 +358,8 @@ pub fn run_remove_key(args: RemoveKeyArgs) -> Result<()> {
         key_title,
     } = args;
 
-    if !user_config_path.exists() {
-        return Err(KeysError::UserFileDoesNotExist.into());
-    }
-
-    if !keystore_path.exists() {
-        return Err(KeysError::KeystoreFileDoesNotExist.into());
-    }
-
-    let user_config_yaml = std::fs::read_to_string(&user_config_path)?;
-    let mut user_config: UserConfig = serde_yaml::from_str(&user_config_yaml)?;
-
-    let keystore_yaml = std::fs::read_to_string(&keystore_path)?;
-    let mut keystore: Keystore = serde_yaml::from_str(&keystore_yaml)?;
+    let (mut user_config, mut keystore) =
+        load_user_config_and_keystore(&user_config_path, &keystore_path)?;
 
     let title_key = KeyTitle::from(key_title.clone());
 
@@ -279,13 +374,12 @@ pub fn run_remove_key(args: RemoveKeyArgs) -> Result<()> {
     {
         keystore.remove(title_key);
 
-        update_user_config(&mut user_config, &keystore, UpdateArgs::default());
-
-        let user_config_yaml = serde_yaml::to_string(&user_config)?;
-        std::fs::write(&user_config_path, &user_config_yaml)?;
-
-        let keystore_yaml = serde_yaml::to_string(&keystore)?;
-        std::fs::write(&keystore_path, &keystore_yaml)?;
+        persist_user_config_and_keystore(
+            &mut user_config,
+            &keystore,
+            &user_config_path,
+            &keystore_path,
+        )?;
 
         println!("Successfully removed key '{key_title}' from files.");
     } else {

--- a/nodes/node/binary/src/cli/keys.rs
+++ b/nodes/node/binary/src/cli/keys.rs
@@ -103,27 +103,31 @@ pub struct AddKeyArgs {
         long = "zk",
         value_parser = parse_hex_zk_key
     )]
-    pub zk_key: Option<UnsecuredZkKey>,
+    zk_key: Option<UnsecuredZkKey>,
 
     #[clap(
         long = "ed25519",
         value_parser = parse_hex_ed25519_key
     )]
-    pub ed25519_key: Option<UnsecuredEd25519Key>,
+    ed25519_key: Option<UnsecuredEd25519Key>,
 }
 
 impl AddKeyArgs {
     /// Creates arguments programmatically (e.g. from the c-bindings crate).
     /// `auto_approve` skips interactive prompts.
     #[must_use]
-    pub const fn new(
+    pub fn new(
         user_config: PathBuf,
         keystore: PathBuf,
         key_title: Option<String>,
-        ed25519_key: Option<UnsecuredEd25519Key>,
-        zk_key: Option<UnsecuredZkKey>,
+        key: &Key,
         auto_approve: bool,
     ) -> Self {
+        let (ed25519_key, zk_key) = match key {
+            Key::Ed25519(key) => (Some(key.clone().into_unsecured()), None),
+            Key::Zk(key) => (None, Some(key.clone().into_unsecured())),
+        };
+
         Self {
             user_config,
             keystore,
@@ -131,6 +135,21 @@ impl AddKeyArgs {
             key_title,
             zk_key,
             ed25519_key,
+        }
+    }
+
+    /// Returns the key provided via the `--ed25519`/`--zk` flags as a [`Key`],
+    /// validating that exactly one was given.
+    pub fn key(&self) -> Result<Key> {
+        match (&self.ed25519_key, &self.zk_key) {
+            (Some(ed_secret), None) => Ok(Ed25519Key::from(ed_secret.clone()).into()),
+            (None, Some(zk_secret)) => Ok(ZkKey::from(zk_secret.clone()).into()),
+            (Some(_), Some(_)) => Err(color_eyre::eyre::eyre!(
+                "Please provide either --ed25519 or --zk, not both."
+            )),
+            (None, None) => Err(color_eyre::eyre::eyre!(
+                "You must provide a key via --ed25519 or --zk."
+            )),
         }
     }
 }
@@ -295,13 +314,14 @@ pub fn run_generate_key(args: GenerateKeyArgs) -> Result<()> {
 }
 
 pub fn run_add_key(args: AddKeyArgs) -> Result<()> {
+    let key = args.key()?;
+
     let AddKeyArgs {
         user_config: user_config_path,
         keystore: keystore_path,
         yes: auto_approve,
         key_title,
-        zk_key,
-        ed25519_key,
+        ..
     } = args;
 
     let (mut user_config, mut keystore) =
@@ -310,27 +330,6 @@ pub fn run_add_key(args: AddKeyArgs) -> Result<()> {
     let user_key_title = key_title
         .as_ref()
         .map_or_else(|| next_user_key_title(&keystore), Clone::clone);
-
-    let key: Key = match (ed25519_key, zk_key) {
-        (Some(ed_secret), None) => {
-            let ed_key = Ed25519Key::from(ed_secret);
-            Key::Ed25519(ed_key)
-        }
-        (None, Some(zk_sercret)) => {
-            let zk_key = ZkKey::from(zk_sercret);
-            Key::Zk(zk_key)
-        }
-        (Some(_), Some(_)) => {
-            return Err(color_eyre::eyre::eyre!(
-                "Please provide either --ed25519 or --zk, not both."
-            ));
-        }
-        (None, None) => {
-            return Err(color_eyre::eyre::eyre!(
-                "You must provide a key via --ed25519 or --zk."
-            ));
-        }
-    };
 
     keystore.set(user_key_title.clone(), key);
 

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -290,6 +290,21 @@ pub struct UpdateArgs {
     state: StateArgs,
 }
 
+impl UpdateArgs {
+    /// Creates arguments programmatically (e.g. from the c-bindings crate),
+    /// leaving all config overrides at their defaults. `auto_approve` skips
+    /// interactive prompts.
+    #[must_use]
+    pub fn new(user_config: PathBuf, keystore: PathBuf, auto_approve: bool) -> Self {
+        Self {
+            user_config,
+            keystore,
+            yes: auto_approve,
+            ..Default::default()
+        }
+    }
+}
+
 // Custom default implementation to require keystore path initialized from clap.
 impl Default for UpdateArgs {
     fn default() -> Self {
@@ -338,6 +353,25 @@ pub struct MigrateArgs {
 
     #[clap(flatten)]
     state: StateArgs,
+}
+
+impl MigrateArgs {
+    /// Creates arguments programmatically (e.g. from the c-bindings crate),
+    /// leaving all config overrides at their defaults.
+    #[must_use]
+    pub fn new(output: PathBuf, keystore: PathBuf) -> Self {
+        Self {
+            output,
+            keystore,
+            log: LogArgs::default(),
+            network: NetworkArgs::default(),
+            blend: BlendArgs::default(),
+            cryptarchia: CryptarchiaArgs::default(),
+            sdp: SdpArgs::default(),
+            api: ApiArgs::default(),
+            state: StateArgs::default(),
+        }
+    }
 }
 
 impl From<MigrateArgs> for InitArgs {


### PR DESCRIPTION
## 1. What does this PR implement?
Exposes all `logos-blockchain-node` CLI commands (except `inscribe`) as C functions in the `c-bindings` crate. `init-config` was already exposed as
  `generate_user_config`.

  ### New FFI functions
  - `update_user_config`, `migrate_user_config`, `migrate_user_config_0_1_2`, `participate`
  - `generate_key` (returns the new key id), `add_key`, `remove_key` (new `KeyType` enum)
  - `get_peer_id` (returns the base58 `PeerId`)

  All run non-interactively (auto-approve), follow the existing null-check/`OperationStatus`/`FfiStatusResult` patterns, and returned strings are freed with
  `free_cstring`.

  ### Node crate changes
  - **Fix**: `generate-key --yes` never persisted the key (inverted confirm condition); it now writes the keystore/config and prints the KeyID.
  - Added programmatic constructors for `UpdateArgs`, both `MigrateArgs`, and the key-args structs (fields were clap-only/private).
  - Extracted reusable cores: `keys::generate_key() -> KeyId`, `get_peer_id::peer_id_from_config() -> PeerId`, plus shared load/persist helpers in `keys.rs`.

  ### Testing
  - New round-trip unit test: init → update → generate/add/remove key → get-peer-id → participate → migrate, against temp dirs.
  - `migrate_user_config_0_1_2` is untested (no 0.1.2 fixture available).

## 2. Does the code have enough context to be clearly understood?

N/A

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @bacv 

## 4. Is the specification accurate and complete?

N/A


## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
