### PR TITLE
test(e2e): wait for mempool recovery before restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5000,6 +5000,7 @@ dependencies = [
  "logos-blockchain-libp2p",
  "logos-blockchain-mmr",
  "logos-blockchain-node",
+ "logos-blockchain-tx-service",
  "logos-blockchain-utils",
  "logos-blockchain-utxotree",
  "logos-blockchain-wallet",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -40,6 +40,7 @@ lb-libp2p                        = { workspace = true }
 lb-mmr                           = { workspace = true }
 lb-node                          = { features = ["testing"], workspace = true }
 lb-testing-framework             = { workspace = true }
+lb-tx-service                    = { workspace = true }
 lb-utils                         = { workspace = true }
 lb-wallet                        = { workspace = true }
 lb-zksign                        = { workspace = true }

--- a/tests/cucumber_tests/features/mempool.feature
+++ b/tests/cucumber_tests/features/mempool.feature
@@ -65,6 +65,7 @@ Feature: Mempool lifecycle
     Then transaction "TX_PENDING_RESTART" is pending in mempool of nodes in 30 seconds:
       | node_name |
       | NODE_1    |
+    And mempool recovery for node "NODE_1" contains transaction "TX_PENDING_RESTART"
     When I restart node "NODE_1"
     # TF only keeps the tx hash here; the node must recover the pending mempool entry.
     Then transaction "TX_PENDING_RESTART" is pending in mempool of nodes in 30 seconds:

--- a/tests/src/cucumber/steps/manual_mempool/actions.rs
+++ b/tests/src/cucumber/steps/manual_mempool/actions.rs
@@ -1,5 +1,14 @@
+use std::{
+    collections::BTreeSet,
+    fs, io,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
 use lb_core::mantle::{SignedMantleTx, Transaction as _, TxHash};
 use lb_key_management_system_service::keys::ZkPublicKey;
+use lb_tx_service::{backend::PoolRecoveryState, tx::state::TxMempoolState};
+use tokio::time::{sleep, timeout};
 use tracing::{info, warn};
 
 use crate::{
@@ -12,9 +21,12 @@ use crate::{
             SignedUserWalletSubmission, prepare_user_wallet_transaction_submission,
             record_signed_user_wallet_submission, sign_prepared_user_wallet_transaction,
         },
-        world::CucumberWorld,
+        world::{CucumberWorld, NodeInfo},
     },
 };
+
+const RECOVERY_FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+const RECOVERY_FLUSH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 pub async fn prepare_transfer_transaction(
     world: &mut CucumberWorld,
@@ -106,6 +118,106 @@ pub async fn try_submit_invalid_transaction(
     }
 
     Ok(())
+}
+
+pub async fn wait_for_mempool_recovery_flush(
+    world: &CucumberWorld,
+    node_name: &str,
+    transaction_alias: &str,
+) -> Result<(), StepError> {
+    let node_info = world
+        .nodes_info
+        .get(node_name)
+        .ok_or_else(|| StepError::LogicalError {
+            message: format!("Node `{node_name}` is not started"),
+        })?;
+    let tx_hash = world.resolve_submitted_transaction(transaction_alias)?;
+
+    let pending_hashes = collect_pending_mempool_hashes(node_info).await?;
+
+    if !pending_hashes.contains(&tx_hash) {
+        return Err(StepError::LogicalError {
+            message: format!(
+                "Transaction `{transaction_alias}` ({tx_hash:?}) is not pending in node `{node_name}` mempool"
+            ),
+        });
+    }
+
+    let recovery_file = mempool_recovery_file(node_info);
+    wait_for_transaction_in_recovery_file(node_name, transaction_alias, tx_hash, recovery_file)
+        .await
+}
+
+async fn collect_pending_mempool_hashes(
+    node_info: &NodeInfo,
+) -> Result<BTreeSet<TxHash>, StepError> {
+    Ok(node_info
+        .started_node
+        .client
+        .test_mempool_view()
+        .await?
+        .into_iter()
+        .collect())
+}
+
+fn mempool_recovery_file(node_info: &NodeInfo) -> PathBuf {
+    node_info
+        .runtime_dir
+        .join("recovery")
+        .join("mempool")
+        .join("recovery.json")
+}
+
+async fn wait_for_transaction_in_recovery_file(
+    node_name: &str,
+    transaction_alias: &str,
+    tx_hash: TxHash,
+    recovery_file: PathBuf,
+) -> Result<(), StepError> {
+    let wait_result = timeout(RECOVERY_FLUSH_TIMEOUT, async {
+        loop {
+            let recovered_hashes = read_recovered_mempool_pending_hashes(&recovery_file)?;
+
+            if recovered_hashes
+                .as_ref()
+                .is_some_and(|hashes| hashes.contains(&tx_hash))
+            {
+                return Ok(());
+            }
+
+            sleep(RECOVERY_FLUSH_POLL_INTERVAL).await;
+        }
+    })
+    .await;
+
+    wait_result.unwrap_or_else(
+        |_| Err(StepError::Timeout {
+            message: format!(
+                "Timed out waiting for node `{node_name}` to flush transaction `{transaction_alias}` ({tx_hash:?}) to '{}'",
+                recovery_file.display()
+            ),
+        }),
+    )
+}
+
+fn read_recovered_mempool_pending_hashes(
+    recovery_file: &Path,
+) -> Result<Option<BTreeSet<TxHash>>, StepError> {
+    let contents = match fs::read_to_string(recovery_file) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+
+    let recovery_state: TxMempoolState<PoolRecoveryState<TxHash>, (), ()> =
+        serde_json::from_str(&contents).map_err(|error| StepError::LogicalError {
+            message: format!(
+                "Failed to parse mempool recovery file '{}': {error}",
+                recovery_file.display()
+            ),
+        })?;
+
+    Ok(recovery_state.pool().map(|pool| pool.pending_items.clone()))
 }
 
 fn wallet_transaction_error(error: &WalletTransactionError) -> StepError {

--- a/tests/src/cucumber/steps/manual_mempool/steps.rs
+++ b/tests/src/cucumber/steps/manual_mempool/steps.rs
@@ -5,7 +5,7 @@ use crate::cucumber::{
     steps::manual_mempool::{
         actions::{
             prepare_transfer_transaction, submit_prepared_transaction_to_nodes,
-            try_submit_invalid_transaction,
+            try_submit_invalid_transaction, wait_for_mempool_recovery_flush,
         },
         assertions::{
             assert_transaction_not_pending_on_all_nodes, assert_transaction_pending_on_nodes,
@@ -60,6 +60,19 @@ async fn step_try_submit_invalid_transaction(
     node_name: String,
 ) -> StepResult {
     try_submit_invalid_transaction(world, &step.value, transaction_alias, node_name).await
+}
+
+#[then(expr = "mempool recovery for node {string} contains transaction {string}")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Cucumber step functions require `&mut World` as the first parameter"
+)]
+async fn step_wait_for_pending_mempool_recovery_flush(
+    world: &mut CucumberWorld,
+    node_name: String,
+    transaction_alias: String,
+) -> StepResult {
+    wait_for_mempool_recovery_flush(world, &node_name, &transaction_alias).await
 }
 
 #[then(expr = "transaction {string} is pending in mempool of nodes in {int} seconds:")]


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes a race in the mempool restart e2e test.

The scenario now waits until the submitted pending transaction is written to the node’s mempool recovery file before restarting the node. This makes the test assert the actual recovery precondition instead of restarting immediately after the transaction appears in the live mempool.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
