### PR TITLE
fix(cryptarchia): use strict_sub for Epoch

### DIFF
--- a/consensus/cryptarchia-engine/src/time.rs
+++ b/consensus/cryptarchia-engine/src/time.rs
@@ -49,6 +49,16 @@ impl Epoch {
     pub const fn strict_add(self, rhs: Self) -> Self {
         Self(self.0.strict_add(rhs.0))
     }
+
+    /// Strict epoch subtraction, panicking if overflow occurred.
+    ///
+    /// # Panics
+    /// This function will always panic on overflow, regardless of whether
+    /// overflow checks are enabled.
+    #[must_use]
+    pub const fn strict_sub(self, rhs: Self) -> Self {
+        Self(self.0.strict_sub(rhs.0))
+    }
 }
 
 impl Display for Epoch {

--- a/ledger/src/config.rs
+++ b/ledger/src/config.rs
@@ -39,18 +39,18 @@ impl Config {
     pub fn nonce_snapshot(&self, epoch: Epoch) -> Slot {
         let offset = self.nonce_contribution_period();
         let base =
-            u64::from(u32::from(epoch).saturating_sub(1)).saturating_mul(self.epoch_length());
-        base.saturating_add(offset).into()
+            u64::from(epoch.strict_sub(1.into()).into_inner()).strict_mul(self.epoch_length());
+        base.strict_add(offset).into()
     }
 
     /// The number of slots in Stake Distribution Snapshot + Buffer phases
     #[must_use]
     pub fn nonce_contribution_period(&self) -> u64 {
-        self.base_period_length().get().saturating_mul(
+        self.base_period_length().get().strict_mul(
             u64::from(NonZeroU64::from(
                 self.epoch_config.epoch_period_nonce_buffer,
             ))
-            .saturating_add(u64::from(NonZeroU64::from(
+            .strict_add(u64::from(NonZeroU64::from(
                 self.epoch_config.epoch_stake_distribution_stabilization,
             ))),
         )
@@ -76,7 +76,7 @@ impl Config {
     /// snapshotted, i.e., the first slot of the previous epoch.
     #[must_use]
     pub fn stake_distribution_snapshot(&self, epoch: Epoch) -> Slot {
-        (u64::from(u32::from(epoch) - 1) * self.epoch_length()).into()
+        (u64::from(epoch.strict_sub(1.into()).into_inner()) * self.epoch_length()).into()
     }
 
     #[must_use]
@@ -158,6 +158,66 @@ mod tests {
         assert_eq!(config.total_stake_snapshot(2.into()), 160.into());
         assert_eq!(config.stake_distribution_snapshot(1.into()), 0.into());
         assert_eq!(config.stake_distribution_snapshot(2.into()), 100.into());
+    }
+
+    fn epoch_zero_test_config() -> super::Config {
+        let epoch_config = EpochConfig {
+            epoch_stake_distribution_stabilization: NonZero::new(3u8).unwrap(),
+            epoch_period_nonce_buffer: NonZero::new(3).unwrap(),
+            epoch_period_nonce_stabilization: NonZero::new(4).unwrap(),
+        };
+        let consensus_config = lb_cryptarchia_engine::Config::new(
+            NonZero::new(5).unwrap(),
+            NonNegativeRatio::new(1, 2.try_into().unwrap()),
+            1f64.try_into().expect("1 > 0"),
+        );
+        let epoch_length = epoch_config.epoch_length(consensus_config.base_period_length());
+        super::Config {
+            epoch_config,
+            consensus_config,
+            sdp_config: crate::mantle::sdp::Config {
+                service_params: Arc::new(
+                    [(
+                        ServiceType::BlendNetwork,
+                        ServiceParameters {
+                            inactivity_period: 1.into(),
+                            retention_period: 1.into(),
+                            epoch: 0.into(),
+                        },
+                    )]
+                    .into(),
+                ),
+                service_rewards_params: ServiceRewardsParameters {
+                    blend: RewardsParameters {
+                        rounds_per_epoch: epoch_length.try_into().unwrap(),
+                        message_frequency_per_round: NonNegativeF64::try_from(1.0).unwrap(),
+                        num_blend_layers: NonZeroU64::new(3).unwrap(),
+                        minimum_network_size: NonZeroU64::new(1).unwrap(),
+                        data_replication_factor: 0,
+                        activity_threshold_sensitivity: 1,
+                    },
+                },
+                min_stake: MinStake {
+                    threshold: 1,
+                    timestamp: 0,
+                },
+            },
+            faucet_pk: None,
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to subtract with overflow")]
+    fn stake_distribution_snapshot_panics_at_epoch_zero() {
+        let config = epoch_zero_test_config();
+        let _ = config.stake_distribution_snapshot(0.into());
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to subtract with overflow")]
+    fn nonce_snapshot_panics_at_epoch_zero() {
+        let config = epoch_zero_test_config();
+        let _ = config.nonce_snapshot(0.into());
     }
 
     #[test]

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -328,7 +328,7 @@ impl LedgerState {
             tracing::warn!(
                 old_epoch = ?current_epoch,
                 new_epoch = ?new_epoch,
-                epochs_skipped = u32::from(new_epoch) - u32::from(current_epoch) - 1,
+                epochs_skipped = new_epoch.strict_sub(current_epoch).strict_sub(1.into()).into_inner(),
                 old_total_stake = self.epoch_state.total_stake,
                 new_total_stake = total_stake,
                 slot = ?slot,


### PR DESCRIPTION
## 1. What does this PR implement?

Replaced all unsafe `Epoch - 1` to `strict_sub` because those operations are never called on the epoch 0.

This fixes the finding 4 in the audit #2922 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
