### PR TITLE
fix(sdp): filter out inactive declarations when snapshotting

### DIFF
--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -229,6 +229,14 @@ impl Declarations {
     ) -> impl Iterator<Item = (&ServiceType, &HashMap<DeclarationId, Declaration>)> {
         self.0.iter()
     }
+
+    #[must_use]
+    pub fn for_service(
+        &self,
+        service_type: &ServiceType,
+    ) -> Option<&HashMap<DeclarationId, Declaration>> {
+        self.0.get(service_type)
+    }
 }
 
 impl From<HashMap<ServiceType, HashMap<DeclarationId, Declaration>>> for Declarations {

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -189,8 +189,17 @@ pub struct Declaration {
     pub locked_note_id: NoteId,
     pub locators: Locators,
     pub zk_id: ZkPublicKey,
+    /// The epoch of the block that contained the declaration
     pub created: Epoch,
+    /// The latest epoch for which the active message was sent.
+    ///
+    /// This is used only for checking if the declaration should
+    /// be marked as inactive, not for checking if it becomes active.
+    /// Idle->Active transition must be handled by the `EpochState`
+    /// snapshot logic.
+    // TODO: Use Option<Epoch> with a better name.
     pub active: Epoch,
+    /// The epoch at which the declaration must be withdrawn
     pub withdrawn: Option<Epoch>,
     pub nonce: Nonce,
 }

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -15,7 +15,7 @@ use lb_core::{
         ops::transfer::{TransferOp, TransferValidationContext},
     },
     proofs::leader_proof::{self, LeaderPublic},
-    sdp::locked_notes::LockedNotes,
+    sdp::{Declarations, locked_notes::LockedNotes},
 };
 use lb_cryptarchia_engine::{Epoch, Slot};
 use lb_groth16::{Fr, fr_from_bytes};
@@ -54,7 +54,7 @@ pub type UtxoTree = lb_utxotree::UtxoTree<NoteId, Utxo, ZkHasher>;
 use super::{Balance, Config, LedgerError, mantle};
 use crate::WINDOW_SIZE;
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EpochState {
     /// The epoch this snapshot is for
     pub epoch: Epoch,
@@ -72,10 +72,13 @@ pub struct EpochState {
     pub lottery_0: Fr,
     #[serde(with = "lb_groth16::serde::serde_fr")]
     pub lottery_1: Fr,
-    /// SDP service-provider declarations (membership) snapshot, frozen at the
-    /// same slot as the stake distribution (`stake_distribution_snapshot`).
-    /// Carried forward in ledger state so the epoch's membership is derivable
-    /// from the tip without walking storage.
+    /// Snapshot of the declarations that are active at the start of
+    /// `self.epoch`, frozen at the same slot as the stake distribution
+    /// (`stake_distribution_snapshot`).
+    ///
+    /// Held behind `Arc` because `EpochState` is cloned for every block in
+    /// cryptarchia's per-branch state; the underlying map is immutable once
+    /// frozen, so all clones can share it.
     ///
     /// TODO: This field reaches "up" into the mantle layer (`SdpLedger`), which
     /// is why the `&SdpLedger` is threaded through `update_from_ledger`,
@@ -84,7 +87,7 @@ pub struct EpochState {
     /// out of `cryptarchia` to sit alongside `cryptarchia_ledger` and
     /// `mantle_ledger` in the outer `LedgerState`, where the freeze can read
     /// both sub-ledgers directly and these `&SdpLedger` parameters disappear.
-    pub sdp: SdpLedger,
+    pub active_declarations: Arc<Declarations>,
 }
 
 impl EpochState {
@@ -96,14 +99,19 @@ impl EpochState {
             self.nonce
         };
 
-        // The SDP membership snapshot is frozen at the same slot as the stake
-        // distribution, so the two halves of the epoch's public info stay
-        // consistent.
+        // The active-declarations snapshot is frozen at the same slot as the
+        // stake distribution, so the two halves of the epoch's public info
+        // stay consistent.
         let stake_snapshot_slot = config.stake_distribution_snapshot(self.epoch);
-        let (utxos, sdp) = if ledger.slot < stake_snapshot_slot {
-            (ledger.utxos.clone(), sdp.clone())
+        let (utxos, active_declarations) = if ledger.slot < stake_snapshot_slot {
+            (
+                ledger.utxos.clone(),
+                // Filter declarations active at the `self.epoch` from `SdpLedger`
+                // regardless of when it was built.
+                Arc::new(sdp.active_declarations(self.epoch, &config.sdp_config.service_params)),
+            )
         } else {
-            (self.utxos, self.sdp)
+            (self.utxos, self.active_declarations)
         };
         Self {
             epoch: self.epoch,
@@ -112,7 +120,7 @@ impl EpochState {
             total_stake: self.total_stake,
             lottery_0: self.lottery_0,
             lottery_1: self.lottery_1,
-            sdp,
+            active_declarations,
         }
     }
 
@@ -271,14 +279,20 @@ impl LedgerState {
                 lottery_1,
                 ..next_epoch_state
             };
+            let next_epoch_state_epoch = new_epoch.strict_add(1.into());
             let next_epoch_state = EpochState {
-                epoch: new_epoch.strict_add(1.into()),
+                epoch: next_epoch_state_epoch,
                 nonce: self.nonce,
                 utxos: self.utxos.clone(),
                 total_stake,
                 lottery_0,
                 lottery_1,
-                sdp: sdp.clone(),
+                // Filter declarations active at the `next_epoch_state_epoch`
+                // from `SdpLedger` regardless of when it was built.
+                active_declarations: Arc::new(sdp.active_declarations(
+                    next_epoch_state_epoch,
+                    &config.sdp_config.service_params,
+                )),
             };
             let (new_price, new_ema) = update_storage_market(
                 self.storage_gas_price,
@@ -342,16 +356,26 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
-                sdp: sdp.clone(),
+                // Filter declarations active at the `new_epoch`
+                // from `SdpLedger` regardless of when it was built.
+                active_declarations: Arc::new(
+                    sdp.active_declarations(new_epoch, &config.sdp_config.service_params),
+                ),
             };
+            let next_epoch_state_epoch = new_epoch.strict_add(1.into());
             let next_epoch_state = EpochState {
-                epoch: new_epoch.strict_add(1.into()),
+                epoch: next_epoch_state_epoch,
                 nonce: self.nonce,
                 utxos: self.utxos.clone(),
                 total_stake,
                 lottery_0,
                 lottery_1,
-                sdp: sdp.clone(),
+                // Filter declarations active at the `next_epoch_state_epoch`
+                // from `SdpLedger` regardless of when it was built.
+                active_declarations: Arc::new(sdp.active_declarations(
+                    next_epoch_state_epoch,
+                    &config.sdp_config.service_params,
+                )),
             };
             Ok(Self {
                 slot,
@@ -524,13 +548,16 @@ impl LedgerState {
     ///
     /// At genesis the cryptarchia ledger is built before the mantle `SdpLedger`
     /// exists (the mantle ledger is derived from the cryptarchia epoch state),
-    /// so the initial epoch states start with an empty SDP snapshot. Once the
-    /// genesis `SdpLedger` is available, this seeds it into the epoch 0/1
-    /// snapshots so they carry the genesis membership. Genesis use only.
+    /// so the initial epoch states start with an empty active-declarations
+    /// snapshot. Once the genesis `SdpLedger` is available, this seeds the
+    /// active-declarations snapshot for epochs 0 and 1.
     #[must_use]
-    pub fn with_genesis_sdp(mut self, sdp: SdpLedger) -> Self {
-        self.next_epoch_state.sdp = sdp.clone();
-        self.epoch_state.sdp = sdp;
+    pub fn with_genesis_sdp(mut self, sdp: &SdpLedger, config: &Config) -> Self {
+        let service_params = &config.sdp_config.service_params;
+        self.epoch_state.active_declarations =
+            Arc::new(sdp.active_declarations(self.epoch_state.epoch, service_params));
+        self.next_epoch_state.active_declarations =
+            Arc::new(sdp.active_declarations(self.next_epoch_state.epoch, service_params));
         self
     }
 
@@ -635,7 +662,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
-                sdp: SdpLedger::new(1.into()),
+                active_declarations: Arc::new(Declarations::default()),
             },
             epoch_state: EpochState {
                 epoch: 0.into(),
@@ -644,7 +671,7 @@ impl LedgerState {
                 total_stake,
                 lottery_0,
                 lottery_1,
-                sdp: SdpLedger::new(0.into()),
+                active_declarations: Arc::new(Declarations::default()),
             },
             block_density,
             stake_inference,
@@ -939,33 +966,24 @@ pub mod tests {
         ));
         let block_density = BlockDensity::new(config.epoch(slot), &config);
 
-        let mut epoch_state = EpochState {
+        let epoch_state = EpochState {
             epoch: 0.into(),
             nonce: Fr::ZERO,
             utxos: utxos.clone(),
             total_stake,
             lottery_0,
             lottery_1,
-            sdp: SdpLedger::new(0.into()),
+            active_declarations: Arc::new(Declarations::default()),
         };
-        epoch_state.sdp = epoch_state.sdp.clone().with_blend_service(
-            &config.sdp_config.service_rewards_params.blend,
-            &epoch_state,
-        );
-
-        let mut next_epoch_state = EpochState {
+        let next_epoch_state = EpochState {
             epoch: 1.into(),
             nonce: Fr::ZERO,
             utxos: utxos.clone(),
             total_stake,
             lottery_0,
             lottery_1,
-            sdp: SdpLedger::new(1.into()),
+            active_declarations: Arc::new(Declarations::default()),
         };
-        next_epoch_state.sdp = next_epoch_state.sdp.clone().with_blend_service(
-            &config.sdp_config.service_rewards_params.blend,
-            &next_epoch_state,
-        );
 
         LedgerState {
             utxos,
@@ -1071,16 +1089,20 @@ pub mod tests {
         header_id: &HeaderId,
         snapshot_header_id: &HeaderId,
     ) {
+        let epoch = ledger.states[header_id]
+            .cryptarchia_ledger
+            .epoch_state
+            .epoch;
+        let expected = ledger.states[snapshot_header_id]
+            .mantle_ledger
+            .sdp
+            .active_declarations(epoch, &config().sdp_config.service_params);
         assert_eq!(
-            ledger.states[header_id]
+            *ledger.states[header_id]
                 .cryptarchia_ledger
                 .epoch_state
-                .sdp
-                .declarations(),
-            ledger.states[snapshot_header_id]
-                .mantle_ledger
-                .sdp
-                .declarations(),
+                .active_declarations,
+            expected,
         );
     }
 
@@ -1106,8 +1128,9 @@ pub mod tests {
         ledger.states[header_id]
             .cryptarchia_ledger
             .epoch_state
-            .sdp
-            .get_declaration(declaration_id)
+            .active_declarations
+            .for_service(&ServiceType::BlendNetwork)
+            .and_then(|m| m.get(declaration_id))
     }
 
     #[test]
@@ -1258,6 +1281,77 @@ pub mod tests {
                 .block_density
                 .period_range(),
             &(200.into()..=259.into())
+        );
+    }
+
+    /// A declaration that lapses past `inactivity_period` but has not yet
+    /// been garbage-collected must be filtered out of the `EpochState`
+    /// snapshot built at a later epoch.
+    #[test]
+    fn epoch_state_snapshot_excludes_inactive_declaration() {
+        let leader_utxo = utxo();
+        let (sdp_utxo_key, sdp_utxo) = utxo_with_sk();
+        let new_utxo = utxo();
+        let config = config();
+        let epoch_length = config.epoch_length();
+        let (mut ledger0, genesis) = ledger(&[leader_utxo, sdp_utxo], config);
+
+        // Declare at slot 1 (epoch 0). The declaration's `active` field is
+        // initialized to `created + 2 = 2`.
+        let (head0, declare) = apply_and_add_utxo_and_declaration(
+            &mut ledger0,
+            genesis,
+            1,
+            leader_utxo,
+            new_utxo,
+            sdp_utxo,
+            sdp_utxo_key,
+        );
+
+        // Advance to epoch 4 (one-by-one).
+        // With inactivity_period=1, the declaration goes inactive at epoch 4.
+        // With retention_period=1, GC fires at epoch 5.
+        // So, at epoch 4, the declaration is inactive yet still present in the ledger.
+        let mut ledger = ledger0.clone();
+        let mut head = head0;
+        for epoch in 1..=4u64 {
+            head = update_ledger(&mut ledger, head, epoch * epoch_length, leader_utxo).unwrap();
+        }
+        assert_eq!(
+            ledger.states[&head].cryptarchia_ledger.epoch_state.epoch,
+            Epoch::new(4)
+        );
+        assert!(
+            ledger.states[&head]
+                .mantle_ledger
+                .sdp
+                .get_declaration(&declare.id())
+                .is_some(),
+            "declaration must still be in the live SDP ledger before GC removes it"
+        );
+        assert!(
+            declaration_in_snapshot(&ledger, &head, &declare.id()).is_none(),
+            "inactive declaration must be filtered out of the EpochState snapshot"
+        );
+
+        // Jump from epoch 0 to 4, and check the same conditions
+        let mut ledger = ledger0;
+        head = update_ledger(&mut ledger, head0, 4 * epoch_length, leader_utxo).unwrap();
+        assert_eq!(
+            ledger.states[&head].cryptarchia_ledger.epoch_state.epoch,
+            Epoch::new(4)
+        );
+        assert!(
+            ledger.states[&head]
+                .mantle_ledger
+                .sdp
+                .get_declaration(&declare.id())
+                .is_some(),
+            "declaration must still be in the live SDP ledger before GC removes it"
+        );
+        assert!(
+            declaration_in_snapshot(&ledger, &head, &declare.id()).is_none(),
+            "inactive declaration must be filtered out of the EpochState snapshot"
         );
     }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -429,7 +429,7 @@ impl LedgerState {
         let mantle_ledger = MantleLedger::new(config, cryptarchia_ledger.epoch_state());
         // Seed the genesis epoch-state membership snapshots from the genesis SDP
         // ledger, which only exists after the mantle ledger is built.
-        let cryptarchia_ledger = cryptarchia_ledger.with_genesis_sdp(mantle_ledger.sdp.clone());
+        let cryptarchia_ledger = cryptarchia_ledger.with_genesis_sdp(&mantle_ledger.sdp, config);
         Self {
             block_number: 0,
             cryptarchia_ledger,
@@ -451,7 +451,7 @@ impl LedgerState {
         )?;
         // Seed the genesis epoch-state membership snapshots from the genesis SDP
         // ledger (which carries the genesis declarations applied above).
-        let cryptarchia_ledger = cryptarchia_ledger.with_genesis_sdp(mantle_ledger.sdp.clone());
+        let cryptarchia_ledger = cryptarchia_ledger.with_genesis_sdp(&mantle_ledger.sdp, config);
         Ok((
             Self {
                 block_number: 0,
@@ -783,16 +783,31 @@ mod tests {
         (ledger, [0; 32], utxo)
     }
 
-    /// The genesis epoch-state membership snapshots must be seeded from the
-    /// genesis SDP ledger, not left as the empty `SdpLedger::new` placeholder
-    /// the cryptarchia genesis constructor initializes them with.
+    /// The genesis epoch-state active-declarations snapshots must be seeded
+    /// from the genesis SDP ledger, not left as the empty default the
+    /// cryptarchia genesis constructor initializes them with.
     #[test]
     fn genesis_seeds_epoch_state_sdp_from_mantle() {
         let config = config();
         let ledger = LedgerState::from_utxos([utxo()], &config);
 
-        assert_eq!(ledger.epoch_state().sdp, ledger.mantle_ledger.sdp);
-        assert_eq!(ledger.next_epoch_state().sdp, ledger.mantle_ledger.sdp);
+        let expected_for_epoch_0 = ledger
+            .mantle_ledger
+            .sdp
+            .active_declarations(0.into(), &config.sdp_config.service_params);
+        let expected_for_epoch_1 = ledger
+            .mantle_ledger
+            .sdp
+            .active_declarations(1.into(), &config.sdp_config.service_params);
+
+        assert_eq!(
+            *ledger.epoch_state().active_declarations,
+            expected_for_epoch_0
+        );
+        assert_eq!(
+            *ledger.next_epoch_state().active_declarations,
+            expected_for_epoch_1
+        );
     }
 
     fn create_test_keys_with_seed(seed: u8) -> (Ed25519Key, Ed25519PublicKey) {

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -840,7 +840,7 @@ mod tests {
 
         // The declaration is still present in the live ledger (no GC)
         assert!(ledger.get_declaration(&declaration_id).is_some());
-        // but active_declarations at epoch 10 must filter it out.
+        // but active_declarations at epoch 5 must filter it out.
         assert!(
             ledger
                 .active_declarations(5.into(), &config.service_params)

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -282,11 +282,6 @@ impl<R: Rewards> ServiceState<R> {
 /// Returns true if the declaration is active at `current_epoch`:
 /// an activity message has been accepted within `inactivity_period` epochs,
 /// and its withdrawal (if any) has not yet taken effect.
-///
-/// We don't check `declaration.active >= current_epoch` because genesis
-/// declarations which are initialized with `active = 2` must be treated as
-/// active from the epoch 0. To make it clearer, the spec should update
-/// `active` to `Option` and define a clearer way to handle it.
 fn is_active(declaration: &Declaration, current_epoch: Epoch, config: &ServiceParameters) -> bool {
     declaration.active.strict_add(config.inactivity_period) >= current_epoch
         && declaration

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -279,6 +279,21 @@ impl<R: Rewards> ServiceState<R> {
     }
 }
 
+/// Returns true if the declaration is active at `current_epoch`:
+/// an activity message has been accepted within `inactivity_period` epochs,
+/// and its withdrawal (if any) has not yet taken effect.
+///
+/// We don't check `declaration.active >= current_epoch` because genesis
+/// declarations which are initialized with `active = 2` must be treated as
+/// active from the epoch 0. To make it clearer, the spec should update
+/// `active` to `Option` and define a clearer way to handle it.
+fn is_active(declaration: &Declaration, current_epoch: Epoch, config: &ServiceParameters) -> bool {
+    declaration.active.strict_add(config.inactivity_period) >= current_epoch
+        && declaration
+            .withdrawn
+            .is_none_or(|withdrawn| withdrawn > current_epoch)
+}
+
 /// A SDP state of the mantle ledger
 ///
 /// NOTE: Most collection fields in this struct should use `rpds`
@@ -553,7 +568,7 @@ impl SdpLedger {
     }
 
     /// Declarations of all services, which have been accumulated until the
-    /// current block.
+    /// current block, regardless of whether they are active or not.
     #[must_use]
     pub fn declarations(&self) -> lb_core::sdp::Declarations {
         self.services
@@ -567,6 +582,36 @@ impl SdpLedger {
                         .map(|(declaration_id, declaration)| (*declaration_id, declaration.clone()))
                         .collect(),
                 )
+            })
+            .collect()
+    }
+
+    /// Returns the declarations that are active at `epoch`, grouped by
+    /// service type.
+    ///
+    /// Service entries with no active declarations are omitted.
+    /// Services missing from `service_params` are skipped.
+    #[must_use]
+    pub fn active_declarations(
+        &self,
+        epoch: Epoch,
+        service_params: &HashMap<ServiceType, ServiceParameters>,
+    ) -> lb_core::sdp::Declarations {
+        self.services
+            .iter()
+            .filter_map(|(service_type, service)| {
+                let params = service_params.get(service_type)?;
+                let entries: HashMap<DeclarationId, Declaration> = service
+                    .declarations()
+                    .iter()
+                    .filter(|(_, declaration)| is_active(declaration, epoch, params))
+                    .map(|(declaration_id, declaration)| (*declaration_id, declaration.clone()))
+                    .collect();
+                if entries.is_empty() {
+                    None
+                } else {
+                    Some((*service_type, entries))
+                }
             })
             .collect()
     }
@@ -611,7 +656,11 @@ mod tests {
     use std::{num::NonZeroU64, sync::Arc};
 
     use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
-    use lb_core::{crypto::ZkHash, mantle::ledger::Utxos, sdp::Locator};
+    use lb_core::{
+        crypto::ZkHash,
+        mantle::ledger::Utxos,
+        sdp::{Locator, SNAPSHOT_FINALIZATION_DELAY},
+    };
     use lb_groth16::{AdditiveGroup as _, Fr};
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
     use lb_utils::math::NonNegativeF64;
@@ -705,23 +754,23 @@ mod tests {
             .map(|(sdp_ledger, _)| sdp_ledger)
     }
 
-    fn dummy_epoch_state(epoch: Epoch, rewards_settings: &blend::RewardsParameters) -> EpochState {
-        let mut epoch_state = EpochState {
+    fn dummy_epoch_state(epoch: Epoch) -> EpochState {
+        EpochState {
             epoch,
             nonce: ZkHash::ZERO,
             utxos: UtxoTree::default(),
             total_stake: 100,
             lottery_0: Fr::ZERO,
             lottery_1: Fr::ZERO,
-            sdp: SdpLedger::new(epoch),
-        };
+            active_declarations: Arc::new(lb_core::sdp::Declarations::default()),
+        }
+    }
 
-        epoch_state.sdp = epoch_state
-            .sdp
-            .clone()
-            .with_blend_service(rewards_settings, &epoch_state);
-
-        epoch_state
+    fn dummy_sdp_ledger(epoch: Epoch, config: &Config) -> SdpLedger {
+        SdpLedger::new(epoch).with_blend_service(
+            &config.service_rewards_params.blend,
+            &dummy_epoch_state(epoch),
+        )
     }
 
     fn next_epoch_state(epoch: Epoch, last_epoch_state: EpochState) -> EpochState {
@@ -729,6 +778,124 @@ mod tests {
             epoch,
             nonce: ZkHash::from(epoch.into_inner()),
             ..last_epoch_state
+        }
+    }
+
+    /// `active_declarations` must drop entries that have gone inactive (i.e.,
+    /// `active + inactivity_period < snapshot_epoch`) even if they have not
+    /// been garbage-collected yet.
+    #[test]
+    fn active_declarations_filters_out_inactive() {
+        // Long retention so GC never runs in the window we test, short
+        // inactivity so the declaration goes inactive quickly.
+        let config = setup(ServiceParameters {
+            inactivity_period: 1.into(),
+            retention_period: 100.into(),
+            epoch: 0.into(),
+        });
+
+        let epoch0 = dummy_epoch_state(0.into());
+        let mut ledger = dummy_sdp_ledger(0.into(), &config);
+
+        // Advance to epoch 1 and declare. The new declaration's `active`
+        // initializes to created + 2 = 3.
+        let mut last_epoch_state = epoch0.clone();
+        let new_epoch_state = next_epoch_state(1.into(), epoch0);
+        (ledger, _) = ledger
+            .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
+            .unwrap();
+        last_epoch_state = new_epoch_state;
+
+        let (_utxo_sk, utxo) = utxo_with_sk();
+        let signing_key = create_signing_key();
+        let zk_key = create_zk_key(1);
+        let declare_op = &SDPDeclareOp {
+            service_type: ServiceType::BlendNetwork,
+            locked_note_id: utxo.id(),
+            zk_id: zk_key.to_public_key(),
+            provider_id: ProviderId(signing_key.public_key()),
+            locators: "/ip4/1.1.1.1/udp/0".parse::<Locator>().unwrap().into(),
+        };
+        let declaration_id = declare_op.id();
+        let ledger = apply_declare_with_dummies(
+            &utxo_tree(vec![utxo]),
+            ledger,
+            declare_op,
+            &zk_key,
+            &config,
+        )
+        .unwrap();
+
+        // Advance to epoch 5 without an activity message; GC won't fire
+        // (retention=100), but the declaration is inactive past epoch 4
+        // (active=3, inactivity=1 -> 3+1 < 5).
+        let mut ledger = ledger;
+        for epoch in 2..=5 {
+            let new_epoch_state = next_epoch_state(epoch.into(), last_epoch_state.clone());
+            (ledger, _) = ledger
+                .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
+                .unwrap();
+            last_epoch_state = new_epoch_state;
+        }
+
+        // The declaration is still present in the live ledger (no GC)
+        assert!(ledger.get_declaration(&declaration_id).is_some());
+        // but active_declarations at epoch 10 must filter it out.
+        assert!(
+            ledger
+                .active_declarations(5.into(), &config.service_params)
+                .for_service(&ServiceType::BlendNetwork)
+                .is_none_or(|m| !m.contains_key(&declaration_id)),
+            "inactive declaration must be excluded from the active-declarations snapshot"
+        );
+    }
+
+    /// Genesis declarations are initialized with `active = created + 2`, so a
+    /// declaration created at epoch 0 must still appear in the active set when
+    /// it's consumed at epochs 0 and 1.
+    #[test]
+    fn active_declarations_includes_genesis_at_epochs_0_and_1() {
+        let config = setup(ServiceParameters {
+            inactivity_period: 1.into(),
+            retention_period: 1.into(),
+            epoch: 0.into(),
+        });
+
+        // Build an SDP ledger with an declaration at epoch 0.
+        let ledger = dummy_sdp_ledger(0.into(), &config);
+        let (_utxo_sk, utxo) = utxo_with_sk();
+        let signing_key = create_signing_key();
+        let zk_key = create_zk_key(1);
+        let declare_op = &SDPDeclareOp {
+            service_type: ServiceType::BlendNetwork,
+            locked_note_id: utxo.id(),
+            zk_id: zk_key.to_public_key(),
+            provider_id: ProviderId(signing_key.public_key()),
+            locators: "/ip4/1.1.1.1/udp/0".parse::<Locator>().unwrap().into(),
+        };
+        let declaration_id = declare_op.id();
+        let ledger = apply_declare_with_dummies(
+            &utxo_tree(vec![utxo]),
+            ledger,
+            declare_op,
+            &zk_key,
+            &config,
+        )
+        .unwrap();
+
+        // `active` is initialized to created + 2.
+        let declaration = ledger.get_declaration(&declaration_id).unwrap();
+        assert_eq!(declaration.active, SNAPSHOT_FINALIZATION_DELAY);
+
+        // At epoch 0 and 1, the declaration must be included in the active set.
+        for epoch in [0u32, 1] {
+            assert!(
+                ledger
+                    .active_declarations(epoch.into(), &config.service_params)
+                    .for_service(&ServiceType::BlendNetwork)
+                    .is_some_and(|m| m.contains_key(&declaration_id)),
+                "genesis declaration must be active at epoch {epoch}"
+            );
         }
     }
 
@@ -745,8 +912,8 @@ mod tests {
         });
 
         // Init ledger with no declaration
-        let epoch0 = dummy_epoch_state(0.into(), &config.service_rewards_params.blend);
-        let mut ledger = epoch0.sdp.clone();
+        let epoch0 = dummy_epoch_state(0.into());
+        let mut ledger = dummy_sdp_ledger(0.into(), &config);
 
         // Move forward to the epoch 1
         let mut last_epoch_state = epoch0.clone();
@@ -928,8 +1095,8 @@ mod tests {
         let declaration_id = declare_op.id();
 
         // Initialize ledger with service config and declare
-        let epoch0 = dummy_epoch_state(0.into(), &config.service_rewards_params.blend);
-        let sdp_ledger = epoch0.sdp.clone();
+        let epoch0 = dummy_epoch_state(0.into());
+        let sdp_ledger = dummy_sdp_ledger(0.into(), &config);
 
         let utxo_tree = utxo_tree(vec![utxo]);
         let sdp_ledger =

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -894,6 +894,94 @@ mod tests {
         }
     }
 
+    /// A withdrawn declaration must remain active until its `withdrawn` epoch
+    /// is reached, and become inactive from that epoch onward — even while
+    /// the declaration is still present in the live SDP ledger.
+    #[test]
+    fn active_declarations_filters_out_withdrawn_at_effective_epoch() {
+        // Long inactivity/retention so the only filter that fires in this test
+        // is the withdrawn-effective-epoch check.
+        let config = setup(ServiceParameters {
+            inactivity_period: 100.into(),
+            retention_period: 100.into(),
+            epoch: 0.into(),
+        });
+
+        let epoch0 = dummy_epoch_state(0.into());
+        let mut ledger = dummy_sdp_ledger(0.into(), &config);
+
+        // Advance to epoch 1 and declare. The declaration's `active`
+        // initializes to created + 2 = 3.
+        let last_epoch_state = epoch0.clone();
+        let new_epoch_state = next_epoch_state(1.into(), epoch0);
+        (ledger, _) = ledger
+            .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
+            .unwrap();
+
+        let (utxo_sk, utxo) = utxo_with_sk();
+        let note_id = utxo.id();
+        let signing_key = create_signing_key();
+        let zk_key = create_zk_key(1);
+        let declare_op = &SDPDeclareOp {
+            service_type: ServiceType::BlendNetwork,
+            locked_note_id: note_id,
+            zk_id: zk_key.to_public_key(),
+            provider_id: ProviderId(signing_key.public_key()),
+            locators: "/ip4/1.1.1.1/udp/0".parse::<Locator>().unwrap().into(),
+        };
+        let declaration_id = declare_op.id();
+        let ledger = apply_declare_with_dummies(
+            &utxo_tree(vec![utxo]),
+            ledger,
+            declare_op,
+            &zk_key,
+            &config,
+        )
+        .unwrap();
+
+        // Withdraw at epoch 1: `withdrawn = 1 + SNAPSHOT_FINALIZATION_DELAY = 3`.
+        let withdraw_op = &SDPWithdrawOp {
+            declaration_id,
+            nonce: 1,
+            locked_note_id: note_id,
+        };
+        let ledger =
+            apply_withdraw_with_dummies(ledger, withdraw_op, utxo_sk, zk_key, &config).unwrap();
+        let withdrawn_epoch = ledger
+            .get_declaration(&declaration_id)
+            .unwrap()
+            .withdrawn
+            .expect("withdraw must set the withdrawn epoch");
+        assert_eq!(withdrawn_epoch, Epoch::new(3));
+
+        // The declaration is still in the live SDP ledger — cleanup runs only
+        // when the ledger advances past `withdrawn_epoch`.
+        assert!(ledger.get_declaration(&declaration_id).is_some());
+
+        // Snapshot at any epoch strictly less than `withdrawn_epoch` must
+        // include the declaration.
+        for epoch in 0..withdrawn_epoch.into_inner() {
+            assert!(
+                ledger
+                    .active_declarations(epoch.into(), &config.service_params)
+                    .for_service(&ServiceType::BlendNetwork)
+                    .is_some_and(|m| m.contains_key(&declaration_id)),
+                "withdrawn-but-not-yet-effective declaration must be active at epoch {epoch}"
+            );
+        }
+
+        // Snapshot at `withdrawn_epoch` (and beyond) must exclude it.
+        for epoch in withdrawn_epoch.into_inner()..=withdrawn_epoch.into_inner() + 2 {
+            assert!(
+                ledger
+                    .active_declarations(epoch.into(), &config.service_params)
+                    .for_service(&ServiceType::BlendNetwork)
+                    .is_none_or(|m| !m.contains_key(&declaration_id)),
+                "withdrawn declaration must be excluded from the snapshot at epoch {epoch}"
+            );
+        }
+    }
+
     /// A provider that hasn't submit a new active message during
     /// `inactivity_period + retention_period` epochs must be removed.
     #[test]

--- a/ledger/src/mantle/sdp/rewards/blend/current_epoch.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/current_epoch.rs
@@ -105,13 +105,10 @@ impl CurrentEpochTracker {
         );
 
         let declarations = last_epoch_state
-            .sdp
-            .declarations()
-            .iter()
-            .filter(|(service_type, _)| matches!(service_type, ServiceType::BlendNetwork))
-            .flat_map(|(_, declarations)| declarations.values())
-            .cloned()
-            .collect::<Vec<_>>();
+            .active_declarations
+            .for_service(&ServiceType::BlendNetwork)
+            .map(|declarations| declarations.values().cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
 
         if declarations.len() < settings.minimum_network_size.get() as usize {
             debug!(target: LOG_TARGET, "Declaration count({}) is below minimum network size({}). Switching to WithoutTargetEpoch mode",

--- a/ledger/src/mantle/sdp/rewards/blend/current_epoch.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/current_epoch.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use lb_blend_crypto::merkle::sort_nodes_and_build_merkle_tree;
 use lb_blend_message::{
     crypto::proofs::PoQVerificationInputsMinusSigningKey,
@@ -104,15 +106,14 @@ impl CurrentEpochTracker {
             last_epoch_state.epoch,
         );
 
-        let declarations = last_epoch_state
+        let maybe_declarations = last_epoch_state
             .active_declarations
-            .for_service(&ServiceType::BlendNetwork)
-            .map(|declarations| declarations.values().cloned().collect::<Vec<_>>())
-            .unwrap_or_default();
+            .for_service(&ServiceType::BlendNetwork);
 
-        if declarations.len() < settings.minimum_network_size.get() as usize {
+        let declaration_count = maybe_declarations.map_or(0, HashMap::len);
+        if declaration_count < settings.minimum_network_size.get() as usize {
             debug!(target: LOG_TARGET, "Declaration count({}) is below minimum network size({}). Switching to WithoutTargetEpoch mode",
-                declarations.len(),
+                declaration_count,
                 settings.minimum_network_size.get()
             );
             return CurrentEpochTrackerOutput::WithoutTargetEpoch {
@@ -121,7 +122,11 @@ impl CurrentEpochTracker {
             };
         }
 
-        let (providers, zk_root) = Self::providers_and_zk_root(declarations.iter());
+        let (providers, zk_root) = Self::providers_and_zk_root(
+            maybe_declarations
+                .expect("declaration set must exist since it's larger than minimum network size")
+                .values(),
+        );
 
         let (core_quota, token_evaluation) = settings.core_quota_and_token_evaluation(
             providers.size() as u64,

--- a/ledger/src/mantle/sdp/rewards/test_utils.rs
+++ b/ledger/src/mantle/sdp/rewards/test_utils.rs
@@ -1,22 +1,14 @@
-use std::marker::PhantomData;
+use std::{collections::HashMap, sync::Arc};
 
-use lb_core::{
-    mantle::Note,
-    sdp::{
-        Declaration, DeclarationId, Locator, MinStake, ProviderId, ServiceParameters, ServiceType,
-        locked_notes::LockedNotes,
-    },
+use lb_core::sdp::{
+    Declaration, DeclarationId, Declarations, Locator, ProviderId, ServiceParameters, ServiceType,
 };
 use lb_cryptarchia_engine::Epoch;
 use lb_groth16::{AdditiveGroup as _, Fr};
 use lb_key_management_system_keys::keys::{Ed25519Key, ZkPublicKey};
 use num_bigint::BigUint;
-use rpds::HashTrieMapSync;
 
-use crate::{
-    EpochState, UtxoTree,
-    mantle::sdp::{SdpLedger, Service, ServiceState, rewards::blend},
-};
+use crate::{EpochState, UtxoTree, mantle::sdp::rewards::blend};
 
 pub fn create_epoch_state(
     provider_ids: &[ProviderId],
@@ -25,62 +17,37 @@ pub fn create_epoch_state(
     nonce: Fr,
     _params: &blend::RewardsParameters,
 ) -> EpochState {
-    let mut declarations = rpds::RedBlackTreeMapSync::new_sync();
-    let mut locked_notes = LockedNotes::new();
-    for (i, provider_id) in provider_ids.iter().enumerate() {
-        let note = Note::new(100, ZkPublicKey::zero());
-        let note_id = Fr::from(i as u64).into();
-        let declaration = Declaration {
-            service_type,
-            provider_id: *provider_id,
-            locked_note_id: note_id,
-            locators: "/ip4/1.1.1.1/udp/0".parse::<Locator>().unwrap().into(),
-            zk_id: ZkPublicKey::new(BigUint::from(i as u64).into()),
-            created: 0.into(),
-            active: 0.into(),
-            withdrawn: None,
-            nonce: 0,
-        };
-        declarations = declarations.insert(DeclarationId([i as u8; 32]), declaration);
-        locked_notes = locked_notes
-            .lock(
-                &MinStake {
-                    threshold: 1,
-                    timestamp: 0,
-                },
+    let entries: HashMap<DeclarationId, Declaration> = provider_ids
+        .iter()
+        .enumerate()
+        .map(|(i, provider_id)| {
+            let note_id = Fr::from(i as u64).into();
+            let declaration = Declaration {
                 service_type,
-                note,
-                &note_id,
-            )
-            .unwrap();
-    }
+                provider_id: *provider_id,
+                locked_note_id: note_id,
+                locators: "/ip4/1.1.1.1/udp/0".parse::<Locator>().unwrap().into(),
+                zk_id: ZkPublicKey::new(BigUint::from(i as u64).into()),
+                created: 0.into(),
+                active: 2.into(),
+                withdrawn: None,
+                nonce: 0,
+            };
+            (DeclarationId([i as u8; 32]), declaration)
+        })
+        .collect();
 
-    let mut epoch_state = EpochState {
+    let active_declarations: Declarations = HashMap::from([(service_type, entries)]).into();
+
+    EpochState {
         epoch,
         nonce,
         utxos: UtxoTree::default(),
         total_stake: 0,
         lottery_0: Fr::ZERO,
         lottery_1: Fr::ZERO,
-        sdp: SdpLedger::new(epoch),
-    };
-
-    let ledger = SdpLedger {
-        services: HashTrieMapSync::new_sync().insert(
-            ServiceType::BlendNetwork,
-            Service::BlendNetwork(ServiceState {
-                declarations,
-                // TODO: enable after making `rewards` module stable
-                // rewards: blend::Rewards::new(params, &epoch_state),
-                _phantom: PhantomData,
-            }),
-        ),
-        locked_notes,
-        epoch,
-    };
-
-    epoch_state.sdp = ledger;
-    epoch_state
+        active_declarations: Arc::new(active_declarations),
+    }
 }
 
 pub fn create_provider_id(byte: u8) -> ProviderId {

--- a/services/blend/src/membership/service.rs
+++ b/services/blend/src/membership/service.rs
@@ -33,7 +33,7 @@ where
     let mut nodes: Vec<ZkNode<NodeId>> = epoch_state
         .active_declarations
         .for_service(&ServiceType::BlendNetwork)
-        .into_iter()
+        .iter()
         .flat_map(|declarations| declarations.values())
         .filter_map(|declaration| {
             let provider_info = ProviderInfo {

--- a/services/blend/src/membership/service.rs
+++ b/services/blend/src/membership/service.rs
@@ -30,11 +30,11 @@ pub fn membership_info_from_epoch_state<NodeId>(
 where
     NodeId: node_id::TryFrom + Clone + Hash + Eq,
 {
-    let declarations = epoch_state.sdp.declarations();
-    let mut nodes: Vec<ZkNode<NodeId>> = declarations
-        .iter()
-        .filter(|(service_type, _)| matches!(service_type, ServiceType::BlendNetwork))
-        .flat_map(|(_, declarations)| declarations.values())
+    let mut nodes: Vec<ZkNode<NodeId>> = epoch_state
+        .active_declarations
+        .for_service(&ServiceType::BlendNetwork)
+        .into_iter()
+        .flat_map(|declarations| declarations.values())
         .filter_map(|declaration| {
             let provider_info = ProviderInfo {
                 locators: declaration.locators.clone(),

--- a/services/chain/chain-leader/src/leadership.rs
+++ b/services/chain/chain-leader/src/leadership.rs
@@ -422,7 +422,7 @@ mod pol_tests {
             total_stake,
             lottery_0,
             lottery_1,
-            sdp: lb_ledger::mantle::sdp::SdpLedger::new(1.into()),
+            active_declarations: Arc::new(lb_core::sdp::Declarations::default()),
         };
 
         // Create notifier channel (not used in this test)

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -104,7 +104,7 @@ async fn sdp_blend_activity() {
     }
 }
 
-const INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
+const INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(2);
 const RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
 
 fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig {


### PR DESCRIPTION
## 1. What does this PR implement?

When taking a SDP snapshot, we were correctly filtering declarations that are becoming active. But, we were not filtering out declarations that became inactive but not-yet-GC-ed. 

This is a bug that we've had since we moved the snapshot into `EpochState`.

This PR implements the filtering-out logic by changing `EpochState` to hold only the active set instead of the entire `SdpLedger`.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
