### PR TITLE
chore(zone-sdk): add a cmd facade for publish/subscribe commands

### DIFF
--- a/deployment/tui-zone/src/lib.rs
+++ b/deployment/tui-zone/src/lib.rs
@@ -66,10 +66,8 @@ pub async fn run(args: InscribeArgs) {
     loop {
         tokio::select! {
             event = sequencer.next_event() => {
-                if let Some(event) = event {
-                    state.set_channel_view(view_rx.borrow().clone());
-                    handle_event(event, &mut state, &mut sequencer, &mut ready_tx);
-                }
+                state.set_channel_view(view_rx.borrow().clone());
+                handle_event(event, &mut state, &mut sequencer, &mut ready_tx);
             }
 
             input = stdin_rx.recv() => {

--- a/tests/cucumber_tests/features/zone.feature
+++ b/tests/cucumber_tests/features/zone.feature
@@ -109,6 +109,45 @@ Feature: Zone SDK
     And I stop all nodes
 
   @zone_ci
+  Scenario: Publishes issued while the node is down are accepted locally and posted on reconnect
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 3           | 100000       |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet and sequencer resources:
+      | node_name | account_index | wallet_name | connected_to | sequencers |
+      | NODE_1    | 1             | WALLET_1A   |              | SEQ_A      |
+    When node "NODE_1" is at height 1 in 120 seconds
+    And I start zone sequencer "SEQ_A" with indexer
+    # Take the node down: the sequencer enters its reconnect loop, but its
+    # in-process SequencerClient stays alive.
+    When I stop node "NODE_1"
+    # Publishes issued via SequencerClient while the node is down must be
+    # accepted locally and return promptly — the inscription is appended to
+    # state and posted on reconnect, the same as a republish-while-down. With
+    # the pre-fix behavior these client calls would block until connectivity
+    # returned (the request was never drained during reconnect), hanging here.
+    # This step publishes without waiting for inclusion (no node calls), so it
+    # works while the node is down; inclusion/finalization is asserted after
+    # restart below.
+    And sequencer "SEQ_A" submits the following zone messages without waiting for inclusion:
+      | alias | data           |
+      | MSG_1 | While down (1) |
+      | MSG_2 | While down (2) |
+      | MSG_3 | While down (3) |
+    # Bring the node back; the locally-queued inscriptions are posted, mined
+    # and adopted, preserving publish order.
+    When I restart node "NODE_1"
+    Then all zone messages are safe in 120 seconds
+    And all zone messages are finalized in 180 seconds
+    And the zone indexer returns messages in this order:
+      | alias |
+      | MSG_1 |
+      | MSG_2 |
+      | MSG_3 |
+    And I stop all nodes
+
+  @zone_ci
   # [tests/src/tests/zone_sdk/e2e.rs] test_sequential_multi_sequencer
   Scenario: Sequential multi-sequencer publishing keeps channel order
     Given the genesis block has the following wallet resources:

--- a/tests/cucumber_tests/features/zone.feature
+++ b/tests/cucumber_tests/features/zone.feature
@@ -122,14 +122,6 @@ Feature: Zone SDK
     # Take the node down: the sequencer enters its reconnect loop, but its
     # in-process SequencerClient stays alive.
     When I stop node "NODE_1"
-    # Publishes issued via SequencerClient while the node is down must be
-    # accepted locally and return promptly — the inscription is appended to
-    # state and posted on reconnect, the same as a republish-while-down. With
-    # the pre-fix behavior these client calls would block until connectivity
-    # returned (the request was never drained during reconnect), hanging here.
-    # This step publishes without waiting for inclusion (no node calls), so it
-    # works while the node is down; inclusion/finalization is asserted after
-    # restart below.
     And sequencer "SEQ_A" submits the following zone messages without waiting for inclusion:
       | alias | data           |
       | MSG_1 | While down (1) |

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -29,7 +29,7 @@ use crate::{
                     get_cryptarchia_info_all_nodes, nodes_converged,
                     parse_genesis_wallet_tokens_row, parse_url, parse_wallet_resources_table_row,
                     poll_all_nodes_and_update_consensus_cache, restart_node, start_node,
-                    start_nodes_order_respecting_dependencies,
+                    start_nodes_order_respecting_dependencies, stop_node,
                     verify_genesis_wallet_resources_table_indexes,
                     verify_node_wallet_resources_table_indexes,
                     verify_reponsive_and_network_ready_with_timeout, wait_all_nodes_responive,
@@ -347,6 +347,15 @@ async fn step_restart_node(
     node_name: String,
 ) -> StepResult {
     restart_node(world, &step.value, &node_name).await
+}
+
+#[when(expr = "I stop node {string}")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Cucumber step functions require the world as the first `&mut` argument"
+)]
+async fn step_stop_node(world: &mut CucumberWorld, step: &Step, node_name: String) -> StepResult {
+    stop_node(world, &step.value, &node_name).await
 }
 
 #[given(expr = "we use IBD peers")]

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -768,9 +768,8 @@ pub async fn start_node(
 /// Stop a node and leave it down.
 ///
 /// Unlike [`restart_node`], which brings it back up and waits for readiness,
-/// this leaves the node down. Used to exercise reconnect behavior: while the
-/// node is down, an in-process sequencer enters its reconnect loop but its
-/// `SequencerClient` stays alive.
+/// this leaves the node down, useful to exercise reconnect behavior while the
+/// node is down.
 pub async fn stop_node(world: &CucumberWorld, step: &str, node_name: &str) -> StepResult {
     let cluster = world
         .local_cluster

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -765,6 +765,39 @@ pub async fn start_node(
     Ok(())
 }
 
+/// Stop a node and leave it down.
+///
+/// Unlike [`restart_node`], which brings it back up and waits for readiness,
+/// this leaves the node down. Used to exercise reconnect behavior: while the
+/// node is down, an in-process sequencer enters its reconnect loop but its
+/// `SequencerClient` stays alive.
+pub async fn stop_node(world: &CucumberWorld, step: &str, node_name: &str) -> StepResult {
+    let cluster = world
+        .local_cluster
+        .as_ref()
+        .ok_or(StepError::LogicalError {
+            message: "No local cluster available".into(),
+        })?;
+    let started_node_name = world
+        .resolve_node_runtime_name(node_name)
+        .inspect_err(|e| {
+            warn!(target: TARGET, "Step `{step}` error: {e}");
+        })?;
+
+    cluster
+        .stop_node(&started_node_name)
+        .await
+        .inspect_err(|e| {
+            warn!(target: TARGET, "Step `{step}` error: {e}");
+        })?;
+
+    info!(
+        target: TARGET,
+        "Stopped node `{node_name}` (runtime name `{started_node_name}`)"
+    );
+    Ok(())
+}
+
 pub async fn restart_node(world: &CucumberWorld, step: &str, node_name: &str) -> StepResult {
     let cluster = world
         .local_cluster

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -97,7 +97,7 @@ struct PublishedZoneMessage {
 
 struct StartedSequencerRuntime {
     task: JoinHandle<()>,
-    client: SequencerClient<ZoneNodeHttpClient>,
+    client: SequencerClient,
     events: broadcast::Receiver<Event>,
     checkpoint_rx: tokio::sync::watch::Receiver<Option<SequencerCheckpoint>>,
     ready_rx: tokio::sync::watch::Receiver<bool>,

--- a/tests/src/cucumber/steps/manual_zone/runner.rs
+++ b/tests/src/cucumber/steps/manual_zone/runner.rs
@@ -1,36 +1,27 @@
 //! Single per-scenario drive loop for a
-//! [`lb_zone_sdk::sequencer::ZoneSequencer`] plus a cloneable cross-task
-//! command surface for cucumber step functions.
+//! [`lb_zone_sdk::sequencer::ZoneSequencer`].
 //!
-//! The drive task owns the sequencer and `tokio::select!`s between:
-//!
-//! - block stream events (passed to a [`Policy`] inline, then forwarded to a
-//!   fan-out mpsc that tests observe)
-//! - step-issued commands from [`SequencerClient`] (processed against the same
-//!   `&mut sequencer`)
+//! The drive task owns the sequencer and polls
+//! [`ZoneSequencer::next_event`] in a loop, invoking a [`Policy`] inline for
+//! each event. Step bodies issue commands via the SDK's
+//! [`SequencerClient`] (handed out from [`Runtime::client`]) — those route
+//! through the SDK's internal request channel and get processed by the same
+//! drive loop, so reactions land before the next event is observed.
 //!
 //! Because the policy runs on the same task as event handling, reactions
 //! (e.g. orphan republish) happen before the event is forwarded to tests —
 //! there is no window where an event was observed but the policy's reaction
 //! hasn't been applied to the SDK's state.
 
-use std::marker::PhantomData;
-
-use lb_core::mantle::{
-    MantleTx, SignedMantleTx,
-    channel::{SlotTimeframe, SlotTimeout},
-    encoding::Ops,
-    ops::channel::{MsgId, config::Keys, inscribe::Inscription},
-};
-use lb_key_management_system_service::keys::Ed25519Signature;
 pub use lb_zone_sdk::sequencer::{
     AtomicWithdrawInfo, ChannelUpdate, DepositInfo, Error, Event, FinalizedOp, FinalizedTx,
     InscriptionId, InscriptionInfo, OrphanedTx, PendingTx, PublishResult, SequencerChannelView,
-    SequencerCheckpoint, SequencerConfig, TurnNotification, WithdrawArg, WithdrawInfo,
+    SequencerCheckpoint, SequencerClient, SequencerConfig, TurnNotification, WithdrawArg,
+    WithdrawInfo,
 };
 use lb_zone_sdk::{adapter, sequencer::ZoneSequencer};
 use tokio::{
-    sync::{broadcast, mpsc, oneshot, watch},
+    sync::{broadcast, watch},
     task::JoinHandle,
 };
 
@@ -62,171 +53,15 @@ where
     async fn on_event(&mut self, _sequencer: &mut ZoneSequencer<Node>, _event: &Event) {}
 }
 
-/// Step-issued command dispatched against the sequencer by the drive task.
-pub(super) enum Cmd {
-    Publish {
-        data: Inscription,
-        reply: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint), Error>>,
-    },
-    PublishAtomicWithdraw {
-        inscribe: Inscription,
-        withdraws: Vec<WithdrawArg>,
-        reply: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint), Error>>,
-    },
-    ChannelConfig {
-        keys: Keys,
-        posting_timeframe: SlotTimeframe,
-        posting_timeout: SlotTimeout,
-        configuration_threshold: u16,
-        withdraw_threshold: u16,
-        reply: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint, SignedMantleTx), Error>>,
-    },
-    PrepareTx {
-        ops: Ops,
-        msg: Inscription,
-        reply: oneshot::Sender<Result<(MantleTx, MsgId, Ed25519Signature), Error>>,
-    },
-    SignTx {
-        tx: MantleTx,
-        reply: oneshot::Sender<Result<Ed25519Signature, Error>>,
-    },
-    SubmitSignedTx {
-        tx: SignedMantleTx,
-        msg_id: MsgId,
-        reply: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint), Error>>,
-    },
-}
-
-/// Cloneable cross-task client for issuing commands to the drive task.
-///
-/// Mirrors the SDK's drive-loop [`lb_zone_sdk::sequencer::SequencerHandle`]
-/// at the type level; each method dispatches a [`Cmd`] over an mpsc and
-/// awaits the reply. State-mutating methods return the SDK's
-/// [`PublishResult`] paired with the resulting [`SequencerCheckpoint`] so
-/// step bodies can persist outbox + checkpoint atomically just like a
-/// real SDK consumer would.
-pub struct SequencerClient<Node> {
-    cmd_tx: mpsc::Sender<Cmd>,
-    _marker: PhantomData<fn() -> Node>,
-}
-
-impl<Node> Clone for SequencerClient<Node> {
-    fn clone(&self) -> Self {
-        Self {
-            cmd_tx: self.cmd_tx.clone(),
-            _marker: PhantomData,
-        }
-    }
-}
-
-const CLOSED: Error = Error::Unavailable {
-    reason: "runner: drive task closed",
-};
-const DROPPED: Error = Error::Unavailable {
-    reason: "runner: drive task dropped reply",
-};
-
-impl<Node> SequencerClient<Node> {
-    pub async fn publish(
-        &self,
-        data: Inscription,
-    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        let (reply, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(Cmd::Publish { data, reply })
-            .await
-            .map_err(|_| CLOSED)?;
-        rx.await.map_err(|_| DROPPED)?
-    }
-
-    pub async fn publish_atomic_withdraw(
-        &self,
-        inscribe: Inscription,
-        withdraws: Vec<WithdrawArg>,
-    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        let (reply, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(Cmd::PublishAtomicWithdraw {
-                inscribe,
-                withdraws,
-                reply,
-            })
-            .await
-            .map_err(|_| CLOSED)?;
-        rx.await.map_err(|_| DROPPED)?
-    }
-
-    pub async fn prepare_tx(
-        &self,
-        ops: Ops,
-        msg: Inscription,
-    ) -> Result<(MantleTx, MsgId, Ed25519Signature), Error> {
-        let (reply, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(Cmd::PrepareTx { ops, msg, reply })
-            .await
-            .map_err(|_| CLOSED)?;
-        rx.await.map_err(|_| DROPPED)?
-    }
-
-    pub async fn sign_tx(&self, tx: &MantleTx) -> Result<Ed25519Signature, Error> {
-        let (reply, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(Cmd::SignTx {
-                tx: tx.clone(),
-                reply,
-            })
-            .await
-            .map_err(|_| CLOSED)?;
-        rx.await.map_err(|_| DROPPED)?
-    }
-
-    pub async fn submit_signed_tx(
-        &self,
-        tx: SignedMantleTx,
-        msg_id: MsgId,
-    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        let (reply, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(Cmd::SubmitSignedTx { tx, msg_id, reply })
-            .await
-            .map_err(|_| CLOSED)?;
-        rx.await.map_err(|_| DROPPED)?
-    }
-
-    pub async fn channel_config(
-        &self,
-        keys: Keys,
-        posting_timeframe: SlotTimeframe,
-        posting_timeout: SlotTimeout,
-        configuration_threshold: u16,
-        withdraw_threshold: u16,
-    ) -> Result<(PublishResult, SequencerCheckpoint, SignedMantleTx), Error> {
-        let (reply, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(Cmd::ChannelConfig {
-                keys,
-                posting_timeframe,
-                posting_timeout,
-                configuration_threshold,
-                withdraw_threshold,
-                reply,
-            })
-            .await
-            .map_err(|_| CLOSED)?;
-        rx.await.map_err(|_| DROPPED)?
-    }
-}
-
 /// Bundle returned from [`spawn`].
 ///
-/// Drive task handle + cloneable client + receivers for events and the
-/// SDK's watch channels. `event_rx` is the SDK's broadcast subscriber —
-/// fire-and-forget; consumers who fall behind get a `RecvError::Lagged`
-/// they can recover from.
-pub struct Runtime<Node> {
+/// Drive task handle + the SDK's cloneable [`SequencerClient`] + receivers
+/// for events and the SDK's watch channels. `event_rx` is the SDK's broadcast
+/// subscriber — fire-and-forget; consumers who fall behind get a
+/// `RecvError::Lagged` they can recover from.
+pub struct Runtime {
     pub task: JoinHandle<()>,
-    pub client: SequencerClient<Node>,
+    pub client: SequencerClient,
     pub event_rx: broadcast::Receiver<Event>,
     pub checkpoint_rx: watch::Receiver<Option<SequencerCheckpoint>>,
     pub ready_rx: watch::Receiver<bool>,
@@ -234,119 +69,54 @@ pub struct Runtime<Node> {
     pub turn_to_write_rx: watch::Receiver<TurnNotification>,
 }
 
-/// Drive loop body. Owns the sequencer until both the block stream
-/// disconnects and the command channel closes; for each event invokes
-/// the policy inline. Events reach observers via the SDK's own
-/// broadcast channel (subscribed in [`spawn`]) — the drive loop does
-/// not forward them, so there's no backpressure on the runner from
-/// idle subscribers.
+/// Drive loop body. Owns the sequencer and pumps
+/// [`ZoneSequencer::next_event`] until aborted. For each event invokes the
+/// policy inline. Events reach observers via the SDK's own broadcast channel
+/// (subscribed in [`spawn`]) — the drive loop does not forward them.
 ///
-/// Pulled out as a free async function so callers can spawn it
-/// themselves (e.g. onto a custom runtime, a `LocalSet`, or interleaved
-/// with other state in the same task). [`spawn`] is the convenience
-/// wrapper that creates channels + a tokio task.
-pub(super) async fn run<Node, P>(
-    mut sequencer: ZoneSequencer<Node>,
-    mut policy: P,
-    mut cmd_rx: mpsc::Receiver<Cmd>,
-) where
+/// Step-issued commands ride through the SDK's internal request channel and
+/// are processed inside `next_event`; no separate command path is needed.
+///
+/// Pulled out as a free async function so callers can spawn it themselves.
+pub(super) async fn run<Node, P>(mut sequencer: ZoneSequencer<Node>, mut policy: P)
+where
     Node: adapter::Node + Clone + Send + Sync + 'static,
     P: Policy<Node>,
 {
     loop {
-        tokio::select! {
-            ev = sequencer.next_event() => {
-                let Some(ev) = ev else { continue; };
-                policy.on_event(&mut sequencer, &ev).await;
-                // Event already broadcast via the SDK's `emit_now`; nothing
-                // for the runner to forward.
-            }
-            cmd = cmd_rx.recv() => {
-                let Some(cmd) = cmd else { break; };
-                process_cmd(cmd, &mut sequencer);
-            }
-        }
+        let ev = sequencer.next_event().await;
+        policy.on_event(&mut sequencer, &ev).await;
+        // Event already broadcast via the SDK's `emit_now`; nothing for the
+        // runner to forward.
     }
 }
 
 /// Spawn the drive loop on the current tokio runtime.
 ///
-/// Wires the cmd channel and grabs SDK watch subscriptions before moving
-/// the sequencer into the task. Events flow via the SDK's broadcast
-/// channel — `event_rx` is a fresh subscriber.
-pub fn spawn<Node, P>(sequencer: ZoneSequencer<Node>, policy: P) -> Runtime<Node>
+/// Grabs SDK watch subscriptions and the SDK client before moving the
+/// sequencer into the task. Events flow via the SDK's broadcast channel —
+/// `event_rx` is a fresh subscriber.
+pub fn spawn<Node, P>(sequencer: ZoneSequencer<Node>, policy: P) -> Runtime
 where
     Node: adapter::Node + Clone + Send + Sync + 'static,
     P: Policy<Node>,
 {
-    let (cmd_tx, cmd_rx) = mpsc::channel(64);
     let checkpoint_rx = sequencer.subscribe_checkpoint();
     let ready_rx = sequencer.subscribe_ready();
     let channel_view_rx = sequencer.subscribe_channel_view();
     let turn_to_write_rx = sequencer.subscribe_turn_to_write();
     let event_rx = sequencer.subscribe_events();
+    let client = sequencer.client();
 
-    let task = tokio::spawn(run(sequencer, policy, cmd_rx));
+    let task = tokio::spawn(run(sequencer, policy));
 
     Runtime {
         task,
-        client: SequencerClient {
-            cmd_tx,
-            _marker: PhantomData,
-        },
+        client,
         event_rx,
         checkpoint_rx,
         ready_rx,
         channel_view_rx,
         turn_to_write_rx,
-    }
-}
-
-fn process_cmd<Node>(cmd: Cmd, sequencer: &mut ZoneSequencer<Node>)
-where
-    Node: adapter::Node + Clone + Send + Sync + 'static,
-{
-    match cmd {
-        Cmd::Publish { data, reply } => {
-            drop(reply.send(sequencer.handle().publish(data)));
-        }
-        Cmd::PublishAtomicWithdraw {
-            inscribe,
-            withdraws,
-            reply,
-        } => {
-            drop(
-                reply.send(
-                    sequencer
-                        .handle()
-                        .publish_atomic_withdraw(inscribe, withdraws),
-                ),
-            );
-        }
-        Cmd::ChannelConfig {
-            keys,
-            posting_timeframe,
-            posting_timeout,
-            configuration_threshold,
-            withdraw_threshold,
-            reply,
-        } => {
-            drop(reply.send(sequencer.handle().channel_config(
-                keys,
-                posting_timeframe,
-                posting_timeout,
-                configuration_threshold,
-                withdraw_threshold,
-            )));
-        }
-        Cmd::PrepareTx { ops, msg, reply } => {
-            drop(reply.send(sequencer.handle().prepare_tx(ops, msg)));
-        }
-        Cmd::SignTx { tx, reply } => {
-            drop(reply.send(sequencer.handle().sign_tx(&tx)));
-        }
-        Cmd::SubmitSignedTx { tx, msg_id, reply } => {
-            drop(reply.send(sequencer.handle().submit_signed_tx(tx, msg_id)));
-        }
     }
 }

--- a/tests/src/cucumber/steps/manual_zone/steps.rs
+++ b/tests/src/cucumber/steps/manual_zone/steps.rs
@@ -372,6 +372,47 @@ async fn step_publish_zone_messages_to_queue_for_sequencer(
     Ok(())
 }
 
+/// Publish via [`SequencerClient`] and record each inscription id, without
+/// waiting for on-chain inclusion.
+///
+/// Unlike `publishes the following zone messages` (which polls the node to
+/// confirm inclusion), this performs no node HTTP calls, so it can be issued
+/// while the node is down: each publish is accepted locally and posted on
+/// reconnect. Recording the ids (the publish returns them locally) lets later
+/// `... are finalized` / indexer assertions track the messages once the node is
+/// back.
+#[when(
+    expr = "sequencer {string} submits the following zone messages without waiting for inclusion:"
+)]
+async fn step_publish_zone_messages_without_inclusion_for_sequencer(
+    world: &mut CucumberWorld,
+    step: &Step,
+    sequencer_alias: String,
+) -> StepResult {
+    let rows = zone_message_rows(step)?;
+    let handle = world.zone.sequencer_client(&sequencer_alias)?.clone();
+
+    for (message_alias, payload) in rows {
+        let (published, _checkpoint) = handle
+            .publish(payload.clone())
+            .await
+            .map_err(|error| StepError::LogicalError {
+                message: format!(
+                    "Zone publish failed for sequencer '{sequencer_alias}' and message '{message_alias}': {error}"
+                ),
+            })?;
+        remember_published_zone_message(
+            world,
+            &sequencer_alias,
+            message_alias,
+            payload,
+            &published,
+        );
+    }
+
+    Ok(())
+}
+
 #[when(expr = "I save current checkpoint of sequencer {string} as {string}")]
 fn step_save_zone_checkpoint(
     world: &mut CucumberWorld,

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -166,7 +166,7 @@ impl PublishDeadline {
 /// drive task; the event mpsc is purely for test observation.
 pub struct PolicyRuntime {
     pub task: JoinHandle<()>,
-    pub client: SequencerClient<ZoneNodeHttpClient>,
+    pub client: SequencerClient,
     pub events: tokio::sync::broadcast::Receiver<Event>,
     pub checkpoint_rx: tokio::sync::watch::Receiver<Option<SequencerCheckpoint>>,
     pub ready_rx: tokio::sync::watch::Receiver<bool>,
@@ -174,7 +174,7 @@ pub struct PolicyRuntime {
     pub turn_to_write_rx: tokio::sync::watch::Receiver<TurnNotification>,
 }
 
-fn to_policy_runtime(rt: runner::Runtime<ZoneNodeHttpClient>) -> PolicyRuntime {
+fn to_policy_runtime(rt: runner::Runtime) -> PolicyRuntime {
     PolicyRuntime {
         task: rt.task,
         client: rt.client,
@@ -527,7 +527,7 @@ pub fn sequencer_config_with_pending_submit_depth(
 /// the deadline elapses. No "wait for event" — the new SDK publishes
 /// synchronously and the runner forwards the call through the drive task.
 pub async fn publish_message_with_retry(
-    client: &SequencerClient<ZoneNodeHttpClient>,
+    client: &SequencerClient,
     data: &Inscription,
     deadline: PublishDeadline,
 ) -> Result<PublishResult, ZoneTestError> {
@@ -1143,7 +1143,7 @@ pub async fn submit_zone_deposit(
 /// and publishes the zone inscription that consumes it.
 pub async fn submit_atomic_zone_deposit(
     node_url: &Url,
-    client: &SequencerClient<ZoneNodeHttpClient>,
+    client: &SequencerClient,
     request: AtomicZoneDepositRequest,
 ) -> Result<AtomicZoneDepositSubmission, ZoneTestError> {
     let AtomicZoneDepositRequest {
@@ -1237,7 +1237,7 @@ fn build_atomic_deposit_op(
 /// Submits a channel withdraw signed by the active zone sequencer and publishes
 /// the withdraw inscription as part of the same SDK flow.
 pub async fn submit_zone_withdraw(
-    client: &SequencerClient<ZoneNodeHttpClient>,
+    client: &SequencerClient,
     channel_id: ChannelId,
     funding_public_key: ZkPublicKey,
     amount: Value,
@@ -1319,7 +1319,7 @@ pub struct ZoneAtomicWithdrawSubmission {
 /// listed amount). Exercises the SDK API at full width: multiple args, with
 /// any arg able to carry multiple output notes.
 pub async fn publish_atomic_zone_withdraw(
-    client: &SequencerClient<ZoneNodeHttpClient>,
+    client: &SequencerClient,
     funding_public_key: ZkPublicKey,
     outputs_per_arg: Vec<Vec<Value>>,
     inscription_data: Inscription,

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -150,7 +150,7 @@ pub struct ZoneSequencerIdentity {
 }
 
 pub struct ZoneSequencerRuntime {
-    client: SequencerClient<ZoneNodeHttpClient>,
+    client: SequencerClient,
     task: JoinHandle<()>,
     events: tokio::sync::broadcast::Receiver<Event>,
     checkpoint_rx: tokio::sync::watch::Receiver<Option<SequencerCheckpoint>>,
@@ -529,7 +529,7 @@ impl ZoneState {
     pub fn set_sequencer_runtime(
         &mut self,
         alias: String,
-        sequencer_client: SequencerClient<ZoneNodeHttpClient>,
+        sequencer_client: SequencerClient,
         sequencer_task: JoinHandle<()>,
         sequencer_events: tokio::sync::broadcast::Receiver<Event>,
         checkpoint_rx: tokio::sync::watch::Receiver<Option<SequencerCheckpoint>>,
@@ -605,10 +605,7 @@ impl ZoneState {
         Ok(())
     }
 
-    pub fn sequencer_client(
-        &self,
-        alias: &str,
-    ) -> Result<&SequencerClient<ZoneNodeHttpClient>, StepError> {
+    pub fn sequencer_client(&self, alias: &str) -> Result<&SequencerClient, StepError> {
         self.runtimes
             .get(alias)
             .map(|runtime| &runtime.client)

--- a/zone-sdk/src/lib.rs
+++ b/zone-sdk/src/lib.rs
@@ -13,12 +13,19 @@
 //!
 //! # Quick start (sequencer)
 //!
-//! The sequencer is owned by a single drive task. State-mutating commands go
-//! through a borrowing handle obtained via
-//! [`sequencer::ZoneSequencer::handle`]; every publish returns the resulting
-//! [`sequencer::SequencerCheckpoint`] inline so the caller can persist outbox +
-//! checkpoint atomically. Read-only observers (other tasks) get cloneable watch
-//! receivers from the subscribe methods.
+//! The sequencer is owned by a single drive task. Two command surfaces:
+//!
+//! - [`sequencer::SequencerHandle`] (sync, drive-loop only) — obtained via
+//!   [`sequencer::ZoneSequencer::handle`]. Borrows the sequencer mutably so it
+//!   can only be used from the drive task. Every state-mutating method returns
+//!   the resulting [`sequencer::SequencerCheckpoint`] inline so the caller can
+//!   persist outbox + checkpoint atomically.
+//! - [`sequencer::SequencerClient`] (async, cross-task) — obtained via
+//!   [`sequencer::ZoneSequencer::client`]. Cheap-to-clone; routes publish/admin
+//!   commands through the actor's request channel and vends subscription
+//!   receivers off cloned senders. Useful for service-style integrations where
+//!   publish calls originate from tasks other than the drive loop. The drive
+//!   loop must still be polled for client publish awaits to resolve.
 //!
 //! ```ignore
 //! use lb_zone_sdk::{
@@ -32,20 +39,19 @@
 //! let node = NodeHttpClient::new(CommonHttpClient::new(None), "http://localhost:8080".parse().unwrap());
 //! let mut sequencer = ZoneSequencer::init(channel_id, signing_key, node, None);
 //!
-//! // Other tasks observe via cloneable watch receivers (subscribe before
-//! // moving the sequencer into its drive task).
-//! let _ready_rx      = sequencer.subscribe_ready();
-//! let _checkpoint_rx = sequencer.subscribe_checkpoint();
+//! // Cross-task surface: clone and move into any task. Carries both
+//! // publish/admin methods and subscription receivers.
+//! let client = sequencer.client();
+//! let _ready_rx      = client.subscribe_ready();
+//! let _checkpoint_rx = client.subscribe_checkpoint();
 //!
 //! loop {
-//!     tokio::select! {
-//!         Some(ev) = sequencer.next_event() => match ev {
-//!             Event::BlocksProcessed { checkpoint, channel_update, finalized } => {
-//!                 let _ = (checkpoint, channel_update, finalized);
-//!             }
-//!             Event::Ready                             => {}
-//!             Event::TurnNotification { notification } => { let _ = notification; }
-//!         },
+//!     match sequencer.next_event().await {
+//!         Event::BlocksProcessed { checkpoint, channel_update, finalized } => {
+//!             let _ = (checkpoint, channel_update, finalized);
+//!         }
+//!         Event::Ready                             => {}
+//!         Event::TurnNotification { notification } => { let _ = notification; }
 //!     }
 //! }
 //! # }

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -602,7 +602,7 @@ mod tests {
 
         // Drive sequencer until ready
         loop {
-            if matches!(sequencer.next_event().await, Some(Event::Ready)) {
+            if matches!(sequencer.next_event().await, Event::Ready) {
                 break;
             }
         }
@@ -1111,11 +1111,11 @@ mod tests {
         let mut finalized_items: Vec<FinalizedTx> = Vec::new();
         loop {
             match sequencer.next_event().await {
-                Some(Event::Ready) => break,
-                Some(Event::BlocksProcessed { finalized, .. }) => {
+                Event::Ready => break,
+                Event::BlocksProcessed { finalized, .. } => {
                     finalized_items.extend(finalized);
                 }
-                Some(_) | None => {}
+                Event::TurnNotification { .. } => {}
             }
         }
 

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -592,10 +592,13 @@ mod tests {
     use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature, ZkKey};
     use num_bigint::BigUint;
     use rand::{RngCore as _, thread_rng};
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, watch};
 
     use super::{
-        super::{types::FinalizedOp, zone_sequencer::restore_pending_tx},
+        super::{
+            types::{FinalizedOp, SequencerConfig},
+            zone_sequencer::restore_pending_tx,
+        },
         *,
     };
     use crate::{ZoneMessage, adapter::BoxStream};
@@ -725,6 +728,211 @@ mod tests {
                 rx,
             )
         }
+    }
+
+    /// Like [`MockNode`], but with a controllable connectivity flag.
+    ///
+    /// Used to exercise reconnect behavior. While "down" (`up` set to `false`),
+    /// `block_stream` errors and any previously-returned live stream ends, so
+    /// the sequencer notices the disconnect and re-enters `ensure_connected`.
+    #[derive(Clone)]
+    struct ReconnectMockNode {
+        inner: MockNode,
+        up_rx: watch::Receiver<bool>,
+    }
+
+    impl ReconnectMockNode {
+        fn new() -> (Self, mpsc::Receiver<SignedMantleTx>, watch::Sender<bool>) {
+            let (inner, posted_rx) = MockNode::new();
+            let (up_tx, up_rx) = watch::channel(true);
+            (Self { inner, up_rx }, posted_rx, up_tx)
+        }
+    }
+
+    #[async_trait]
+    impl adapter::Node for ReconnectMockNode {
+        async fn consensus_info(&self) -> Result<ChainServiceInfo, lb_common_http_client::Error> {
+            self.inner.consensus_info().await
+        }
+
+        async fn time_info(&self) -> Result<TimeInfo, lb_common_http_client::Error> {
+            self.inner.time_info().await
+        }
+
+        async fn channel_state(
+            &self,
+            channel_id: ChannelId,
+        ) -> Result<Option<ChannelState>, lb_common_http_client::Error> {
+            self.inner.channel_state(channel_id).await
+        }
+
+        async fn block_stream(
+            &self,
+        ) -> Result<BoxStream<ProcessedBlockEvent>, lb_common_http_client::Error> {
+            if !*self.up_rx.borrow() {
+                return Err(lb_common_http_client::Error::Client("node down".to_owned()));
+            }
+            let initial = futures::stream::once(async {
+                ProcessedBlockEvent {
+                    block: ApiBlock {
+                        header: ApiHeader {
+                            id: HeaderId::from([1; 32]),
+                            parent_block: HeaderId::from([0; 32]),
+                            slot: 1.into(),
+                            block_root: ContentId::from([0; 32]),
+                            proof_of_leadership: Groth16LeaderProof::genesis(),
+                        },
+                        transactions: Vec::new(),
+                    },
+                    tip: HeaderId::from([1; 32]),
+                    tip_slot: 1.into(),
+                    lib: HeaderId::from([0; 32]),
+                    lib_slot: Slot::genesis(),
+                }
+            });
+            // Stay open until the node goes down, then end so the sequencer
+            // re-enters `ensure_connected` (where `block_stream` errors).
+            let up_rx = self.up_rx.clone();
+            let until_down = futures::stream::once(async move {
+                let mut up_rx = up_rx;
+                while *up_rx.borrow_and_update() {
+                    if up_rx.changed().await.is_err() {
+                        break;
+                    }
+                }
+            })
+            .filter_map(async |()| None::<ProcessedBlockEvent>);
+            Ok(Box::pin(initial.chain(until_down)))
+        }
+
+        async fn blocks_range_stream(
+            &self,
+            params: BlocksStreamQuery,
+        ) -> Result<BoxStream<ProcessedBlockEvent>, lb_common_http_client::Error> {
+            self.inner.blocks_range_stream(params).await
+        }
+
+        async fn lib_stream(&self) -> Result<BoxStream<BlockInfo>, lb_common_http_client::Error> {
+            self.inner.lib_stream().await
+        }
+
+        async fn block(
+            &self,
+            id: HeaderId,
+        ) -> Result<Option<ApiBlock>, lb_common_http_client::Error> {
+            self.inner.block(id).await
+        }
+
+        async fn block_events(
+            &self,
+            id: HeaderId,
+        ) -> Result<Option<lb_common_http_client::Events>, lb_common_http_client::Error> {
+            self.inner.block_events(id).await
+        }
+
+        async fn immutable_blocks(
+            &self,
+            slot_from: Slot,
+            slot_to: Slot,
+        ) -> Result<Vec<ApiBlock>, lb_common_http_client::Error> {
+            self.inner.immutable_blocks(slot_from, slot_to).await
+        }
+
+        async fn zone_messages_in_block(
+            &self,
+            id: HeaderId,
+            channel_id: ChannelId,
+        ) -> Result<BoxStream<ZoneMessage>, lb_common_http_client::Error> {
+            self.inner.zone_messages_in_block(id, channel_id).await
+        }
+
+        async fn zone_messages_in_blocks(
+            &self,
+            slot_from: Slot,
+            slot_to: Slot,
+            channel_id: ChannelId,
+        ) -> Result<BoxStream<(ZoneMessage, Slot)>, lb_common_http_client::Error> {
+            self.inner
+                .zone_messages_in_blocks(slot_from, slot_to, channel_id)
+                .await
+        }
+
+        async fn post_transaction(
+            &self,
+            tx: SignedMantleTx,
+        ) -> Result<(), lb_common_http_client::Error> {
+            self.inner.post_transaction(tx).await
+        }
+    }
+
+    /// Comment #1 regression guard for client publishes during reconnect.
+    ///
+    /// A `SequencerClient::publish` issued while the node is down (reconnect in
+    /// progress) must be accepted locally and resolve promptly — matching
+    /// `SequencerHandle::publish` — instead of blocking until connectivity is
+    /// restored. It must also be posted once the node comes back.
+    #[tokio::test]
+    async fn client_publish_accepted_locally_during_reconnect() {
+        let channel_id = ChannelId::from([0; 32]);
+        let sequencer_key = Ed25519Key::from_bytes(&[0; 32]);
+        let (node, mut posted_txs, up_tx) = ReconnectMockNode::new();
+        let config = SequencerConfig {
+            reconnect_delay: std::time::Duration::from_millis(20),
+            resubmit_interval: std::time::Duration::from_millis(20),
+            ..SequencerConfig::default()
+        };
+        let mut sequencer =
+            ZoneSequencer::init_with_config(channel_id, sequencer_key, node, config, None);
+        let client = sequencer.client();
+
+        // Drive until the sequencer has emitted `Ready`.
+        loop {
+            if matches!(sequencer.next_event().await, Event::Ready) {
+                break;
+            }
+        }
+
+        // Take the node down: the live stream ends and the sequencer enters
+        // reconnect (subsequent `block_stream` calls error).
+        up_tx.send(false).unwrap();
+
+        // A client publish while the node is down must resolve promptly. We
+        // drive `next_event` concurrently; the publish is serviced from inside
+        // `wait_reconnect_delay` while the node is still down. With the old
+        // behavior the request would never be drained during reconnect and this
+        // would hang (caught by the timeout).
+        let publish = client.publish(b"during-reconnect".into());
+        let (_result, _checkpoint) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                tokio::select! {
+                    result = publish => result,
+                    () = async { loop { drop(sequencer.next_event().await); } } => unreachable!(),
+                }
+            })
+            .await
+            .expect("client publish must resolve during reconnect, not block on connectivity")
+            .expect("publish should be accepted locally after Ready");
+
+        // Bring the node back up; the locally-queued inscription must be posted.
+        up_tx.send(true).unwrap();
+        let posted = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            tokio::select! {
+                tx = posted_txs.recv() => tx,
+                () = async { loop { drop(sequencer.next_event().await); } } => unreachable!(),
+            }
+        })
+        .await
+        .expect("inscription should be posted after reconnect")
+        .expect("posted_txs channel should be open");
+
+        assert!(
+            posted
+                .mantle_tx
+                .ops()
+                .iter()
+                .any(|op| matches!(op, Op::ChannelInscribe(_))),
+            "posted tx should carry the inscription published during reconnect"
+        );
     }
 
     #[test]

--- a/zone-sdk/src/sequencer/backfill.rs
+++ b/zone-sdk/src/sequencer/backfill.rs
@@ -62,7 +62,7 @@ where
                     to = batch_end,
                     "Backfill batch failed; will retry same range after delay: {e}"
                 );
-                tokio::time::sleep(self.config.reconnect_delay).await;
+                self.wait_reconnect_delay().await;
                 // Leave `backfill_from` untouched so the next tick retries
                 // the same range. Active but no event this turn.
                 return Some(None);
@@ -165,7 +165,7 @@ where
             Ok(info) => info,
             Err(err) => {
                 warn!(target: TARGET, "Failed to fetch time info: {err}");
-                tokio::time::sleep(self.config.reconnect_delay).await;
+                self.wait_reconnect_delay().await;
                 return false;
             }
         };
@@ -179,7 +179,7 @@ where
                 );
                 if let Err(err) = self.refresh_channel_state().await {
                     warn!(target: TARGET, "Failed to fetch initial channel state: {err}");
-                    tokio::time::sleep(self.config.reconnect_delay).await;
+                    self.wait_reconnect_delay().await;
                     return false;
                 }
                 if self.state.is_none() {
@@ -190,7 +190,7 @@ where
                         Ok(clock) => clock,
                         Err(err) => {
                             warn!(target: TARGET, "Invalid time info from node: {err}");
-                            tokio::time::sleep(self.config.reconnect_delay).await;
+                            self.wait_reconnect_delay().await;
                             return false;
                         }
                     };
@@ -200,7 +200,7 @@ where
             }
             Err(e) => {
                 warn!(target: TARGET, "Failed to fetch consensus info: {e}");
-                tokio::time::sleep(self.config.reconnect_delay).await;
+                self.wait_reconnect_delay().await;
                 false
             }
         }
@@ -246,7 +246,7 @@ where
             }
             Err(e) => {
                 warn!(target: TARGET, "Failed to connect to blocks stream: {e}");
-                tokio::time::sleep(self.config.reconnect_delay).await;
+                self.wait_reconnect_delay().await;
                 false
             }
         }

--- a/zone-sdk/src/sequencer/client.rs
+++ b/zone-sdk/src/sequencer/client.rs
@@ -1,0 +1,216 @@
+use lb_core::mantle::{
+    MantleTx, SignedMantleTx,
+    channel::{SlotTimeframe, SlotTimeout},
+    encoding::Ops,
+    ops::channel::{MsgId, config::Keys, inscribe::Inscription},
+};
+use lb_key_management_system_service::keys::Ed25519Signature;
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
+
+use super::{
+    types::{
+        Error, Event, PublishResult, SequencerChannelView, SequencerCheckpoint, TurnNotification,
+        WithdrawArg,
+    },
+    zone_sequencer::ActorRequest,
+};
+
+/// Cheap-to-clone client for driving the sequencer from any task.
+///
+/// Obtained via [`super::ZoneSequencer::client`]. Mirrors the full surface a
+/// consumer needs from outside the drive loop:
+///
+/// - Publish/admin methods route commands through an internal channel to the
+///   actor, which processes them inside [`super::ZoneSequencer::next_event`].
+///   The drive loop must therefore be polled for these calls to make progress;
+///   an unpolled sequencer leaves client `.await`s pending forever.
+/// - Subscription methods vend receivers from senders the client owns — they
+///   work regardless of whether the drive loop is being polled.
+///
+/// Cloning is cheap (channel-sender clones). Each clone can be moved into a
+/// separate task.
+#[derive(Clone)]
+pub struct SequencerClient {
+    request_tx: mpsc::UnboundedSender<ActorRequest>,
+    event_tx: broadcast::Sender<Event>,
+    ready_tx: watch::Sender<bool>,
+    channel_view_tx: watch::Sender<SequencerChannelView>,
+    turn_to_write_tx: watch::Sender<TurnNotification>,
+    checkpoint_tx: watch::Sender<Option<SequencerCheckpoint>>,
+}
+
+impl SequencerClient {
+    pub(super) const fn new(
+        request_tx: mpsc::UnboundedSender<ActorRequest>,
+        event_tx: broadcast::Sender<Event>,
+        ready_tx: watch::Sender<bool>,
+        channel_view_tx: watch::Sender<SequencerChannelView>,
+        turn_to_write_tx: watch::Sender<TurnNotification>,
+        checkpoint_tx: watch::Sender<Option<SequencerCheckpoint>>,
+    ) -> Self {
+        Self {
+            request_tx,
+            event_tx,
+            ready_tx,
+            channel_view_tx,
+            turn_to_write_tx,
+            checkpoint_tx,
+        }
+    }
+
+    /// Enqueue an inscription onto the zone's channel.
+    ///
+    /// Async counterpart of [`super::SequencerHandle::publish`].
+    pub async fn publish(
+        &self,
+        data: Inscription,
+    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(ActorRequest::Publish { data, response_tx })?;
+        Self::recv(response_rx).await?
+    }
+
+    /// Publish an atomic inscription+withdraw bundle.
+    ///
+    /// Async counterpart of
+    /// [`super::SequencerHandle::publish_atomic_withdraw`].
+    pub async fn publish_atomic_withdraw(
+        &self,
+        inscribe: Inscription,
+        withdraws: Vec<WithdrawArg>,
+    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(ActorRequest::PublishAtomicWithdraw {
+            inscribe,
+            withdraws,
+            response_tx,
+        })?;
+        Self::recv(response_rx).await?
+    }
+
+    /// Update the channel's config.
+    ///
+    /// Async counterpart of [`super::SequencerHandle::channel_config`].
+    pub async fn channel_config(
+        &self,
+        keys: Keys,
+        posting_timeframe: SlotTimeframe,
+        posting_timeout: SlotTimeout,
+        configuration_threshold: u16,
+        withdraw_threshold: u16,
+    ) -> Result<(PublishResult, SequencerCheckpoint, SignedMantleTx), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(ActorRequest::ChannelConfig {
+            keys,
+            posting_timeframe,
+            posting_timeout,
+            configuration_threshold,
+            withdraw_threshold,
+            response_tx,
+        })?;
+        Self::recv(response_rx).await?
+    }
+
+    /// Enqueue a pre-signed [`SignedMantleTx`] for posting.
+    ///
+    /// Async counterpart of [`super::SequencerHandle::submit_signed_tx`].
+    pub async fn submit_signed_tx(
+        &self,
+        tx: SignedMantleTx,
+        msg_id: MsgId,
+    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(ActorRequest::SubmitSignedTx {
+            tx,
+            msg_id,
+            response_tx,
+        })?;
+        Self::recv(response_rx).await?
+    }
+
+    /// Build a [`MantleTx`] for the given ops and an inscription message.
+    ///
+    /// Async counterpart of [`super::SequencerHandle::prepare_tx`].
+    pub async fn prepare_tx(
+        &self,
+        ops: Ops,
+        data: Inscription,
+    ) -> Result<(MantleTx, MsgId, Ed25519Signature), Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(ActorRequest::PrepareTx {
+            ops,
+            data,
+            response_tx,
+        })?;
+        Self::recv(response_rx).await?
+    }
+
+    /// Sign a [`MantleTx`] using the sequencer's key.
+    ///
+    /// Async counterpart of [`super::SequencerHandle::sign_tx`]. Clones `tx`
+    /// internally so the call site can keep its borrow.
+    pub async fn sign_tx(&self, tx: &MantleTx) -> Result<Ed25519Signature, Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.send(ActorRequest::SignTx {
+            tx: tx.clone(),
+            response_tx,
+        })?;
+        Self::recv(response_rx).await?
+    }
+
+    /// Subscribe to the broadcast channel of events.
+    ///
+    /// Late subscribers see events emitted from this point on (not the full
+    /// history).
+    #[must_use]
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.event_tx.subscribe()
+    }
+
+    /// Subscribe to readiness. See
+    /// [`super::ZoneSequencer::subscribe_ready`] for semantics.
+    #[must_use]
+    pub fn subscribe_ready(&self) -> watch::Receiver<bool> {
+        let mut rx = self.ready_tx.subscribe();
+        rx.mark_changed();
+        rx
+    }
+
+    /// Subscribe to channel-view changes.
+    #[must_use]
+    pub fn subscribe_channel_view(&self) -> watch::Receiver<SequencerChannelView> {
+        let mut rx = self.channel_view_tx.subscribe();
+        rx.mark_changed();
+        rx
+    }
+
+    /// Subscribe to turn-to-write changes.
+    #[must_use]
+    pub fn subscribe_turn_to_write(&self) -> watch::Receiver<TurnNotification> {
+        let mut rx = self.turn_to_write_tx.subscribe();
+        rx.mark_changed();
+        rx
+    }
+
+    /// Subscribe to persistence checkpoint changes.
+    #[must_use]
+    pub fn subscribe_checkpoint(&self) -> watch::Receiver<Option<SequencerCheckpoint>> {
+        let mut rx = self.checkpoint_tx.subscribe();
+        rx.mark_changed();
+        rx
+    }
+
+    fn send(&self, request: ActorRequest) -> Result<(), Error> {
+        self.request_tx
+            .send(request)
+            .map_err(|_| Error::Unavailable {
+                reason: "sequencer actor not running",
+            })
+    }
+
+    async fn recv<T>(response_rx: oneshot::Receiver<T>) -> Result<T, Error> {
+        response_rx.await.map_err(|_| Error::Unavailable {
+            reason: "sequencer actor dropped request",
+        })
+    }
+}

--- a/zone-sdk/src/sequencer/handle.rs
+++ b/zone-sdk/src/sequencer/handle.rs
@@ -1,30 +1,13 @@
 use lb_core::mantle::{
-    MantleTx, SignedMantleTx, Transaction as _,
+    MantleTx, SignedMantleTx,
     channel::{SlotTimeframe, SlotTimeout},
     encoding::Ops,
-    ops::{
-        Op,
-        channel::{
-            MsgId,
-            config::Keys,
-            inscribe::{Inscription, InscriptionOp},
-            withdraw::ChannelWithdrawOp,
-        },
-    },
+    ops::channel::{MsgId, config::Keys, inscribe::Inscription},
 };
 use lb_key_management_system_service::keys::Ed25519Signature;
-use tracing::{debug, info};
 
 use super::{
-    TARGET,
-    tx_builder::{
-        build_atomic_withdraw_ops_proofs, create_channel_config_tx, create_inscribe_tx,
-        find_own_key_index, prepare_tx, sign_tx,
-    },
-    types::{
-        AtomicWithdrawInfo, Error, InscriptionInfo, PendingTx, PublishResult, SequencerCheckpoint,
-        WithdrawArg, WithdrawInfo,
-    },
+    types::{Error, PublishResult, SequencerCheckpoint, WithdrawArg},
     zone_sequencer::ZoneSequencer,
 };
 use crate::adapter;
@@ -46,7 +29,7 @@ use crate::adapter;
 ///             let (result, cp) = sequencer.handle().publish(msg)?;
 ///             db.tx(|t| { t.outbox(result); t.save_checkpoint(cp); });
 ///         }
-///         Some(ev) = sequencer.next_event() => {
+///         ev = sequencer.next_event() => {
 ///             handle_event(ev, &mut sequencer, &mut db).await;
 ///         }
 ///     }
@@ -88,62 +71,7 @@ where
         &mut self,
         data: Inscription,
     ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        self.ensure_ready()?;
-
-        let parent = self.compute_publish_parent();
-        let (signed_tx, new_msg_id) = create_inscribe_tx(
-            self.sequencer.channel_id,
-            &self.sequencer.signing_key,
-            data.clone(),
-            parent,
-        );
-        let id = signed_tx.mantle_tx.hash();
-
-        debug!(target: TARGET,
-            "Prepared publish: payload={:?}, parent={}, msg_id={}, tx={}",
-            String::from_utf8_lossy(&data),
-            hex::encode(parent.as_ref()),
-            hex::encode(new_msg_id.as_ref()),
-            hex::encode(id.0),
-        );
-
-        let info = InscriptionInfo {
-            tx_hash: id,
-            parent_msg: parent,
-            this_msg: new_msg_id,
-            payload: data.clone(),
-        };
-
-        // Safe to unwrap — ensure_ready() guarantees state is initialized.
-        let state = self.sequencer.state.as_mut().unwrap();
-        state.submit_inscription(signed_tx.clone(), parent, new_msg_id, data);
-        self.sequencer.last_msg_id = new_msg_id;
-
-        // Queue the post into the in-flight batch pool only if it's our
-        // turn — otherwise the tx sits in `state.pending` as `!posted` and
-        // is drained by `submit_unposted_inscriptions` on the next turn-
-        // change. Failure of the immediate post is handled the same way:
-        // tx stays `!posted` and the `resubmit_interval` self-heal tick (or
-        // the next turn-change) re-queues.
-        if self.sequencer.can_publish_inscription_now() {
-            self.sequencer.queue_publish_post(id, signed_tx);
-        }
-
-        self.sequencer.publish_channel_view();
-
-        let checkpoint = self
-            .sequencer
-            .publish_checkpoint()
-            .ok_or(Error::Unavailable {
-                reason: "checkpoint unavailable",
-            })?;
-
-        Ok((
-            PublishResult {
-                tx: PendingTx::Inscription(info),
-            },
-            checkpoint,
-        ))
+        self.sequencer.do_publish(data)
     }
 
     /// Build a [`MantleTx`] for the given ops and an inscription message,
@@ -156,14 +84,7 @@ where
         ops: Ops,
         data: Inscription,
     ) -> Result<(MantleTx, MsgId, Ed25519Signature), Error> {
-        self.ensure_ready()?;
-        Ok(prepare_tx(
-            ops,
-            self.sequencer.channel_id,
-            &self.sequencer.signing_key,
-            data,
-            self.sequencer.last_msg_id,
-        ))
+        self.sequencer.do_prepare_tx(ops, data)
     }
 
     /// Sign a [`MantleTx`] using the sequencer's key.
@@ -171,8 +92,7 @@ where
     /// Useful when signing tx built by other sequencers (e.g. withdraw). Does
     /// not mutate sequencer state.
     pub fn sign_tx(&mut self, tx: &MantleTx) -> Result<Ed25519Signature, Error> {
-        self.ensure_ready()?;
-        Ok(sign_tx(tx.hash(), &self.sequencer.signing_key))
+        self.sequencer.do_sign_tx(tx)
     }
 
     /// Enqueue a [`SignedMantleTx`] associated with a [`MsgId`] for posting.
@@ -187,58 +107,7 @@ where
         tx: SignedMantleTx,
         msg_id: MsgId,
     ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        self.ensure_ready()?;
-
-        // Safe to unwrap — ensure_ready() guarantees state is initialized.
-        let state = self.sequencer.state.as_mut().unwrap();
-        let id = tx.mantle_tx.hash();
-        state.submit_other(tx.clone());
-        let parent_msg = self.sequencer.last_msg_id;
-        self.sequencer.last_msg_id = msg_id;
-
-        info!(target: TARGET,
-            "Submitted tx including inscription {:?}",
-            id
-        );
-
-        // Locate the inscription payload in the tx ops to populate
-        // `PendingTx::Inscription`. Falls back to an empty payload if the
-        // tx carries no inscription op for our channel (e.g. a pure deposit
-        // or admin tx submitted via this entry point).
-        let payload = tx
-            .mantle_tx
-            .ops()
-            .iter()
-            .find_map(|op| match op {
-                Op::ChannelInscribe(i) if i.channel_id == self.sequencer.channel_id => {
-                    Some(i.inscription.clone())
-                }
-                _ => None,
-            })
-            .unwrap_or_else(|| Inscription::new_unchecked(Vec::new()));
-
-        // Queue the post into the in-flight batch pool; the drive loop will
-        // drain it.
-        self.sequencer.queue_publish_post(id, tx);
-
-        let checkpoint = self
-            .sequencer
-            .publish_checkpoint()
-            .ok_or(Error::Unavailable {
-                reason: "checkpoint unavailable",
-            })?;
-
-        Ok((
-            PublishResult {
-                tx: PendingTx::Inscription(InscriptionInfo {
-                    tx_hash: id,
-                    parent_msg,
-                    this_msg: msg_id,
-                    payload,
-                }),
-            },
-            checkpoint,
-        ))
+        self.sequencer.do_submit_signed_tx(tx, msg_id)
     }
 
     /// Update the channel's config.
@@ -264,54 +133,13 @@ where
         configuration_threshold: u16,
         withdraw_threshold: u16,
     ) -> Result<(PublishResult, SequencerCheckpoint, SignedMantleTx), Error> {
-        self.ensure_ready()?;
-
-        let signed_tx = create_channel_config_tx(
-            self.sequencer.channel_id,
-            &[&self.sequencer.signing_key],
+        self.sequencer.do_channel_config(
             keys,
             posting_timeframe,
             posting_timeout,
             configuration_threshold,
             withdraw_threshold,
-        );
-        let tx_hash = signed_tx.mantle_tx.hash();
-
-        // Safe to unwrap — ensure_ready() guarantees state is initialized.
-        let state = self.sequencer.state.as_mut().unwrap();
-        state.submit_other(signed_tx.clone());
-
-        info!(target: TARGET, "Submitted channel_config transaction {}", hex::encode(tx_hash.0));
-
-        // Queue the post into the in-flight batch pool; the drive loop will
-        // drain it.
-        self.sequencer
-            .queue_publish_post(tx_hash, signed_tx.clone());
-
-        self.sequencer.publish_channel_view();
-
-        let checkpoint = self
-            .sequencer
-            .publish_checkpoint()
-            .ok_or(Error::Unavailable {
-                reason: "checkpoint unavailable",
-            })?;
-
-        // Channel-config txs don't carry an inscription payload — surface
-        // them as an inscription entry with an empty payload, sharing the
-        // tx hash as `this_msg` so consumers can correlate via `tx_hash`.
-        Ok((
-            PublishResult {
-                tx: PendingTx::Inscription(InscriptionInfo {
-                    tx_hash,
-                    parent_msg: self.sequencer.last_msg_id,
-                    this_msg: self.sequencer.last_msg_id,
-                    payload: Inscription::new_unchecked(Vec::new()),
-                }),
-            },
-            checkpoint,
-            signed_tx,
-        ))
+        )
     }
 
     /// Publish an atomic inscription+withdraw bundle.
@@ -335,132 +163,7 @@ where
         inscribe: Inscription,
         withdraws: Vec<WithdrawArg>,
     ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
-        self.ensure_ready()?;
-
-        if withdraws.is_empty() {
-            return Err(Error::Network(
-                "publish_atomic_withdraw requires at least one withdraw".into(),
-            ));
-        }
-
-        // Use the cached channel state kept fresh by the drive loop — see
-        // `ensure_connected` for the staleness gate.
-        let channel_state = self.sequencer.channel_state.as_ref().ok_or_else(|| {
-            Error::Network(format!(
-                "publish_atomic_withdraw requires channel state for {:?}",
-                self.sequencer.channel_id
-            ))
-        })?;
-        if channel_state.withdraw_threshold > 1 {
-            return Err(Error::Network(format!(
-                "publish_atomic_withdraw requires withdraw_threshold == 1, got {}",
-                channel_state.withdraw_threshold
-            )));
-        }
-        let own_key_index = find_own_key_index(channel_state, &self.sequencer.signing_key)?;
-        let mut next_nonce = channel_state.withdrawal_nonce;
-
-        let parent = self.compute_publish_parent();
-
-        let mut ops: Vec<Op> = Vec::with_capacity(withdraws.len() + 1);
-        let mut withdraw_ops = Vec::with_capacity(withdraws.len());
-        for arg in withdraws {
-            let op = ChannelWithdrawOp {
-                channel_id: self.sequencer.channel_id,
-                outputs: arg.outputs,
-                withdraw_nonce: next_nonce,
-            };
-            withdraw_ops.push(op.clone());
-            ops.push(Op::ChannelWithdraw(op));
-            next_nonce = next_nonce
-                .checked_add(1)
-                .ok_or_else(|| Error::Network("withdraw nonce overflow".into()))?;
-        }
-
-        let inscription_op = InscriptionOp {
-            channel_id: self.sequencer.channel_id,
-            inscription: inscribe.clone(),
-            parent,
-            signer: self.sequencer.signing_key.public_key(),
-        };
-        let msg_id = inscription_op.id();
-        ops.push(Op::ChannelInscribe(inscription_op));
-
-        let tx = MantleTx(Ops::try_from(ops).map_err(|e| {
-            Error::Network(format!("atomic withdraw bundle exceeds op limit: {e:?}"))
-        })?);
-        let own_sig = sign_tx(tx.hash(), &self.sequencer.signing_key);
-        let ops_proofs = build_atomic_withdraw_ops_proofs(&tx, own_key_index, own_sig)?;
-        let signed_tx = SignedMantleTx::new(tx, ops_proofs)
-            .map_err(|e| Error::Network(format!("signed tx assembly failed: {e:?}")))?;
-
-        let tx_hash = signed_tx.mantle_tx.hash();
-        let withdraw_infos: Vec<WithdrawInfo> = withdraw_ops
-            .into_iter()
-            .map(|op| WithdrawInfo { tx_hash, op })
-            .collect();
-
-        // Safe to unwrap — ensure_ready() guarantees state is initialized.
-        let state = self.sequencer.state.as_mut().unwrap();
-        state.submit_atomic_withdraw(
-            signed_tx.clone(),
-            parent,
-            msg_id,
-            inscribe.clone(),
-            withdraw_infos.clone(),
-        );
-        self.sequencer.last_msg_id = msg_id;
-
-        // Queue the post only if it's our turn — see `publish` for the
-        // turn-gate rationale.
-        if self.sequencer.can_publish_inscription_now() {
-            self.sequencer.queue_publish_post(tx_hash, signed_tx);
-        }
-
-        self.sequencer.publish_channel_view();
-
-        let checkpoint = self
-            .sequencer
-            .publish_checkpoint()
-            .ok_or(Error::Unavailable {
-                reason: "checkpoint unavailable",
-            })?;
-
-        Ok((
-            PublishResult {
-                tx: PendingTx::AtomicWithdraw(AtomicWithdrawInfo {
-                    tx_hash,
-                    inscription: InscriptionInfo {
-                        tx_hash,
-                        parent_msg: parent,
-                        this_msg: msg_id,
-                        payload: inscribe,
-                    },
-                    withdraws: withdraw_infos,
-                }),
-            },
-            checkpoint,
-        ))
-    }
-
-    fn ensure_ready(&self) -> Result<(), Error> {
-        if !self.sequencer.is_ready() {
-            return Err(Error::Unavailable {
-                reason: "sequencer not yet ready",
-            });
-        }
-        if self.sequencer.state.is_none() {
-            return Err(Error::Unavailable {
-                reason: "sequencer state not initialized",
-            });
-        }
-        Ok(())
-    }
-
-    fn compute_publish_parent(&self) -> MsgId {
-        let state = self.sequencer.state.as_ref().unwrap();
         self.sequencer
-            .current_tip
-            .map_or(self.sequencer.last_msg_id, |tip| state.publish_parent(tip))
+            .do_publish_atomic_withdraw(inscribe, withdraws)
     }
 }

--- a/zone-sdk/src/sequencer/mod.rs
+++ b/zone-sdk/src/sequencer/mod.rs
@@ -13,8 +13,16 @@
 //! - [`SequencerHandle`] is the drive-loop command surface — publish,
 //!   prepare/sign/submit, channel config. Obtained from
 //!   [`ZoneSequencer::handle`]; borrows the sequencer mutably so it can only
-//!   live on the drive task. Every state-mutating method returns the resulting
-//!   [`SequencerCheckpoint`] inline for atomic outbox + checkpoint persistence.
+//!   live on the drive task. Synchronous; every state-mutating method returns
+//!   the resulting [`SequencerCheckpoint`] inline for atomic outbox +
+//!   checkpoint persistence.
+//! - [`SequencerClient`] is the cross-task command surface — same set of
+//!   publish/admin methods as [`SequencerHandle`] plus the subscription
+//!   accessors. Obtained from [`ZoneSequencer::client`]; cheap-to-clone, can be
+//!   moved into any task. Routes commands through an internal channel processed
+//!   inside [`ZoneSequencer::next_event`], so the drive loop must still be
+//!   polled for client publish awaits to resolve. Subscriptions work regardless
+//!   of poll state.
 //!
 //! # Driving the sequencer
 //!
@@ -29,7 +37,7 @@
 //!             let (result, cp) = sequencer.handle().publish(msg)?;
 //!             db.tx(|t| { t.outbox(result); t.save_checkpoint(cp); });
 //!         }
-//!         Some(ev) = sequencer.next_event() => {
+//!         ev = sequencer.next_event() => {
 //!             handle_event(ev, &mut sequencer, &mut db).await;
 //!         }
 //!     }
@@ -40,6 +48,14 @@
 //! `sequencer.handle().publish(...)` to (e.g.) re-publish orphans surfaced
 //! by [`ChannelUpdate`].
 //!
+//! If publish calls need to originate from tasks other than the drive
+//! loop — e.g. an HTTP request handler or a service-style integration —
+//! obtain a [`SequencerClient`] via [`ZoneSequencer::client`] before moving
+//! the sequencer into its drive task and clone it into the calling tasks.
+//! The client's `publish(...).await` resolves once the drive loop processes
+//! the command, with the same `(PublishResult, SequencerCheckpoint)` return
+//! as the synchronous handle.
+//!
 //! # Restart
 //!
 //! Persist [`SequencerCheckpoint`] received via [`Event::BlocksProcessed`]
@@ -49,6 +65,7 @@
 mod actor;
 mod backfill;
 mod block_fetch;
+mod client;
 mod handle;
 mod slot_clock;
 mod state;
@@ -58,6 +75,7 @@ mod zone_sequencer;
 
 pub(super) const TARGET: &str = lb_log_targets::zone_sdk::SEQUENCER;
 
+pub use client::SequencerClient;
 pub use handle::SequencerHandle;
 pub use types::{
     AtomicWithdrawInfo, ChannelUpdate, DepositInfo, Error, Event, FinalizedOp, FinalizedTx,

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -523,6 +523,33 @@ where
         }
     }
 
+    /// Wait the configured reconnect delay, but keep servicing client
+    /// [`ActorRequest`]s while waiting.
+    ///
+    /// This preserves the same post-[`Event::Ready`] local-acceptance
+    /// semantics as
+    /// [`SequencerHandle::publish`](super::SequencerHandle::publish):
+    /// a publish that arrives via [`SequencerClient`](super::SequencerClient)
+    /// during a reconnect is handled immediately (queued locally via
+    /// `do_publish`) instead of blocking until connectivity is restored.
+    /// Without this, client requests would sit unserviced until
+    /// [`Self::ensure_connected`] succeeds, since `request_rx` is otherwise
+    /// only drained from `step`'s `select!` after connection.
+    ///
+    /// The sleep is pinned so the backoff keeps elapsing across iterations: any
+    /// number of requests can be serviced during the wait without resetting or
+    /// short-circuiting the delay.
+    pub(super) async fn wait_reconnect_delay(&mut self) {
+        let sleep = tokio::time::sleep(self.config.reconnect_delay);
+        tokio::pin!(sleep);
+        loop {
+            tokio::select! {
+                () = &mut sleep => break,
+                Some(request) = self.request_rx.recv() => self.handle_request(request),
+            }
+        }
+    }
+
     fn ensure_ready(&self) -> Result<(), Error> {
         if !self.is_ready() {
             return Err(Error::Unavailable {

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -11,23 +11,35 @@ use lb_common_http_client::{ProcessedBlockEvent, Slot};
 use lb_core::{
     header::HeaderId,
     mantle::{
-        Op, SignedMantleTx, Transaction as _,
-        channel::ChannelState,
-        ops::channel::{ChannelId, MsgId, inscribe::Inscription},
+        MantleTx, Op, SignedMantleTx, Transaction as _,
+        channel::{ChannelState, SlotTimeframe, SlotTimeout},
+        encoding::Ops,
+        ops::channel::{
+            ChannelId, MsgId,
+            config::Keys,
+            inscribe::{Inscription, InscriptionOp},
+            withdraw::ChannelWithdrawOp,
+        },
         tx::TxHash,
     },
 };
-use lb_key_management_system_service::keys::Ed25519Key;
-use tokio::sync::{broadcast, watch};
-use tracing::{info, warn};
+use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tracing::{debug, info, warn};
 
 use super::{
     TARGET,
+    client::SequencerClient,
     handle::SequencerHandle,
     slot_clock::SlotClock,
     state::TxState,
+    tx_builder::{
+        build_atomic_withdraw_ops_proofs, create_channel_config_tx, create_inscribe_tx,
+        find_own_key_index, prepare_tx as build_prepare_tx, sign_tx as build_sign_tx,
+    },
     types::{
-        Event, SequencerChannelView, SequencerCheckpoint, SequencerConfig, TurnNotification,
+        AtomicWithdrawInfo, Error, Event, InscriptionInfo, PendingTx, PublishResult,
+        SequencerChannelView, SequencerCheckpoint, SequencerConfig, TurnNotification, WithdrawArg,
         WithdrawInfo,
     },
 };
@@ -35,8 +47,8 @@ use crate::{adapter, adapter::BoxStream};
 
 /// Zone sequencer.
 ///
-/// The caller drives execution by pumping [`Self::next_event`] or
-/// [`Self::events`] in a loop. Publish and admin operations go through a
+/// The caller drives execution by pumping [`Self::next_event`] in a loop.
+/// Publish and admin operations go through a
 /// borrowing [`SequencerHandle`] obtained via [`Self::handle`] — the handle's
 /// `&mut self` borrow means it can only be used from the drive task, which
 /// removes any actor-vs-caller deadlock window and lets every state-mutating
@@ -116,6 +128,53 @@ pub struct ZoneSequencer<Node> {
     pub(super) channel_view_tx: watch::Sender<SequencerChannelView>,
     pub(super) turn_to_write_tx: watch::Sender<TurnNotification>,
     pub(super) checkpoint_tx: watch::Sender<Option<SequencerCheckpoint>>,
+
+    // Request channel for actor-routed commands from cheap-to-clone
+    // `SequencerClient`s. `request_tx` is retained so `client()` can vend new
+    // senders; `request_rx` is drained inside `next_event`.
+    request_tx: mpsc::UnboundedSender<ActorRequest>,
+    request_rx: mpsc::UnboundedReceiver<ActorRequest>,
+}
+
+/// Internal request enum routed through the actor's `request_rx` channel.
+///
+/// Sent by [`SequencerClient`] from any task; processed inside
+/// [`ZoneSequencer::next_event`] and replied to via the embedded oneshot.
+/// One variant per [`SequencerHandle`] method, so the client surface is a
+/// 1:1 async mirror of the drive-loop handle.
+pub(super) enum ActorRequest {
+    Publish {
+        data: Inscription,
+        response_tx: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint), Error>>,
+    },
+    PublishAtomicWithdraw {
+        inscribe: Inscription,
+        withdraws: Vec<WithdrawArg>,
+        response_tx: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint), Error>>,
+    },
+    ChannelConfig {
+        keys: Keys,
+        posting_timeframe: SlotTimeframe,
+        posting_timeout: SlotTimeout,
+        configuration_threshold: u16,
+        withdraw_threshold: u16,
+        response_tx:
+            oneshot::Sender<Result<(PublishResult, SequencerCheckpoint, SignedMantleTx), Error>>,
+    },
+    SubmitSignedTx {
+        tx: SignedMantleTx,
+        msg_id: MsgId,
+        response_tx: oneshot::Sender<Result<(PublishResult, SequencerCheckpoint), Error>>,
+    },
+    PrepareTx {
+        ops: Ops,
+        data: Inscription,
+        response_tx: oneshot::Sender<Result<(MantleTx, MsgId, Ed25519Signature), Error>>,
+    },
+    SignTx {
+        tx: MantleTx,
+        response_tx: oneshot::Sender<Result<Ed25519Signature, Error>>,
+    },
 }
 
 impl<Node> ZoneSequencer<Node>
@@ -191,6 +250,7 @@ where
             .as_ref()
             .map(|s| build_checkpoint(s, last_msg_id, lib_slot));
         let (checkpoint_tx, _) = watch::channel(initial_checkpoint);
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
 
         Self {
             channel_id,
@@ -219,6 +279,8 @@ where
             channel_view_tx,
             turn_to_write_tx,
             checkpoint_tx,
+            request_tx,
+            request_rx,
         }
     }
 
@@ -230,6 +292,30 @@ where
     /// the publish + checkpoint atomically.
     pub const fn handle(&mut self) -> SequencerHandle<'_, Node> {
         SequencerHandle::new(self)
+    }
+
+    /// Obtain a cheap-to-clone client for driving the sequencer from tasks
+    /// outside the drive loop.
+    ///
+    /// Unlike [`Self::handle`], the client does not borrow the sequencer —
+    /// publish/admin commands are routed through an internal channel and
+    /// processed inside [`Self::next_event`], and watch/broadcast
+    /// subscriptions are vended directly from cloned senders. The drive loop
+    /// must therefore still be polled for client publish calls to make
+    /// progress; an unpolled sequencer will leave client awaits pending
+    /// forever. Subscriptions, on the other hand, work regardless of whether
+    /// the drive loop is being polled (they're just receivers attached to the
+    /// senders the actor updates).
+    #[must_use]
+    pub fn client(&self) -> SequencerClient {
+        SequencerClient::new(
+            self.request_tx.clone(),
+            self.event_tx.clone(),
+            self.ready_tx.clone(),
+            self.channel_view_tx.clone(),
+            self.turn_to_write_tx.clone(),
+            self.checkpoint_tx.clone(),
+        )
     }
 
     /// Whether the sequencer has completed cold-start backfill.
@@ -300,39 +386,33 @@ where
     ///
     /// Late subscribers see events emitted from this point on (not the
     /// full history). The primary way to consume events is
-    /// [`Self::next_event`] / [`Self::events`] on the drive task; this
-    /// broadcast is for additional read-only observers.
+    /// [`Self::next_event`] on the drive task; this broadcast is for
+    /// additional read-only observers.
     #[must_use]
     pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
         self.event_tx.subscribe()
     }
 
-    /// Convert the sequencer into a [`futures::Stream`] of [`Event`]s.
+    /// Drive the sequencer until the next public event.
     ///
-    /// The returned stream borrows `self` mutably for its lifetime. For
-    /// drive loops that also need to call [`Self::handle`] in response to
-    /// events, prefer [`Self::next_event`] in a `tokio::select!` so the
-    /// borrow is released between turns.
-    pub fn events(&mut self) -> impl futures::Stream<Item = Event> + Send + Unpin + '_ {
-        Box::pin(futures::stream::unfold(self, async |seq| {
-            // `next_event` can complete a drive step without emitting a public
-            // event; loop until we have one. All such non-emitting paths await
-            // (network call, sleep, or channel/timer poll), so this loop is
-            // not a hot spin.
-            loop {
-                if let Some(event) = seq.next_event().await {
-                    return Some((event, seq));
-                }
+    /// Loops internally over drive steps that complete work without emitting
+    /// (in-progress backfill batches, periodic resubmit ticks, in-flight post
+    /// completions, reconnect retries), so the caller's loop body always
+    /// receives a real [`Event`] — no `Option` unwrapping required.
+    pub async fn next_event(&mut self) -> Event {
+        loop {
+            if let Some(ev) = self.step().await {
+                return ev;
             }
-        }))
+        }
     }
 
     /// Drive the sequencer one step. Returns `None` when the step completed
     /// without emitting a public event (e.g. an empty backfill batch, a
     /// failed reconnect attempt that already slept, a periodic resubmit
-    /// tick). Designed for `tokio::select!` so the drive task can interleave
-    /// publish calls via [`Self::handle`] between turns.
-    pub async fn next_event(&mut self) -> Option<Event> {
+    /// tick). Internal: callers use [`Self::next_event`] which loops until
+    /// an event is produced.
+    async fn step(&mut self) -> Option<Event> {
         // Return buffered event from previous call if any.
         if let Some(event) = self.buffered_events.pop_front() {
             return Some(self.emit_now(event));
@@ -370,7 +450,356 @@ where
                 }
                 None
             }
+            Some(request) = self.request_rx.recv() => {
+                self.handle_request(request);
+                None
+            }
         }
+    }
+
+    fn handle_request(&mut self, request: ActorRequest) {
+        match request {
+            ActorRequest::Publish { data, response_tx } => {
+                drop(response_tx.send(self.do_publish(data)));
+            }
+            ActorRequest::PublishAtomicWithdraw {
+                inscribe,
+                withdraws,
+                response_tx,
+            } => {
+                drop(response_tx.send(self.do_publish_atomic_withdraw(inscribe, withdraws)));
+            }
+            ActorRequest::ChannelConfig {
+                keys,
+                posting_timeframe,
+                posting_timeout,
+                configuration_threshold,
+                withdraw_threshold,
+                response_tx,
+            } => {
+                drop(response_tx.send(self.do_channel_config(
+                    keys,
+                    posting_timeframe,
+                    posting_timeout,
+                    configuration_threshold,
+                    withdraw_threshold,
+                )));
+            }
+            ActorRequest::SubmitSignedTx {
+                tx,
+                msg_id,
+                response_tx,
+            } => {
+                drop(response_tx.send(self.do_submit_signed_tx(tx, msg_id)));
+            }
+            ActorRequest::PrepareTx {
+                ops,
+                data,
+                response_tx,
+            } => {
+                drop(response_tx.send(self.do_prepare_tx(ops, data)));
+            }
+            ActorRequest::SignTx { tx, response_tx } => {
+                drop(response_tx.send(self.do_sign_tx(&tx)));
+            }
+        }
+    }
+
+    fn ensure_ready(&self) -> Result<(), Error> {
+        if !self.is_ready() {
+            return Err(Error::Unavailable {
+                reason: "sequencer not yet ready",
+            });
+        }
+        if self.state.is_none() {
+            return Err(Error::Unavailable {
+                reason: "sequencer state not initialized",
+            });
+        }
+        Ok(())
+    }
+
+    /// Core publish logic. Shared by [`SequencerHandle::publish`] (called
+    /// from the drive task) and the actor's [`ActorRequest::Publish`] handler
+    /// (called from outside the drive task via [`SequencerClient`]).
+    pub(super) fn do_publish(
+        &mut self,
+        data: Inscription,
+    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
+        self.ensure_ready()?;
+
+        let parent = self.compute_publish_parent();
+        let (signed_tx, new_msg_id) =
+            create_inscribe_tx(self.channel_id, &self.signing_key, data.clone(), parent);
+        let id = signed_tx.mantle_tx.hash();
+
+        debug!(target: TARGET,
+            "Prepared publish: payload={:?}, parent={}, msg_id={}, tx={}",
+            String::from_utf8_lossy(&data),
+            hex::encode(parent.as_ref()),
+            hex::encode(new_msg_id.as_ref()),
+            hex::encode(id.0),
+        );
+
+        let info = InscriptionInfo {
+            tx_hash: id,
+            parent_msg: parent,
+            this_msg: new_msg_id,
+            payload: data.clone(),
+        };
+
+        // Safe to unwrap — `ensure_ready` checks state.
+        let state = self.state.as_mut().unwrap();
+        state.submit_inscription(signed_tx.clone(), parent, new_msg_id, data);
+        self.last_msg_id = new_msg_id;
+
+        if self.can_publish_inscription_now() {
+            self.queue_publish_post(id, signed_tx);
+        }
+
+        self.publish_channel_view();
+
+        let checkpoint = self.publish_checkpoint().ok_or(Error::Unavailable {
+            reason: "checkpoint unavailable",
+        })?;
+
+        Ok((
+            PublishResult {
+                tx: PendingTx::Inscription(info),
+            },
+            checkpoint,
+        ))
+    }
+
+    pub(super) fn do_publish_atomic_withdraw(
+        &mut self,
+        inscribe: Inscription,
+        withdraws: Vec<WithdrawArg>,
+    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
+        self.ensure_ready()?;
+
+        if withdraws.is_empty() {
+            return Err(Error::Network(
+                "publish_atomic_withdraw requires at least one withdraw".into(),
+            ));
+        }
+
+        // Use the cached channel state kept fresh by the drive loop — see
+        // `ensure_connected` for the staleness gate.
+        let channel_state = self.channel_state.as_ref().ok_or_else(|| {
+            Error::Network(format!(
+                "publish_atomic_withdraw requires channel state for {:?}",
+                self.channel_id
+            ))
+        })?;
+        if channel_state.withdraw_threshold > 1 {
+            return Err(Error::Network(format!(
+                "publish_atomic_withdraw requires withdraw_threshold == 1, got {}",
+                channel_state.withdraw_threshold
+            )));
+        }
+        let own_key_index = find_own_key_index(channel_state, &self.signing_key)?;
+        let mut next_nonce = channel_state.withdrawal_nonce;
+
+        let parent = self.compute_publish_parent();
+
+        let mut ops: Vec<Op> = Vec::with_capacity(withdraws.len() + 1);
+        let mut withdraw_ops = Vec::with_capacity(withdraws.len());
+        for arg in withdraws {
+            let op = ChannelWithdrawOp {
+                channel_id: self.channel_id,
+                outputs: arg.outputs,
+                withdraw_nonce: next_nonce,
+            };
+            withdraw_ops.push(op.clone());
+            ops.push(Op::ChannelWithdraw(op));
+            next_nonce = next_nonce
+                .checked_add(1)
+                .ok_or_else(|| Error::Network("withdraw nonce overflow".into()))?;
+        }
+
+        let inscription_op = InscriptionOp {
+            channel_id: self.channel_id,
+            inscription: inscribe.clone(),
+            parent,
+            signer: self.signing_key.public_key(),
+        };
+        let msg_id = inscription_op.id();
+        ops.push(Op::ChannelInscribe(inscription_op));
+
+        let tx = MantleTx(Ops::try_from(ops).map_err(|e| {
+            Error::Network(format!("atomic withdraw bundle exceeds op limit: {e:?}"))
+        })?);
+        let own_sig = build_sign_tx(tx.hash(), &self.signing_key);
+        let ops_proofs = build_atomic_withdraw_ops_proofs(&tx, own_key_index, own_sig)?;
+        let signed_tx = SignedMantleTx::new(tx, ops_proofs)
+            .map_err(|e| Error::Network(format!("signed tx assembly failed: {e:?}")))?;
+
+        let tx_hash = signed_tx.mantle_tx.hash();
+        let withdraw_infos: Vec<WithdrawInfo> = withdraw_ops
+            .into_iter()
+            .map(|op| WithdrawInfo { tx_hash, op })
+            .collect();
+
+        // Safe to unwrap — `ensure_ready` checks state.
+        let state = self.state.as_mut().unwrap();
+        state.submit_atomic_withdraw(
+            signed_tx.clone(),
+            parent,
+            msg_id,
+            inscribe.clone(),
+            withdraw_infos.clone(),
+        );
+        self.last_msg_id = msg_id;
+
+        if self.can_publish_inscription_now() {
+            self.queue_publish_post(tx_hash, signed_tx);
+        }
+
+        self.publish_channel_view();
+
+        let checkpoint = self.publish_checkpoint().ok_or(Error::Unavailable {
+            reason: "checkpoint unavailable",
+        })?;
+
+        Ok((
+            PublishResult {
+                tx: PendingTx::AtomicWithdraw(AtomicWithdrawInfo {
+                    tx_hash,
+                    inscription: InscriptionInfo {
+                        tx_hash,
+                        parent_msg: parent,
+                        this_msg: msg_id,
+                        payload: inscribe,
+                    },
+                    withdraws: withdraw_infos,
+                }),
+            },
+            checkpoint,
+        ))
+    }
+
+    pub(super) fn do_channel_config(
+        &mut self,
+        keys: Keys,
+        posting_timeframe: SlotTimeframe,
+        posting_timeout: SlotTimeout,
+        configuration_threshold: u16,
+        withdraw_threshold: u16,
+    ) -> Result<(PublishResult, SequencerCheckpoint, SignedMantleTx), Error> {
+        self.ensure_ready()?;
+
+        let signed_tx = create_channel_config_tx(
+            self.channel_id,
+            &[&self.signing_key],
+            keys,
+            posting_timeframe,
+            posting_timeout,
+            configuration_threshold,
+            withdraw_threshold,
+        );
+        let tx_hash = signed_tx.mantle_tx.hash();
+
+        // Safe to unwrap — `ensure_ready` checks state.
+        let state = self.state.as_mut().unwrap();
+        state.submit_other(signed_tx.clone());
+
+        info!(target: TARGET, "Submitted channel_config transaction {}", hex::encode(tx_hash.0));
+
+        self.queue_publish_post(tx_hash, signed_tx.clone());
+
+        self.publish_channel_view();
+
+        let checkpoint = self.publish_checkpoint().ok_or(Error::Unavailable {
+            reason: "checkpoint unavailable",
+        })?;
+
+        Ok((
+            PublishResult {
+                tx: PendingTx::Inscription(InscriptionInfo {
+                    tx_hash,
+                    parent_msg: self.last_msg_id,
+                    this_msg: self.last_msg_id,
+                    payload: Inscription::new_unchecked(Vec::new()),
+                }),
+            },
+            checkpoint,
+            signed_tx,
+        ))
+    }
+
+    pub(super) fn do_submit_signed_tx(
+        &mut self,
+        tx: SignedMantleTx,
+        msg_id: MsgId,
+    ) -> Result<(PublishResult, SequencerCheckpoint), Error> {
+        self.ensure_ready()?;
+
+        // Safe to unwrap — `ensure_ready` checks state.
+        let state = self.state.as_mut().unwrap();
+        let id = tx.mantle_tx.hash();
+        state.submit_other(tx.clone());
+        let parent_msg = self.last_msg_id;
+        self.last_msg_id = msg_id;
+
+        info!(target: TARGET, "Submitted tx including inscription {:?}", id);
+
+        let payload = tx
+            .mantle_tx
+            .ops()
+            .iter()
+            .find_map(|op| match op {
+                Op::ChannelInscribe(i) if i.channel_id == self.channel_id => {
+                    Some(i.inscription.clone())
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| Inscription::new_unchecked(Vec::new()));
+
+        self.queue_publish_post(id, tx);
+
+        let checkpoint = self.publish_checkpoint().ok_or(Error::Unavailable {
+            reason: "checkpoint unavailable",
+        })?;
+
+        Ok((
+            PublishResult {
+                tx: PendingTx::Inscription(InscriptionInfo {
+                    tx_hash: id,
+                    parent_msg,
+                    this_msg: msg_id,
+                    payload,
+                }),
+            },
+            checkpoint,
+        ))
+    }
+
+    pub(super) fn do_prepare_tx(
+        &self,
+        ops: Ops,
+        data: Inscription,
+    ) -> Result<(MantleTx, MsgId, Ed25519Signature), Error> {
+        self.ensure_ready()?;
+        Ok(build_prepare_tx(
+            ops,
+            self.channel_id,
+            &self.signing_key,
+            data,
+            self.last_msg_id,
+        ))
+    }
+
+    pub(super) fn do_sign_tx(&self, tx: &MantleTx) -> Result<Ed25519Signature, Error> {
+        self.ensure_ready()?;
+        Ok(build_sign_tx(tx.hash(), &self.signing_key))
+    }
+
+    pub(super) fn compute_publish_parent(&self) -> MsgId {
+        // Safe to unwrap — callers gate on `state.is_some()`.
+        let state = self.state.as_ref().unwrap();
+        self.current_tip
+            .map_or(self.last_msg_id, |tip| state.publish_parent(tip))
     }
 
     pub(super) fn emit_now(&self, event: Event) -> Event {


### PR DESCRIPTION
## 1. What does this PR implement?

Adds a cloneable `SequencerClient` (sequencer.client()) that mirrors the SequencerHandle surface async, so publishes can originate from any task — not just the drive loop. Carries the watch/broadcast subscribe methods too, so it's the single "everything I need from outside the drive loop" handle.

Usage:
```
    let client = sequencer.client();   // cheap to clone, move into any task
    client.publish(payload).await?;
    let ready = client.subscribe_ready();
```

 The drive loop must still be polled for client publish awaits to resolve; commands route through an internal channel processed inside next_event().

  Also: next_event() returns Event (not Option<Event>) — looping over transient empty steps is now internal. Drops dead events() Stream method.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
