### PR TITLE
fix(sdp): enforce min value of 2 for `inactivity_period`

### DIFF
--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -36,8 +36,8 @@ pub struct MinStake {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServiceParameters {
-    /// Maximum epochs during which an activity message must be sent
-    pub inactivity_period: NumberOfEpochs,
+    /// Maximum epochs during which an activity message must be sent.
+    pub inactivity_period: InactivityPeriod,
     /// Epochs after which a declaration can be safely deleted by Garbage
     /// Collection
     pub retention_period: NumberOfEpochs,
@@ -46,6 +46,56 @@ pub struct ServiceParameters {
 }
 
 pub type NumberOfEpochs = Epoch;
+
+/// Number of epochs without an activity message before a declaration is
+/// considered inactive
+///
+/// Invariant: must be at least [`SNAPSHOT_FINALIZATION_DELAY`].
+/// Otherwise, the declaration may be excluded from the active set before
+/// the [`Declaration::active`] value (refreshed by an activity message)
+/// is reflected in the next snapshot.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "NumberOfEpochs")]
+pub struct InactivityPeriod(NumberOfEpochs);
+
+impl InactivityPeriod {
+    pub const fn new(period: NumberOfEpochs) -> Result<Self, InactivityPeriodTooSmall> {
+        if period.into_inner() < SNAPSHOT_FINALIZATION_DELAY.into_inner() {
+            Err(InactivityPeriodTooSmall { period })
+        } else {
+            Ok(Self(period))
+        }
+    }
+
+    #[must_use]
+    pub const fn into_inner(self) -> NumberOfEpochs {
+        self.0
+    }
+}
+
+impl TryFrom<u32> for InactivityPeriod {
+    type Error = InactivityPeriodTooSmall;
+
+    fn try_from(period: u32) -> Result<Self, Self::Error> {
+        Self::new(period.into())
+    }
+}
+
+impl TryFrom<NumberOfEpochs> for InactivityPeriod {
+    type Error = InactivityPeriodTooSmall;
+
+    fn try_from(period: NumberOfEpochs) -> Result<Self, Self::Error> {
+        Self::new(period)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "inactivity_period must be >= SNAPSHOT_FINALIZATION_DELAY ({SNAPSHOT_FINALIZATION_DELAY:?}); got {period:?}"
+)]
+pub struct InactivityPeriodTooSmall {
+    pub period: NumberOfEpochs,
+}
 
 // TODO: Check spec for max limit once we migrate the SDP Declare op to use the
 // `NomEncode` and `NomDecode` traits.

--- a/deployment/ceremony/genesis/devnet/deployment-template.yaml
+++ b/deployment/ceremony/genesis/devnet/deployment-template.yaml
@@ -30,7 +30,7 @@ cryptarchia:
   sdp_config:
     service_params:
       BN:
-        inactivity_period: 1
+        inactivity_period: 2
         retention_period: 1
         epoch: 0
     min_stake:

--- a/deployment/ceremony/genesis/standalone/deployment-template.yaml
+++ b/deployment/ceremony/genesis/standalone/deployment-template.yaml
@@ -30,7 +30,7 @@ cryptarchia:
   sdp_config:
     service_params:
       BN:
-        inactivity_period: 1
+        inactivity_period: 2
         retention_period: 1
         epoch: 0
     min_stake:

--- a/deployment/cfgsync/deployment-settings.yaml
+++ b/deployment/cfgsync/deployment-settings.yaml
@@ -30,7 +30,7 @@ cryptarchia:
   sdp_config:
     service_params:
       BN:
-        inactivity_period: 1
+        inactivity_period: 2
         retention_period: 1
         epoch: 0
     min_stake:

--- a/ledger/src/config.rs
+++ b/ledger/src/config.rs
@@ -127,7 +127,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 1.into(),
+                            inactivity_period: 2.try_into().unwrap(),
                             retention_period: 1.into(),
                             epoch: 0.into(),
                         },
@@ -180,7 +180,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 1.into(),
+                            inactivity_period: 2.try_into().unwrap(),
                             retention_period: 1.into(),
                             epoch: 0.into(),
                         },
@@ -242,7 +242,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 1.into(),
+                            inactivity_period: 2.try_into().unwrap(),
                             retention_period: 1.into(),
                             epoch: 0.into(),
                         },

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -834,7 +834,7 @@ pub mod tests {
         }
     }
 
-    fn update_ledger(
+    pub fn update_ledger(
         ledger: &mut Ledger<HeaderId>,
         parent: HeaderId,
         slot: impl Into<Slot>,
@@ -905,7 +905,7 @@ pub mod tests {
         service_params.insert(
             ServiceType::BlendNetwork,
             ServiceParameters {
-                inactivity_period: 1.into(),
+                inactivity_period: 2.try_into().unwrap(),
                 retention_period: 1.into(),
                 epoch: 0.into(),
             },
@@ -1011,7 +1011,8 @@ pub mod tests {
         }
     }
 
-    fn ledger(utxos: &[Utxo], config: Config) -> (Ledger<HeaderId>, HeaderId) {
+    #[must_use]
+    pub fn ledger(utxos: &[Utxo], config: Config) -> (Ledger<HeaderId>, HeaderId) {
         let genesis_state = genesis_state(utxos);
         (
             Ledger::new([0; 32], full_ledger_state(genesis_state, &config), config),
@@ -1019,7 +1020,7 @@ pub mod tests {
         )
     }
 
-    fn apply_and_add_utxo(
+    pub fn apply_and_add_utxo(
         ledger: &mut Ledger<HeaderId>,
         parent: HeaderId,
         slot: impl Into<Slot>,
@@ -1040,7 +1041,7 @@ pub mod tests {
         id
     }
 
-    fn apply_and_add_utxo_and_declaration(
+    pub fn apply_and_add_utxo_and_declaration(
         ledger: &mut Ledger<HeaderId>,
         parent: HeaderId,
         slot: impl Into<Slot>,
@@ -1048,7 +1049,7 @@ pub mod tests {
         utxo_add: Utxo,
         sdp_utxo: Utxo,
         sdp_note_sk: ZkKey,
-    ) -> (HeaderId, SDPDeclareOp) {
+    ) -> (HeaderId, SDPDeclareOp, ZkKey) {
         let id = apply_and_add_utxo(ledger, parent, slot, utxo_proof, utxo_add);
 
         let tx_hash = TxHash::from([0u8; 32]);
@@ -1072,7 +1073,7 @@ pub mod tests {
             .clone()
             .try_apply_sdp_declaration(
                 &declare_op,
-                &ZkKey::multi_sign(&[sdp_note_sk, zk_key], &tx_hash.to_fr()).unwrap(),
+                &ZkKey::multi_sign(&[sdp_note_sk, zk_key.clone()], &tx_hash.to_fr()).unwrap(),
                 &signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref()),
                 block_ledger.cryptarchia_ledger.latest_utxos(),
                 tx_hash,
@@ -1081,7 +1082,7 @@ pub mod tests {
             .unwrap()
             .0;
 
-        (id, declare_op)
+        (id, declare_op, zk_key)
     }
 
     fn assert_sdp_snapshot(
@@ -1120,7 +1121,8 @@ pub mod tests {
         );
     }
 
-    fn declaration_in_snapshot<'l>(
+    #[must_use]
+    pub fn declaration_in_snapshot<'l>(
         ledger: &'l Ledger<HeaderId>,
         header_id: &HeaderId,
         declaration_id: &DeclarationId,
@@ -1185,7 +1187,7 @@ pub mod tests {
 
         let h_2 = update_ledger(&mut ledger, h_1, 60, leader_utxos[1]).unwrap();
 
-        let (h_3, declare_1) = apply_and_add_utxo_and_declaration(
+        let (h_3, declare_1, _) = apply_and_add_utxo_and_declaration(
             &mut ledger,
             h_2,
             90,
@@ -1223,7 +1225,7 @@ pub mod tests {
         );
 
         // Epoch transition: 0 -> 1
-        let (h_5, declare_2) = apply_and_add_utxo_and_declaration(
+        let (h_5, declare_2, _) = apply_and_add_utxo_and_declaration(
             &mut ledger,
             h_3,
             100,
@@ -1298,7 +1300,7 @@ pub mod tests {
 
         // Declare at slot 1 (epoch 0). The declaration's `active` field is
         // initialized to `created + 2 = 2`.
-        let (head0, declare) = apply_and_add_utxo_and_declaration(
+        let (head0, declare, _) = apply_and_add_utxo_and_declaration(
             &mut ledger0,
             genesis,
             1,
@@ -1309,17 +1311,17 @@ pub mod tests {
         );
 
         // Advance to epoch 4 (one-by-one).
-        // With inactivity_period=1, the declaration goes inactive at epoch 4.
-        // With retention_period=1, GC fires at epoch 5.
-        // So, at epoch 4, the declaration is inactive yet still present in the ledger.
+        // With inactivity_period=2, the declaration goes inactive at epoch 5.
+        // With retention_period=1, GC fires at epoch 6.
+        // So, at epoch 5, the declaration is inactive yet still present in the ledger.
         let mut ledger = ledger0.clone();
         let mut head = head0;
-        for epoch in 1..=4u64 {
+        for epoch in 1..=5u64 {
             head = update_ledger(&mut ledger, head, epoch * epoch_length, leader_utxo).unwrap();
         }
         assert_eq!(
             ledger.states[&head].cryptarchia_ledger.epoch_state.epoch,
-            Epoch::new(4)
+            Epoch::new(5)
         );
         assert!(
             ledger.states[&head]
@@ -1334,12 +1336,12 @@ pub mod tests {
             "inactive declaration must be filtered out of the EpochState snapshot"
         );
 
-        // Jump from epoch 0 to 4, and check the same conditions
+        // Jump from epoch 0 to 5, and check the same conditions
         let mut ledger = ledger0;
-        head = update_ledger(&mut ledger, head0, 4 * epoch_length, leader_utxo).unwrap();
+        head = update_ledger(&mut ledger, head0, 5 * epoch_length, leader_utxo).unwrap();
         assert_eq!(
             ledger.states[&head].cryptarchia_ledger.epoch_state.epoch,
-            Epoch::new(4)
+            Epoch::new(5)
         );
         assert!(
             ledger.states[&head]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -723,7 +723,7 @@ mod tests {
     use lb_core::{
         events::{Event, EventPayload},
         mantle::{
-            MantleTx, Note, SignedMantleTx, Transaction as _,
+            MantleTx, Note, SignedMantleTx, Transaction as _, TxHash,
             encoding::Ops,
             gas::MainnetGasConstants,
             ledger::{Inputs, Outputs},
@@ -736,16 +736,22 @@ mod tests {
                     inscribe::InscriptionOp,
                     withdraw::ChannelWithdrawOp,
                 },
+                sdp::SDPActiveOp,
                 transfer::TransferOp,
             },
         },
         proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
+        sdp::{ActivityMetadata, DeclarationId, Nonce, blend::ActivityProof},
     };
+    use lb_cryptarchia_engine::Epoch;
     use lb_key_management_system_keys::keys::{Ed25519Key, Ed25519PublicKey, ZkKey, ZkPublicKey};
     use num_bigint::BigUint;
 
     use super::*;
-    use crate::cryptarchia::tests::utxo_with_sk;
+    use crate::cryptarchia::tests::{
+        apply_and_add_utxo, apply_and_add_utxo_and_declaration, declaration_in_snapshot, ledger,
+        update_ledger, utxo_with_sk,
+    };
 
     fn create_test_keys() -> (Ed25519Key, Ed25519PublicKey) {
         create_test_keys_with_seed(0)
@@ -875,6 +881,46 @@ mod tests {
             )
             .unwrap()
             .0
+    }
+
+    #[expect(clippy::too_many_arguments, reason = "test fn")]
+    fn apply_and_add_utxo_and_activity(
+        ledger: &mut Ledger<HeaderId>,
+        parent: HeaderId,
+        slot: impl Into<Slot>,
+        utxo_proof: Utxo,
+        utxo_add: Utxo,
+        declaration_id: DeclarationId,
+        zk_key: ZkKey,
+        nonce: Nonce,
+    ) -> HeaderId {
+        use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
+
+        let id = apply_and_add_utxo(ledger, parent, slot, utxo_proof, utxo_add);
+
+        let signing_key = Ed25519Key::from_bytes(&[0; 32]);
+        let active_op = SDPActiveOp {
+            declaration_id,
+            nonce,
+            metadata: ActivityMetadata::Blend(Box::new(ActivityProof {
+                // TODO: Create real proofs once the blend rewards module is enabled
+                epoch: 0.into(),
+                signing_key: signing_key.public_key(),
+                proof_of_quota: VerifiedProofOfQuota::from_bytes_unchecked([0; _]).into(),
+                proof_of_selection: VerifiedProofOfSelection::from_bytes_unchecked([1; _]).into(),
+            })),
+        };
+        let tx_hash = TxHash::from([1u8; 32]);
+        let zk_sig = ZkKey::multi_sign(&[zk_key], &tx_hash.to_fr()).unwrap();
+        let config = ledger.config().clone();
+        let block_ledger = ledger.states.get_mut(&id).unwrap();
+        block_ledger.mantle_ledger = block_ledger
+            .mantle_ledger
+            .clone()
+            .try_apply_sdp_active(&active_op, &zk_sig, tx_hash, &config)
+            .unwrap()
+            .0;
+        id
     }
 
     #[test]
@@ -1491,6 +1537,87 @@ mod tests {
                 .unwrap()
                 .tip_message,
             inscribe_op3.id()
+        );
+    }
+
+    /// Tests the snapshot-finalization-delay scenario behind the
+    /// `inactivity_period >= SNAPSHOT_FINALIZATION_DELAY` invariant:
+    ///
+    ///   - A declaration is created at epoch 3 — `active = created +
+    ///     SNAPSHOT_FINALIZATION_DELAY = 5`.
+    ///   - An activity message accepted at epoch 6 refreshes the live SDP's
+    ///     `active` to 6.
+    ///   - But the snapshot for epoch 7 was built at the 5→6 transition, before
+    ///     the activity message landed. The snapshot sees the decl with
+    ///     `active=5`, not 6.
+    ///
+    /// With `inactivity_period = SNAPSHOT_FINALIZATION_DELAY = 2`, the
+    /// filter at epoch 7 is `5 + 2 ≥ 7` → INCLUDED. The decl survives the
+    /// finalization-delay gap.
+    #[test]
+    fn snapshot_includes_decl_when_active_refresh_lags_finalization() {
+        let leader_utxo = utxo();
+        let (sdp_utxo_key, sdp_utxo) = utxo_with_sk();
+        let new_utxo_1 = utxo();
+        let new_utxo_2 = utxo();
+        let config = config();
+        let epoch_length = config.epoch_length();
+        let (mut ledger, genesis) = ledger(&[leader_utxo, sdp_utxo], config);
+
+        // Declare at the first slot of epoch 3 — `active = 3 + 2 = 5`.
+        let (h_3, declare, zk_key) = apply_and_add_utxo_and_declaration(
+            &mut ledger,
+            genesis,
+            3 * epoch_length,
+            leader_utxo,
+            new_utxo_1,
+            sdp_utxo,
+            sdp_utxo_key,
+        );
+
+        // Advance to the first slot of epoch 6 and submit an Active message.
+        // This sets the live SDP's `active` to 6.
+        let h_6 = apply_and_add_utxo_and_activity(
+            &mut ledger,
+            h_3,
+            6 * epoch_length,
+            leader_utxo,
+            new_utxo_2,
+            declare.id(),
+            zk_key,
+            1,
+        );
+
+        // Advance to epoch 7. The snapshot for epoch 7 was built at the 5→6
+        // transition, before the epoch-6 Active was applied.
+        let h_7 = update_ledger(&mut ledger, h_6, 7 * epoch_length, leader_utxo).unwrap();
+        assert_eq!(
+            ledger.states[&h_7].cryptarchia_ledger.epoch_state.epoch,
+            Epoch::new(7)
+        );
+        let decl = declaration_in_snapshot(&ledger, &h_7, &declare.id()).expect(
+            "decl must be in the epoch-7 because inactivity_period >= SNAPSHOT_FINALIZATION_DELAY",
+        );
+        assert_eq!(
+            decl.active,
+            Epoch::new(5),
+            "decl must have active=5 because the snapshot was taken at the end of epoch 5 before the activity message was accepted"
+        );
+
+        // Advance to epoch 8. The snapshot for epoch 8 was built at the 6→7
+        // transition, after the epoch-6 Active was applied.
+        let h_8 = update_ledger(&mut ledger, h_7, 8 * epoch_length, leader_utxo).unwrap();
+        assert_eq!(
+            ledger.states[&h_8].cryptarchia_ledger.epoch_state.epoch,
+            Epoch::new(8)
+        );
+        let decl = declaration_in_snapshot(&ledger, &h_8, &declare.id()).expect(
+            "decl must be in the epoch-7 because inactivity_period >= SNAPSHOT_FINALIZATION_DELAY",
+        );
+        assert_eq!(
+            decl.active,
+            Epoch::new(6),
+            "decl must have active=6 because the snapshot was taken at the end of epoch 6 after the activity message was accepted"
         );
     }
 

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -259,7 +259,7 @@ impl<R: Rewards> ServiceState<R> {
             .is_some_and(|withdrawn| withdrawn.strict_add(config.retention_period) < current_epoch);
         let inactive = declaration
             .active
-            .strict_add(config.inactivity_period)
+            .strict_add(config.inactivity_period.into_inner())
             .strict_add(config.retention_period)
             < current_epoch;
         withdrawn || inactive
@@ -283,7 +283,10 @@ impl<R: Rewards> ServiceState<R> {
 /// an activity message has been accepted within `inactivity_period` epochs,
 /// and its withdrawal (if any) has not yet taken effect.
 fn is_active(declaration: &Declaration, current_epoch: Epoch, config: &ServiceParameters) -> bool {
-    declaration.active.strict_add(config.inactivity_period) >= current_epoch
+    declaration
+        .active
+        .strict_add(config.inactivity_period.into_inner())
+        >= current_epoch
         && declaration
             .withdrawn
             .is_none_or(|withdrawn| withdrawn > current_epoch)
@@ -784,7 +787,7 @@ mod tests {
         // Long retention so GC never runs in the window we test, short
         // inactivity so the declaration goes inactive quickly.
         let config = setup(ServiceParameters {
-            inactivity_period: 1.into(),
+            inactivity_period: 2.try_into().unwrap(),
             retention_period: 100.into(),
             epoch: 0.into(),
         });
@@ -821,11 +824,11 @@ mod tests {
         )
         .unwrap();
 
-        // Advance to epoch 5 without an activity message; GC won't fire
-        // (retention=100), but the declaration is inactive past epoch 4
-        // (active=3, inactivity=1 -> 3+1 < 5).
+        // Advance to epoch 6 without an activity message; GC won't fire
+        // (retention=100), but the declaration is inactive past epoch 5
+        // (active=3, inactivity=2 -> 3+2 < 6).
         let mut ledger = ledger;
-        for epoch in 2..=5 {
+        for epoch in 2..=6 {
             let new_epoch_state = next_epoch_state(epoch.into(), last_epoch_state.clone());
             (ledger, _) = ledger
                 .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
@@ -835,10 +838,10 @@ mod tests {
 
         // The declaration is still present in the live ledger (no GC)
         assert!(ledger.get_declaration(&declaration_id).is_some());
-        // but active_declarations at epoch 5 must filter it out.
+        // but active_declarations at epoch 6 must filter it out.
         assert!(
             ledger
-                .active_declarations(5.into(), &config.service_params)
+                .active_declarations(6.into(), &config.service_params)
                 .for_service(&ServiceType::BlendNetwork)
                 .is_none_or(|m| !m.contains_key(&declaration_id)),
             "inactive declaration must be excluded from the active-declarations snapshot"
@@ -851,7 +854,7 @@ mod tests {
     #[test]
     fn active_declarations_includes_genesis_at_epochs_0_and_1() {
         let config = setup(ServiceParameters {
-            inactivity_period: 1.into(),
+            inactivity_period: 2.try_into().unwrap(),
             retention_period: 1.into(),
             epoch: 0.into(),
         });
@@ -902,7 +905,7 @@ mod tests {
         // Long inactivity/retention so the only filter that fires in this test
         // is the withdrawn-effective-epoch check.
         let config = setup(ServiceParameters {
-            inactivity_period: 100.into(),
+            inactivity_period: 100.try_into().unwrap(),
             retention_period: 100.into(),
             epoch: 0.into(),
         });
@@ -989,7 +992,7 @@ mod tests {
         let config = setup(ServiceParameters {
             // Set inactivity/retention periods very short to check that
             // declaration is NOT removed before an activity message is submitted.
-            inactivity_period: 1.into(),
+            inactivity_period: 2.try_into().unwrap(),
             retention_period: 1.into(),
             epoch: 0.into(),
         });
@@ -1062,9 +1065,9 @@ mod tests {
             Epoch::new(4) // epoch when the activity message is submitted/accepted
         );
 
-        // Move forward to the epoch 6. The declaration should be still present
+        // Move forward to the epoch 7. The declaration should be still present
         // because the activity message was accepted at epoch 4.
-        for epoch in 5..=6 {
+        for epoch in 5..=7 {
             let new_epoch_state = next_epoch_state(epoch.into(), last_epoch_state.clone());
             (ledger, _) = ledger
                 .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
@@ -1074,8 +1077,8 @@ mod tests {
         let declarations = ledger.get_declarations(ServiceType::BlendNetwork).unwrap();
         assert!(declarations.contains_key(&declaration_id));
 
-        // Before moving to epoch 7 where declaration will be removed,
-        // applying another header within the same epoch 6 must be a no-op
+        // Before moving to epoch 8 where declaration will be removed,
+        // applying another header within the same epoch 7 must be a no-op
         // (GC and unlock are gated to epoch transitions only).
         let ledger_before = ledger.clone();
         (ledger, _) = ledger
@@ -1086,9 +1089,9 @@ mod tests {
             "within-epoch try_apply_header must not change ledger state"
         );
 
-        // Move forward to epoch 7 where declaration should be removed
+        // Move forward to epoch 8 where declaration should be removed
         // because no activity message has been submitted since epoch 4
-        let new_epoch_state = next_epoch_state(7.into(), last_epoch_state.clone());
+        let new_epoch_state = next_epoch_state(8.into(), last_epoch_state.clone());
         (ledger, _) = ledger
             .try_apply_header(&config, &last_epoch_state, &new_epoch_state)
             .unwrap();
@@ -1157,7 +1160,7 @@ mod tests {
             // inactivity/retention periods should be long enough
             // for this test to avoid the declaration being removed due to
             // inacitivity before we can test the withdraw logic.
-            inactivity_period: 20.into(),
+            inactivity_period: 20.try_into().unwrap(),
             retention_period: 20.into(),
             epoch: 0.into(),
         });

--- a/ledger/src/mantle/sdp/rewards/test_utils.rs
+++ b/ledger/src/mantle/sdp/rewards/test_utils.rs
@@ -59,7 +59,7 @@ pub fn create_provider_id(byte: u8) -> ProviderId {
 
 pub fn create_service_parameters() -> ServiceParameters {
     ServiceParameters {
-        inactivity_period: 1.into(),
+        inactivity_period: 2.try_into().unwrap(),
         retention_period: 1.into(),
         epoch: 0.into(),
     }

--- a/nodes/node/binary/src/config/cryptarchia/deployment.rs
+++ b/nodes/node/binary/src/config/cryptarchia/deployment.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use lb_chain_service::Epoch;
 use lb_core::{
     block::genesis::GenesisBlock,
-    sdp::{MinStake, NumberOfEpochs, ServiceType},
+    sdp::{InactivityPeriod, MinStake, NumberOfEpochs, ServiceType},
 };
 use lb_cryptarchia_engine::{
     Config as ConsensusConfig, average_slots_for_blocks, base_period_length, time::epoch_length,
@@ -87,7 +87,7 @@ pub struct SdpConfig {
 // The same as `lb_core::sdp::ServiceParameters`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServiceParameters {
-    pub inactivity_period: NumberOfEpochs,
+    pub inactivity_period: InactivityPeriod,
     pub retention_period: NumberOfEpochs,
     pub epoch: Epoch,
 }

--- a/nodes/node/binary/src/config/deployment/devnet/deployment.yaml
+++ b/nodes/node/binary/src/config/deployment/devnet/deployment.yaml
@@ -30,7 +30,7 @@ cryptarchia:
   sdp_config:
     service_params:
       BN:
-        inactivity_period: 1
+        inactivity_period: 2
         retention_period: 1
         epoch: 0
     min_stake:

--- a/nodes/node/standalone-deployment-config.yaml
+++ b/nodes/node/standalone-deployment-config.yaml
@@ -30,7 +30,7 @@ cryptarchia:
   sdp_config:
     service_params:
       BN:
-        inactivity_period: 1
+        inactivity_period: 2
         retention_period: 1
         epoch: 0
     min_stake:

--- a/services/chain/chain-leader/src/leadership.rs
+++ b/services/chain/chain-leader/src/leadership.rs
@@ -506,7 +506,7 @@ mod pol_tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 20.into(),
+                            inactivity_period: 20.try_into().unwrap(),
                             retention_period: 100.into(),
                             epoch: 0.into(),
                         },

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -1140,7 +1140,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 20.into(),
+                            inactivity_period: 20.try_into().unwrap(),
                             retention_period: 100.into(),
                             epoch: 0.into(),
                         },

--- a/services/chain/chain-service/src/states.rs
+++ b/services/chain/chain-service/src/states.rs
@@ -147,7 +147,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 20.into(),
+                            inactivity_period: 20.try_into().unwrap(),
                             retention_period: 100.into(),
                             epoch: 0.into(),
                         },
@@ -280,7 +280,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 20.into(),
+                            inactivity_period: 20.try_into().unwrap(),
                             retention_period: 100.into(),
                             epoch: 0.into(),
                         },

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -394,7 +394,7 @@ pub fn ledger_config(security_param: NonZero<u32>) -> lb_ledger::Config {
     service_params.insert(
         lb_core::sdp::ServiceType::BlendNetwork,
         ServiceParameters {
-            inactivity_period: 1.into(),
+            inactivity_period: 2.try_into().unwrap(),
             retention_period: 1.into(),
             epoch: 0.into(),
         },

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -136,7 +136,7 @@ fn test_config(mut config: RunConfig, slots_per_epoch: &AtomicU64) -> RunConfig 
         .service_params
         .get_mut(&ServiceType::BlendNetwork)
         .expect("blend network params should exist");
-    blend_params.inactivity_period = INACTIVITY_PERIOD;
+    blend_params.inactivity_period = INACTIVITY_PERIOD.try_into().unwrap();
     blend_params.retention_period = RETENTION_PERIOD;
 
     // Shorten Blend delay to speed up the test

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -462,7 +462,7 @@ fn patch_sdp_manual_cluster_config(mut config: RunConfig) -> RunConfig {
         .service_params
         .get_mut(&ServiceType::BlendNetwork)
         .expect("blend network params should exist");
-    service_params.inactivity_period = 10.into();
+    service_params.inactivity_period = 10.try_into().unwrap();
     service_params.retention_period = RETENTION_PERIOD;
 
     config.deployment.blend.common.num_blend_layers = 1.try_into().unwrap();

--- a/tools/config/src/deployment.rs
+++ b/tools/config/src/deployment.rs
@@ -53,7 +53,7 @@ const EPOCH_STAKE_DISTRIBUTION_STABILIZATION: u8 = 3;
 const EPOCH_PERIOD_NONCE_BUFFER: u8 = 3;
 const EPOCH_PERIOD_NONCE_STABILIZATION: u8 = 4;
 
-const SDP_INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
+const SDP_INACTIVITY_PERIOD: NumberOfEpochs = NumberOfEpochs::new(2);
 const SDP_RETENTION_PERIOD: NumberOfEpochs = NumberOfEpochs::new(1);
 const SDP_EPOCH: Epoch = Epoch::new(0);
 const MIN_STAKE_THRESHOLD: u64 = 1;
@@ -131,7 +131,7 @@ pub fn e2e_deployment_settings_with_genesis_block(
                 service_params: [(
                     ServiceType::BlendNetwork,
                     ServiceParameters {
-                        inactivity_period: SDP_INACTIVITY_PERIOD,
+                        inactivity_period: SDP_INACTIVITY_PERIOD.try_into().unwrap(),
                         retention_period: SDP_RETENTION_PERIOD,
                         epoch: SDP_EPOCH,
                     },

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1111,7 +1111,7 @@ mod tests {
                     [(
                         ServiceType::BlendNetwork,
                         ServiceParameters {
-                            inactivity_period: 20.into(),
+                            inactivity_period: 20.try_into().unwrap(),
                             retention_period: 100.into(),
                             epoch: 0.into(),
                         },


### PR DESCRIPTION
## 1. What does this PR implement?

I realized that the `inactivity_period` must be at least `SNAPSHOT_FINALIZATION_DELAY` which is 2. This issue hasn't been revealed until the PR https://github.com/logos-blockchain/logos-blockchain/pull/2942 is merged.
If it is 1, a declaration is excluded from the active set earlier than it is intended, in the following example.
- The declaration became active at epoch 5.
- The activity message was submitted/accepted at epoch 6. The `active` field of the declaration in the SDP ledger was updated to 6.
- Now, we're transitioning to epoch 7, using the snapshot taken at the end of epoch 5 (because of `SNAPSHOT_FINALIZATION_DELAY = 2`).
- But, the snapshot filters out the declaration because its `active` field is still 5 in the SDP ledger at the end of epoch 5.

In other words, declarations shouldn't be excluded from the active set before their new `active` value is seen in the snapshot.

Therefore, this PR defines the new `InactivityPeriod` type that guarantees that the value is always `>= SNAPSHOT_FINALIZATION_DELAY`.

## 2. Does the code have enough context to be clearly understood?

Yes. The spec doesn't contain this change, but I put a [comment](https://app.notion.com/p/1-0-0-Service-Declaration-Protocol-33d261aa09df808f834bc728ae0c5e0f?d=380261aa09df80a0802d001c6961e800&source=copy_link#33d261aa09df80d0bd1ce9c4f5262d39) in the RFC, and let @madxor know about it.

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

The RFC should be updated, as I commented, after reviewed by @madxor 

## 5. Does the implementation introduce changes in the specification?
Yes, as mentioned above.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
