### PR TITLE
fix(blend): wait until chain becomes online before requesting epoch states

### DIFF
--- a/services/blend/src/lib.rs
+++ b/services/blend/src/lib.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::StreamExt as _;
 pub use lb_blend::message::{crypto::proofs::RealProofsVerifier, encap::ProofsVerifier};
 use lb_blend::scheduling::epoch::UninitializedEpochEventStream;
-use lb_chain_service::api::CryptarchiaServiceData;
+use lb_chain_service::api::{CryptarchiaServiceApi, CryptarchiaServiceData};
 use lb_core::{
     mantle::NoteId,
     sdp::{DeclarationId, DeclarationMessage, Locator, ProviderId, ServiceType},
@@ -179,7 +179,8 @@ where
             &overwatch_handle,
             Some(Duration::from_mins(1)),
             PreloadKmsService<_>,
-            SdpService
+            SdpService,
+            <EdgeService as EdgeServiceComponents>::ChainService
         )
         .await?;
 
@@ -208,6 +209,24 @@ where
         let local_node_id =
             CoreService::NodeId::try_from_provider_id(non_ephemeral_signing_key_public.as_bytes())
                 .expect("non-ephemeral signing public key should decode into a valid node id");
+
+        // Wait until the chain becomes Online mode before subscribing to memberships.
+        // Chain service provides the correct epoch state only after the chain becomes
+        // Online.
+        let chain_api = CryptarchiaServiceApi::<
+            <EdgeService as EdgeServiceComponents>::ChainService,
+            RuntimeServiceId,
+        >::new(
+            overwatch_handle
+                .relay::<<EdgeService as EdgeServiceComponents>::ChainService>()
+                .await?,
+        );
+        info!(target: LOG_TARGET, "Waiting for chain to become Online mode");
+        chain_api
+            .wait_until_chain_becomes_online()
+            .await
+            .expect("Waiting for chain to be online should succeed");
+        info!(target: LOG_TARGET, "Chain is now Online.");
 
         let membership_stream = membership::chain::subscribe::<
             <EdgeService as EdgeServiceComponents>::ChainService,


### PR DESCRIPTION
## 1. What does this PR implement?

The blend service should wait until the chain become online, because the chain service can't provide correct `EpochState`s during bootstrapping (because it never knows whether there are still blocks left to be added to the epoch that could change the `EpochState`).


## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee
spec: @madxor @davidrusu  

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
