### PR TITLE
feat(chain-network): proactive tip-poll lag watchdog

### DIFF
--- a/.github/workflows/end-to-end-with-cucumber.yml
+++ b/.github/workflows/end-to-end-with-cucumber.yml
@@ -112,6 +112,28 @@ jobs:
           command: nextest
           args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --features mantle_sdp --test test_mantle_sdp_ops --test test_mantle_sdp_blend --no-fail-fast
 
+      # Build the testing-featured node binary required by tip_poll_self_heal.
+      - name: Build testing binary for tip_poll_self_heal
+        if: ${{ !cancelled() && steps.verify_local_ntp.conclusion == 'success' }}
+        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72
+        with:
+          command: build
+          args: --locked --release -p logos-blockchain-node --features testing-disable-proposal-publish
+        env:
+          CARGO_INCREMENTAL: 0  # Disable incremental compilation
+
+      # Run the isolated tip-poll self-heal test that requires the testing-featured node binary.
+      - name: End-to-end integration tests - tip_poll_self_heal
+        id: tip_poll_self_heal_end_to_end
+        if: ${{ !cancelled() && steps.verify_local_ntp.conclusion == 'success' }}
+        timeout-minutes: 90
+        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
+        env:
+          USE_LOCAL_HOST_NTP_TIME_CONFIG: true # Ensure tests use local NTP server for time sync
+        with:
+          command: nextest
+          args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --features tip_poll_self_heal --test test_cryptarchia_tip_poll_self_heal --no-fail-fast
+
       # Build release binaries for the remaining end-to-end tests.
       - name: Build binaries for remaining end-to-end tests
         if: ${{ !cancelled() && steps.verify_local_ntp.conclusion == 'success' }}
@@ -136,7 +158,7 @@ jobs:
           args: run --locked --jobs ${{ env.E2E_NEXTEST_JOBS }} --retries 2 -p logos-blockchain-tests --no-fail-fast
 
       - name: Upload integration tests results on failure
-        if: ${{ failure() && (steps.mantle_sdp_end_to_end.conclusion == 'failure' || steps.end_to_end.conclusion == 'failure') }}
+        if: ${{ failure() && (steps.mantle_sdp_end_to_end.conclusion == 'failure' || steps.tip_poll_self_heal_end_to_end.conclusion == 'failure' || steps.end_to_end.conclusion == 'failure') }}
         uses: actions/upload-artifact@6027e3dd177782cd8ab9af838c04fd81a07f1d47 # Version 4.6.2
         with:
           name: integration-test-artifacts-${{ runner.os }}-${{ github.sha }}

--- a/nodes/node/binary/Cargo.toml
+++ b/nodes/node/binary/Cargo.toml
@@ -84,9 +84,10 @@ rand             = { workspace = true }
 serde_urlencoded = { workspace = true }
 
 [features]
-default   = ["tracing"]
-dhat-heap = ["dep:dhat"]
-jemalloc  = ["dep:tikv-jemallocator"]
-profiling = ["lb-http-api-common/profiling", "lb-tracing-service/profiling"]
-testing   = ["lb-key-management-system-service/unsafe"]
-tracing   = []
+default                          = ["tracing"]
+dhat-heap                        = ["dep:dhat"]
+jemalloc                         = ["dep:tikv-jemallocator"]
+profiling                        = ["lb-http-api-common/profiling", "lb-tracing-service/profiling"]
+testing                          = ["lb-key-management-system-service/unsafe"]
+testing-disable-proposal-publish = ["lb-chain-leader-service/testing-disable-proposal-publish"]
+tracing                          = []

--- a/nodes/node/binary/src/config/cryptarchia/mod.rs
+++ b/nodes/node/binary/src/config/cryptarchia/mod.rs
@@ -132,6 +132,11 @@ impl ServiceConfig {
                 orphan: lb_chain_network_service::OrphanConfig {
                     max_orphan_cache_size: self.user.network.sync.orphan.max_orphan_cache_size,
                 },
+                tip_poll: lb_chain_network_service::TipPollConfig {
+                    enabled: self.user.network.sync.tip_poll.enabled,
+                    lag_threshold_blocks: self.user.network.sync.tip_poll.lag_threshold_blocks,
+                    max_peers_to_sample: self.user.network.sync.tip_poll.max_peers_to_sample,
+                },
             },
         };
         let chain_leader_settings = lb_chain_leader_service::LeaderSettings {

--- a/nodes/node/binary/src/config/cryptarchia/serde/network.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/network.rs
@@ -1,4 +1,7 @@
-use core::{num::NonZeroUsize, time::Duration};
+use core::{
+    num::{NonZeroU64, NonZeroUsize},
+    time::Duration,
+};
 use std::collections::HashSet;
 
 use libp2p::PeerId;
@@ -43,6 +46,7 @@ impl Default for IbdConfig {
 #[serde(default)]
 pub struct SyncConfig {
     pub orphan: OrphanConfig,
+    pub tip_poll: TipPollConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -56,6 +60,28 @@ impl Default for OrphanConfig {
     fn default() -> Self {
         Self {
             max_orphan_cache_size: NonZeroUsize::new(1000).unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TipPollConfig {
+    /// Whether the proactive tip-polling lag watchdog is enabled.
+    pub enabled: bool,
+    /// How many expected block-intervals (`1/f` slots each) the local tip may
+    /// lag behind the current slot before we proactively poll peers.
+    pub lag_threshold_blocks: NonZeroU64,
+    /// Maximum number of peers to sample with `GetTip` on each poll.
+    pub max_peers_to_sample: NonZeroUsize,
+}
+
+impl Default for TipPollConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            lag_threshold_blocks: NonZeroU64::new(3).unwrap(),
+            max_peers_to_sample: NonZeroUsize::new(5).unwrap(),
         }
     }
 }

--- a/services/chain/chain-leader/Cargo.toml
+++ b/services/chain/chain-leader/Cargo.toml
@@ -42,3 +42,6 @@ lb-utils   = { workspace = true }
 
 [features]
 default = []
+# Suppresses publishing of locally-proposed blocks over the blend network.
+# The block is still self-applied to this node's chain. Test-only build flag.
+testing-disable-proposal-publish = []

--- a/services/chain/chain-leader/src/blend.rs
+++ b/services/chain/chain-leader/src/blend.rs
@@ -1,3 +1,7 @@
+// When `testing-disable-proposal-publish` is on, some functions and struct
+// fields are not used.
+#![cfg_attr(feature = "testing-disable-proposal-publish", allow(dead_code))]
+
 use std::marker::PhantomData;
 
 use lb_blend_service::message::{NetworkMessage, ProxyServiceMessage, ServiceMessage};

--- a/services/chain/chain-leader/src/blend.rs
+++ b/services/chain/chain-leader/src/blend.rs
@@ -1,6 +1,10 @@
-// When `testing-disable-proposal-publish` is on, some functions and struct
-// fields are not used.
-#![cfg_attr(feature = "testing-disable-proposal-publish", allow(dead_code))]
+#![cfg_attr(
+    feature = "testing-disable-proposal-publish",
+    allow(
+        dead_code,
+        reason = "with proposal publishing disabled for testing, some functions and struct fields are unused"
+    )
+)]
 
 use std::marker::PhantomData;
 

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -690,7 +690,11 @@ where
         #[cfg(not(feature = "testing-disable-proposal-publish"))]
         blend_adapter.publish_proposal(block.to_proposal()).await;
         #[cfg(feature = "testing-disable-proposal-publish")]
-        let _ = blend_adapter;
+        let _ = {
+            tracing::warn!(target: LOG_TARGET, "proposal publishing is disabled by the `testing-disable-proposal-publish` feature");
+            blend_adapter
+        };
+
         metrics::consensus_proposals_created_local();
     }
 

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -687,7 +687,10 @@ where
             return;
         }
 
+        #[cfg(not(feature = "testing-disable-proposal-publish"))]
         blend_adapter.publish_proposal(block.to_proposal()).await;
+        #[cfg(feature = "testing-disable-proposal-publish")]
+        let _ = blend_adapter;
         metrics::consensus_proposals_created_local();
     }
 

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -1036,6 +1036,10 @@ mod tests {
             }
         }
 
+        async fn sample_tips(&self, _max_peers: usize) -> BoxedStream<GetTipResponse> {
+            Box::new(futures::stream::empty())
+        }
+
         async fn request_blocks_from_peer(
             &self,
             peer: Self::PeerId,

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -641,15 +641,16 @@ where
     /// Proactive tip-poll lag watchdog.
     ///
     /// Fires on a slot-tick cadence (`params.cadence_slots`, ≈ one expected
-    /// block interval). When the local tip has fallen behind the current slot by
-    /// more than `params.lag_threshold_slots`, it samples a handful of peers
-    /// with `GetTip` and hands the most-advanced tip that is strictly ahead of
-    /// the local height to the orphan downloader, which performs the actual
-    /// catch-up download and full validation.
+    /// block interval). When the local tip has fallen behind the current slot
+    /// by more than `params.lag_threshold_slots`, it samples a handful of
+    /// peers with `GetTip` and hands the most-advanced tip that is strictly
+    /// ahead of the local height to the orphan downloader, which performs
+    /// the actual catch-up download and full validation.
     ///
     /// Polled tips are unauthenticated peer hearsay, but enqueuing one only
     /// triggers a download: every downloaded block still goes through normal
-    /// `apply_block` validation, and a bogus tip is dropped on download failure.
+    /// `apply_block` validation, and a bogus tip is dropped on download
+    /// failure.
     async fn poll_peer_tips_if_behind(
         network_adapter: &NetAdapter,
         cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
@@ -781,8 +782,8 @@ struct TipPollParams {
 
 impl TipPollParams {
     /// Derive the polling cadence and lag threshold from the active slot
-    /// coefficient `f`. The expected number of slots between blocks is `1/f`, so
-    /// the cadence is `ceil(1/f)` slots and the lag threshold is
+    /// coefficient `f`. The expected number of slots between blocks is `1/f`,
+    /// so the cadence is `ceil(1/f)` slots and the lag threshold is
     /// `lag_threshold_blocks` such intervals.
     async fn derive<Cryptarchia, RuntimeServiceId>(
         config: &TipPollConfig,
@@ -809,8 +810,7 @@ impl TipPollParams {
         }
 
         let cadence_slots = denominator.div_ceil(numerator).max(1);
-        let lag_threshold_slots =
-            cadence_slots.saturating_mul(config.lag_threshold_blocks.get());
+        let lag_threshold_slots = cadence_slots.saturating_mul(config.lag_threshold_blocks.get());
 
         Ok(Self {
             cadence_slots,

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -701,7 +701,11 @@ where
         };
         metrics::tip_poll_triggered_total();
 
-        let tips = network_adapter.sample_tips(params.max_peers).await;
+        let tips: Vec<GetTipResponse> = network_adapter
+            .sample_tips(params.max_peers)
+            .await
+            .collect()
+            .await;
 
         // Pick the most-advanced reported tip that is strictly ahead of us.
         let Some((height, _, tip)) = select_catchup_tip(tips, info.height) else {

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -694,25 +694,11 @@ where
             return;
         }
 
-        let info = match cryptarchia.info().await {
-            Ok(info) => info.cryptarchia_info,
-            Err(e) => {
-                warn!(target: LOG_TARGET, %e, "tip poll: failed to read local chain info");
-                return;
-            }
-        };
-
-        let tip_slot = u64::from(info.slot);
-        let lag = current_slot.saturating_sub(tip_slot);
-        if lag <= params.lag_threshold_slots {
+        let Some(info) =
+            Self::lagging_local_info(cryptarchia, current_slot, params.lag_threshold_slots).await
+        else {
             return;
-        }
-
-        debug!(
-            target: LOG_TARGET,
-            lag, tip_slot, current_slot,
-            "Chain tip lagging; polling peers for their tip"
-        );
+        };
         metrics::tip_poll_triggered_total();
 
         let tips = network_adapter.sample_tips(params.max_peers).await;
@@ -737,6 +723,39 @@ where
         {
             debug!(target: LOG_TARGET, %e, "tip poll: select! loop has dropped the polled-tip receiver");
         }
+    }
+
+    /// Read the local chain info and return it only if the tip is lagging the
+    /// current slot by more than `lag_threshold_slots`. Returns `None` (and
+    /// logs) when the info can't be read or the node is keeping up.
+    async fn lagging_local_info(
+        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+        current_slot: u64,
+        lag_threshold_slots: u64,
+    ) -> Option<lb_chain_service::CryptarchiaInfo>
+    where
+        RuntimeServiceId: Send + Sync,
+    {
+        let info = match cryptarchia.info().await {
+            Ok(info) => info.cryptarchia_info,
+            Err(e) => {
+                warn!(target: LOG_TARGET, %e, "tip poll: failed to read local chain info");
+                return None;
+            }
+        };
+
+        let tip_slot = u64::from(info.slot);
+        let lag = current_slot.saturating_sub(tip_slot);
+        if lag <= lag_threshold_slots {
+            return None;
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            lag, tip_slot, current_slot,
+            "Chain tip lagging; polling peers for their tip"
+        );
+        Some(info)
     }
 
     /// Hand a tip discovered by the watchdog to the orphan downloader and

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -666,11 +666,6 @@ where
             return;
         }
 
-        // Don't pile on while a catch-up download is already in flight.
-        if orphan_downloader.should_poll() {
-            return;
-        }
-
         let info = match cryptarchia.info().await {
             Ok(info) => info.cryptarchia_info,
             Err(e) => {

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -348,6 +348,10 @@ where
             None
         };
 
+        let (polled_tip_tx, mut polled_tip_rx) =
+            tokio::sync::mpsc::channel::<PolledTip>(POLLED_TIP_CHANNEL_CAPACITY);
+        let mut tip_poll_task: Option<tokio::task::JoinHandle<()>> = None;
+
         self.notify_service_ready();
 
         let async_loop = async {
@@ -367,6 +371,15 @@ where
                         if let Err(e) = relays.cryptarchia().handle_chainsync_event(event).await {
                             error!(target: LOG_TARGET, "Failed to forward chainsync event to chain-service: {e}");
                         }
+                    }
+
+                    Some(polled) = polled_tip_rx.recv() => {
+                        Self::enqueue_polled_tip(
+                            orphan_downloader.as_mut().get_mut(),
+                            polled.tip,
+                            polled.height,
+                            &polled.local,
+                        );
                     }
 
                     Some(block) = orphan_downloader.next(), if orphan_downloader.should_poll() => {
@@ -399,17 +412,32 @@ where
                     }
 
                     Some(tick) = slot_ticks.next(), if tip_poll_params.is_some() => {
-                        let params = tip_poll_params
+                        // Don't start a new poll if the previous one is still running.
+                        if tip_poll_task.as_ref().is_some_and(|handle| !handle.is_finished()) {
+                            continue;
+                        }
+
+                        let params = *tip_poll_params
                             .as_ref()
                             .expect("tip_poll_params is Some, guaranteed by the select arm condition");
-                        Self::poll_peer_tips_if_behind(
-                            &tip_poll_adapter,
-                            relays.cryptarchia(),
-                            orphan_downloader.as_mut().get_mut(),
-                            tick,
-                            params,
-                        )
-                        .await;
+
+                        // Spawn a task to not block this event loop.
+                        // The task makes `GetTip` requests handled by this event loop in peers' side.
+                        // All two nodes make `GetTip` requests simultaneously to each other,
+                        // `poll_peer_tips_if_behind` will cause deadlock unless it's spawned off.
+                        let adapter = tip_poll_adapter.clone();
+                        let cryptarchia = relays.cryptarchia().clone();
+                        let tx = polled_tip_tx.clone();
+                        tip_poll_task = Some(tokio::spawn(async move {
+                            Self::poll_peer_tips_if_behind(
+                                &adapter,
+                                &cryptarchia,
+                                tick,
+                                &params,
+                                &tx,
+                            )
+                            .await;
+                        }));
                     }
 
                     Some(msg) = self.service_resources_handle.inbound_relay.next() => {
@@ -654,9 +682,9 @@ where
     async fn poll_peer_tips_if_behind(
         network_adapter: &NetAdapter,
         cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
-        orphan_downloader: &mut OrphanBlocksDownloader<NetAdapter, RuntimeServiceId>,
         tick: SlotTick,
         params: &TipPollParams,
+        polled_tip_tx: &tokio::sync::mpsc::Sender<PolledTip>,
     ) where
         RuntimeServiceId: Send + Sync + 'static,
     {
@@ -699,7 +727,16 @@ where
             return;
         };
 
-        Self::enqueue_polled_tip(orphan_downloader, tip, height, &info);
+        if let Err(e) = polled_tip_tx
+            .send(PolledTip {
+                tip,
+                height,
+                local: info,
+            })
+            .await
+        {
+            debug!(target: LOG_TARGET, %e, "tip poll: select! loop has dropped the polled-tip receiver");
+        }
     }
 
     /// Hand a tip discovered by the watchdog to the orphan downloader and
@@ -779,7 +816,16 @@ fn select_catchup_tip(
         .max_by_key(|(height, slot, _)| (*height, u64::from(*slot)))
 }
 
+struct PolledTip {
+    tip: HeaderId,
+    height: u64,
+    local: lb_chain_service::CryptarchiaInfo,
+}
+
+const POLLED_TIP_CHANNEL_CAPACITY: usize = 32;
+
 /// Derived parameters for the proactive tip-poll lag watchdog.
+#[derive(Clone, Copy)]
 struct TipPollParams {
     /// Act every this many slots (≈ one expected block interval, `1/f`).
     cadence_slots: u64,

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -22,11 +22,10 @@ use lb_core::{
     mantle::{AuthenticatedMantleTx, Transaction, TxHash},
 };
 pub use lb_cryptarchia_engine::{Epoch, Slot};
-use lb_cryptarchia_sync::GetTipResponse;
 pub use lb_ledger::EpochState;
 use lb_network_service::NetworkService;
 use lb_services_utils::wait_until_services_are_ready;
-use lb_time_service::{SlotTick, TimeService, TimeServiceMessage};
+use lb_time_service::{TimeService, TimeServiceMessage};
 use lb_tx_service::{
     TxMempoolService, backend::RecoverableMempool,
     network::NetworkAdapter as MempoolNetworkAdapter, storage::MempoolStorageAdapter,
@@ -41,7 +40,11 @@ use overwatch::{
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
-use tokio::{sync::oneshot, time::sleep};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+    time::sleep,
+};
 use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 use tracing_futures::Instrument as _;
 
@@ -53,7 +56,10 @@ use crate::{
     bootstrap::ibd::InitialBlockDownload,
     mempool::{MempoolAdapter as _, adapter::MempoolAdapter},
     relays::ChainNetworkRelays,
-    sync::orphan_handler::OrphanBlocksDownloader,
+    sync::{
+        orphan_handler::OrphanBlocksDownloader,
+        tip_poll::{PolledTip, TipPollParams, poll_peer_tips_if_behind},
+    },
 };
 
 const SERVICE_ID: &str = "ChainNetwork";
@@ -348,9 +354,8 @@ where
             None
         };
 
-        let (polled_tip_tx, mut polled_tip_rx) =
-            tokio::sync::mpsc::channel::<PolledTip>(POLLED_TIP_CHANNEL_CAPACITY);
-        let mut tip_poll_task: Option<tokio::task::JoinHandle<()>> = None;
+        let (polled_tip_tx, mut polled_tip_rx) = mpsc::channel::<PolledTip>(32);
+        let mut tip_poll_task: Option<JoinHandle<()>> = None;
 
         self.notify_service_ready();
 
@@ -429,14 +434,15 @@ where
                         let cryptarchia = relays.cryptarchia().clone();
                         let tx = polled_tip_tx.clone();
                         tip_poll_task = Some(tokio::spawn(async move {
-                            Self::poll_peer_tips_if_behind(
+                            if let Some(polled) = poll_peer_tips_if_behind(
                                 &adapter,
                                 &cryptarchia,
                                 tick,
                                 &params,
-                                &tx,
                             )
-                            .await;
+                            .await && let Err(e) = tx.send(polled).await {
+                                error!(target: LOG_TARGET, %e, "the polled-tip receiver has been dropped");
+                            }
                         }));
                     }
 
@@ -666,102 +672,6 @@ where
         );
     }
 
-    /// Proactive tip-poll lag watchdog.
-    ///
-    /// Fires on a slot-tick cadence (`params.cadence_slots`, ≈ one expected
-    /// block interval). When the local tip has fallen behind the current slot
-    /// by more than `params.lag_threshold_slots`, it samples a handful of
-    /// peers with `GetTip` and hands the most-advanced tip that is strictly
-    /// ahead of the local height to the orphan downloader, which performs
-    /// the actual catch-up download and full validation.
-    ///
-    /// Polled tips are unauthenticated peer hearsay, but enqueuing one only
-    /// triggers a download: every downloaded block still goes through normal
-    /// `apply_block` validation, and a bogus tip is dropped on download
-    /// failure.
-    async fn poll_peer_tips_if_behind(
-        network_adapter: &NetAdapter,
-        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
-        tick: SlotTick,
-        params: &TipPollParams,
-        polled_tip_tx: &tokio::sync::mpsc::Sender<PolledTip>,
-    ) where
-        RuntimeServiceId: Send + Sync + 'static,
-    {
-        // Cadence gate: only act roughly once per expected block interval.
-        let current_slot = u64::from(tick.slot);
-        if current_slot % params.cadence_slots != 0 {
-            return;
-        }
-
-        let Some(info) =
-            Self::lagging_local_info(cryptarchia, current_slot, params.lag_threshold_slots).await
-        else {
-            return;
-        };
-        metrics::tip_poll_triggered_total();
-
-        let tips: Vec<GetTipResponse> = network_adapter
-            .sample_tips(params.max_peers)
-            .await
-            .collect()
-            .await;
-
-        // Pick the most-advanced reported tip that is strictly ahead of us.
-        let Some((height, _, tip)) = select_catchup_tip(tips, info.height) else {
-            debug!(
-                target: LOG_TARGET,
-                local_height = info.height,
-                "tip poll: no sampled peer reported a tip ahead of us"
-            );
-            return;
-        };
-
-        if let Err(e) = polled_tip_tx
-            .send(PolledTip {
-                tip,
-                height,
-                local: info,
-            })
-            .await
-        {
-            debug!(target: LOG_TARGET, %e, "tip poll: select! loop has dropped the polled-tip receiver");
-        }
-    }
-
-    /// Read the local chain info and return it only if the tip is lagging the
-    /// current slot by more than `lag_threshold_slots`. Returns `None` (and
-    /// logs) when the info can't be read or the node is keeping up.
-    async fn lagging_local_info(
-        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
-        current_slot: u64,
-        lag_threshold_slots: u64,
-    ) -> Option<lb_chain_service::CryptarchiaInfo>
-    where
-        RuntimeServiceId: Send + Sync,
-    {
-        let info = match cryptarchia.info().await {
-            Ok(info) => info.cryptarchia_info,
-            Err(e) => {
-                warn!(target: LOG_TARGET, %e, "tip poll: failed to read local chain info");
-                return None;
-            }
-        };
-
-        let tip_slot = u64::from(info.slot);
-        let lag = current_slot.saturating_sub(tip_slot);
-        if lag <= lag_threshold_slots {
-            return None;
-        }
-
-        debug!(
-            target: LOG_TARGET,
-            lag, tip_slot, current_slot,
-            "Chain tip lagging; polling peers for their tip"
-        );
-        Some(info)
-    }
-
     /// Hand a tip discovered by the watchdog to the orphan downloader and
     /// record the outcome. `chosen_tip`/`chosen_height` describe the polled
     /// tip; `local` is the local chain info it is being caught up against.
@@ -817,84 +727,6 @@ where
                 }
             }
         }
-    }
-}
-
-/// From a set of polled tip responses, pick the most-advanced tip that is
-/// strictly ahead of `local_height`. Ties on height are broken by the higher
-/// slot. `Failure` responses are ignored. Returns `(height, slot, tip)`.
-fn select_catchup_tip(
-    tips: impl IntoIterator<Item = GetTipResponse>,
-    local_height: u64,
-) -> Option<(u64, Slot, HeaderId)> {
-    tips.into_iter()
-        .filter_map(|resp| match resp {
-            GetTipResponse::Tip { tip, slot, height } => Some((height, slot, tip)),
-            GetTipResponse::Failure(reason) => {
-                debug!(target: LOG_TARGET, %reason, "tip poll: peer reported failure");
-                None
-            }
-        })
-        .filter(|(height, _, _)| *height > local_height)
-        .max_by_key(|(height, slot, _)| (*height, u64::from(*slot)))
-}
-
-struct PolledTip {
-    tip: HeaderId,
-    height: u64,
-    local: lb_chain_service::CryptarchiaInfo,
-}
-
-const POLLED_TIP_CHANNEL_CAPACITY: usize = 32;
-
-/// Derived parameters for the proactive tip-poll lag watchdog.
-#[derive(Clone, Copy)]
-struct TipPollParams {
-    /// Act every this many slots (≈ one expected block interval, `1/f`).
-    cadence_slots: u64,
-    /// Lag, in slots, beyond which we proactively poll peers for their tip.
-    lag_threshold_slots: u64,
-    /// Maximum number of peers to sample with `GetTip` per poll.
-    max_peers: usize,
-}
-
-impl TipPollParams {
-    /// Derive the polling cadence and lag threshold from the active slot
-    /// coefficient `f`. The expected number of slots between blocks is `1/f`,
-    /// so the cadence is `ceil(1/f)` slots and the lag threshold is
-    /// `lag_threshold_blocks` such intervals.
-    async fn derive<Cryptarchia, RuntimeServiceId>(
-        config: &TipPollConfig,
-        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
-    ) -> Result<Self, DynError>
-    where
-        Cryptarchia: CryptarchiaServiceData<Tx: Send + Sync>,
-        RuntimeServiceId: Sync,
-    {
-        let (_, consensus_config) = cryptarchia
-            .get_epoch_config()
-            .await
-            .map_err(|e| DynError::from(format!("failed to fetch epoch config: {e}")))?;
-
-        // `f = numerator / denominator`, so `1/f = denominator / numerator`.
-        // Compute `ceil(1/f)` with integer arithmetic to avoid float casts.
-        let coeff = consensus_config.slot_activation_coeff();
-        let numerator = u64::from(coeff.numerator);
-        let denominator = core::num::NonZeroU64::from(coeff.denominator).get();
-        if numerator == 0 {
-            return Err(DynError::from(
-                "active slot coefficient f must be > 0 for tip polling",
-            ));
-        }
-
-        let cadence_slots = denominator.div_ceil(numerator).max(1);
-        let lag_threshold_slots = cadence_slots.saturating_mul(config.lag_threshold_blocks.get());
-
-        Ok(Self {
-            cadence_slots,
-            lag_threshold_slots,
-            max_peers: config.max_peers_to_sample.get(),
-        })
     }
 }
 
@@ -1201,51 +1033,5 @@ mod tests {
 
         assert!(matches!(result, Err(Error::InvalidBlock(_))));
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
-    }
-
-    fn tip(height: u64, slot: u64, id: u8) -> GetTipResponse {
-        GetTipResponse::Tip {
-            tip: HeaderId::from([id; 32]),
-            slot: Slot::new(slot),
-            height,
-        }
-    }
-
-    #[test]
-    fn select_catchup_tip_ignores_tips_at_or_below_local_height() {
-        let tips = vec![tip(10, 100, 1), tip(9, 200, 2)];
-        // local height is 10: nothing strictly ahead.
-        assert!(select_catchup_tip(tips, 10).is_none());
-    }
-
-    #[test]
-    fn select_catchup_tip_picks_highest_then_breaks_ties_by_slot() {
-        let tips = vec![
-            tip(12, 100, 1),
-            tip(15, 300, 2), // highest height
-            tip(15, 400, 3), // same height, higher slot -> winner
-            tip(14, 999, 4),
-        ];
-        let (height, slot, id) = select_catchup_tip(tips, 11).expect("a tip ahead exists");
-        assert_eq!(height, 15);
-        assert_eq!(slot, Slot::new(400));
-        assert_eq!(id, HeaderId::from([3; 32]));
-    }
-
-    #[test]
-    fn select_catchup_tip_skips_failures() {
-        let tips = vec![
-            GetTipResponse::Failure("busy".to_owned()),
-            tip(20, 500, 7),
-            GetTipResponse::Failure("nope".to_owned()),
-        ];
-        let (height, _, id) = select_catchup_tip(tips, 5).expect("a tip ahead exists");
-        assert_eq!(height, 20);
-        assert_eq!(id, HeaderId::from([7; 32]));
-    }
-
-    #[test]
-    fn select_catchup_tip_empty_is_none() {
-        assert!(select_catchup_tip(Vec::new(), 0).is_none());
     }
 }

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -704,17 +704,31 @@ where
             return;
         };
 
-        match orphan_downloader.enqueue_orphan(tip, info.tip, info.lib) {
+        Self::enqueue_polled_tip(orphan_downloader, tip, height, &info);
+    }
+
+    /// Hand a tip discovered by the watchdog to the orphan downloader and
+    /// record the outcome. `chosen_tip`/`chosen_height` describe the polled
+    /// tip; `local` is the local chain info it is being caught up against.
+    fn enqueue_polled_tip(
+        orphan_downloader: &mut OrphanBlocksDownloader<NetAdapter, RuntimeServiceId>,
+        chosen_tip: HeaderId,
+        chosen_height: u64,
+        local: &lb_chain_service::CryptarchiaInfo,
+    ) where
+        RuntimeServiceId: Send + Sync + 'static,
+    {
+        match orphan_downloader.enqueue_orphan(chosen_tip, local.tip, local.lib) {
             Ok(()) => {
                 info!(
                     target: LOG_TARGET,
-                    ?tip, height, local_height = info.height,
+                    tip = ?chosen_tip, height = chosen_height, local_height = local.height,
                     "tip poll: enqueued peer tip for catch-up"
                 );
                 metrics::tip_poll_enqueued_total();
             }
             Err(e) => {
-                debug!(target: LOG_TARGET, %e, ?tip, "tip poll: did not enqueue polled tip");
+                debug!(target: LOG_TARGET, %e, tip = ?chosen_tip, "tip poll: did not enqueue polled tip");
             }
         }
     }
@@ -802,7 +816,7 @@ impl TipPollParams {
         // Compute `ceil(1/f)` with integer arithmetic to avoid float casts.
         let coeff = consensus_config.slot_activation_coeff();
         let numerator = u64::from(coeff.numerator);
-        let denominator = u64::from(coeff.denominator.get());
+        let denominator = core::num::NonZeroU64::from(coeff.denominator).get();
         if numerator == 0 {
             return Err(DynError::from(
                 "active slot coefficient f must be > 0 for tip polling",

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -22,10 +22,11 @@ use lb_core::{
     mantle::{AuthenticatedMantleTx, Transaction, TxHash},
 };
 pub use lb_cryptarchia_engine::{Epoch, Slot};
+use lb_cryptarchia_sync::GetTipResponse;
 pub use lb_ledger::EpochState;
 use lb_network_service::NetworkService;
 use lb_services_utils::wait_until_services_are_ready;
-use lb_time_service::TimeService;
+use lb_time_service::{SlotTick, TimeService, TimeServiceMessage};
 use lb_tx_service::{
     TxMempoolService, backend::RecoverableMempool,
     network::NetworkAdapter as MempoolNetworkAdapter, storage::MempoolStorageAdapter,
@@ -46,7 +47,7 @@ use tracing_futures::Instrument as _;
 
 pub use crate::{
     bootstrap::config::{BootstrapConfig, IbdConfig},
-    sync::config::{OrphanConfig, SyncConfig},
+    sync::config::{OrphanConfig, SyncConfig, TipPollConfig},
 };
 use crate::{
     bootstrap::ibd::InitialBlockDownload,
@@ -300,10 +301,52 @@ where
         let mut incoming_proposals = network_adapter.proposals_stream().await?;
         let mut chainsync_events = network_adapter.chainsync_events_stream().await?;
 
+        // Keep a handle to the adapter for the proactive tip-poll watchdog before
+        // the downloader takes ownership of it.
+        let tip_poll_adapter = network_adapter.clone();
+
         let mut orphan_downloader = Box::pin(OrphanBlocksDownloader::new(
             network_adapter,
             sync_config.orphan.max_orphan_cache_size,
         ));
+
+        // Set up the proactive tip-poll lag watchdog: subscribe to slot ticks and
+        // derive the polling cadence / lag threshold from the active slot
+        // coefficient `f`. If it can't be derived (or polling is disabled), the
+        // watchdog stays inert and the slot-tick arm is gated off.
+        let mut slot_ticks = {
+            let (sender, receiver) = oneshot::channel();
+            relays
+                .time_relay()
+                .send(TimeServiceMessage::Subscribe { sender })
+                .await
+                .map_err(|(e, _)| {
+                    DynError::from(format!("failed to subscribe to slot ticks: {e}"))
+                })?;
+            receiver
+                .await
+                .map_err(|e| DynError::from(format!("failed to receive slot tick stream: {e}")))?
+        };
+        let tip_poll_params = if sync_config.tip_poll.enabled {
+            match TipPollParams::derive(&sync_config.tip_poll, relays.cryptarchia()).await {
+                Ok(params) => {
+                    info!(
+                        target: LOG_TARGET,
+                        cadence_slots = params.cadence_slots,
+                        lag_threshold_slots = params.lag_threshold_slots,
+                        max_peers = params.max_peers,
+                        "Tip-poll lag watchdog enabled"
+                    );
+                    Some(params)
+                }
+                Err(e) => {
+                    error!(target: LOG_TARGET, %e, "Failed to derive tip-poll params; watchdog disabled");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         self.notify_service_ready();
 
@@ -353,6 +396,20 @@ where
                                 orphan_downloader.cancel_active_download();
                             }
                         }
+                    }
+
+                    Some(tick) = slot_ticks.next(), if tip_poll_params.is_some() => {
+                        let params = tip_poll_params
+                            .as_ref()
+                            .expect("tip_poll_params is Some, guaranteed by the select arm condition");
+                        Self::poll_peer_tips_if_behind(
+                            &tip_poll_adapter,
+                            relays.cryptarchia(),
+                            orphan_downloader.as_mut().get_mut(),
+                            tick,
+                            params,
+                        )
+                        .await;
                     }
 
                     Some(msg) = self.service_resources_handle.inbound_relay.next() => {
@@ -581,6 +638,86 @@ where
         );
     }
 
+    /// Proactive tip-poll lag watchdog.
+    ///
+    /// Fires on a slot-tick cadence (`params.cadence_slots`, ≈ one expected
+    /// block interval). When the local tip has fallen behind the current slot by
+    /// more than `params.lag_threshold_slots`, it samples a handful of peers
+    /// with `GetTip` and hands the most-advanced tip that is strictly ahead of
+    /// the local height to the orphan downloader, which performs the actual
+    /// catch-up download and full validation.
+    ///
+    /// Polled tips are unauthenticated peer hearsay, but enqueuing one only
+    /// triggers a download: every downloaded block still goes through normal
+    /// `apply_block` validation, and a bogus tip is dropped on download failure.
+    async fn poll_peer_tips_if_behind(
+        network_adapter: &NetAdapter,
+        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+        orphan_downloader: &mut OrphanBlocksDownloader<NetAdapter, RuntimeServiceId>,
+        tick: SlotTick,
+        params: &TipPollParams,
+    ) where
+        RuntimeServiceId: Send + Sync + 'static,
+    {
+        // Cadence gate: only act roughly once per expected block interval.
+        if u64::from(tick.slot) % params.cadence_slots != 0 {
+            return;
+        }
+
+        // Don't pile on while a catch-up download is already in flight.
+        if orphan_downloader.should_poll() {
+            return;
+        }
+
+        let info = match cryptarchia.info().await {
+            Ok(info) => info.cryptarchia_info,
+            Err(e) => {
+                warn!(target: LOG_TARGET, %e, "tip poll: failed to read local chain info");
+                return;
+            }
+        };
+
+        let current_slot = u64::from(tick.slot);
+        let tip_slot = u64::from(info.slot);
+        let lag = current_slot.saturating_sub(tip_slot);
+        if lag <= params.lag_threshold_slots {
+            return;
+        }
+
+        debug!(
+            target: LOG_TARGET,
+            lag, tip_slot, current_slot,
+            "Chain tip lagging; polling peers for their tip"
+        );
+        metrics::tip_poll_triggered_total();
+
+        let tips = network_adapter.sample_tips(params.max_peers).await;
+
+        // Pick the most-advanced reported tip that is strictly ahead of us.
+        let Some((height, _, tip)) = select_catchup_tip(tips, info.height) else {
+            debug!(
+                target: LOG_TARGET,
+                local_height = info.height,
+                "tip poll: no sampled peer reported a tip ahead of us"
+            );
+            return;
+        };
+
+        match orphan_downloader.enqueue_orphan(tip, info.tip, info.lib) {
+            Ok(()) => {
+                info!(
+                    target: LOG_TARGET,
+                    ?tip, height, local_height = info.height,
+                    "tip poll: enqueued peer tip for catch-up"
+                );
+                metrics::tip_poll_enqueued_total();
+            }
+            Err(e) => {
+                debug!(target: LOG_TARGET, %e, ?tip, "tip poll: did not enqueue polled tip");
+            }
+        }
+    }
+
     async fn handle_message(
         msg: Message<Mempool::Item>,
         relays: &ChainNetworkRelays<
@@ -610,6 +747,76 @@ where
                 }
             }
         }
+    }
+}
+
+/// From a set of polled tip responses, pick the most-advanced tip that is
+/// strictly ahead of `local_height`. Ties on height are broken by the higher
+/// slot. `Failure` responses are ignored. Returns `(height, slot, tip)`.
+fn select_catchup_tip(
+    tips: impl IntoIterator<Item = GetTipResponse>,
+    local_height: u64,
+) -> Option<(u64, Slot, HeaderId)> {
+    tips.into_iter()
+        .filter_map(|resp| match resp {
+            GetTipResponse::Tip { tip, slot, height } => Some((height, slot, tip)),
+            GetTipResponse::Failure(reason) => {
+                debug!(target: LOG_TARGET, %reason, "tip poll: peer reported failure");
+                None
+            }
+        })
+        .filter(|(height, _, _)| *height > local_height)
+        .max_by_key(|(height, slot, _)| (*height, u64::from(*slot)))
+}
+
+/// Derived parameters for the proactive tip-poll lag watchdog.
+struct TipPollParams {
+    /// Act every this many slots (≈ one expected block interval, `1/f`).
+    cadence_slots: u64,
+    /// Lag, in slots, beyond which we proactively poll peers for their tip.
+    lag_threshold_slots: u64,
+    /// Maximum number of peers to sample with `GetTip` per poll.
+    max_peers: usize,
+}
+
+impl TipPollParams {
+    /// Derive the polling cadence and lag threshold from the active slot
+    /// coefficient `f`. The expected number of slots between blocks is `1/f`, so
+    /// the cadence is `ceil(1/f)` slots and the lag threshold is
+    /// `lag_threshold_blocks` such intervals.
+    async fn derive<Cryptarchia, RuntimeServiceId>(
+        config: &TipPollConfig,
+        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+    ) -> Result<Self, DynError>
+    where
+        Cryptarchia: CryptarchiaServiceData<Tx: Send + Sync>,
+        RuntimeServiceId: Sync,
+    {
+        let (_, consensus_config) = cryptarchia
+            .get_epoch_config()
+            .await
+            .map_err(|e| DynError::from(format!("failed to fetch epoch config: {e}")))?;
+
+        // `f = numerator / denominator`, so `1/f = denominator / numerator`.
+        // Compute `ceil(1/f)` with integer arithmetic to avoid float casts.
+        let coeff = consensus_config.slot_activation_coeff();
+        let numerator = u64::from(coeff.numerator);
+        let denominator = u64::from(coeff.denominator.get());
+        if numerator == 0 {
+            return Err(DynError::from(
+                "active slot coefficient f must be > 0 for tip polling",
+            ));
+        }
+
+        let cadence_slots = denominator.div_ceil(numerator).max(1);
+        let lag_threshold_slots =
+            cadence_slots.saturating_mul(config.lag_threshold_blocks.get());
+
+        Ok(Self {
+            cadence_slots,
+            lag_threshold_slots,
+            max_peers: config.max_peers_to_sample.get(),
+        })
     }
 }
 
@@ -916,5 +1123,51 @@ mod tests {
 
         assert!(matches!(result, Err(Error::InvalidBlock(_))));
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    fn tip(height: u64, slot: u64, id: u8) -> GetTipResponse {
+        GetTipResponse::Tip {
+            tip: HeaderId::from([id; 32]),
+            slot: Slot::new(slot),
+            height,
+        }
+    }
+
+    #[test]
+    fn select_catchup_tip_ignores_tips_at_or_below_local_height() {
+        let tips = vec![tip(10, 100, 1), tip(9, 200, 2)];
+        // local height is 10: nothing strictly ahead.
+        assert!(select_catchup_tip(tips, 10).is_none());
+    }
+
+    #[test]
+    fn select_catchup_tip_picks_highest_then_breaks_ties_by_slot() {
+        let tips = vec![
+            tip(12, 100, 1),
+            tip(15, 300, 2), // highest height
+            tip(15, 400, 3), // same height, higher slot -> winner
+            tip(14, 999, 4),
+        ];
+        let (height, slot, id) = select_catchup_tip(tips, 11).expect("a tip ahead exists");
+        assert_eq!(height, 15);
+        assert_eq!(slot, Slot::new(400));
+        assert_eq!(id, HeaderId::from([3; 32]));
+    }
+
+    #[test]
+    fn select_catchup_tip_skips_failures() {
+        let tips = vec![
+            GetTipResponse::Failure("busy".to_owned()),
+            tip(20, 500, 7),
+            GetTipResponse::Failure("nope".to_owned()),
+        ];
+        let (height, _, id) = select_catchup_tip(tips, 5).expect("a tip ahead exists");
+        assert_eq!(height, 20);
+        assert_eq!(id, HeaderId::from([7; 32]));
+    }
+
+    #[test]
+    fn select_catchup_tip_empty_is_none() {
+        assert!(select_catchup_tip(Vec::new(), 0).is_none());
     }
 }

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -661,7 +661,8 @@ where
         RuntimeServiceId: Send + Sync + 'static,
     {
         // Cadence gate: only act roughly once per expected block interval.
-        if u64::from(tick.slot) % params.cadence_slots != 0 {
+        let current_slot = u64::from(tick.slot);
+        if current_slot % params.cadence_slots != 0 {
             return;
         }
 
@@ -678,7 +679,6 @@ where
             }
         };
 
-        let current_slot = u64::from(tick.slot);
         let tip_slot = u64::from(info.slot);
         let lag = current_slot.saturating_sub(tip_slot);
         if lag <= params.lag_threshold_slots {

--- a/services/chain/chain-network/src/metrics.rs
+++ b/services/chain/chain-network/src/metrics.rs
@@ -93,6 +93,14 @@ pub fn orphan_blocks_fetch_failed_total() {
     lb_tracing::increase_counter_u64!(orphan_blocks_fetch_failed_total, 1);
 }
 
+pub fn tip_poll_triggered_total() {
+    lb_tracing::increase_counter_u64!(tip_poll_triggered_total, 1);
+}
+
+pub fn tip_poll_enqueued_total() {
+    lb_tracing::increase_counter_u64!(tip_poll_enqueued_total, 1);
+}
+
 pub fn chainsync_observe_download_blocks_ok(duration: Duration, blocks_downloaded: u64) {
     lb_tracing::increase_counter_u64!(chainsync_requests_total, 1, kind = "blocks", result = "ok");
     lb_tracing::metric_histogram_f64!(chainsync_download_blocks_seconds, duration.as_secs_f64());

--- a/services/chain/chain-network/src/network/adapters/libp2p.rs
+++ b/services/chain/chain-network/src/network/adapters/libp2p.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashSet, fmt::Debug, hash::Hash, marker::PhantomData, time::Instant};
+use std::{collections::HashSet, fmt::Debug, hash::Hash, iter, marker::PhantomData, time::Instant};
 
-use futures::{FutureExt as _, TryStreamExt as _, future::select_ok, stream::FuturesUnordered};
+use futures::{FutureExt as _, TryStreamExt as _, future::select_ok, stream};
 use lb_chain_service_common::NetworkMessage;
 use lb_core::{
     block::{Block, Proposal},
@@ -275,11 +275,12 @@ where
     }
 
     async fn sample_tips(&self, max_peers: usize) -> BoxedStream<GetTipResponse> {
+        use futures::stream::StreamExt as FuturesStreamExt;
         let connected_peers = match Self::get_connected_peers(&self.network_relay).await {
             Ok(peers) => peers,
             Err(e) => {
                 tracing::warn!("tip poll: failed to fetch connected peers: {e}");
-                return Box::new(futures::stream::empty::<GetTipResponse>());
+                return Box::new(stream::empty::<GetTipResponse>());
             }
         };
 
@@ -288,38 +289,38 @@ where
             .choose_multiple(&mut thread_rng(), max_peers);
 
         if sampled.is_empty() {
-            tracing::debug!("tip poll: no connected peers to sample");
-            return Box::new(futures::stream::empty::<GetTipResponse>());
+            debug!("tip poll: no connected peers to sample");
+            return Box::new(stream::empty::<GetTipResponse>());
         }
-
-        // Fire a GetTip request to each sampled peer, collecting the response
-        // receivers. Returning a stream over the (owned) receivers lets the
-        // caller drive the round-trips concurrently and consume tips as they
-        // resolve, rather than blocking on all of them here.
-        let mut receivers = Vec::with_capacity(sampled.len());
-        for peer in sampled {
-            let (reply_sender, receiver) = oneshot::channel();
-            if let Err((e, _)) = self
-                .network_relay
-                .send(NetworkMsg::Process(Command::ChainSync(
-                    ChainSyncCommand::RequestTip { peer, reply_sender },
-                )))
-                .await
-            {
-                tracing::debug!("tip poll: failed to send GetTip to peer {peer:?}: {e}");
-                continue;
-            }
-            receivers.push(receiver);
-        }
-
-        // `oneshot::Receiver` is itself a `Future`, so collecting the receivers
-        // into `FuturesUnordered` drives all the round-trips concurrently and
-        // yields each as it resolves. Drop receive/provider errors.
-        let responses: FuturesUnordered<_> = receivers.into_iter().collect();
-        let tips = futures::StreamExt::filter_map(responses, |res| {
-            std::future::ready(res.ok().and_then(Result::ok))
-        });
-        Box::new(Box::pin(tips))
+        let result_stream = FuturesStreamExt::filter_map(
+            stream::iter(
+                sampled
+                    .into_iter()
+                    .zip(iter::repeat(self.network_relay.clone())),
+            ),
+            async |(peer, relay)| {
+                let (reply_sender, receiver) = oneshot::channel();
+                if let Err((e, _)) = relay
+                    .send(NetworkMsg::Process(Command::ChainSync(
+                        ChainSyncCommand::RequestTip { peer, reply_sender },
+                    )))
+                    .await
+                {
+                    debug!("tip poll: failed to send GetTip to peer {peer:?}: {e}");
+                    None
+                } else {
+                    match receiver.await.ok() {
+                        None => None,
+                        Some(Err(e)) => {
+                            debug!("tip poll: failed to send GetTip to peer {peer:?}: {e}");
+                            None
+                        }
+                        Some(Ok(tip)) => Some(tip),
+                    }
+                }
+            },
+        );
+        Box::new(Box::pin(result_stream))
     }
 
     async fn request_blocks_from_peer(

--- a/services/chain/chain-network/src/network/adapters/libp2p.rs
+++ b/services/chain/chain-network/src/network/adapters/libp2p.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, fmt::Debug, hash::Hash, marker::PhantomData, time::Instant};
 
-use futures::{FutureExt as _, TryStreamExt as _, future::select_ok};
+use futures::{FutureExt as _, TryStreamExt as _, future::select_ok, stream::FuturesUnordered};
 use lb_chain_service_common::NetworkMessage;
 use lb_core::{
     block::{Block, Proposal},
@@ -274,12 +274,12 @@ where
         metrics::chainsync_observe_request_tip(started_at.elapsed(), response)
     }
 
-    async fn sample_tips(&self, max_peers: usize) -> Vec<GetTipResponse> {
+    async fn sample_tips(&self, max_peers: usize) -> BoxedStream<GetTipResponse> {
         let connected_peers = match Self::get_connected_peers(&self.network_relay).await {
             Ok(peers) => peers,
             Err(e) => {
                 tracing::warn!("tip poll: failed to fetch connected peers: {e}");
-                return Vec::new();
+                return Box::new(futures::stream::empty::<GetTipResponse>());
             }
         };
 
@@ -289,16 +289,37 @@ where
 
         if sampled.is_empty() {
             tracing::debug!("tip poll: no connected peers to sample");
-            return Vec::new();
+            return Box::new(futures::stream::empty::<GetTipResponse>());
         }
 
-        let requests = sampled.into_iter().map(|peer| self.request_tip(peer));
+        // Fire a GetTip request to each sampled peer, collecting the response
+        // receivers. Returning a stream over the (owned) receivers lets the
+        // caller drive the round-trips concurrently and consume tips as they
+        // resolve, rather than blocking on all of them here.
+        let mut receivers = Vec::with_capacity(sampled.len());
+        for peer in sampled {
+            let (reply_sender, receiver) = oneshot::channel();
+            if let Err((e, _)) = self
+                .network_relay
+                .send(NetworkMsg::Process(Command::ChainSync(
+                    ChainSyncCommand::RequestTip { peer, reply_sender },
+                )))
+                .await
+            {
+                tracing::debug!("tip poll: failed to send GetTip to peer {peer:?}: {e}");
+                continue;
+            }
+            receivers.push(receiver);
+        }
 
-        futures::future::join_all(requests)
-            .await
-            .into_iter()
-            .filter_map(Result::ok)
-            .collect()
+        // `oneshot::Receiver` is itself a `Future`, so collecting the receivers
+        // into `FuturesUnordered` drives all the round-trips concurrently and
+        // yields each as it resolves. Drop receive/provider errors.
+        let responses: FuturesUnordered<_> = receivers.into_iter().collect();
+        let tips = futures::StreamExt::filter_map(responses, |res| {
+            std::future::ready(res.ok().and_then(Result::ok))
+        });
+        Box::new(Box::pin(tips))
     }
 
     async fn request_blocks_from_peer(

--- a/services/chain/chain-network/src/network/adapters/libp2p.rs
+++ b/services/chain/chain-network/src/network/adapters/libp2p.rs
@@ -274,6 +274,33 @@ where
         metrics::chainsync_observe_request_tip(started_at.elapsed(), response)
     }
 
+    async fn sample_tips(&self, max_peers: usize) -> Vec<GetTipResponse> {
+        let connected_peers = match Self::get_connected_peers(&self.network_relay).await {
+            Ok(peers) => peers,
+            Err(e) => {
+                tracing::warn!("tip poll: failed to fetch connected peers: {e}");
+                return Vec::new();
+            }
+        };
+
+        let sampled: Vec<PeerId> = connected_peers
+            .into_iter()
+            .choose_multiple(&mut thread_rng(), max_peers);
+
+        if sampled.is_empty() {
+            tracing::debug!("tip poll: no connected peers to sample");
+            return Vec::new();
+        }
+
+        let requests = sampled.into_iter().map(|peer| self.request_tip(peer));
+
+        futures::future::join_all(requests)
+            .await
+            .into_iter()
+            .filter_map(Result::ok)
+            .collect()
+    }
+
     async fn request_blocks_from_peer(
         &self,
         peer: Self::PeerId,

--- a/services/chain/chain-network/src/network/mod.rs
+++ b/services/chain/chain-network/src/network/mod.rs
@@ -34,15 +34,11 @@ pub trait NetworkAdapter<RuntimeServiceId> {
     async fn request_tip(&self, peer: Self::PeerId) -> Result<GetTipResponse, DynError>;
 
     /// Sample up to `max_peers` currently-connected peers and request their
-    /// chain tip via `GetTip`, concurrently. Per-peer failures are dropped, so
-    /// the returned vector only contains the responses that came back.
+    /// chain tip via `GetTip`, concurrently. The returned stream yields each
+    /// successful response as it resolves; per-peer failures are dropped.
     ///
-    /// Used by the proactive tip-polling lag watchdog. The default
-    /// implementation returns an empty vector, effectively disabling the
-    /// watchdog for adapters that don't support peer sampling.
-    async fn sample_tips(&self, _max_peers: usize) -> Vec<GetTipResponse> {
-        Vec::new()
-    }
+    /// Used by the proactive tip-polling lag watchdog.
+    async fn sample_tips(&self, max_peers: usize) -> BoxedStream<GetTipResponse>;
 
     async fn request_blocks_from_peer(
         &self,

--- a/services/chain/chain-network/src/network/mod.rs
+++ b/services/chain/chain-network/src/network/mod.rs
@@ -33,6 +33,17 @@ pub trait NetworkAdapter<RuntimeServiceId> {
 
     async fn request_tip(&self, peer: Self::PeerId) -> Result<GetTipResponse, DynError>;
 
+    /// Sample up to `max_peers` currently-connected peers and request their
+    /// chain tip via `GetTip`, concurrently. Per-peer failures are dropped, so
+    /// the returned vector only contains the responses that came back.
+    ///
+    /// Used by the proactive tip-polling lag watchdog. The default
+    /// implementation returns an empty vector, effectively disabling the
+    /// watchdog for adapters that don't support peer sampling.
+    async fn sample_tips(&self, _max_peers: usize) -> Vec<GetTipResponse> {
+        Vec::new()
+    }
+
     async fn request_blocks_from_peer(
         &self,
         peer: Self::PeerId,

--- a/services/chain/chain-network/src/relays.rs
+++ b/services/chain/chain-network/src/relays.rs
@@ -10,7 +10,7 @@ use lb_core::{
     mantle::{AuthenticatedMantleTx, TxHash},
 };
 use lb_network_service::{NetworkService, message::BackendNetworkMsg};
-use lb_time_service::{TimeService, backends::TimeBackend as TimeBackendTrait};
+use lb_time_service::{TimeService, TimeServiceMessage, backends::TimeBackend as TimeBackendTrait};
 use lb_tx_service::{
     MempoolMsg, TxMempoolService, backend::RecoverableMempool,
     network::NetworkAdapter as MempoolNetworkAdapter, storage::MempoolStorageAdapter,
@@ -25,6 +25,7 @@ use crate::{ChainNetwork, mempool::adapter::MempoolAdapter, network};
 
 type NetworkRelay<NetworkBackend, RuntimeServiceId> =
     OutboundRelay<BackendNetworkMsg<NetworkBackend, RuntimeServiceId>>;
+type TimeRelay = OutboundRelay<TimeServiceMessage>;
 
 pub struct ChainNetworkRelays<
     Cryptarchia,
@@ -41,6 +42,7 @@ pub struct ChainNetworkRelays<
     cryptarchia: CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
     network_relay: NetworkRelay<NetworkAdapter::Backend, RuntimeServiceId>,
     mempool_adapter: MempoolAdapter<Mempool::Item>,
+    time_relay: TimeRelay,
     _mempool_adapter: PhantomData<MempoolNetAdapter>,
 }
 
@@ -73,12 +75,14 @@ where
         cryptarchia: CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
         network_relay: NetworkRelay<NetworkAdapter::Backend, RuntimeServiceId>,
         mempool_relay: OutboundRelay<MempoolMsg<HeaderId, Mempool::Item, Mempool::Item, TxHash>>,
+        time_relay: TimeRelay,
     ) -> Self {
         let mempool_adapter = MempoolAdapter::new(mempool_relay);
         Self {
             cryptarchia,
             network_relay,
             mempool_adapter,
+            time_relay,
             _mempool_adapter: PhantomData,
         }
     }
@@ -134,7 +138,13 @@ where
             .await
             .expect("Relay connection with MempoolService should succeed");
 
-        Self::new(cryptarchia, network_relay, mempool_relay)
+        let time_relay = service_resources_handle
+            .overwatch_handle
+            .relay::<TimeService<_, _>>()
+            .await
+            .expect("Relay connection with TimeService should succeed");
+
+        Self::new(cryptarchia, network_relay, mempool_relay, time_relay)
     }
 
     pub const fn cryptarchia(&self) -> &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId> {
@@ -147,5 +157,9 @@ where
 
     pub const fn mempool_adapter(&self) -> &MempoolAdapter<Mempool::Item> {
         &self.mempool_adapter
+    }
+
+    pub const fn time_relay(&self) -> &TimeRelay {
+        &self.time_relay
     }
 }

--- a/services/chain/chain-network/src/sync/config.rs
+++ b/services/chain/chain-network/src/sync/config.rs
@@ -5,12 +5,6 @@ use serde::{Deserialize, Serialize};
 const MAX_ORPHAN_CACHE_SIZE: NonZeroUsize =
     NonZeroUsize::new(1000).expect("MAX_ORPHAN_CACHE_SIZE must be non-zero");
 
-const DEFAULT_TIP_POLL_LAG_THRESHOLD_BLOCKS: NonZeroU64 =
-    NonZeroU64::new(3).expect("DEFAULT_TIP_POLL_LAG_THRESHOLD_BLOCKS must be non-zero");
-
-const DEFAULT_TIP_POLL_MAX_PEERS_TO_SAMPLE: NonZeroUsize =
-    NonZeroUsize::new(5).expect("DEFAULT_TIP_POLL_MAX_PEERS_TO_SAMPLE must be non-zero");
-
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SyncConfig {
     pub orphan: OrphanConfig,
@@ -35,41 +29,27 @@ pub struct OrphanConfig {
 /// coefficient), it samples up to `max_peers_to_sample` peers with `GetTip` and
 /// hands the most-advanced reported tip to the orphan downloader to catch up.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct TipPollConfig {
     /// Whether the proactive tip-polling watchdog is enabled.
-    #[serde(default = "default_tip_poll_enabled")]
     pub enabled: bool,
     /// How many expected block-intervals (`1/f` slots each) the local tip may
     /// lag behind the current slot before we proactively poll peers.
-    #[serde(default = "default_tip_poll_lag_threshold_blocks")]
     pub lag_threshold_blocks: NonZeroU64,
     /// Maximum number of peers to sample with `GetTip` on each poll.
-    #[serde(default = "default_tip_poll_max_peers_to_sample")]
     pub max_peers_to_sample: NonZeroUsize,
 }
 
 impl Default for TipPollConfig {
     fn default() -> Self {
         Self {
-            enabled: default_tip_poll_enabled(),
-            lag_threshold_blocks: default_tip_poll_lag_threshold_blocks(),
-            max_peers_to_sample: default_tip_poll_max_peers_to_sample(),
+            enabled: true,
+            lag_threshold_blocks: NonZeroU64::new(3).expect("3 is non-zero"),
+            max_peers_to_sample: NonZeroUsize::new(5).expect("5 is non-zero"),
         }
     }
 }
 
 const fn default_max_orphan_cache_size() -> NonZeroUsize {
     MAX_ORPHAN_CACHE_SIZE
-}
-
-const fn default_tip_poll_enabled() -> bool {
-    true
-}
-
-const fn default_tip_poll_lag_threshold_blocks() -> NonZeroU64 {
-    DEFAULT_TIP_POLL_LAG_THRESHOLD_BLOCKS
-}
-
-const fn default_tip_poll_max_peers_to_sample() -> NonZeroUsize {
-    DEFAULT_TIP_POLL_MAX_PEERS_TO_SAMPLE
 }

--- a/services/chain/chain-network/src/sync/config.rs
+++ b/services/chain/chain-network/src/sync/config.rs
@@ -1,13 +1,23 @@
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU64, NonZeroUsize};
 
 use serde::{Deserialize, Serialize};
 
 const MAX_ORPHAN_CACHE_SIZE: NonZeroUsize =
     NonZeroUsize::new(1000).expect("MAX_ORPHAN_CACHE_SIZE must be non-zero");
 
+const DEFAULT_TIP_POLL_LAG_THRESHOLD_BLOCKS: NonZeroU64 =
+    NonZeroU64::new(3).expect("DEFAULT_TIP_POLL_LAG_THRESHOLD_BLOCKS must be non-zero");
+
+const DEFAULT_TIP_POLL_MAX_PEERS_TO_SAMPLE: NonZeroUsize =
+    NonZeroUsize::new(5).expect("DEFAULT_TIP_POLL_MAX_PEERS_TO_SAMPLE must be non-zero");
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SyncConfig {
     pub orphan: OrphanConfig,
+    /// Proactive tip-polling watchdog that catches a node up when it stops
+    /// receiving gossiped blocks (e.g. partial eclipse / network partition).
+    #[serde(default)]
+    pub tip_poll: TipPollConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -17,6 +27,49 @@ pub struct OrphanConfig {
     pub max_orphan_cache_size: NonZeroUsize,
 }
 
+/// Configuration for the proactive tip-polling lag watchdog.
+///
+/// On a slot-tick cadence the node compares its local tip slot against the
+/// current slot. If it has fallen behind by more than `lag_threshold_blocks`
+/// expected block-intervals (each `1/f` slots, where `f` is the active slot
+/// coefficient), it samples up to `max_peers_to_sample` peers with `GetTip` and
+/// hands the most-advanced reported tip to the orphan downloader to catch up.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TipPollConfig {
+    /// Whether the proactive tip-polling watchdog is enabled.
+    #[serde(default = "default_tip_poll_enabled")]
+    pub enabled: bool,
+    /// How many expected block-intervals (`1/f` slots each) the local tip may
+    /// lag behind the current slot before we proactively poll peers.
+    #[serde(default = "default_tip_poll_lag_threshold_blocks")]
+    pub lag_threshold_blocks: NonZeroU64,
+    /// Maximum number of peers to sample with `GetTip` on each poll.
+    #[serde(default = "default_tip_poll_max_peers_to_sample")]
+    pub max_peers_to_sample: NonZeroUsize,
+}
+
+impl Default for TipPollConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_tip_poll_enabled(),
+            lag_threshold_blocks: default_tip_poll_lag_threshold_blocks(),
+            max_peers_to_sample: default_tip_poll_max_peers_to_sample(),
+        }
+    }
+}
+
 const fn default_max_orphan_cache_size() -> NonZeroUsize {
     MAX_ORPHAN_CACHE_SIZE
+}
+
+const fn default_tip_poll_enabled() -> bool {
+    true
+}
+
+const fn default_tip_poll_lag_threshold_blocks() -> NonZeroU64 {
+    DEFAULT_TIP_POLL_LAG_THRESHOLD_BLOCKS
+}
+
+const fn default_tip_poll_max_peers_to_sample() -> NonZeroUsize {
+    DEFAULT_TIP_POLL_MAX_PEERS_TO_SAMPLE
 }

--- a/services/chain/chain-network/src/sync/mod.rs
+++ b/services/chain/chain-network/src/sync/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod orphan_handler;
+pub mod tip_poll;
 
 const LOG_TARGET: &str = "chain_network::service::sync";

--- a/services/chain/chain-network/src/sync/orphan_handler.rs
+++ b/services/chain/chain-network/src/sync/orphan_handler.rs
@@ -628,6 +628,10 @@ mod tests {
             unimplemented!()
         }
 
+        async fn sample_tips(&self, _max_peers: usize) -> BoxedStream<GetTipResponse> {
+            Box::new(stream::empty())
+        }
+
         async fn request_blocks_from_peer(
             &self,
             _peer: Self::PeerId,

--- a/services/chain/chain-network/src/sync/tip_poll.rs
+++ b/services/chain/chain-network/src/sync/tip_poll.rs
@@ -1,0 +1,231 @@
+use futures::StreamExt as _;
+use lb_chain_service::{
+    Slot,
+    api::{CryptarchiaServiceApi, CryptarchiaServiceData},
+};
+use lb_cryptarchia_sync::{GetTipResponse, HeaderId};
+use lb_time_service::SlotTick;
+use overwatch::DynError;
+use tracing::{debug, warn};
+
+use crate::{TipPollConfig, metrics, network::NetworkAdapter, sync::LOG_TARGET};
+
+/// Proactive tip-poll lag watchdog.
+///
+/// Fires on a slot-tick cadence (`params.cadence_slots`, ≈ one expected
+/// block interval). When the local tip has fallen behind the current slot
+/// by more than `params.lag_threshold_slots`, it samples a handful of
+/// peers with `GetTip` and returns the most-advanced tip that is strictly
+/// ahead of the local height. The caller is expected to hand it to the
+/// orphan downloader, which performs the actual catch-up download and
+/// full validation.
+///
+/// Polled tips are unauthenticated peer hearsay, but enqueuing one only
+/// triggers a download: every downloaded block still goes through normal
+/// `apply_block` validation, and a bogus tip is dropped on download
+/// failure.
+pub async fn poll_peer_tips_if_behind<NetAdapter, Cryptarchia, RuntimeServiceId>(
+    network_adapter: &NetAdapter,
+    cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+    tick: SlotTick,
+    params: &TipPollParams,
+) -> Option<PolledTip>
+where
+    NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
+    Cryptarchia: CryptarchiaServiceData,
+    Cryptarchia::Tx: Send + Sync,
+    RuntimeServiceId: Send + Sync + 'static,
+{
+    // Cadence gate: only act roughly once per expected block interval.
+    let current_slot = u64::from(tick.slot);
+    if current_slot % params.cadence_slots != 0 {
+        return None;
+    }
+
+    let info = lagging_local_info(cryptarchia, current_slot, params.lag_threshold_slots).await?;
+    metrics::tip_poll_triggered_total();
+
+    let tips: Vec<GetTipResponse> = network_adapter
+        .sample_tips(params.max_peers)
+        .await
+        .collect()
+        .await;
+
+    // Pick the most-advanced reported tip that is strictly ahead of us.
+    let Some((height, _, tip)) = select_catchup_tip(tips, info.height) else {
+        debug!(
+            target: LOG_TARGET,
+            local_height = info.height,
+            "tip poll: no sampled peer reported a tip ahead of us"
+        );
+        return None;
+    };
+
+    Some(PolledTip {
+        tip,
+        height,
+        local: info,
+    })
+}
+
+/// Read the local chain info and return it only if the tip is lagging the
+/// current slot by more than `lag_threshold_slots`. Returns `None` (and
+/// logs) when the info can't be read or the node is keeping up.
+async fn lagging_local_info<Cryptarchia, RuntimeServiceId>(
+    cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+    current_slot: u64,
+    lag_threshold_slots: u64,
+) -> Option<lb_chain_service::CryptarchiaInfo>
+where
+    Cryptarchia: CryptarchiaServiceData,
+    Cryptarchia::Tx: Send + Sync,
+    RuntimeServiceId: Send + Sync,
+{
+    let info = match cryptarchia.info().await {
+        Ok(info) => info.cryptarchia_info,
+        Err(e) => {
+            warn!(target: LOG_TARGET, %e, "tip poll: failed to read local chain info");
+            return None;
+        }
+    };
+
+    let tip_slot = u64::from(info.slot);
+    let lag = current_slot.saturating_sub(tip_slot);
+    if lag <= lag_threshold_slots {
+        return None;
+    }
+
+    debug!(
+        target: LOG_TARGET,
+        lag, tip_slot, current_slot,
+        "Chain tip lagging; polling peers for their tip"
+    );
+    Some(info)
+}
+
+/// From a set of polled tip responses, pick the most-advanced tip that is
+/// strictly ahead of `local_height`. Ties on height are broken by the higher
+/// slot. `Failure` responses are ignored. Returns `(height, slot, tip)`.
+fn select_catchup_tip(
+    tips: impl IntoIterator<Item = GetTipResponse>,
+    local_height: u64,
+) -> Option<(u64, Slot, HeaderId)> {
+    tips.into_iter()
+        .filter_map(|resp| match resp {
+            GetTipResponse::Tip { tip, slot, height } => Some((height, slot, tip)),
+            GetTipResponse::Failure(reason) => {
+                debug!(target: LOG_TARGET, %reason, "tip poll: peer reported failure");
+                None
+            }
+        })
+        .filter(|(height, _, _)| *height > local_height)
+        .max_by_key(|(height, slot, _)| (*height, u64::from(*slot)))
+}
+
+pub struct PolledTip {
+    pub tip: HeaderId,
+    pub height: u64,
+    pub local: lb_chain_service::CryptarchiaInfo,
+}
+
+/// Derived parameters for the proactive tip-poll lag watchdog.
+#[derive(Clone, Copy)]
+pub struct TipPollParams {
+    /// Act every this many slots (≈ one expected block interval, `1/f`).
+    pub cadence_slots: u64,
+    /// Lag, in slots, beyond which we proactively poll peers for their tip.
+    pub lag_threshold_slots: u64,
+    /// Maximum number of peers to sample with `GetTip` per poll.
+    pub max_peers: usize,
+}
+
+impl TipPollParams {
+    /// Derive the polling cadence and lag threshold from the active slot
+    /// coefficient `f`. The expected number of slots between blocks is `1/f`,
+    /// so the cadence is `ceil(1/f)` slots and the lag threshold is
+    /// `lag_threshold_blocks` such intervals.
+    pub async fn derive<Cryptarchia, RuntimeServiceId>(
+        config: &TipPollConfig,
+        cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
+    ) -> Result<Self, DynError>
+    where
+        Cryptarchia: CryptarchiaServiceData<Tx: Send + Sync>,
+        RuntimeServiceId: Sync,
+    {
+        let (_, consensus_config) = cryptarchia
+            .get_epoch_config()
+            .await
+            .map_err(|e| DynError::from(format!("failed to fetch epoch config: {e}")))?;
+
+        // `f = numerator / denominator`, so `1/f = denominator / numerator`.
+        // Compute `ceil(1/f)` with integer arithmetic to avoid float casts.
+        let coeff = consensus_config.slot_activation_coeff();
+        let numerator = u64::from(coeff.numerator);
+        let denominator = core::num::NonZeroU64::from(coeff.denominator).get();
+        if numerator == 0 {
+            return Err(DynError::from(
+                "active slot coefficient f must be > 0 for tip polling",
+            ));
+        }
+
+        let cadence_slots = denominator.div_ceil(numerator).max(1);
+        let lag_threshold_slots = cadence_slots.saturating_mul(config.lag_threshold_blocks.get());
+
+        Ok(Self {
+            cadence_slots,
+            lag_threshold_slots,
+            max_peers: config.max_peers_to_sample.get(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tip(height: u64, slot: u64, id: u8) -> GetTipResponse {
+        GetTipResponse::Tip {
+            tip: HeaderId::from([id; 32]),
+            slot: Slot::new(slot),
+            height,
+        }
+    }
+
+    #[test]
+    fn select_catchup_tip_ignores_tips_at_or_below_local_height() {
+        let tips = vec![tip(10, 100, 1), tip(9, 200, 2)];
+        // local height is 10: nothing strictly ahead.
+        assert!(select_catchup_tip(tips, 10).is_none());
+    }
+
+    #[test]
+    fn select_catchup_tip_picks_highest_then_breaks_ties_by_slot() {
+        let tips = vec![
+            tip(12, 100, 1),
+            tip(15, 300, 2), // highest height
+            tip(15, 400, 3), // same height, higher slot -> winner
+            tip(14, 999, 4),
+        ];
+        let (height, slot, id) = select_catchup_tip(tips, 11).expect("a tip ahead exists");
+        assert_eq!(height, 15);
+        assert_eq!(slot, Slot::new(400));
+        assert_eq!(id, HeaderId::from([3; 32]));
+    }
+
+    #[test]
+    fn select_catchup_tip_skips_failures() {
+        let tips = vec![
+            GetTipResponse::Failure("busy".to_owned()),
+            tip(20, 500, 7),
+            GetTipResponse::Failure("nope".to_owned()),
+        ];
+        let (height, _, id) = select_catchup_tip(tips, 5).expect("a tip ahead exists");
+        assert_eq!(height, 20);
+        assert_eq!(id, HeaderId::from([7; 32]));
+    }
+
+    #[test]
+    fn select_catchup_tip_empty_is_none() {
+        assert!(select_catchup_tip(Vec::new(), 0).is_none());
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -69,6 +69,7 @@ cucumber             = []
 cucumber_stand_alone = []
 mantle_sdp           = []
 testing_framework    = []
+tip_poll_self_heal   = []
 
 [[test]]
 name = "blend_devnet_setup"
@@ -81,6 +82,11 @@ path = "src/tests/cli/restart.rs"
 [[test]]
 name = "test_cryptarchia_blocks_streaming"
 path = "src/tests/cryptarchia/blocks_streaming.rs"
+
+[[test]]
+name              = "test_cryptarchia_tip_poll_self_heal"
+path              = "src/tests/cryptarchia/tip_poll_self_heal.rs"
+required-features = ["tip_poll_self_heal"]
 
 [[test]]
 name = "test_mantle_chain_start"

--- a/tests/src/tests/cryptarchia/tip_poll_self_heal.rs
+++ b/tests/src/tests/cryptarchia/tip_poll_self_heal.rs
@@ -13,11 +13,14 @@
 //! through the watchdog's tip-polling and catch-up downloads.
 //!
 //! Run locally:
-//!   cargo build -p logos-blockchain-node --release \
-//!     --features testing-disable-proposal-publish
-//!   LOGOS_BLOCKCHAIN_NODE_BIN=$(pwd)/target/release/logos-blockchain-node \
-//!     cargo test -p logos-blockchain-tests --features tip_poll_self_heal \
-//!     --test test_cryptarchia_tip_poll_self_heal -- --nocapture
+//!
+//! ```text
+//! cargo build -p logos-blockchain-node --release \
+//!   --features testing-disable-proposal-publish
+//! LOGOS_BLOCKCHAIN_NODE_BIN=$(pwd)/target/release/logos-blockchain-node \
+//!   cargo test -p logos-blockchain-tests --features tip_poll_self_heal \
+//!   --test test_cryptarchia_tip_poll_self_heal -- --nocapture
+//! ```
 
 use std::{num::NonZeroU64, path::PathBuf, time::Duration};
 

--- a/tests/src/tests/cryptarchia/tip_poll_self_heal.rs
+++ b/tests/src/tests/cryptarchia/tip_poll_self_heal.rs
@@ -1,0 +1,147 @@
+//! Verify that the proactive tip-poll lag watchdog can prevent permanent
+//! forks when publishing proposals to the blend network doesn't work
+//! for some reason.
+//!
+//! The four nodes are spawned from a node binary built with
+//! `--features testing-disable-proposal-publish`, which disables publishing
+//! block proposals to the blend network while keep self-applying them to the
+//! local chain.
+//!
+//! With that feature on, each node grow their local chain with blocks proposed
+//! by themselves, until the watchdog triggers catch-up downloads.
+//! This test confirms that all nodes eventually converge on a common tip
+//! through the watchdog's tip-polling and catch-up downloads.
+//!
+//! Run locally:
+//!   cargo build -p logos-blockchain-node --release \
+//!     --features testing-disable-proposal-publish
+//!   LOGOS_BLOCKCHAIN_NODE_BIN=$(pwd)/target/release/logos-blockchain-node \
+//!     cargo test -p logos-blockchain-tests --features tip_poll_self_heal \
+//!     --test test_cryptarchia_tip_poll_self_heal -- --nocapture
+
+use std::{num::NonZeroU64, path::PathBuf, time::Duration};
+
+use futures::stream::{self, StreamExt as _};
+use lb_node::config::RunConfig;
+use lb_testing_framework::{DeploymentBuilder, LbcEnv, TopologyConfig as TfTopologyConfig};
+use lb_utils::math::NonNegativeRatio;
+use logos_blockchain_tests::{
+    common::manual_cluster::{
+        LocalManualClusterHarnessBase, ManualNodeLayout, start_local_manual_cluster_with_layout,
+    },
+    cucumber::defaults::E2E_ARTIFACTS_DIR,
+};
+use serial_test::serial;
+use testing_framework_core::scenario::{DynError, StartedNode};
+
+#[tokio::test]
+#[serial]
+async fn silent_cluster_converges_via_tip_poll() {
+    let (_base, nodes) = start_silent_cluster("silent_cluster_converges_via_tip_poll").await;
+    wait_for_tip_convergence(&nodes, Duration::from_mins(10)).await;
+}
+
+const NODE_COUNT: usize = 4;
+
+async fn start_silent_cluster(
+    test_name: &str,
+) -> (LocalManualClusterHarnessBase, Vec<StartedNode<LbcEnv>>) {
+    start_local_manual_cluster_with_layout(
+        test_name,
+        "tip-poll-self-heal",
+        DeploymentBuilder::new(
+            TfTopologyConfig::with_node_numbers(NODE_COUNT)
+                .with_test_context(Some(test_name.to_owned())),
+        ),
+        NODE_COUNT,
+        ManualNodeLayout::SelectNodeSeed(0),
+        |cfg| Ok::<_, DynError>(config(cfg)),
+        Some(PathBuf::from(E2E_ARTIFACTS_DIR)),
+    )
+    .await
+}
+
+fn config(mut config: RunConfig) -> RunConfig {
+    config.deployment.time.slot_duration = Duration::from_secs(1);
+    config
+        .user
+        .cryptarchia
+        .service
+        .bootstrap
+        .prolonged_bootstrap_period = Duration::ZERO;
+    config.deployment.cryptarchia.security_param = 5.try_into().unwrap();
+    // Fast block production to speed up the test
+    config.deployment.cryptarchia.slot_activation_coeff =
+        NonNegativeRatio::new(1, 2.try_into().unwrap());
+    // Aggressive watchdog to speed up the test
+    config
+        .user
+        .cryptarchia
+        .network
+        .sync
+        .tip_poll
+        .lag_threshold_blocks = NonZeroU64::new(1).unwrap();
+    // Catch-up downloads must reach as many peers as possible to speed up the test
+    let network = &mut config.user.cryptarchia.network.network;
+    network.max_connected_peers_to_try_download = NODE_COUNT;
+    network.max_discovered_peers_to_try_download = NODE_COUNT;
+
+    config
+}
+
+const MIN_HEIGHT_TO_WAIT: u64 = 20;
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+async fn wait_for_tip_convergence(nodes: &[StartedNode<LbcEnv>], timeout: Duration) {
+    let work = async {
+        let mut tick: u32 = 0;
+        loop {
+            if let Some(infos) = collect_infos(nodes).await {
+                let node0_tip = infos[0].tip;
+                let node0_height = infos[0].height;
+                let all_at_min_height = infos.iter().all(|info| info.height >= MIN_HEIGHT_TO_WAIT);
+                let all_share_tip = infos.iter().all(|info| info.tip == node0_tip);
+
+                if all_at_min_height && all_share_tip {
+                    println!(
+                        "converged: all {NODE_COUNT} nodes agree on tip {node0_tip:?} at height {node0_height}",
+                    );
+                    return;
+                }
+
+                if tick.is_multiple_of(10) {
+                    let summary = infos
+                        .iter()
+                        .enumerate()
+                        .map(|(i, info)| {
+                            format!("n{i}=h{}/s{}", info.height, info.slot.into_inner())
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" | ");
+                    println!("waiting on tip convergence: {summary}");
+                }
+                tick = tick.wrapping_add(1);
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    };
+
+    tokio::time::timeout(timeout, work)
+        .await
+        .unwrap_or_else(|_| panic!("nodes did not converge on a shared tip within {timeout:?}"));
+}
+
+async fn collect_infos(
+    nodes: &[StartedNode<LbcEnv>],
+) -> Option<Vec<lb_chain_service::CryptarchiaInfo>> {
+    let infos = stream::iter(nodes)
+        .then(async |node| node.client.consensus_info().await.ok())
+        .collect::<Vec<_>>()
+        .await;
+    infos.into_iter().collect::<Option<Vec<_>>>().map(|infos| {
+        infos
+            .into_iter()
+            .map(|info| info.cryptarchia_info)
+            .collect()
+    })
+}

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -647,6 +647,7 @@ fn build_cryptarchia_user_config(
                     max_orphan_cache_size: NonZeroUsize::new(1000)
                         .expect("max orphan cache size must be non-zero"),
                 },
+                tip_poll: network::TipPollConfig::default(),
             },
         },
         service: ServiceConfig {


### PR DESCRIPTION
## 1. What does this PR implement?

Adds a **proactive tip-poll lag watchdog** to the `chain-network` service.

Today, recovery from a gossip stall (partial eclipse / network partition) is purely *reactive*: a node only catches up if a brand-new proposal happens to arrive referencing an unknown parent, which then drives the orphan downloader. If gossip simply goes quiet, the node can sit behind indefinitely without a restart or fresh IBD.

This watchdog closes that gap. On a slot-tick cadence (~one expected block interval, `ceil(1/f)` slots, where `f` is the active slot coefficient), it compares the local tip slot against the current slot. When the node has fallen behind by more than `lag_threshold_blocks` such intervals (default `3`), it samples a handful of connected peers with `GetTip` and hands the most-advanced reported tip (strictly ahead of local height) to the **existing** `OrphanBlocksDownloader`, which performs the actual catch-up download and full validation.

Key points:
- **No new download path.** It reuses the orphan downloader as-is — `enqueue_orphan(tip, local_tip, lib)` already fetches from a target back to known blocks, including the target block itself.
- **Trust model unchanged.** Polled tips are unauthenticated peer hearsay, but enqueuing one only triggers a *download*: every downloaded block still goes through normal `apply_block` validation, and a bogus tip is simply dropped on download failure. This is the same trust model orphan handling already relies on.
- **Quiet by default when healthy.** A `should_poll()` guard skips polling while a catch-up is already draining; the cadence gate keeps polling to roughly once per block interval; only tips strictly ahead of local height are enqueued (duplicates dedupe for free via `AlreadyInQueue`).
- **Default-on, fully config-gated** via `TipPollConfig { enabled, lag_threshold_blocks, max_peers_to_sample }`.

### Changes
- `sync/config.rs`: new `TipPollConfig`, added to `SyncConfig` (serde-defaulted); threaded through node binary config.
- `network`: `NetworkAdapter::sample_tips(max_peers)` with a default no-op impl (other adapters / test mocks compile unchanged); libp2p impl samples connected peers and requests tips concurrently.
- `relays.rs`: `TimeService` relay wired into chain-network for slot ticks.
- `lib.rs`: slot-tick subscription, `TipPollParams::derive` (integer `ceil(1/f)` from the active slot coeff), new `select!` arm → `poll_peer_tips_if_behind`, plus a pure `select_catchup_tip` helper.
- `metrics.rs`: `tip_poll_triggered_total`, `tip_poll_enqueued_total`.

## 2. Does the code have enough context to be clearly understood?

> [!NOTE]
> No specification document is associated with this change — it is a resilience/liveness improvement to the existing sync subsystem, not a spec implementation. The rationale and trust model are documented inline (doc-comments on `poll_peer_tips_if_behind`, `TipPollParams::derive`, and `TipPollConfig`) and in the commit message. Reviewers familiar with the orphan downloader (`sync/orphan_handler.rs`) and IBD (`bootstrap/ibd.rs`) have the necessary context.

## 3. Who are the specification authors and who is accountable for this PR?

Accountable: @davidrusu. No external spec author; requesting review from the consensus/sync owners (see CODEOWNERS for `services/chain/chain-network`).

## 4. Is the specification accurate and complete?

N/A — no associated specification document.

## 5. Does the implementation introduce changes in the specification?

N/A — no associated specification document.

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added. — _N/A: resilience improvement, no spec doc._
* [x] 4. Main contact(s) added.
* [ ] 5. Implementation and Specification are 100% in sync. — _N/A: no spec._
* [ ] 6. Link PR to a specific milestone. — _maintainer to set._
* [x] 7. New or changed logs were reviewed against the logging guidelines (correct levels + per-subsystem `LOG_TARGET`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
