### PR TITLE
feat(c-bindings): deposit operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,7 +4139,6 @@ dependencies = [
  "logos-blockchain-utils",
  "logos-blockchain-wallet-service",
  "multiaddr",
- "num-bigint",
  "overwatch",
  "serde_json",
  "serde_yaml",

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -21,7 +21,6 @@ lb-sdp-service                = { workspace = true }
 lb-utils                      = { workspace = true }
 lb-wallet-service             = { workspace = true }
 multiaddr                     = { workspace = true }
-num-bigint                    = { workspace = true }
 overwatch                     = { workspace = true }
 serde_json                    = { workspace = true }
 tempfile                      = { workspace = true }

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -29,6 +29,9 @@ impl From<lb_chain_service::ChainServiceMode> for State {
 pub type Hash = [u8; 32];
 pub type HeaderId = Hash;
 pub type TxHash = Hash;
+/// A note (UTXO) identifier, as 32 little-endian bytes. The FFI representation
+/// of [`lb_core::mantle::NoteId`].
+pub type NoteId = Hash;
 
 /// Converts a raw pointer to a `TxHash` into a `lb_core::mantle::TxHash`.
 ///

--- a/c-bindings/src/api/types/mod.rs
+++ b/c-bindings/src/api/types/mod.rs
@@ -3,3 +3,4 @@ pub mod claimable_vouchers;
 pub mod config;
 pub mod known_addresses;
 pub mod value;
+pub mod wallet_notes;

--- a/c-bindings/src/api/types/wallet_notes.rs
+++ b/c-bindings/src/api/types/wallet_notes.rs
@@ -1,15 +1,15 @@
 use std::ptr;
 
 use crate::api::{
-    cryptarchia::{Hash, HeaderId},
+    cryptarchia::{HeaderId, NoteId},
     types::value::Value,
 };
 
 /// A single spendable wallet note (UTXO): its note ID and value.
 #[repr(C)]
 pub struct WalletNote {
-    /// The note ID, as 32 little-endian bytes.
-    pub id: Hash,
+    /// The note ID.
+    pub id: NoteId,
     /// The value held by the note.
     pub value: Value,
 }

--- a/c-bindings/src/api/types/wallet_notes.rs
+++ b/c-bindings/src/api/types/wallet_notes.rs
@@ -1,0 +1,33 @@
+use std::ptr;
+
+use crate::api::{
+    cryptarchia::{Hash, HeaderId},
+    types::value::Value,
+};
+
+/// A single spendable wallet note (UTXO): its note ID and value.
+#[repr(C)]
+pub struct WalletNote {
+    /// The note ID, as 32 little-endian bytes.
+    pub id: Hash,
+    /// The value held by the note.
+    pub value: Value,
+}
+
+/// The set of spendable notes for a wallet address at a given tip.
+#[repr(C)]
+pub struct WalletNotes {
+    pub tip: HeaderId,
+    pub notes: *mut WalletNote,
+    pub len: usize,
+}
+
+impl Default for WalletNotes {
+    fn default() -> Self {
+        Self {
+            tip: [0; 32],
+            notes: ptr::null_mut(),
+            len: 0,
+        }
+    }
+}

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -25,7 +25,6 @@ use lb_node::{
     generic_services::{CryptarchiaService, WalletService as NodeWalletService},
 };
 use lb_wallet_service::{ClaimableVoucherInfo, TipResponse, api::WalletApi};
-use num_bigint::BigUint;
 use overwatch::services::status::ServiceStatus;
 
 use crate::{
@@ -745,11 +744,8 @@ pub unsafe extern "C" fn transfer_funds(
     } else {
         lb_core::header::HeaderId::from(unsafe { *arguments.optional_tip })
     };
-    let change_public_key = {
-        let change_public_key_bytes =
-            unsafe { std::slice::from_raw_parts(arguments.change_public_key, 32) };
-        ZkPublicKey::from(BigUint::from_bytes_le(change_public_key_bytes))
-    };
+    let change_public_key =
+        unwrap_or_return_error!(unsafe { parse_public_key(arguments.change_public_key) });
     let funding_public_keys = {
         let funding_public_keys_pointers = unsafe {
             std::slice::from_raw_parts(
@@ -757,20 +753,17 @@ pub unsafe extern "C" fn transfer_funds(
                 arguments.funding_public_keys_len,
             )
         };
-        funding_public_keys_pointers
-            .iter()
-            .map(|funding_public_key_pointer| {
-                let funding_public_key_bytes =
-                    unsafe { std::slice::from_raw_parts(*funding_public_key_pointer, 32) };
-                ZkPublicKey::from(BigUint::from_bytes_le(funding_public_key_bytes))
-            })
-            .collect::<Vec<_>>()
+        unwrap_or_return_error!(
+            funding_public_keys_pointers
+                .iter()
+                .map(|funding_public_key_pointer| unsafe {
+                    parse_public_key(*funding_public_key_pointer)
+                })
+                .collect::<StatusResult<Vec<_>>>()
+        )
     };
-    let recipient_public_key = {
-        let recipient_public_key_bytes =
-            unsafe { std::slice::from_raw_parts(arguments.recipient_public_key, 32) };
-        ZkPublicKey::from(BigUint::from_bytes_le(recipient_public_key_bytes))
-    };
+    let recipient_public_key =
+        unwrap_or_return_error!(unsafe { parse_public_key(arguments.recipient_public_key) });
     let amount = Value::from(arguments.amount);
 
     let transaction = unwrap_or_return_error!(transfer_funds_sync(
@@ -794,12 +787,19 @@ pub unsafe extern "C" fn transfer_funds(
 
 /// Parses a 32-byte little-endian buffer into a [`ZkPublicKey`].
 ///
+/// Validates that the bytes encode a canonical field element (rather than
+/// silently reducing modulo the field order), matching the parsing used by
+/// [`get_balance`] and [`get_wallet_notes`].
+///
 /// # Safety
 ///
 /// `pointer` must be non-null and point to at least 32 readable bytes.
-unsafe fn parse_public_key(pointer: *const u8) -> ZkPublicKey {
+unsafe fn parse_public_key(pointer: *const u8) -> StatusResult<ZkPublicKey> {
     let bytes = unsafe { std::slice::from_raw_parts(pointer, 32) };
-    ZkPublicKey::from(BigUint::from_bytes_le(bytes))
+    fr_from_bytes(bytes).map(ZkPublicKey::new).map_err(|error| {
+        logging::error!("parse_public_key", "Invalid public key: {error:?}");
+        OperationStatus::DynError
+    })
 }
 
 pub type FfiChannelDepositResult = FfiStatusResult<Hash>;
@@ -852,6 +852,12 @@ impl ChannelDepositWithNotesArguments {
             return Err((
                 "ChannelDeposit contains a null `input_note_ids` pointer.".to_owned(),
                 OperationStatus::NullPointer,
+            ));
+        }
+        if self.input_note_ids_len == 0 {
+            return Err((
+                "ChannelDeposit requires at least one input note.".to_owned(),
+                OperationStatus::RuntimeError,
             ));
         }
         for i in 0..self.input_note_ids_len {
@@ -923,7 +929,7 @@ impl ChannelDepositWithNotesArguments {
 /// [`OperationStatus`] error on failure.
 pub(crate) fn channel_deposit_with_notes_sync(
     node: &LogosBlockchainNode,
-    tip: Option<lb_core::header::HeaderId>,
+    tip: lb_core::header::HeaderId,
     deposit: DepositOp,
     change_public_key: ZkPublicKey,
     funding_public_keys: Vec<ZkPublicKey>,
@@ -936,7 +942,7 @@ pub(crate) fn channel_deposit_with_notes_sync(
 
         // Mirrors the node's `channel_deposit` handler: build -> fund -> check
         // fee -> sign -> submit.
-        let tx_context = api.get_tx_context(tip).await.map_err(|error| {
+        let tx_context = api.get_tx_context(Some(tip)).await.map_err(|error| {
             logging::error!(
                 "channel_deposit_with_notes_sync",
                 "Failed to get tx context: {error}"
@@ -956,7 +962,12 @@ pub(crate) fn channel_deposit_with_notes_sync(
             tip: funded_tip,
             response: funded_tx_builder,
         } = api
-            .fund_tx(tip, tx_builder, change_public_key, funding_public_keys)
+            .fund_tx(
+                Some(tip),
+                tx_builder,
+                change_public_key,
+                funding_public_keys,
+            )
             .await
             .map_err(|error| {
                 logging::error!(
@@ -1042,9 +1053,16 @@ pub unsafe extern "C" fn channel_deposit_with_notes(
 
     let node = unsafe { &*node };
     let tip = if arguments.optional_tip.is_null() {
-        None
+        unwrap_or_return_error!(get_cryptarchia_info_sync(node), |_| {
+            logging::error!(
+                "channel_deposit_with_notes",
+                "Failed to get cryptarchia info. Aborting."
+            );
+        })
+        .cryptarchia_info
+        .tip
     } else {
-        Some(CoreHeaderId::from(unsafe { *arguments.optional_tip }))
+        CoreHeaderId::from(unsafe { *arguments.optional_tip })
     };
 
     let channel_id = {
@@ -1092,17 +1110,20 @@ pub unsafe extern "C" fn channel_deposit_with_notes(
         metadata,
     };
 
-    let change_public_key = unsafe { parse_public_key(arguments.change_public_key) };
+    let change_public_key =
+        unwrap_or_return_error!(unsafe { parse_public_key(arguments.change_public_key) });
     let funding_public_key_pointers = unsafe {
         std::slice::from_raw_parts(
             arguments.funding_public_keys,
             arguments.funding_public_keys_len,
         )
     };
-    let funding_public_keys = funding_public_key_pointers
-        .iter()
-        .map(|pointer| unsafe { parse_public_key(*pointer) })
-        .collect::<Vec<_>>();
+    let funding_public_keys = unwrap_or_return_error!(
+        funding_public_key_pointers
+            .iter()
+            .map(|pointer| unsafe { parse_public_key(*pointer) })
+            .collect::<StatusResult<Vec<_>>>()
+    );
     let max_tx_fee = GasCost::new(arguments.max_tx_fee);
 
     let transaction = unwrap_or_return_error!(channel_deposit_with_notes_sync(
@@ -1307,6 +1328,15 @@ pub(crate) fn channel_deposit_sync(
 
         // 5. Assemble [transfer, deposit] in order and sign both ops with a single ZK
         //    signature by the funding key (which owns every input).
+        //
+        //    NOTE: we deliberately sign with `sign_tx_with_zk` (explicit keys) rather
+        //    than the usual `WalletApi::sign_tx`. `sign_tx` resolves each op's input
+        //    public keys from the *committed* ledger state, but the deposit consumes
+        //    the note this same transaction's transfer creates (it is not on-chain
+        //    yet), so `sign_tx` would fail with `MissingInputNote`. Both the transfer
+        //    inputs and the deposit's input note are owned by `funding_public_key`, so
+        //    one signature over the tx hash satisfies both op proofs. Do not "simplify"
+        //    this to `sign_tx`.
         let tx = MantleTx([Op::Transfer(transfer), Op::ChannelDeposit(deposit)].into());
         let tx_hash = tx.hash();
         let user_sig = api
@@ -1389,7 +1419,8 @@ pub unsafe extern "C" fn channel_deposit(
         };
         ChannelId::from(array)
     };
-    let funding_public_key = unsafe { parse_public_key(arguments.funding_public_key) };
+    let funding_public_key =
+        unwrap_or_return_error!(unsafe { parse_public_key(arguments.funding_public_key) });
     let amount = Value::from(arguments.amount);
 
     let metadata_bytes = if arguments.metadata_len == 0 {

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -4,7 +4,19 @@ use std::time::Duration;
 use lb_api_service::http::mempool;
 use lb_core::{
     header::HeaderId as CoreHeaderId,
-    mantle::{SignedMantleTx, Transaction},
+    mantle::{
+        MantleTx, Note, NoteId, Op, OpProof, SignedMantleTx, Transaction,
+        gas::{GasCost, MainnetGasConstants},
+        ledger::{Inputs, Outputs},
+        ops::{
+            channel::{
+                ChannelId,
+                deposit::{DepositOp, Metadata},
+            },
+            transfer::TransferOp,
+        },
+        tx_builder::MantleTxBuilder,
+    },
 };
 use lb_groth16::{fr_from_bytes, fr_to_bytes};
 use lb_key_management_system_keys::keys::ZkPublicKey;
@@ -24,6 +36,7 @@ use crate::{
             claimable_vouchers::{ClaimableVoucher, ClaimableVouchers},
             known_addresses::KnownAddresses,
             value::Value,
+            wallet_notes::{WalletNote, WalletNotes},
         },
     },
     errors::OperationStatus,
@@ -35,6 +48,9 @@ use crate::{
 pub type FfiClaimableVouchersResult = FfiStatusResult<ClaimableVouchers>;
 
 type WalletService = NodeWalletService<CryptarchiaService<RuntimeServiceId>, RuntimeServiceId>;
+
+/// Resolved tip plus the `(note ID, value)` pairs for a wallet address.
+type WalletNotesData = (lb_core::header::HeaderId, Vec<(NoteId, Value)>);
 
 /// Gets the known wallet addresses from the wallet service.
 ///
@@ -436,6 +452,136 @@ pub unsafe extern "C" fn get_balance(
     }
 }
 
+/// Gets the spendable notes (UTXOs) of a wallet address.
+///
+/// This is a synchronous wrapper around [`WalletApi::get_balance`] that, unlike
+/// [`get_balance_sync`], preserves the individual notes rather than collapsing
+/// them into a single total. Callers need the note IDs to build operations that
+/// consume specific notes (e.g. [`channel_deposit_with_notes`]).
+///
+/// # Arguments
+///
+/// - `node`: A [`LogosBlockchainNode`] instance.
+/// - `tip`: The header ID to query the notes at.
+/// - `wallet_address`: The public key of the wallet address to query.
+///
+/// # Returns
+///
+/// A [`Result`] containing the resolved tip and the `(note ID, value)` pairs on
+/// success (or `None` if the address is unknown), or an [`OperationStatus`]
+/// error on failure.
+pub(crate) fn get_wallet_notes_sync(
+    node: &LogosBlockchainNode,
+    tip: lb_core::header::HeaderId,
+    wallet_address: ZkPublicKey,
+) -> StatusResult<Option<WalletNotesData>> {
+    let runtime_handle = node.get_runtime_handle();
+    runtime_handle
+        .block_on(async {
+            let api = WalletApi::<WalletService, RuntimeServiceId>::from_overwatch_handle(
+                node.get_overwatch_handle(),
+            )
+            .await;
+            api.get_balance(Some(tip), wallet_address)
+                .await
+                .map(|tip_response| {
+                    let resolved_tip = tip_response.tip;
+                    tip_response
+                        .response
+                        .map(|balance| (resolved_tip, balance.notes.into_iter().collect()))
+                })
+        })
+        .map_err(|_| OperationStatus::DynError)
+}
+
+pub type FfiWalletNotesResult = FfiStatusResult<WalletNotes>;
+
+/// Retrieves the spendable notes (UTXOs) of a wallet address.
+///
+/// # Arguments
+///
+/// - `node`: A non-null pointer to a [`LogosBlockchainNode`] instance.
+/// - `wallet_address`: A non-null pointer to the 32-byte public key of the
+///   wallet address to query.
+/// - `optional_tip`: An optional pointer to the header ID to query at. If null,
+///   the current tip will be used.
+///
+/// # Returns
+///
+/// A [`FfiWalletNotesResult`] containing the tip and the array of notes on
+/// success, or an [`OperationStatus`] error on failure. Note IDs are in
+/// little-endian format.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid, and must free the returned
+/// [`WalletNotes`] with [`free_wallet_notes`] exactly once.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_wallet_notes(
+    node: *const LogosBlockchainNode,
+    wallet_address: *const u8,
+    optional_tip: *const HeaderId,
+) -> FfiWalletNotesResult {
+    return_error_if_null_pointer!("get_wallet_notes", node);
+    return_error_if_null_pointer!("get_wallet_notes", wallet_address);
+    let node = unsafe { &*node };
+    let tip = if optional_tip.is_null() {
+        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+            .cryptarchia_info
+            .tip
+    } else {
+        lb_core::header::HeaderId::from(unsafe { *optional_tip })
+    };
+    let wallet_address_bytes = unsafe { std::slice::from_raw_parts(wallet_address, 32) };
+    let wallet_address = unwrap_or_return_error!(
+        fr_from_bytes(wallet_address_bytes)
+            .map(ZkPublicKey::new)
+            .map_err(|error| {
+                logging::error!("get_wallet_notes", "{error:?}");
+                OperationStatus::DynError
+            })
+    );
+
+    match get_wallet_notes_sync(node, tip, wallet_address) {
+        Ok(Some((resolved_tip, notes))) => {
+            let notes: Vec<WalletNote> = notes
+                .into_iter()
+                .map(|(id, value)| WalletNote {
+                    id: fr_to_bytes(id.as_fr()),
+                    value,
+                })
+                .collect();
+            let len = notes.len();
+            let notes_ptr = Box::leak(notes.into_boxed_slice()).as_mut_ptr();
+            FfiWalletNotesResult::ok(WalletNotes {
+                tip: resolved_tip.into(),
+                notes: notes_ptr,
+                len,
+            })
+        }
+        Ok(None) => FfiWalletNotesResult::err(OperationStatus::NotFound),
+        Err(status) => FfiWalletNotesResult::err(status),
+    }
+}
+
+/// Frees the memory allocated for a [`WalletNotes`] structure.
+///
+/// # Safety
+///
+/// This function is unsafe because it reconstructs a boxed slice from a raw
+/// pointer. The caller must only pass values returned by [`get_wallet_notes`]
+/// and must call this exactly once per result.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn free_wallet_notes(notes: WalletNotes) -> OperationStatus {
+    if notes.notes.is_null() {
+        return OperationStatus::Ok;
+    }
+    let notes = unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(notes.notes, notes.len)) };
+    drop(notes);
+    OperationStatus::Ok
+}
+
 #[repr(C)]
 pub struct TransferFundsArguments {
     pub optional_tip: *const HeaderId,
@@ -644,4 +790,633 @@ pub unsafe extern "C" fn transfer_funds(
         return FfiTransferFundsResult::err(OperationStatus::RuntimeError);
     };
     FfiTransferFundsResult::ok(transaction_hash_array)
+}
+
+/// Parses a 32-byte little-endian buffer into a [`ZkPublicKey`].
+///
+/// # Safety
+///
+/// `pointer` must be non-null and point to at least 32 readable bytes.
+unsafe fn parse_public_key(pointer: *const u8) -> ZkPublicKey {
+    let bytes = unsafe { std::slice::from_raw_parts(pointer, 32) };
+    ZkPublicKey::from(BigUint::from_bytes_le(bytes))
+}
+
+pub type FfiChannelDepositResult = FfiStatusResult<Hash>;
+
+/// Arguments for [`channel_deposit_with_notes`].
+///
+/// Mirrors the node's `POST /channel/deposit` request body: the caller supplies
+/// the exact notes to deposit (their whole value enters the channel), so
+/// callers must select notes themselves (see [`get_wallet_notes`]).
+#[repr(C)]
+pub struct ChannelDepositWithNotesArguments {
+    /// Optional pointer to the header ID to build against. If null, the current
+    /// tip is used.
+    pub optional_tip: *const HeaderId,
+    /// The 32-byte channel ID to deposit into.
+    pub channel_id: *const u8,
+    /// Array of pointers to 32-byte note IDs to deposit. Their combined value
+    /// is the deposited amount.
+    pub input_note_ids: *const *const u8,
+    pub input_note_ids_len: usize,
+    /// Optional metadata bytes attached to the deposit. May be null iff
+    /// `metadata_len` is 0.
+    pub metadata: *const u8,
+    pub metadata_len: usize,
+    /// The 32-byte public key to receive any change from funding the gas fee.
+    pub change_public_key: *const u8,
+    /// Array of pointers to 32-byte public keys used to fund the gas fee.
+    pub funding_public_keys: *const *const u8,
+    pub funding_public_keys_len: usize,
+    /// The maximum gas fee the caller is willing to pay. The deposit is
+    /// rejected if the computed fee exceeds this.
+    pub max_tx_fee: u64,
+}
+
+impl ChannelDepositWithNotesArguments {
+    /// Validates that all required pointers are non-null.
+    ///
+    /// # Safety
+    ///
+    /// This function dereferences raw pointers. The caller must ensure the
+    /// pointer-array lengths are accurate.
+    pub unsafe fn validate(&self) -> Result<(), (String, OperationStatus)> {
+        if self.channel_id.is_null() {
+            return Err((
+                "ChannelDeposit contains a null `channel_id` pointer.".to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        if self.input_note_ids.is_null() {
+            return Err((
+                "ChannelDeposit contains a null `input_note_ids` pointer.".to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        for i in 0..self.input_note_ids_len {
+            let element_pointer = unsafe { self.input_note_ids.add(i) };
+            let note_id_pointer = unsafe { *element_pointer };
+            if note_id_pointer.is_null() {
+                return Err((
+                    format!("ChannelDeposit contains a null pointer at `input_note_ids[{i}]`."),
+                    OperationStatus::NullPointer,
+                ));
+            }
+        }
+        if self.metadata.is_null() && self.metadata_len != 0 {
+            return Err((
+                "ChannelDeposit contains a null `metadata` pointer with non-zero length."
+                    .to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        if self.change_public_key.is_null() {
+            return Err((
+                "ChannelDeposit contains a null `change_public_key` pointer.".to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        if self.funding_public_keys.is_null() {
+            return Err((
+                "ChannelDeposit contains a null `funding_public_keys` pointer.".to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        for i in 0..self.funding_public_keys_len {
+            let element_pointer = unsafe { self.funding_public_keys.add(i) };
+            let funding_public_key_pointer = unsafe { *element_pointer };
+            if funding_public_key_pointer.is_null() {
+                return Err((
+                    format!(
+                        "ChannelDeposit contains a null pointer at `funding_public_keys[{i}]`."
+                    ),
+                    OperationStatus::NullPointer,
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Builds, funds, signs and submits a channel deposit consuming the given
+/// notes.
+///
+/// This is a synchronous wrapper that mirrors the node's `channel_deposit` HTTP
+/// handler: it builds a [`DepositOp`], funds the gas fee from
+/// `funding_public_keys` (change to `change_public_key`), rejects the deposit
+/// if the fee exceeds `max_tx_fee`, signs the transaction and adds it to the
+/// mempool.
+///
+/// # Arguments
+///
+/// - `node`: A [`LogosBlockchainNode`] instance.
+/// - `tip`: Optional header ID to build against (`None` uses the current tip).
+/// - `deposit`: The fully-formed [`DepositOp`].
+/// - `change_public_key`: Receives any change from funding the fee.
+/// - `funding_public_keys`: Fund the gas fee.
+/// - `max_tx_fee`: Maximum acceptable gas fee.
+///
+/// # Returns
+///
+/// A [`Result`] containing the submitted [`SignedMantleTx`] on success, or an
+/// [`OperationStatus`] error on failure.
+pub(crate) fn channel_deposit_with_notes_sync(
+    node: &LogosBlockchainNode,
+    tip: Option<lb_core::header::HeaderId>,
+    deposit: DepositOp,
+    change_public_key: ZkPublicKey,
+    funding_public_keys: Vec<ZkPublicKey>,
+    max_tx_fee: GasCost,
+) -> StatusResult<SignedMantleTx> {
+    let runtime_handle = node.get_runtime_handle();
+    runtime_handle.block_on(async {
+        let handle = node.get_overwatch_handle();
+        let api = WalletApi::<WalletService, RuntimeServiceId>::from_overwatch_handle(handle).await;
+
+        // Mirrors the node's `channel_deposit` handler: build -> fund -> check
+        // fee -> sign -> submit.
+        let tx_context = api.get_tx_context(tip).await.map_err(|error| {
+            logging::error!(
+                "channel_deposit_with_notes_sync",
+                "Failed to get tx context: {error}"
+            );
+            OperationStatus::DynError
+        })?;
+        let tx_builder = MantleTxBuilder::new(tx_context)
+            .push_op(Op::ChannelDeposit(deposit))
+            .map_err(|error| {
+                logging::error!(
+                    "channel_deposit_with_notes_sync",
+                    "Failed to push deposit op: {error}"
+                );
+                OperationStatus::DynError
+            })?;
+        let TipResponse {
+            tip: funded_tip,
+            response: funded_tx_builder,
+        } = api
+            .fund_tx(tip, tx_builder, change_public_key, funding_public_keys)
+            .await
+            .map_err(|error| {
+                logging::error!(
+                    "channel_deposit_with_notes_sync",
+                    "Failed to fund tx: {error}"
+                );
+                OperationStatus::DynError
+            })?;
+
+        let tx_fee = funded_tx_builder
+            .gas_cost::<MainnetGasConstants>()
+            .map_err(|error| {
+                logging::error!(
+                    "channel_deposit_with_notes_sync",
+                    "Failed to compute gas cost: {error}"
+                );
+                OperationStatus::DynError
+            })?;
+        if tx_fee > max_tx_fee {
+            logging::error!(
+                "channel_deposit_with_notes_sync",
+                "tx_fee({tx_fee}) exceeds max_tx_fee({max_tx_fee})"
+            );
+            return Err(OperationStatus::DynError);
+        }
+
+        let signed_tx = api
+            .sign_tx(Some(funded_tip), funded_tx_builder)
+            .await
+            .map_err(|error| {
+                logging::error!(
+                    "channel_deposit_with_notes_sync",
+                    "Failed to sign tx: {error}"
+                );
+                OperationStatus::DynError
+            })?
+            .response;
+
+        if let Err(error) = mempool::add_tx(handle, signed_tx.clone(), Transaction::hash).await {
+            logging::error!(
+                "channel_deposit_with_notes_sync",
+                "Failed to add transaction to mempool: {error}"
+            );
+            return Err(OperationStatus::DynError);
+        }
+        Ok(signed_tx)
+    })
+}
+
+/// Submits a channel deposit consuming caller-specified notes.
+///
+/// The whole value of each supplied note enters the channel, so the deposited
+/// amount equals the sum of the notes' values. Callers that want to deposit an
+/// arbitrary amount should use the amount-based variant instead.
+///
+/// # Arguments
+///
+/// - `node`: A non-null pointer to a [`LogosBlockchainNode`] instance.
+/// - `arguments`: A non-null pointer to a [`ChannelDepositWithNotesArguments`].
+///
+/// # Returns
+///
+/// A [`FfiChannelDepositResult`] containing the submitted transaction [`Hash`]
+/// (little-endian) on success, or an [`OperationStatus`] error on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid and that the array lengths are
+/// accurate.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn channel_deposit_with_notes(
+    node: *const LogosBlockchainNode,
+    arguments: *const ChannelDepositWithNotesArguments,
+) -> FfiChannelDepositResult {
+    return_error_if_null_pointer!("channel_deposit_with_notes", node);
+    return_error_if_null_pointer!("channel_deposit_with_notes", arguments);
+    let arguments = unsafe { &*arguments };
+    if let Err((error_message, status)) = unsafe { arguments.validate() } {
+        logging::error!("channel_deposit_with_notes", "{error_message} Exiting.");
+        return FfiChannelDepositResult::err(status);
+    }
+
+    let node = unsafe { &*node };
+    let tip = if arguments.optional_tip.is_null() {
+        None
+    } else {
+        Some(CoreHeaderId::from(unsafe { *arguments.optional_tip }))
+    };
+
+    let channel_id = {
+        let bytes = unsafe { std::slice::from_raw_parts(arguments.channel_id, 32) };
+        let Ok(array): Result<[u8; 32], _> = bytes.try_into() else {
+            logging::error!("channel_deposit_with_notes", "Invalid channel_id length.");
+            return FfiChannelDepositResult::err(OperationStatus::RuntimeError);
+        };
+        ChannelId::from(array)
+    };
+
+    let note_id_pointers = unsafe {
+        std::slice::from_raw_parts(arguments.input_note_ids, arguments.input_note_ids_len)
+    };
+    let mut note_ids = Vec::with_capacity(arguments.input_note_ids_len);
+    for note_id_pointer in note_id_pointers {
+        let bytes = unsafe { std::slice::from_raw_parts(*note_id_pointer, 32) };
+        let note_id = unwrap_or_return_error!(fr_from_bytes(bytes).map(NoteId).map_err(|error| {
+            logging::error!("channel_deposit_with_notes", "Invalid note ID: {error:?}");
+            OperationStatus::DynError
+        }));
+        note_ids.push(note_id);
+    }
+    let inputs = unwrap_or_return_error!(Inputs::try_new(note_ids).map_err(|error| {
+        logging::error!(
+            "channel_deposit_with_notes",
+            "Invalid deposit inputs: {error:?}"
+        );
+        OperationStatus::DynError
+    }));
+
+    let metadata_bytes = if arguments.metadata_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(arguments.metadata, arguments.metadata_len) }.to_vec()
+    };
+    let metadata = unwrap_or_return_error!(Metadata::try_from(metadata_bytes).map_err(|error| {
+        logging::error!("channel_deposit_with_notes", "Invalid metadata: {error:?}");
+        OperationStatus::DynError
+    }));
+
+    let deposit = DepositOp {
+        channel_id,
+        inputs,
+        metadata,
+    };
+
+    let change_public_key = unsafe { parse_public_key(arguments.change_public_key) };
+    let funding_public_key_pointers = unsafe {
+        std::slice::from_raw_parts(
+            arguments.funding_public_keys,
+            arguments.funding_public_keys_len,
+        )
+    };
+    let funding_public_keys = funding_public_key_pointers
+        .iter()
+        .map(|pointer| unsafe { parse_public_key(*pointer) })
+        .collect::<Vec<_>>();
+    let max_tx_fee = GasCost::new(arguments.max_tx_fee);
+
+    let transaction = unwrap_or_return_error!(channel_deposit_with_notes_sync(
+        node,
+        tip,
+        deposit,
+        change_public_key,
+        funding_public_keys,
+        max_tx_fee,
+    ));
+    let transaction_hash = transaction.hash().as_signing_bytes();
+    let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
+        logging::error!(
+            "channel_deposit_with_notes",
+            "Failed to convert transaction hash to array. Exiting."
+        );
+        return FfiChannelDepositResult::err(OperationStatus::RuntimeError);
+    };
+    FfiChannelDepositResult::ok(transaction_hash_array)
+}
+
+/// Selects notes (largest-first) whose combined value covers `amount`.
+///
+/// Returns the selected note IDs and their combined value, or `None` if the
+/// supplied notes cannot cover `amount`.
+fn select_notes_covering(
+    mut notes: Vec<(NoteId, Value)>,
+    amount: Value,
+) -> Option<(Vec<NoteId>, Value)> {
+    notes.sort_by_key(|(_, value)| std::cmp::Reverse(*value));
+    let mut selected = Vec::new();
+    let mut total: Value = 0;
+    for (id, value) in notes {
+        if total >= amount {
+            break;
+        }
+        selected.push(id);
+        total = total.saturating_add(value);
+    }
+    (total >= amount).then_some((selected, total))
+}
+
+/// Arguments for [`channel_deposit`].
+///
+/// The binding selects funding notes itself and, when no exact-value note
+/// exists, splits one via a transfer so the channel receives exactly `amount`.
+/// The `funding_public_key` owns the funding notes, the deposit note and any
+/// change.
+#[repr(C)]
+pub struct ChannelDepositArguments {
+    /// Optional pointer to the header ID to build against. If null, the current
+    /// tip is used.
+    pub optional_tip: *const HeaderId,
+    /// The 32-byte channel ID to deposit into.
+    pub channel_id: *const u8,
+    /// The 32-byte public key funding the deposit (owns the funding notes, the
+    /// deposit note and any change).
+    pub funding_public_key: *const u8,
+    /// The exact amount to deposit into the channel.
+    pub amount: u64,
+    /// Optional metadata bytes attached to the deposit. May be null iff
+    /// `metadata_len` is 0.
+    pub metadata: *const u8,
+    pub metadata_len: usize,
+}
+
+impl ChannelDepositArguments {
+    /// Validates that all required pointers are non-null.
+    ///
+    /// # Safety
+    ///
+    /// This function dereferences raw pointers.
+    pub unsafe fn validate(&self) -> Result<(), (String, OperationStatus)> {
+        if self.channel_id.is_null() {
+            return Err((
+                "ChannelDeposit contains a null `channel_id` pointer.".to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        if self.funding_public_key.is_null() {
+            return Err((
+                "ChannelDeposit contains a null `funding_public_key` pointer.".to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        if self.metadata.is_null() && self.metadata_len != 0 {
+            return Err((
+                "ChannelDeposit contains a null `metadata` pointer with non-zero length."
+                    .to_owned(),
+                OperationStatus::NullPointer,
+            ));
+        }
+        if self.amount == 0 {
+            return Err((
+                "ChannelDeposit `amount` must be greater than zero.".to_owned(),
+                OperationStatus::RuntimeError,
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Builds, signs and submits an amount-based channel deposit, splitting a note
+/// via a transfer when no exact-value note is available.
+///
+/// This mirrors the atomic deposit path used in the e2e tests: a [`TransferOp`]
+/// produces the exact deposit note (plus change), the [`DepositOp`] consumes
+/// that freshly-created note, and both ops are signed with a single ZK
+/// signature over the transaction by `funding_public_key` (which owns every
+/// input). Gas is not funded because the platform gas price is currently 0.
+///
+/// # Arguments
+///
+/// - `node`: A [`LogosBlockchainNode`] instance.
+/// - `tip`: The header ID to query notes and sign against.
+/// - `channel_id`: The channel to deposit into.
+/// - `funding_public_key`: Owns the funding notes, deposit note and change.
+/// - `amount`: The exact amount to deposit.
+/// - `metadata`: Metadata attached to the deposit.
+///
+/// # Returns
+///
+/// A [`Result`] containing the submitted [`SignedMantleTx`] on success, or an
+/// [`OperationStatus`] error on failure.
+pub(crate) fn channel_deposit_sync(
+    node: &LogosBlockchainNode,
+    tip: lb_core::header::HeaderId,
+    channel_id: ChannelId,
+    funding_public_key: ZkPublicKey,
+    amount: Value,
+    metadata: Metadata,
+) -> StatusResult<SignedMantleTx> {
+    let runtime_handle = node.get_runtime_handle();
+    runtime_handle.block_on(async {
+        let handle = node.get_overwatch_handle();
+        let api = WalletApi::<WalletService, RuntimeServiceId>::from_overwatch_handle(handle).await;
+
+        // 1. Fetch the funding key's spendable notes.
+        let balance = api
+            .get_balance(Some(tip), funding_public_key)
+            .await
+            .map_err(|error| {
+                logging::error!("channel_deposit_sync", "Failed to get balance: {error}");
+                OperationStatus::DynError
+            })?;
+        let notes: Vec<(NoteId, Value)> = balance
+            .response
+            .map(|balance| balance.notes.into_iter().collect())
+            .ok_or_else(|| {
+                logging::error!("channel_deposit_sync", "Unknown funding address.");
+                OperationStatus::NotFound
+            })?;
+
+        // 2. Select notes covering the deposit amount.
+        let (selected_ids, selected_total) =
+            select_notes_covering(notes, amount).ok_or_else(|| {
+                logging::error!(
+                    "channel_deposit_sync",
+                    "Insufficient funds to cover deposit amount."
+                );
+                OperationStatus::DynError
+            })?;
+        let change = selected_total - amount;
+
+        // 3. Build a transfer whose output[0] is the exact deposit note, with any
+        //    remainder returned as change to the same key.
+        let mut outputs = vec![Note::new(amount, funding_public_key)];
+        if change > 0 {
+            outputs.push(Note::new(change, funding_public_key));
+        }
+        let transfer = TransferOp {
+            inputs: Inputs::try_new(selected_ids).map_err(|error| {
+                logging::error!("channel_deposit_sync", "Invalid transfer inputs: {error:?}");
+                OperationStatus::DynError
+            })?,
+            outputs: Outputs::try_new(outputs).map_err(|error| {
+                logging::error!(
+                    "channel_deposit_sync",
+                    "Invalid transfer outputs: {error:?}"
+                );
+                OperationStatus::DynError
+            })?,
+        };
+
+        // 4. The deposit consumes the freshly-created note at output index 0.
+        let deposit_note_id = transfer
+            .outputs
+            .utxo_by_index(0, &transfer)
+            .ok_or_else(|| {
+                logging::error!(
+                    "channel_deposit_sync",
+                    "Transfer did not produce a deposit note."
+                );
+                OperationStatus::RuntimeError
+            })?
+            .id();
+        let deposit = DepositOp {
+            channel_id,
+            inputs: Inputs::new([deposit_note_id]),
+            metadata,
+        };
+
+        // 5. Assemble [transfer, deposit] in order and sign both ops with a single ZK
+        //    signature by the funding key (which owns every input).
+        let tx = MantleTx([Op::Transfer(transfer), Op::ChannelDeposit(deposit)].into());
+        let tx_hash = tx.hash();
+        let user_sig = api
+            .sign_tx_with_zk(tx_hash, vec![funding_public_key])
+            .await
+            .map_err(|error| {
+                logging::error!("channel_deposit_sync", "Failed to sign deposit tx: {error}");
+                OperationStatus::DynError
+            })?;
+        let signed_tx = SignedMantleTx::new(
+            tx,
+            vec![OpProof::ZkSig(user_sig.clone()), OpProof::ZkSig(user_sig)],
+        )
+        .map_err(|error| {
+            logging::error!(
+                "channel_deposit_sync",
+                "Failed to assemble signed tx: {error:?}"
+            );
+            OperationStatus::DynError
+        })?;
+
+        // 6. Submit to the mempool.
+        if let Err(error) = mempool::add_tx(handle, signed_tx.clone(), Transaction::hash).await {
+            logging::error!(
+                "channel_deposit_sync",
+                "Failed to add transaction to mempool: {error}"
+            );
+            return Err(OperationStatus::DynError);
+        }
+        Ok(signed_tx)
+    })
+}
+
+/// Submits an amount-based channel deposit.
+///
+/// The binding selects the funding notes itself and splits one via a transfer
+/// when no exact-value note exists, so the channel receives exactly `amount`.
+///
+/// # Arguments
+///
+/// - `node`: A non-null pointer to a [`LogosBlockchainNode`] instance.
+/// - `arguments`: A non-null pointer to a [`ChannelDepositArguments`].
+///
+/// # Returns
+///
+/// A [`FfiChannelDepositResult`] containing the submitted transaction [`Hash`]
+/// (little-endian) on success, or an [`OperationStatus`] error on failure.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers. The caller
+/// must ensure that all pointers are valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn channel_deposit(
+    node: *const LogosBlockchainNode,
+    arguments: *const ChannelDepositArguments,
+) -> FfiChannelDepositResult {
+    return_error_if_null_pointer!("channel_deposit", node);
+    return_error_if_null_pointer!("channel_deposit", arguments);
+    let arguments = unsafe { &*arguments };
+    if let Err((error_message, status)) = unsafe { arguments.validate() } {
+        logging::error!("channel_deposit", "{error_message} Exiting.");
+        return FfiChannelDepositResult::err(status);
+    }
+
+    let node = unsafe { &*node };
+    let tip = if arguments.optional_tip.is_null() {
+        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+            .cryptarchia_info
+            .tip
+    } else {
+        lb_core::header::HeaderId::from(unsafe { *arguments.optional_tip })
+    };
+
+    let channel_id = {
+        let bytes = unsafe { std::slice::from_raw_parts(arguments.channel_id, 32) };
+        let Ok(array): Result<[u8; 32], _> = bytes.try_into() else {
+            logging::error!("channel_deposit", "Invalid channel_id length.");
+            return FfiChannelDepositResult::err(OperationStatus::RuntimeError);
+        };
+        ChannelId::from(array)
+    };
+    let funding_public_key = unsafe { parse_public_key(arguments.funding_public_key) };
+    let amount = Value::from(arguments.amount);
+
+    let metadata_bytes = if arguments.metadata_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(arguments.metadata, arguments.metadata_len) }.to_vec()
+    };
+    let metadata = unwrap_or_return_error!(Metadata::try_from(metadata_bytes).map_err(|error| {
+        logging::error!("channel_deposit", "Invalid metadata: {error:?}");
+        OperationStatus::DynError
+    }));
+
+    let transaction = unwrap_or_return_error!(channel_deposit_sync(
+        node,
+        tip,
+        channel_id,
+        funding_public_key,
+        amount,
+        metadata,
+    ));
+    let transaction_hash = transaction.hash().as_signing_bytes();
+    let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
+        logging::error!(
+            "channel_deposit",
+            "Failed to convert transaction hash to array. Exiting."
+        );
+        return FfiChannelDepositResult::err(OperationStatus::RuntimeError);
+    };
+    FfiChannelDepositResult::ok(transaction_hash_array)
 }

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -5,7 +5,7 @@ use lb_api_service::http::mempool;
 use lb_core::{
     header::HeaderId as CoreHeaderId,
     mantle::{
-        MantleTx, Note, NoteId, Op, OpProof, SignedMantleTx, Transaction,
+        MantleTx, Note, NoteId as CoreNoteId, Op, OpProof, SignedMantleTx, Transaction,
         gas::{GasCost, MainnetGasConstants},
         ledger::{Inputs, Outputs},
         ops::{
@@ -30,7 +30,7 @@ use overwatch::services::status::ServiceStatus;
 use crate::{
     LogosBlockchainNode,
     api::{
-        cryptarchia::{Hash, HeaderId, get_cryptarchia_info_sync},
+        cryptarchia::{Hash, HeaderId, NoteId, get_cryptarchia_info_sync},
         types::{
             claimable_vouchers::{ClaimableVoucher, ClaimableVouchers},
             known_addresses::KnownAddresses,
@@ -49,7 +49,7 @@ pub type FfiClaimableVouchersResult = FfiStatusResult<ClaimableVouchers>;
 type WalletService = NodeWalletService<CryptarchiaService<RuntimeServiceId>, RuntimeServiceId>;
 
 /// Resolved tip plus the `(note ID, value)` pairs for a wallet address.
-type WalletNotesData = (lb_core::header::HeaderId, Vec<(NoteId, Value)>);
+type WalletNotesData = (lb_core::header::HeaderId, Vec<(CoreNoteId, Value)>);
 
 /// Gets the known wallet addresses from the wallet service.
 ///
@@ -816,9 +816,9 @@ pub struct ChannelDepositWithNotesArguments {
     pub optional_tip: *const HeaderId,
     /// The 32-byte channel ID to deposit into.
     pub channel_id: *const u8,
-    /// Array of pointers to 32-byte note IDs to deposit. Their combined value
-    /// is the deposited amount.
-    pub input_note_ids: *const *const u8,
+    /// Array of note IDs to deposit. Their combined value is the deposited
+    /// amount.
+    pub input_note_ids: *const NoteId,
     pub input_note_ids_len: usize,
     /// Optional metadata bytes attached to the deposit. May be null iff
     /// `metadata_len` is 0.
@@ -859,16 +859,6 @@ impl ChannelDepositWithNotesArguments {
                 "ChannelDeposit requires at least one input note.".to_owned(),
                 OperationStatus::RuntimeError,
             ));
-        }
-        for i in 0..self.input_note_ids_len {
-            let element_pointer = unsafe { self.input_note_ids.add(i) };
-            let note_id_pointer = unsafe { *element_pointer };
-            if note_id_pointer.is_null() {
-                return Err((
-                    format!("ChannelDeposit contains a null pointer at `input_note_ids[{i}]`."),
-                    OperationStatus::NullPointer,
-                ));
-            }
         }
         if self.metadata.is_null() && self.metadata_len != 0 {
             return Err((
@@ -1074,16 +1064,18 @@ pub unsafe extern "C" fn channel_deposit_with_notes(
         ChannelId::from(array)
     };
 
-    let note_id_pointers = unsafe {
+    let input_note_ids = unsafe {
         std::slice::from_raw_parts(arguments.input_note_ids, arguments.input_note_ids_len)
     };
     let mut note_ids = Vec::with_capacity(arguments.input_note_ids_len);
-    for note_id_pointer in note_id_pointers {
-        let bytes = unsafe { std::slice::from_raw_parts(*note_id_pointer, 32) };
-        let note_id = unwrap_or_return_error!(fr_from_bytes(bytes).map(NoteId).map_err(|error| {
-            logging::error!("channel_deposit_with_notes", "Invalid note ID: {error:?}");
-            OperationStatus::DynError
-        }));
+    for note_id_bytes in input_note_ids {
+        let note_id =
+            unwrap_or_return_error!(fr_from_bytes(note_id_bytes).map(CoreNoteId).map_err(
+                |error| {
+                    logging::error!("channel_deposit_with_notes", "Invalid note ID: {error:?}");
+                    OperationStatus::DynError
+                }
+            ));
         note_ids.push(note_id);
     }
     let inputs = unwrap_or_return_error!(Inputs::try_new(note_ids).map_err(|error| {
@@ -1150,9 +1142,9 @@ pub unsafe extern "C" fn channel_deposit_with_notes(
 /// Returns the selected note IDs and their combined value, or `None` if the
 /// supplied notes cannot cover `amount`.
 fn select_notes_covering(
-    mut notes: Vec<(NoteId, Value)>,
+    mut notes: Vec<(CoreNoteId, Value)>,
     amount: Value,
-) -> Option<(Vec<NoteId>, Value)> {
+) -> Option<(Vec<CoreNoteId>, Value)> {
     notes.sort_by_key(|(_, value)| std::cmp::Reverse(*value));
     let mut selected = Vec::new();
     let mut total: Value = 0;
@@ -1269,7 +1261,7 @@ pub(crate) fn channel_deposit_sync(
                 logging::error!("channel_deposit_sync", "Failed to get balance: {error}");
                 OperationStatus::DynError
             })?;
-        let notes: Vec<(NoteId, Value)> = balance
+        let notes: Vec<(CoreNoteId, Value)> = balance
             .response
             .map(|balance| balance.notes.into_iter().collect())
             .ok_or_else(|| {


### PR DESCRIPTION
## 1. What does this PR implement?
This PR adds channel deposit operations to the FFI bindings. There are two deposit calls:
  - channel_deposit_with_notes — the simpler call; the caller supplies the exact notes to deposit (their whole value enters the channel). A 1:1 port of the existing POST /channel/deposit handler.
  - channel_deposit — the automatic call; the caller passes an amount and the binding
  selects the notes itself, splitting one via a transfer when no exact-value note exists.

  It also adds get_wallet_notes (+ free_wallet_notes), which exposes a wallet address's spendable notes (note ID, value). This is needed so callers can discover the note IDs to pass to channel_deposit_with_notes — the existing get_balance binding only returned a total and discarded the per-note list.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
