### PR TITLE
fix(chain-network): replace queued orphan parent with descendant orphan

### DIFF
--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -572,7 +572,9 @@ where
                     target: LOG_TARGET, ?block_id, ?parent,
                     "Parent block missing. Trying to enqueue block for orphan processing",
                 );
-                if let Err(e) = orphan_downloader.enqueue_orphan(block_id, info.tip, info.lib) {
+                if let Err(e) =
+                    orphan_downloader.enqueue_orphan(block_id, Some(parent), info.tip, info.lib)
+                {
                     error!(
                         target: LOG_TARGET, %e, ?block_id, ?parent,
                         "Failed to enqueue block for orphan processing",
@@ -683,7 +685,7 @@ where
     ) where
         RuntimeServiceId: Send + Sync + 'static,
     {
-        match orphan_downloader.enqueue_orphan(chosen_tip, local.tip, local.lib) {
+        match orphan_downloader.enqueue_orphan(chosen_tip, None, local.tip, local.lib) {
             Ok(()) => {
                 info!(
                     target: LOG_TARGET,

--- a/services/chain/chain-network/src/metrics.rs
+++ b/services/chain/chain-network/src/metrics.rs
@@ -85,6 +85,10 @@ pub fn orphan_blocks_removed_total() {
     lb_tracing::increase_counter_u64!(orphan_blocks_removed_total, 1);
 }
 
+pub fn orphan_blocks_replaced_total() {
+    lb_tracing::increase_counter_u64!(orphan_blocks_replaced_total, 1);
+}
+
 pub fn orphan_blocks_received_total() {
     lb_tracing::increase_counter_u64!(orphan_blocks_received_total, 1);
 }

--- a/services/chain/chain-network/src/sync/orphan_handler.rs
+++ b/services/chain/chain-network/src/sync/orphan_handler.rs
@@ -128,9 +128,37 @@ where
     pub fn enqueue_orphan(
         &mut self,
         block_id: HeaderId,
+        parent_id: Option<HeaderId>, // `None` if the caller knows only `block_id`
         current_tip: HeaderId,
         lib: HeaderId,
     ) -> Result<(), OrphanEnqueueError> {
+        if let DownloaderState::Downloading(download) = &self.state
+            && download.orphan_block_id() == block_id
+        {
+            debug!(target: LOG_TARGET, ?block_id, "Orphan block is already being downloaded, skipping enqueue");
+            return Err(OrphanEnqueueError::AlreadyDownloading);
+        }
+
+        if self.pending_orphans_queue.contains_key(&block_id) {
+            debug!(target: LOG_TARGET, ?block_id, "Orphan block is already in the queue, skipping enqueue");
+            return Err(OrphanEnqueueError::AlreadyInQueue);
+        }
+
+        // If the parent is already queued, replace it with this descendant.
+        // Doing this before the capacity check is safe because this removes
+        // the parent from the queue, if any.
+        if let Some(parent_id) = parent_id
+            && self.pending_orphans_queue.contains_key(&parent_id)
+        {
+            debug!(
+                target: LOG_TARGET,
+                ?block_id, ?parent_id,
+                "replacing queued parent orphan with descendant"
+            );
+            self.remove_orphan(&parent_id);
+            metrics::orphan_blocks_replaced_total();
+        }
+
         if self.pending_orphans_queue.len() >= self.max_pending_orphans.get() {
             warn!(
                 target: LOG_TARGET,
@@ -144,18 +172,6 @@ where
             return Err(OrphanEnqueueError::QueueFull {
                 limit: self.max_pending_orphans,
             });
-        }
-
-        if let DownloaderState::Downloading(download) = &self.state
-            && download.orphan_block_id() == block_id
-        {
-            debug!(target: LOG_TARGET, ?block_id, "Orphan block is already being downloaded, skipping enqueue");
-            return Err(OrphanEnqueueError::AlreadyDownloading);
-        }
-
-        if self.pending_orphans_queue.contains_key(&block_id) {
-            debug!(target: LOG_TARGET, ?block_id, "Orphan block is already in the queue, skipping enqueue");
-            return Err(OrphanEnqueueError::AlreadyInQueue);
         }
 
         self.pending_orphans_queue
@@ -733,7 +749,7 @@ mod tests {
         for i in 0..downloader.max_pending_orphans.get() {
             let orphan = [i as u8; 32].into();
             downloader
-                .enqueue_orphan(orphan, TEST_TIP.into(), TEST_LIB.into())
+                .enqueue_orphan(orphan, None, TEST_TIP.into(), TEST_LIB.into())
                 .unwrap();
             added_orphans.push(orphan);
         }
@@ -749,7 +765,7 @@ mod tests {
 
         let extra_orphan = [255u8; 32].into();
         assert!(matches!(
-            downloader.enqueue_orphan(extra_orphan, TEST_TIP.into(), TEST_LIB.into()),
+            downloader.enqueue_orphan(extra_orphan, None, TEST_TIP.into(), TEST_LIB.into()),
             Err(OrphanEnqueueError::QueueFull { .. })
         ));
 
@@ -764,6 +780,134 @@ mod tests {
                 .iter()
                 .any(|(key, _)| *key == extra_orphan)
         );
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_replaces_queued_parent_with_descendant() {
+        let mut downloader = create_downloader();
+
+        let parent: HeaderId = [1u8; 32].into();
+        let child: HeaderId = [2u8; 32].into();
+
+        downloader
+            .enqueue_orphan(parent, None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+        assert!(downloader.pending_orphans_queue.contains_key(&parent));
+
+        downloader
+            .enqueue_orphan(child, Some(parent), TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+
+        assert!(!downloader.pending_orphans_queue.contains_key(&parent));
+        assert!(downloader.pending_orphans_queue.contains_key(&child));
+        assert_eq!(downloader.pending_orphans_queue.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_replaces_queued_parent_when_cache_is_full() {
+        let mut downloader = create_downloader();
+
+        let mut added_orphans = Vec::new();
+        for i in 0..downloader.max_pending_orphans.get() {
+            let orphan: HeaderId = [i as u8; 32].into();
+            downloader
+                .enqueue_orphan(orphan, None, TEST_TIP.into(), TEST_LIB.into())
+                .unwrap();
+            added_orphans.push(orphan);
+        }
+
+        let descendant: HeaderId = [255u8; 32].into();
+        let parent_in_queue = added_orphans[0];
+
+        downloader
+            .enqueue_orphan(
+                descendant,
+                Some(parent_in_queue),
+                TEST_TIP.into(),
+                TEST_LIB.into(),
+            )
+            .unwrap();
+
+        assert!(
+            !downloader
+                .pending_orphans_queue
+                .contains_key(&parent_in_queue)
+        );
+        assert!(downloader.pending_orphans_queue.contains_key(&descendant));
+        assert_eq!(
+            downloader.pending_orphans_queue.len(),
+            downloader.max_pending_orphans.get()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_with_unqueued_parent_does_not_replace() {
+        let mut downloader = create_downloader();
+
+        let other: HeaderId = [1u8; 32].into();
+        let child: HeaderId = [2u8; 32].into();
+        let absent_parent: HeaderId = [99u8; 32].into();
+
+        downloader
+            .enqueue_orphan(other, None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+
+        downloader
+            .enqueue_orphan(child, Some(absent_parent), TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+
+        assert!(downloader.pending_orphans_queue.contains_key(&other));
+        assert!(downloader.pending_orphans_queue.contains_key(&child));
+        assert_eq!(downloader.pending_orphans_queue.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_does_not_replace_active_download_parent() {
+        let ancestor: HeaderId = [0u8; 32].into();
+        let parent: HeaderId = [1u8; 32].into();
+        let descendant: HeaderId = [99u8; 32].into();
+
+        // Mock the download for `parent` to stream back [ancestor, parent].
+        // Two blocks let us drive one poll (yielding `ancestor`) while the
+        // download stays in `Downloading` waiting for `parent`.
+        let network =
+            MockNetworkAdapter::new().with_stream(parent, None, vec![Ok(ancestor), Ok(parent)]);
+        let downloader = OrphanBlocksDownloader::<_, usize>::new(network, ORPHAN_CACHE_SIZE);
+        let mut downloader = pin::pin!(downloader);
+
+        downloader
+            .as_mut()
+            .get_mut()
+            .enqueue_orphan(parent, None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+
+        // Drive one poll: `ancestor` is yielded, `parent`'s download is active.
+        assert_eq!(downloader.next().await, Some(ancestor));
+        assert!(matches!(
+            downloader.as_mut().get_mut().state,
+            DownloaderState::Downloading(_)
+        ));
+
+        // Enqueueing a descendant whose parent is the active download must not
+        // disturb it — the descendant is queued normally, no replacement fires.
+        downloader
+            .as_mut()
+            .get_mut()
+            .enqueue_orphan(descendant, Some(parent), TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+
+        let downloader_ref = downloader.as_mut().get_mut();
+        assert!(
+            downloader_ref
+                .pending_orphans_queue
+                .contains_key(&descendant)
+        );
+        assert_eq!(downloader_ref.pending_orphans_queue.len(), 1);
+        if let DownloaderState::Downloading(download) = &downloader_ref.state {
+            assert_eq!(download.orphan_block_id(), parent);
+        } else {
+            panic!("expected active download to remain in Downloading state");
+        }
     }
 
     #[tokio::test]
@@ -794,10 +938,10 @@ mod tests {
             ],
         );
         downloader
-            .enqueue_orphan(chain[2], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[2], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
         downloader
-            .enqueue_orphan(chain[6], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[6], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);
@@ -824,10 +968,10 @@ mod tests {
         );
 
         downloader
-            .enqueue_orphan(chain[2], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[2], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
         downloader
-            .enqueue_orphan(chain[7], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[7], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);
@@ -852,7 +996,7 @@ mod tests {
             create_downloader_with_responses(&chain, vec![(4, vec![vec![0, 1, 2], vec![3, 4]])]);
 
         downloader
-            .enqueue_orphan(chain[4], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[4], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);
@@ -871,7 +1015,7 @@ mod tests {
         );
 
         downloader
-            .enqueue_orphan(chain[9], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[9], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);
@@ -904,10 +1048,10 @@ mod tests {
         );
 
         downloader
-            .enqueue_orphan(chain[2], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[2], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
         downloader
-            .enqueue_orphan(chain[7], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[7], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut received_blocks = Vec::new();
@@ -948,7 +1092,7 @@ mod tests {
             create_downloader_with_responses(&chain, vec![(4, vec![vec![0, 1, 2, 3, 4]])]);
 
         downloader
-            .enqueue_orphan(chain[4], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[4], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);
@@ -957,6 +1101,7 @@ mod tests {
             assert!(matches!(
                 downloader.as_mut().get_mut().enqueue_orphan(
                     chain[4],
+                    None,
                     [20u8; 32].into(),
                     [21u8; 32].into()
                 ),
@@ -991,10 +1136,10 @@ mod tests {
         );
 
         downloader
-            .enqueue_orphan(chain[3], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[3], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
         downloader
-            .enqueue_orphan(chain[7], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[7], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut received_blocks = Vec::new();
@@ -1030,7 +1175,7 @@ mod tests {
         );
 
         downloader
-            .enqueue_orphan(chain[2], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[2], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);
@@ -1042,7 +1187,7 @@ mod tests {
         downloader
             .as_mut()
             .get_mut()
-            .enqueue_orphan(chain[5], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[5], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let second_batch = receive_blocks(&mut downloader, 3).await;
@@ -1060,7 +1205,7 @@ mod tests {
             create_downloader_with_responses(&chain, vec![(2, vec![vec![0, 1, 2, 3, 4]])]);
 
         downloader
-            .enqueue_orphan(chain[2], TEST_TIP.into(), TEST_LIB.into())
+            .enqueue_orphan(chain[2], None, TEST_TIP.into(), TEST_LIB.into())
             .unwrap();
 
         let mut downloader = pin::pin!(downloader);


### PR DESCRIPTION
## 1. What does this PR implement?

Resolves #2960 

When enqueuing a new orphan, we now check if there is its parent in the queue. If so, we replace the parent with the new orphan, in order to decrease the queue pressure.

Also, I found that we were returning the `QueueIsFull` error more aggressively than necessary. We can silently ignore orphan blocks if they're already in the queue, without returning the error. I fixed it by reordering the logic in the `enqueue` function.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

This is an implementation details, not defined in the chain sync spec.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
