### PR TITLE
fix(mantle): omit empty transfer op and avoid needless funding input

### DIFF
--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -25,6 +25,11 @@ impl TransferOp {
         Self { inputs, outputs }
     }
 
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.inputs.is_empty() && self.outputs.is_empty()
+    }
+
     pub fn balance(&self, utxos: &Utxos) -> Result<i128, TransferError> {
         let mut balance: i128 = 0;
         let input_amount = self.inputs.amount(utxos)?;

--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -253,10 +253,12 @@ impl MantleTxBuilder {
     // TODO: Change this to a `Result` if genesis tx already contains max number of
     // ops.
     pub fn build(mut self) -> Result<MantleTx, TxBuilderError> {
-        self.mantle_tx
-            .0
-            .try_push(Op::Transfer(self.pending_transfer))
-            .map_err(|err| TxBuilderError::from((err, TooManyTag::Ops)))?;
+        if !self.pending_transfer.is_empty() {
+            self.mantle_tx
+                .0
+                .try_push(Op::Transfer(self.pending_transfer))
+                .map_err(|err| TxBuilderError::from((err, TooManyTag::Ops)))?;
+        }
         Ok(self.mantle_tx)
     }
 }

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -129,21 +129,21 @@ async fn sdp_ops_e2e() {
         &declare_hash.to_fr(),
     )
     .expect("SDP declare zk proof should build");
-    let declare_transfer_proof = OpProof::ZkSig(
-        ZkKey::multi_sign(&declare_signing_keys, &declare_hash.to_fr())
-            .expect("transfer proof should build"),
-    );
-    let declare_tx = SignedMantleTx::new(
-        declare_mantle_tx,
-        vec![
-            OpProof::ZkAndEd25519Sigs {
-                zk_sig: declare_zk_sig,
-                ed25519_sig: declare_ed25519_sig,
-            },
-            declare_transfer_proof,
-        ],
-    )
-    .expect("funded SDP declare transaction should be valid");
+    // The SDP declare op is proven first. With zero gas prices the funding step
+    // adds no input, so there is no trailing transfer op to prove; only attach a
+    // transfer proof when funding actually pulled in inputs.
+    let mut declare_proofs = vec![OpProof::ZkAndEd25519Sigs {
+        zk_sig: declare_zk_sig,
+        ed25519_sig: declare_ed25519_sig,
+    }];
+    if !declare_signing_keys.is_empty() {
+        declare_proofs.push(OpProof::ZkSig(
+            ZkKey::multi_sign(&declare_signing_keys, &declare_hash.to_fr())
+                .expect("transfer proof should build"),
+        ));
+    }
+    let declare_tx = SignedMantleTx::new(declare_mantle_tx, declare_proofs)
+        .expect("funded SDP declare transaction should be valid");
 
     node0
         .submit_transaction(&declare_tx)
@@ -182,16 +182,15 @@ async fn sdp_ops_e2e() {
     )
     .expect("SDP withdraw zk proof should build");
 
-    let withdraw_transfer_proof = OpProof::ZkSig(
-        ZkKey::multi_sign(&withdraw_signing_keys, &withdraw_hash.to_fr())
-            .expect("transfer proof should build"),
-    );
-
-    let withdraw_tx = SignedMantleTx::new(
-        withdraw_mantle_tx,
-        vec![OpProof::ZkSig(withdraw_zk_sig), withdraw_transfer_proof],
-    )
-    .expect("funded SDP withdraw transaction should be valid");
+    let mut withdraw_proofs = vec![OpProof::ZkSig(withdraw_zk_sig)];
+    if !withdraw_signing_keys.is_empty() {
+        withdraw_proofs.push(OpProof::ZkSig(
+            ZkKey::multi_sign(&withdraw_signing_keys, &withdraw_hash.to_fr())
+                .expect("transfer proof should build"),
+        ));
+    }
+    let withdraw_tx = SignedMantleTx::new(withdraw_mantle_tx, withdraw_proofs)
+        .expect("funded SDP withdraw transaction should be valid");
 
     node0
         .submit_transaction(&withdraw_tx)

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -111,7 +111,7 @@ async fn sdp_ops_e2e() {
     };
     let declaration_id = declaration.id();
 
-    let (declare_mantle_tx, declare_signing_keys) = fund_sdp_transaction(
+    let declare_mantle_tx = fund_sdp_transaction(
         &node0,
         &genesis_utxos,
         &funding_wallet,
@@ -129,21 +129,14 @@ async fn sdp_ops_e2e() {
         &declare_hash.to_fr(),
     )
     .expect("SDP declare zk proof should build");
-    // The SDP declare op is proven first. With zero gas prices the funding step
-    // adds no input, so there is no trailing transfer op to prove; only attach a
-    // transfer proof when funding actually pulled in inputs.
-    let mut declare_proofs = vec![OpProof::ZkAndEd25519Sigs {
-        zk_sig: declare_zk_sig,
-        ed25519_sig: declare_ed25519_sig,
-    }];
-    if !declare_signing_keys.is_empty() {
-        declare_proofs.push(OpProof::ZkSig(
-            ZkKey::multi_sign(&declare_signing_keys, &declare_hash.to_fr())
-                .expect("transfer proof should build"),
-        ));
-    }
-    let declare_tx = SignedMantleTx::new(declare_mantle_tx, declare_proofs)
-        .expect("funded SDP declare transaction should be valid");
+    let declare_tx = SignedMantleTx::new(
+        declare_mantle_tx,
+        vec![OpProof::ZkAndEd25519Sigs {
+            zk_sig: declare_zk_sig,
+            ed25519_sig: declare_ed25519_sig,
+        }],
+    )
+    .expect("funded SDP declare transaction should be valid");
 
     node0
         .submit_transaction(&declare_tx)
@@ -167,7 +160,7 @@ async fn sdp_ops_e2e() {
         nonce: declaration_created.nonce + 1,
     };
 
-    let (withdraw_mantle_tx, withdraw_signing_keys) = fund_sdp_transaction(
+    let withdraw_mantle_tx = fund_sdp_transaction(
         &node0,
         &genesis_utxos,
         &funding_wallet,
@@ -182,15 +175,9 @@ async fn sdp_ops_e2e() {
     )
     .expect("SDP withdraw zk proof should build");
 
-    let mut withdraw_proofs = vec![OpProof::ZkSig(withdraw_zk_sig)];
-    if !withdraw_signing_keys.is_empty() {
-        withdraw_proofs.push(OpProof::ZkSig(
-            ZkKey::multi_sign(&withdraw_signing_keys, &withdraw_hash.to_fr())
-                .expect("transfer proof should build"),
-        ));
-    }
-    let withdraw_tx = SignedMantleTx::new(withdraw_mantle_tx, withdraw_proofs)
-        .expect("funded SDP withdraw transaction should be valid");
+    let withdraw_tx =
+        SignedMantleTx::new(withdraw_mantle_tx, vec![OpProof::ZkSig(withdraw_zk_sig)])
+            .expect("funded SDP withdraw transaction should be valid");
 
     node0
         .submit_transaction(&withdraw_tx)
@@ -482,7 +469,7 @@ async fn fund_sdp_transaction(
     genesis_utxos: &[Utxo],
     funding_wallet: &WalletAccount,
     extra_op: Op,
-) -> (MantleTx, Vec<ZkKey>) {
+) -> MantleTx {
     let funding_source = current_wallet_funding_source(node, genesis_utxos, funding_wallet.clone())
         .await
         .expect("funding wallet source should sync from chain");
@@ -506,16 +493,9 @@ async fn fund_sdp_transaction(
     let funded_builder = fund_builder_from_wallet_source(&funding_source, &tx_builder)
         .expect("funding mixed-op transaction should succeed");
 
-    let signing_keys = funded_builder
-        .ledger_inputs()
-        .iter()
-        .map(|_| funding_wallet.secret_key.clone())
-        .collect::<Vec<_>>();
-
-    (
-        funded_builder
-            .build()
-            .expect("funded mixed-op builder should build"),
-        signing_keys,
-    )
+    // With zero gas prices the funding step adds no input, so the built tx carries
+    // no trailing transfer op — the SDP op is the only op, and the only proof.
+    funded_builder
+        .build()
+        .expect("funded mixed-op builder should build")
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -184,6 +184,22 @@ impl WalletState {
         // Consume large valued notes first to ensure we converge.
         utxos.sort_by_key(|utxo| -i128::from(utxo.note.value));
 
+        // The transaction may already be funded before we add any of the
+        // wallet's UTXOs, for example when it pays no fee or the caller already
+        // supplied inputs. In that case we must not pull in an extra input (and
+        // the change note it would require).
+        match tx_builder.funding_delta::<G>()?.cmp(&0) {
+            Ordering::Equal => return Ok(tx_builder.clone()),
+            Ordering::Greater => {
+                if let Some(tx_with_change) = tx_builder.clone().return_change::<G>(change_pk)? {
+                    return Ok(tx_with_change);
+                }
+                // The change note costs more than the surplus covers, so fall
+                // through and pull in more UTXO's below.
+            }
+            Ordering::Less => {}
+        }
+
         for i in 0..utxos.len() {
             let funded_tx_builder = tx_builder
                 .clone()
@@ -1138,6 +1154,56 @@ mod tests {
     }
 
     #[test]
+    fn test_fund_tx_no_fee_adds_no_input() {
+        let alice = pk(1);
+        // The wallet has a spendable note available...
+        let utxo = Utxo::new(tx_hash(0), 0, Note::new(5000, alice));
+        let ledger_state = LedgerState::from_utxos([utxo], &ledger_config());
+        let wallet_state =
+            WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
+
+        // ...but with zero gas prices a transfer-less transaction owes no fee,
+        // so it needs no funding at all.
+        let mut tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(0, 0),
+            ),
+            leader_reward_amount: 0,
+        });
+
+        let signing_key = Ed25519Key::from_bytes(&[1; 32]);
+        tx_builder = tx_builder
+            .push_op(Op::ChannelInscribe(InscriptionOp {
+                channel_id: ChannelId::from([0xAA; 32]),
+                inscription: [0xAB; 8].into(),
+                parent: MsgId::from([0xBB; 32]),
+                signer: signing_key.public_key(),
+            }))
+            .unwrap();
+
+        assert_eq!(0, tx_builder.funding_delta::<Gas>().unwrap());
+
+        let funded_tx_builder = wallet_state
+            .fund_tx::<Gas>(&tx_builder, alice, [alice])
+            .unwrap();
+
+        // No input was pulled in (an added input would push the net balance to
+        // 5000) and therefore no change note was added.
+        assert_eq!(0, funded_tx_builder.net_balance());
+
+        // The empty transfer is dropped, so the built tx carries no transfer op.
+        let funded_tx = funded_tx_builder.build().unwrap();
+        assert!(
+            !funded_tx
+                .ops()
+                .iter()
+                .any(|op| matches!(op, Op::Transfer(_))),
+            "a fee-less transaction must not contain a transfer op"
+        );
+    }
+
+    #[test]
     fn test_fund_tx_insufficient_funds() {
         let alice = pk(1);
         let ledger_state = LedgerState::from_utxos(
@@ -1190,7 +1256,15 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
 
-        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context());
+        // Use non-zero gas prices so the transaction actually owes a fee and
+        // therefore needs funding.
+        let tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        });
 
         // Fund the transaction
         let fund_attempt = wallet_state.fund_tx::<Gas>(&tx_builder, alice, [alice]);
@@ -1212,7 +1286,15 @@ mod tests {
         // Lock `utxo` deliberately to ensure that `fund_tx` excludes locked notes
         wallet_state.locked_notes = wallet_state.locked_notes.insert(utxo.id());
 
-        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context());
+        // Use non-zero gas prices so the transaction actually owes a fee and
+        // therefore needs funding.
+        let tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        });
 
         // Fund the transaction
         let fund_attempt = wallet_state.fund_tx::<Gas>(&tx_builder, alice, [alice]);
@@ -1235,7 +1317,15 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1), (bob, 2)]), &ledger_state);
 
-        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context());
+        // Use non-zero gas prices so the transaction actually owes a fee and
+        // therefore needs funding.
+        let tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        });
 
         // Attempt to fund the transaction with Alice's notes.
         let fund_attempt = wallet_state.fund_tx::<Gas>(&tx_builder, alice, [alice]);


### PR DESCRIPTION
## 1. What does this PR implement?

Two related fixes to transaction construction. Previously every transaction ended up carrying a `Transfer` op even when it moved no value, because of two independent behaviours:

**(a) `MantleTxBuilder::build` always appended the pending transfer.** When a tx moved no value (no inputs, no outputs) this produced an empty transfer that carries no information and would fail validation with `TransferError::NoInputTransfer`. `build()` now only appends the pending transfer when it is non-empty (new `TransferOp::is_empty`), allowing genuinely transfer-less transactions (e.g. an SDP op that pays no fee).

**(b) `WalletState::fund_tx` always pulled in an input before checking if funding was needed.** The loop started at the first UTXO and only evaluated `funding_delta` *after* `extend_ledger_inputs`, so the zero-input state was never tested. As a result a tx that needs no funding — it pays no fee (gas prices are `0` today, see #2490), or the caller already balanced it — still pulled in an input and added a change note to hand that value straight back: an unnecessary **self-transfer**. It also returned `InsufficientFunds` when no funding was needed but the wallet had no spare notes.

`fund_tx` now checks the funding delta of the tx *as supplied* first:
- `== 0` → return it untouched (no input, no change),
- `> 0` → add only a change note (no new input),
- `< 0` → fall back to the existing loop that pulls in UTXOs.

Together these remove the spurious Transfer op that was appearing on fee-less transactions (e.g. SDP Active txs).

## 2. Does the code have enough context to be clearly understood?

Changes are local to `MantleTxBuilder::build` / `TransferOp::is_empty` (`core/`) and `WalletState::fund_tx` (`wallet/`). `funding_delta = (Σinputs − Σoutputs) − gas_cost`, so a non-positive delta means the tx is already funded. The two fixes are coupled: with (b), an already-funded fee-less tx returns a builder with an empty pending transfer, and (a) is what makes `build()` omit it so the tx stays valid.

Three existing wallet tests (`test_fund_tx_zero_funds`, `test_fund_tx_all_locked_notes`, `test_fund_tx_respects_pk_list`) asserted `InsufficientFunds` using zero gas prices on an empty tx — which no longer needs funding. They now use `GasPrices::new(1, 1)` so they still exercise the underfunded path and the locked-note / pk-list filtering they were written to check. New test `test_fund_tx_no_fee_adds_no_input` covers the no-fee path: no input pulled in, no transfer op in the built tx.

## 3. Who are the specification authors and who is accountable for this PR?

@davidrusu (accountable). Reviewers TBD.

## 4. Is the specification accurate and complete?

N/A — transaction-builder / wallet funding correctness fixes; no specification change.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the logging guidelines. (No log changes.)
