### PR TITLE
fix(blend): fix a bug in the dial retry logic that would leave a peer below the minimum peering degree

### DIFF
--- a/nodes/node/binary/src/config/blend/mod.rs
+++ b/nodes/node/binary/src/config/blend/mod.rs
@@ -94,6 +94,11 @@ impl ServiceConfig {
                     minimum_messages_coefficient: self.deployment.core.minimum_messages_coefficient,
                     normalization_constant: self.deployment.core.normalization_constant,
                     protocol_name: self.deployment.common.protocol_name.clone(),
+                    peering_degree_check_interval: self
+                        .user
+                        .core
+                        .backend
+                        .peering_degree_check_interval,
                 },
                 scheduler: SchedulerSettings {
                     cover: CoverTrafficSettings {

--- a/nodes/node/binary/src/config/blend/serde/core.rs
+++ b/nodes/node/binary/src/config/blend/serde/core.rs
@@ -24,6 +24,9 @@ pub struct BackendConfig {
     pub edge_node_connection_timeout: Duration,
     pub max_edge_node_incoming_connections: u64,
     pub max_dial_attempts_per_peer: NonZeroU64,
+    #[serde_as(
+        as = "lb_utils::bounded_duration::MinimalBoundedDuration<1, lb_utils::bounded_duration::SECOND>"
+    )]
     pub peering_degree_check_interval: Duration,
 }
 

--- a/nodes/node/binary/src/config/blend/serde/core.rs
+++ b/nodes/node/binary/src/config/blend/serde/core.rs
@@ -24,6 +24,7 @@ pub struct BackendConfig {
     pub edge_node_connection_timeout: Duration,
     pub max_edge_node_incoming_connections: u64,
     pub max_dial_attempts_per_peer: NonZeroU64,
+    pub peering_degree_check_interval: Duration,
 }
 
 impl BackendConfig {
@@ -51,6 +52,7 @@ impl Default for BackendConfig {
             edge_node_connection_timeout: Duration::from_secs(1),
             max_edge_node_incoming_connections: 300,
             max_dial_attempts_per_peer: NonZeroU64::new(3).unwrap(),
+            peering_degree_check_interval: Duration::from_mins(1),
         }
     }
 }

--- a/nodes/node/binary/src/config/blend/serde/core.rs
+++ b/nodes/node/binary/src/config/blend/serde/core.rs
@@ -25,9 +25,9 @@ pub struct BackendConfig {
     pub max_edge_node_incoming_connections: u64,
     pub max_dial_attempts_per_peer: NonZeroU64,
     #[serde_as(
-        as = "lb_utils::bounded_duration::MinimalBoundedDuration<1, lb_utils::bounded_duration::SECOND>"
+        as = "Option<lb_utils::bounded_duration::MinimalBoundedDuration<1, lb_utils::bounded_duration::SECOND>>"
     )]
-    pub peering_degree_check_interval: Duration,
+    pub peering_degree_check_interval: Option<Duration>,
 }
 
 impl BackendConfig {
@@ -55,7 +55,7 @@ impl Default for BackendConfig {
             edge_node_connection_timeout: Duration::from_secs(1),
             max_edge_node_incoming_connections: 300,
             max_dial_attempts_per_peer: NonZeroU64::new(3).unwrap(),
-            peering_degree_check_interval: Duration::from_mins(1),
+            peering_degree_check_interval: Some(Duration::from_mins(1)),
         }
     }
 }

--- a/nodes/node/standalone-node-config.yaml
+++ b/nodes/node/standalone-node-config.yaml
@@ -106,7 +106,6 @@ blend:
       edge_node_connection_timeout: '1.000000000'
       max_edge_node_incoming_connections: 300
       max_dial_attempts_per_peer: 3
-      peering_degree_check_interval: '60.000000000'
     zk:
       secret_key_kms_id: 852efb444db8c3c811625850df39425f43aeffc69571192c0be9f72523256e0a
   edge:

--- a/nodes/node/standalone-node-config.yaml
+++ b/nodes/node/standalone-node-config.yaml
@@ -106,6 +106,7 @@ blend:
       edge_node_connection_timeout: '1.000000000'
       max_edge_node_incoming_connections: 300
       max_dial_attempts_per_peer: 3
+      peering_degree_check_interval: '60.000000000'
     zk:
       secret_key_kms_id: 852efb444db8c3c811625850df39425f43aeffc69571192c0be9f72523256e0a
   edge:

--- a/services/blend/src/core/backends/libp2p/settings.rs
+++ b/services/blend/src/core/backends/libp2p/settings.rs
@@ -1,11 +1,13 @@
-use core::time::Duration;
+use core::{pin::Pin, time::Duration};
 use std::{num::NonZeroU64, ops::RangeInclusive};
 
+use futures::{Stream, StreamExt as _, stream::pending};
 use lb_libp2p::protocol_name::StreamProtocol;
 use lb_utils::math::NonNegativeF64;
 use libp2p::{Multiaddr, PeerId, identity::Keypair};
 use serde::{Deserialize, Serialize};
-use tokio::time::{Instant, Interval, MissedTickBehavior, interval_at};
+use tokio::time::{Instant, MissedTickBehavior, interval_at};
+use tokio_stream::wrappers::IntervalStream;
 
 use crate::core::settings::RunningBlendConfig as BlendConfig;
 
@@ -23,7 +25,7 @@ pub struct Libp2pBlendBackendSettings {
     pub max_edge_node_incoming_connections: u64,
     pub max_dial_attempts_per_peer: NonZeroU64,
     pub protocol_name: StreamProtocol,
-    pub peering_degree_check_interval: Duration,
+    pub peering_degree_check_interval: Option<Duration>,
 }
 
 impl BlendConfig<Libp2pBlendBackendSettings> {
@@ -40,14 +42,19 @@ impl BlendConfig<Libp2pBlendBackendSettings> {
     }
 
     #[must_use]
-    pub fn peering_degree_check_clock(&self) -> Interval {
+    pub fn peering_degree_check_clock(&self) -> Pin<Box<dyn Stream<Item = ()> + Send>> {
+        let Some(interval_duration) = self.backend.peering_degree_check_interval else {
+            // If no interval is configured, return a stream that never yields anything.
+            return Box::pin(pending()) as Pin<Box<dyn Stream<Item = ()> + Send>>;
+        };
         let mut interval = interval_at(
             Instant::now()
-                .checked_add(self.backend.peering_degree_check_interval)
+                .checked_add(interval_duration)
                 .expect("Peering degree check interval value too large."),
-            self.backend.peering_degree_check_interval,
+            interval_duration,
         );
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        interval
+        Box::pin(IntervalStream::new(interval).map(|_| ()))
+            as Pin<Box<dyn Stream<Item = ()> + Send>>
     }
 }

--- a/services/blend/src/core/backends/libp2p/settings.rs
+++ b/services/blend/src/core/backends/libp2p/settings.rs
@@ -5,6 +5,7 @@ use lb_libp2p::protocol_name::StreamProtocol;
 use lb_utils::math::NonNegativeF64;
 use libp2p::{Multiaddr, PeerId, identity::Keypair};
 use serde::{Deserialize, Serialize};
+use tokio::time::{Instant, Interval, MissedTickBehavior, interval_at};
 
 use crate::core::settings::RunningBlendConfig as BlendConfig;
 
@@ -22,6 +23,7 @@ pub struct Libp2pBlendBackendSettings {
     pub max_edge_node_incoming_connections: u64,
     pub max_dial_attempts_per_peer: NonZeroU64,
     pub protocol_name: StreamProtocol,
+    pub peering_degree_check_interval: Duration,
 }
 
 impl BlendConfig<Libp2pBlendBackendSettings> {
@@ -35,5 +37,17 @@ impl BlendConfig<Libp2pBlendBackendSettings> {
     #[must_use]
     pub fn peer_id(&self) -> PeerId {
         self.keypair().public().to_peer_id()
+    }
+
+    #[must_use]
+    pub fn peering_degree_check_clock(&self) -> Interval {
+        let mut interval = interval_at(
+            Instant::now()
+                .checked_add(self.backend.peering_degree_check_interval)
+                .expect("Peering degree check interval value too large."),
+            self.backend.peering_degree_check_interval,
+        );
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        interval
     }
 }

--- a/services/blend/src/core/backends/libp2p/settings.rs
+++ b/services/blend/src/core/backends/libp2p/settings.rs
@@ -45,7 +45,7 @@ impl BlendConfig<Libp2pBlendBackendSettings> {
     pub fn peering_degree_check_clock(&self) -> Pin<Box<dyn Stream<Item = ()> + Send>> {
         let Some(interval_duration) = self.backend.peering_degree_check_interval else {
             // If no interval is configured, return a stream that never yields anything.
-            return Box::pin(pending()) as Pin<Box<dyn Stream<Item = ()> + Send>>;
+            return Box::pin(pending());
         };
         let mut interval = interval_at(
             Instant::now()
@@ -55,6 +55,5 @@ impl BlendConfig<Libp2pBlendBackendSettings> {
         );
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         Box::pin(IntervalStream::new(interval).map(|_| ()))
-            as Pin<Box<dyn Stream<Item = ()> + Send>>
     }
 }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{StreamExt as _, stream::FuturesUnordered};
+use futures::{Stream, StreamExt as _, stream::FuturesUnordered};
 use lb_blend::{
     message::encap::validated::{
         EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
@@ -30,10 +30,7 @@ use lb_chain_service::Epoch;
 use lb_libp2p::{DialOpts, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
-use tokio::{
-    sync::{broadcast, mpsc, oneshot},
-    time::Interval,
-};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::{
     core::{
@@ -110,7 +107,7 @@ where
     minimum_network_size: NonZeroUsize,
     /// Periodic timer that re-runs peering-degree maintenance to keep the
     /// number of healthy peers at or above the minimum.
-    peering_degree_check_interval: Interval,
+    peering_degree_check_clock: Pin<Box<dyn Stream<Item = ()> + Send>>,
 }
 
 pub struct SwarmParams<'config, Rng> {
@@ -176,7 +173,7 @@ where
             ),
             pending_retries: FuturesUnordered::new(),
             minimum_network_size,
-            peering_degree_check_interval: config.peering_degree_check_clock(),
+            peering_degree_check_clock: config.peering_degree_check_clock(),
         };
 
         self_instance.check_and_dial_new_peers();
@@ -480,7 +477,7 @@ where
                 self.execute_retry(peer_id, dial_attempt);
                 false
             }
-            _ = self.peering_degree_check_interval.tick() => {
+            Some(()) = self.peering_degree_check_clock.next() => {
                 tracing::trace!(target: LOG_TARGET, "Periodic peering-degree maintenance: re-checking healthy peer count.");
                 self.check_and_dial_new_peers();
                 false
@@ -771,7 +768,7 @@ where
 {
     #[cfg(test)]
     #[expect(clippy::too_many_arguments, reason = "necessary for testing")]
-    pub fn new_test<BehaviourConstructor>(
+    pub fn new_test<BehaviourConstructor, PeeringDegreeCheckClock>(
         identity: &libp2p::identity::Keypair,
         behaviour_constructor: BehaviourConstructor,
         swarm_messages_receiver: mpsc::Receiver<BlendSwarmMessage>,
@@ -783,11 +780,12 @@ where
         rng: Rng,
         max_dial_attempts_per_connection: NonZeroU64,
         minimum_network_size: NonZeroUsize,
-        peering_degree_check_interval: Interval,
+        peering_degree_check_clock: PeeringDegreeCheckClock,
     ) -> Self
     where
         BehaviourConstructor:
             FnOnce(PeerId, Membership<PeerId>) -> BlendBehaviour<ObservationWindowProvider>,
+        PeeringDegreeCheckClock: Stream<Item = ()> + Send + 'static,
     {
         use crate::test_utils::memory_test_swarm;
 
@@ -807,7 +805,7 @@ where
             ),
             swarm_messages_receiver,
             minimum_network_size,
-            peering_degree_check_interval,
+            peering_degree_check_clock: Box::pin(peering_degree_check_clock),
         }
     }
 }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -172,7 +172,7 @@ where
             minimum_network_size,
         };
 
-        self_instance.check_and_dial_new_peers_except(HashSet::new());
+        self_instance.check_and_dial_new_peers_except(&HashSet::new());
 
         self_instance
     }
@@ -188,17 +188,17 @@ where
     /// excluding the peers with a negotiated connection in the ongoing epoch,
     /// the peers that we are already trying to dial, the blocked peers, and
     /// any extra peers specified in `except`.
-    fn dial_random_peers_except(&mut self, amount: usize, mut except: HashSet<PeerId>) {
+    fn dial_random_peers_except(&mut self, amount: usize, except: &HashSet<PeerId>) {
+        // Nothing to do when the peering degree is already satisfied.
+        if amount == 0 {
+            return;
+        }
+
         let negotiated_peers = self.behaviour().blend.with_core().negotiated_peers().keys();
 
-        // We need to clone else we would not be able to call `self.dial` inside which
+        // We need to clone else we would not be able to call `self.dial` below, which
         // requires access to `&mut self`.
         let current_membership = self.current_epoch_info.0.clone();
-        // Membership contains local node, so we need to exclude that from the count.
-        if except.len() == current_membership.size() - 1 {
-            tracing::debug!(target: LOG_TARGET, "All eligible peers have been tried. Clearing failed peers memory and retrying from scratch.");
-            except.clear();
-        }
 
         let exclude_peers: HashSet<PeerId> = negotiated_peers
             .chain(self.swarm.behaviour().blocked_peers.blocked_peers())
@@ -209,18 +209,32 @@ where
 
         tracing::trace!(target: LOG_TARGET, amount, ?except, ?exclude_peers, "Dialing random peers");
 
-        current_membership
+        let mut peers_to_dial = current_membership
             .filter_and_choose_remote_nodes(&mut self.rng, amount, &exclude_peers)
-            .for_each(|peer| {
-                let peer_address = peer.address.clone();
-                let peer_id = peer.id;
-                self.dial(peer_id, peer_address, except.clone());
-            });
+            .map(|peer| (peer.id, peer.address.clone()))
+            .peekable();
+
+        let no_more_peers_to_dial = peers_to_dial.peek().is_none();
+
+        // When no membership peer is eligible to be dialed but we still have peers
+        // we gave up on earlier in this dial cycle (`except`), clear that memory and
+        // retry the whole membership from scratch. When `except` is
+        // empty there is genuinely nobody left to dial (everyone is already
+        // negotiated, in-flight, or blocked), so we stop.
+        if no_more_peers_to_dial && !except.is_empty() {
+            tracing::debug!(target: LOG_TARGET, "All eligible peers have been tried this cycle. Clearing failed peers memory and retrying from scratch.");
+            self.dial_random_peers_except(amount, &HashSet::new());
+            return;
+        }
+
+        for (peer_id, peer_address) in peers_to_dial {
+            self.dial(peer_id, peer_address, except.clone());
+        }
     }
 
     /// Dial new peers, if necessary, to maintain the peering degree.
     /// We aim to have at least the peering degree number of "healthy" peers.
-    fn check_and_dial_new_peers_except(&mut self, except: HashSet<PeerId>) {
+    fn check_and_dial_new_peers_except(&mut self, except: &HashSet<PeerId>) {
         tracing::trace!(target: LOG_TARGET, ?except, "Checking if we need to dial new peers");
 
         let membership_size = self.current_epoch_info.0.size();
@@ -244,7 +258,7 @@ where
         if peer_state.is_spammy() {
             self.swarm.behaviour_mut().blocked_peers.block_peer(peer_id);
         }
-        self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
+        self.check_and_dial_new_peers_except(&HashSet::from([peer_id]));
     }
 
     fn collect_network_info(&self) -> NetworkInfo<PeerId> {
@@ -269,7 +283,7 @@ where
 
     fn handle_unhealthy_peer(&mut self, peer_id: PeerId) {
         tracing::trace!(target: LOG_TARGET, "Peer {peer_id} is unhealthy");
-        self.check_and_dial_new_peers_except(HashSet::from([peer_id]));
+        self.check_and_dial_new_peers_except(&HashSet::from([peer_id]));
     }
 
     #[expect(
@@ -308,12 +322,12 @@ where
                             failed_peers.insert(peer);
                             failed_peers
                         };
-                        self.check_and_dial_new_peers_except(failed_peers);
+                        self.check_and_dial_new_peers_except(&failed_peers);
                     }
                     upgrade_error @ (ConnectionUpgradeFailureReason::DuplicateConnection | ConnectionUpgradeFailureReason::MaximumPeeringDegreeReached | ConnectionUpgradeFailureReason::ReverseDirectionPreferred) => {
                         tracing::trace!(target: LOG_TARGET, "Outbound connection upgrade somewhat expectedly failed for {peer:?}. Reason: {upgrade_error:?}. Trying with a different peer if necessary.");
                         self.ongoing_dials.remove(&peer);
-                        self.check_and_dial_new_peers_except(HashSet::from([peer]));
+                        self.check_and_dial_new_peers_except(&HashSet::from([peer]));
                     }
                 }
             }
@@ -373,7 +387,7 @@ where
                 // We don't retry if `peer_id` is `None` or if we've achieved the maximum number
                 // of retries for this peer.
                 let Some(peer_id) = peer_id else {
-                    self.check_and_dial_new_peers_except(HashSet::new());
+                    self.check_and_dial_new_peers_except(&HashSet::new());
                     return;
                 };
 
@@ -387,7 +401,7 @@ where
                             failed_peers.insert(peer_id);
                             failed_peers
                         };
-                        self.check_and_dial_new_peers_except(failed_peers);
+                        self.check_and_dial_new_peers_except(&failed_peers);
                     }
                     // Retry in progress.
                     EpochDialAttempt::OngoingEpoch(None) => {}
@@ -412,7 +426,7 @@ where
                     .start_new_epoch(self.current_epoch_info.clone());
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
-                self.check_and_dial_new_peers_except(HashSet::new());
+                self.check_and_dial_new_peers_except(&HashSet::new());
             }
             BlendSwarmMessage::CompleteEpochTransition => {
                 self.swarm.behaviour_mut().blend.finish_epoch_transition();

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -30,7 +30,10 @@ use lb_chain_service::Epoch;
 use lb_libp2p::{DialOpts, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::{
+    sync::{broadcast, mpsc, oneshot},
+    time::Interval,
+};
 
 use crate::{
     core::{
@@ -105,6 +108,9 @@ where
     ongoing_dials: HashMap<PeerId, DialAttempt>,
     pending_retries: PendingRetries,
     minimum_network_size: NonZeroUsize,
+    /// Periodic timer that re-runs peering-degree maintenance to keep the
+    /// number of healthy peers at or above the minimum.
+    peering_degree_check_interval: Interval,
 }
 
 pub struct SwarmParams<'config, Rng> {
@@ -170,9 +176,10 @@ where
             ),
             pending_retries: FuturesUnordered::new(),
             minimum_network_size,
+            peering_degree_check_interval: config.peering_degree_check_clock(),
         };
 
-        self_instance.check_and_dial_new_peers_except(&HashSet::new());
+        self_instance.check_and_dial_new_peers();
 
         self_instance
     }
@@ -230,6 +237,10 @@ where
         for (peer_id, peer_address) in peers_to_dial {
             self.dial(peer_id, peer_address, except.clone());
         }
+    }
+
+    fn check_and_dial_new_peers(&mut self) {
+        self.check_and_dial_new_peers_except(&HashSet::new());
     }
 
     /// Dial new peers, if necessary, to maintain the peering degree.
@@ -387,7 +398,7 @@ where
                 // We don't retry if `peer_id` is `None` or if we've achieved the maximum number
                 // of retries for this peer.
                 let Some(peer_id) = peer_id else {
-                    self.check_and_dial_new_peers_except(&HashSet::new());
+                    self.check_and_dial_new_peers();
                     return;
                 };
 
@@ -426,7 +437,7 @@ where
                     .start_new_epoch(self.current_epoch_info.clone());
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
-                self.check_and_dial_new_peers_except(&HashSet::new());
+                self.check_and_dial_new_peers();
             }
             BlendSwarmMessage::CompleteEpochTransition => {
                 self.swarm.behaviour_mut().blend.finish_epoch_transition();
@@ -467,6 +478,11 @@ where
             }
             Some((peer_id, dial_attempt)) = self.pending_retries.next() => {
                 self.execute_retry(peer_id, dial_attempt);
+                false
+            }
+            _ = self.peering_degree_check_interval.tick() => {
+                tracing::trace!(target: LOG_TARGET, "Periodic peering-degree maintenance: re-checking healthy peer count.");
+                self.check_and_dial_new_peers();
                 false
             }
         }
@@ -767,6 +783,7 @@ where
         rng: Rng,
         max_dial_attempts_per_connection: NonZeroU64,
         minimum_network_size: NonZeroUsize,
+        peering_degree_check_interval: Interval,
     ) -> Self
     where
         BehaviourConstructor:
@@ -790,6 +807,7 @@ where
             ),
             swarm_messages_receiver,
             minimum_network_size,
+            peering_degree_check_interval,
         }
     }
 }

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -342,10 +342,6 @@ async fn core_epoch_rotation_clears_pending_retries() {
 /// set rather than via `except`. So once any peer negotiates, `except` can only
 /// ever reach `size - 2`, the reset never fires, and the node gives up below
 /// the minimum.
-///
-/// The assertion below encodes the *desired* invariant (a node below the
-/// minimum peering degree must not permanently give up), so this test currently
-/// FAILS — that failure is the reproduction.
 #[test(tokio::test)]
 async fn core_does_not_give_up_below_minimum_peering_degree() {
     let min_peering_degree = 2;

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -437,6 +437,70 @@ async fn core_does_not_give_up_below_minimum_peering_degree() {
     );
 }
 
+/// The periodic peering-degree maintenance task must dial peers to reach the
+/// minimum degree even when nothing else triggers a dial — no `StartNewEpoch`,
+/// no dial failure, no disconnection. Here the node starts quiescent and below
+/// degree (`new_test` performs no initial dial and we send no message), so the
+/// ONLY thing that can make it connect to the reachable peer is the maintenance
+/// tick.
+#[test(tokio::test)]
+async fn core_maintenance_task_dials_to_maintain_peering_degree() {
+    let (mut identities, mut nodes) = new_nodes_with_empty_address(2);
+
+    // The reachable peer: a real listening swarm.
+    let TestSwarm {
+        swarm: mut reachable_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+    let (reachable_node, _) = reachable_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    update_nodes(&mut nodes, &reachable_node.id, reachable_node.address);
+
+    // The node under test: a short maintenance interval. No initial dial is
+    // triggered (new_test does not dial, and we send no StartNewEpoch).
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .with_peering_degree_check_interval(time::interval(Duration::from_millis(200)))
+        .build(|id, membership| BlendBehaviourBuilder::new(id, membership).build());
+
+    // Precondition: the node is idle and below the (default) minimum degree of 1.
+    assert!(dialing_swarm.ongoing_dials().is_empty());
+    assert_eq!(
+        dialing_swarm
+            .behaviour()
+            .blend
+            .with_core()
+            .num_healthy_peers(),
+        0
+    );
+
+    // Drive both swarms until a fixed deadline. The only thing that can initiate a
+    // dial is the periodic maintenance tick; once it fires it must connect to the
+    // reachable peer.
+    let deadline = time::Instant::now() + Duration::from_secs(2);
+    loop {
+        select! {
+            () = sleep_until(deadline) => break,
+            () = dialing_swarm.poll_next() => {}
+            () = reachable_swarm.poll_next() => {}
+        }
+    }
+
+    assert!(
+        dialing_swarm
+            .behaviour()
+            .blend
+            .with_core()
+            .negotiated_peers()
+            .contains_key(&reachable_node.id),
+        "the maintenance task should have dialed and negotiated with the reachable peer"
+    );
+}
+
 /// When a retry fires but the peering degree is already satisfied (because
 /// another peer connected in the meantime), the retry should be skipped.
 #[test(tokio::test)]

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -5,12 +5,15 @@ use lb_blend::scheduling::membership::Membership;
 use lb_libp2p::{Protocol, SwarmEvent};
 use libp2p::{Multiaddr, PeerId};
 use test_log::test;
-use tokio::{select, time, time::sleep};
+use tokio::{
+    select,
+    time::{self, sleep, sleep_until},
+};
 
 use crate::core::backends::libp2p::{
     core_swarm_test_utils::{SwarmExt as _, new_nodes_with_empty_address, update_nodes},
     swarm::BlendSwarmMessage,
-    tests::utils::{BlendBehaviourBuilder, SwarmBuilder, TestSwarm},
+    tests::utils::{BlendBehaviourBuilder, SwarmBuilder, TestSwarm, build_membership},
 };
 
 #[test(tokio::test)]
@@ -321,6 +324,117 @@ async fn core_epoch_rotation_clears_pending_retries() {
     // Epoch rotation should have cleared both ongoing dials and pending retries.
     assert!(dialing_swarm.ongoing_dials().is_empty());
     assert_eq!(dialing_swarm.pending_retries_count(), 0);
+}
+
+/// Reproduces the peering-degree maintenance bug at an epoch boundary.
+///
+/// Epochs are independent: when a node enters a new epoch it rebuilds its peer
+/// set from scratch and should keep dialing until it reaches the *minimum*
+/// peering degree. Here the new epoch's membership has one reachable peer and
+/// two unreachable ones, with a minimum peering degree of 2. The reachable peer
+/// negotiates (healthy = 1), the two unreachable peers exhaust their dial
+/// attempts, and the node then stops dialing entirely — stranded one peer below
+/// the configured minimum until the *next* epoch.
+///
+/// Root cause: in `dial_random_peers_except`, the "retry everything from
+/// scratch" reset is gated on `except.len() == membership.size() - 1`, but a
+/// successfully negotiated peer is excluded via the separate `negotiated_peers`
+/// set rather than via `except`. So once any peer negotiates, `except` can only
+/// ever reach `size - 2`, the reset never fires, and the node gives up below
+/// the minimum.
+///
+/// The assertion below encodes the *desired* invariant (a node below the
+/// minimum peering degree must not permanently give up), so this test currently
+/// FAILS — that failure is the reproduction.
+#[test(tokio::test)]
+async fn core_does_not_give_up_below_minimum_peering_degree() {
+    let min_peering_degree = 2;
+
+    // 4 membership nodes: [0] reachable listener, [1] local dialer, [2]/[3]
+    // unreachable.
+    let (mut identities, mut nodes) = new_nodes_with_empty_address(4);
+
+    // The single reachable peer: a real listening swarm.
+    let TestSwarm {
+        swarm: mut reachable_swarm,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes).build(|id, membership| {
+        BlendBehaviourBuilder::new(id, membership)
+            .with_peering_degree(min_peering_degree..=3)
+            .build()
+    });
+    let (reachable_node, _) = reachable_swarm
+        .listen_and_return_membership_entry(None)
+        .await;
+    update_nodes(&mut nodes, &reachable_node.id, reachable_node.address);
+
+    // Two unreachable peers: dialable memory addresses with no listener behind
+    // them, so every dial attempt fails with a transport error.
+    let unreachable_addr: Multiaddr = Protocol::Memory(0).into();
+    let (unreachable_1, unreachable_2) = (nodes[2].id, nodes[3].id);
+    update_nodes(&mut nodes, &unreachable_1, unreachable_addr.clone());
+    update_nodes(&mut nodes, &unreachable_2, unreachable_addr);
+
+    // The node under test.
+    let TestSwarm {
+        swarm: mut dialing_swarm,
+        swarm_message_sender,
+        ..
+    } = SwarmBuilder::new(identities.next().unwrap(), &nodes)
+        .with_max_dial_attempts(1.try_into().unwrap())
+        .build(|id, membership| {
+            BlendBehaviourBuilder::new(id, membership)
+                .with_peering_degree(min_peering_degree..=3)
+                .build()
+        });
+
+    // Enter a new epoch: this triggers the new-epoch peering logic, which dials
+    // peers to reach the minimum degree.
+    let new_membership = build_membership(&nodes, Some(*dialing_swarm.local_peer_id()));
+    swarm_message_sender
+        .send(BlendSwarmMessage::StartNewEpoch((new_membership, 2.into())))
+        .await
+        .unwrap();
+
+    // Drive both swarms for a fixed window: the reachable peer connects and the
+    // two unreachable peers fail. A node below the minimum peering degree keeps
+    // retrying, so the swarm never goes quiet — we therefore run until a fixed
+    // deadline (NOT until quiescence, which would never arrive) and then inspect
+    // the steady state. The deadline is computed once; recreating `sleep` each
+    // iteration would reset the timer and loop forever.
+    let deadline = time::Instant::now() + Duration::from_secs(3);
+    loop {
+        select! {
+            () = sleep_until(deadline) => break,
+            () = dialing_swarm.poll_next() => {}
+            () = reachable_swarm.poll_next() => {}
+        }
+    }
+
+    let healthy = dialing_swarm
+        .behaviour()
+        .blend
+        .with_core()
+        .num_healthy_peers();
+    let ongoing = dialing_swarm.ongoing_dials().len();
+    let pending = dialing_swarm.pending_retries_count();
+
+    // Sanity: the reachable peer connected, so we are genuinely one short of the
+    // minimum (not simply failing to connect to anyone).
+    assert_eq!(
+        healthy, 1,
+        "setup precondition: the single reachable peer should have negotiated"
+    );
+
+    // Regression guard: a node below the minimum peering degree must not give up
+    // — it must still be dialing (an ongoing dial or a pending retry). Before the
+    // fix it ended with no ongoing dials and no pending retries, stranded at degree
+    // 1 < 2 until the next epoch.
+    assert!(
+        healthy >= min_peering_degree || ongoing > 0 || pending > 0,
+        "node gave up below the minimum peering degree: healthy={healthy} < {min_peering_degree}, \
+         ongoing_dials={ongoing}, pending_retries={pending} — it will stay stranded until the next epoch"
+    );
 }
 
 /// When a retry fires but the peering degree is already satisfied (because

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -1,8 +1,8 @@
-use core::{num::NonZeroU64, ops::RangeInclusive, time::Duration};
+use core::{num::NonZeroU64, ops::RangeInclusive, pin::Pin, time::Duration};
 use std::iter::repeat_with;
 
 use async_trait::async_trait;
-use futures::StreamExt as _;
+use futures::{Stream, StreamExt as _, stream::pending};
 use lb_blend::{
     message::{
         crypto::key_ext::Ed25519SecretKeyExt as _,
@@ -95,7 +95,7 @@ pub struct SwarmBuilder {
     identity: Keypair,
     public_info: BackendEpochInfo<PeerId>,
     max_dial_attempts: Option<NonZeroU64>,
-    peering_degree_check_interval: Option<Interval>,
+    peering_degree_check_clock: Option<Pin<Box<dyn Stream<Item = ()> + Send>>>,
 }
 
 impl SwarmBuilder {
@@ -108,7 +108,7 @@ impl SwarmBuilder {
             identity,
             public_info,
             max_dial_attempts: None,
-            peering_degree_check_interval: None,
+            peering_degree_check_clock: None,
         }
     }
 
@@ -118,7 +118,7 @@ impl SwarmBuilder {
     }
 
     pub fn with_peering_degree_check_interval(mut self, interval: Interval) -> Self {
-        self.peering_degree_check_interval = Some(interval);
+        self.peering_degree_check_clock = Some(IntervalStream::new(interval).map(|_| ()).boxed());
         self
     }
 
@@ -143,10 +143,8 @@ impl SwarmBuilder {
             self.max_dial_attempts
                 .unwrap_or_else(|| 3u64.try_into().unwrap()),
             1usize.try_into().unwrap(),
-            // Default to an interval far longer than any test, so the periodic
-            // maintenance task never fires unless a test explicitly opts in.
-            self.peering_degree_check_interval
-                .unwrap_or_else(|| interval(Duration::from_hours(1))),
+            self.peering_degree_check_clock
+                .unwrap_or_else(|| Box::pin(pending())),
         );
 
         TestSwarm {
@@ -238,8 +236,7 @@ impl<Settings> From<&BlendConfig<Settings>> for TestObservationWindowProvider {
 }
 
 impl IntervalStreamProvider for TestObservationWindowProvider {
-    type IntervalStream =
-        Box<dyn futures::Stream<Item = RangeInclusive<u64>> + Send + Unpin + 'static>;
+    type IntervalStream = Box<dyn Stream<Item = RangeInclusive<u64>> + Send + Unpin + 'static>;
     type IntervalItem = RangeInclusive<u64>;
 
     fn interval_stream(&self) -> Self::IntervalStream {

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -150,6 +150,7 @@ pub struct BlendBehaviourBuilder {
     peer_id: PeerId,
     membership: Membership<PeerId>,
     observation_window: Option<(Duration, RangeInclusive<u64>)>,
+    peering_degree: Option<RangeInclusive<usize>>,
 }
 
 impl BlendBehaviourBuilder {
@@ -158,6 +159,7 @@ impl BlendBehaviourBuilder {
             peer_id,
             membership,
             observation_window: None,
+            peering_degree: None,
         }
     }
 
@@ -170,16 +172,22 @@ impl BlendBehaviourBuilder {
         self
     }
 
+    pub fn with_peering_degree(mut self, peering_degree: RangeInclusive<usize>) -> Self {
+        self.peering_degree = Some(peering_degree);
+        self
+    }
+
     pub fn build(self) -> BlendBehaviour<TestObservationWindowProvider> {
         let observation_window_values = self
             .observation_window
             .unwrap_or((Duration::from_secs(1), u64::MIN..=u64::MAX));
+        let peering_degree = self.peering_degree.unwrap_or(1..=100);
 
         BlendBehaviour {
             blend: NetworkBehaviour::new(
                 &Config {
                     with_core: CoreToCoreConfig {
-                        peering_degree: 1..=100,
+                        peering_degree,
                         minimum_network_size: 1.try_into().unwrap(),
                     },
                     with_edge: CoreToEdgeConfig {

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -26,7 +26,7 @@ use libp2p_swarm_test::SwarmExt as _;
 use rand::SeedableRng as _;
 use tokio::{
     sync::{broadcast, mpsc},
-    time::interval,
+    time::{Interval, interval},
 };
 use tokio_stream::wrappers::IntervalStream;
 
@@ -95,6 +95,7 @@ pub struct SwarmBuilder {
     identity: Keypair,
     public_info: BackendEpochInfo<PeerId>,
     max_dial_attempts: Option<NonZeroU64>,
+    peering_degree_check_interval: Option<Interval>,
 }
 
 impl SwarmBuilder {
@@ -107,11 +108,17 @@ impl SwarmBuilder {
             identity,
             public_info,
             max_dial_attempts: None,
+            peering_degree_check_interval: None,
         }
     }
 
     pub fn with_max_dial_attempts(mut self, max_dial_attempts: NonZeroU64) -> Self {
         self.max_dial_attempts = Some(max_dial_attempts);
+        self
+    }
+
+    pub fn with_peering_degree_check_interval(mut self, interval: Interval) -> Self {
+        self.peering_degree_check_interval = Some(interval);
         self
     }
 
@@ -136,6 +143,10 @@ impl SwarmBuilder {
             self.max_dial_attempts
                 .unwrap_or_else(|| 3u64.try_into().unwrap()),
             1usize.try_into().unwrap(),
+            // Default to an interval far longer than any test, so the periodic
+            // maintenance task never fires unless a test explicitly opts in.
+            self.peering_degree_check_interval
+                .unwrap_or_else(|| interval(Duration::from_hours(1))),
         );
 
         TestSwarm {


### PR DESCRIPTION
## 1. What does this PR implement?

The check for when to clear the set of failed peers and try again from scratch if below the minimum peering degree was wrong, and it resulted in a core peer stay at below minimum peering degree in the rc11 devnet run, for the epochs in which this issue took place.

This PR fixes the bug by changing the condition, and also adds an optional monitor clock (set to 1 minute by default) to check the peering degree and establish new connections if needed.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No. This behaviour is implementation-specific to reduce the risk for a node to have a less-than-minimum peering degree.