### PR TITLE
chore(nom): do not manually parse

### DIFF
--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use lb_cryptarchia_engine::Slot;
-use nom::{IResult, Parser as _, combinator::map};
+use nom::IResult;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -43,7 +43,8 @@ impl NomDecode for SlotTimeframe {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map(u32::decode, Self).parse(bytes)
+        let (bytes, inner) = u32::decode(bytes)?;
+        Ok((bytes, Self(inner)))
     }
 }
 
@@ -72,7 +73,8 @@ impl NomDecode for SlotTimeout {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map(u32::decode, Self).parse(bytes)
+        let (bytes, inner) = u32::decode(bytes)?;
+        Ok((bytes, Self(inner)))
     }
 }
 

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -313,7 +313,8 @@ impl NomDecode for Inputs {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> nom::IResult<&[u8], Self::Output> {
-        NomInputs::decode(bytes).map(|(remaining, items)| (remaining, Self(items)))
+        let (bytes, items) = NomInputs::decode(bytes)?;
+        Ok((bytes, Self(items)))
     }
 }
 
@@ -355,7 +356,8 @@ impl NomDecode for NoteId {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> nom::IResult<&[u8], Self::Output> {
-        Fr::decode(bytes).map(|(remaining, fr)| (remaining, Self(fr)))
+        let (bytes, inner) = Fr::decode(bytes)?;
+        Ok((bytes, Self(inner)))
     }
 }
 

--- a/core/src/mantle/nom/array.rs
+++ b/core/src/mantle/nom/array.rs
@@ -31,7 +31,7 @@ where
     type Output = [T::Output; N];
 
     fn decode(input: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (input, items) = count(T::decode, N).parse(input)?;
+        let (input, items) = count(T::decode, N).parse_complete(input)?;
 
         let Ok(items) = items.try_into() else {
             panic!("Decoded `N` elements.");

--- a/core/src/mantle/nom/bounded_vec.rs
+++ b/core/src/mantle/nom/bounded_vec.rs
@@ -76,7 +76,7 @@ where
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
         let () = Self::_N_BYTES_VALUE_CHECK;
 
-        let (bytes, len_bytes): (&[u8], &[u8]) = take(N_BYTES).parse(bytes)?;
+        let (bytes, len_bytes): (&[u8], &[u8]) = take(N_BYTES).parse_complete(bytes)?;
         let mut buf = [0u8; 8];
         buf[..N_BYTES].copy_from_slice(len_bytes);
         let len = u64::from_le_bytes(buf) as usize;
@@ -90,7 +90,7 @@ where
             return Err(nom::Err::Error(Error::new(bytes, ErrorKind::TooLarge)));
         }
 
-        let (bytes, items) = count(T::decode, len).parse(bytes)?;
+        let (bytes, items) = count(T::decode, len).parse_complete(bytes)?;
         Ok((bytes, BoundedVec::new_unchecked(items)))
     }
 }

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -2,8 +2,7 @@ use lb_cryptarchia_engine::Epoch;
 use lb_groth16::{Fr, fr_from_bytes, fr_to_bytes};
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use nom::{
-    IResult, Parser as _,
-    combinator::{map, map_res},
+    IResult,
     error::{Error, ErrorKind},
     number::complete::{le_u16, le_u32, le_u64, u8},
 };
@@ -103,10 +102,12 @@ impl NomDecode for Fr {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map_res(NomArray::<u8, 32>::decode, |bytes: [u8; 32]| {
-            fr_from_bytes(&bytes).map_err(|_| Error::new(bytes, ErrorKind::Fail))
-        })
-        .parse(bytes)
+        let (bytes, inner) = NomArray::<u8, 32>::decode(bytes)?;
+        Ok((
+            bytes,
+            fr_from_bytes(&inner)
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+        ))
     }
 }
 
@@ -120,7 +121,8 @@ impl NomDecode for ChannelId {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        map(NomArray::<u8, 32>::decode, Self::from).parse(bytes)
+        let (bytes, inner) = NomArray::<u8, _>::decode(bytes)?;
+        Ok((bytes, Self::from(inner)))
     }
 }
 
@@ -134,7 +136,8 @@ impl NomDecode for MsgId {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        map(NomArray::<u8, 32>::decode, Self::from).parse(bytes)
+        let (bytes, inner) = NomArray::<u8, _>::decode(bytes)?;
+        Ok((bytes, Self::from(inner)))
     }
 }
 
@@ -149,10 +152,12 @@ impl NomDecode for Ed25519PublicKey {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        map_res(NomArray::<u8, 32>::decode, |key_bytes: [u8; 32]| {
-            Self::from_bytes(&key_bytes).map_err(|_| Error::new(bytes, ErrorKind::Fail))
-        })
-        .parse(bytes)
+        let (bytes, inner) = NomArray::<u8, _>::decode(bytes)?;
+        Ok((
+            bytes,
+            Self::from_bytes(&inner)
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+        ))
     }
 }
 
@@ -166,7 +171,8 @@ impl NomDecode for ZkPublicKey {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map_res(Fr::decode, Self::try_from).parse(bytes)
+        let (bytes, inner) = Fr::decode(bytes)?;
+        Ok((bytes, Self::new(inner)))
     }
 }
 
@@ -180,6 +186,7 @@ impl NomDecode for Epoch {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map(u32::decode, Self::new).parse(bytes)
+        let (bytes, inner) = u32::decode(bytes)?;
+        Ok((bytes, Self::new(inner)))
     }
 }

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -102,9 +102,9 @@ impl NomDecode for Fr {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (bytes, inner) = NomArray::<u8, 32>::decode(bytes)?;
+        let (remaining_bytes, inner) = NomArray::<u8, 32>::decode(bytes)?;
         Ok((
-            bytes,
+            remaining_bytes,
             fr_from_bytes(&inner)
                 .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
@@ -152,9 +152,9 @@ impl NomDecode for Ed25519PublicKey {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        let (bytes, inner) = NomArray::<u8, _>::decode(bytes)?;
+        let (remaining_bytes, inner) = NomArray::<u8, _>::decode(bytes)?;
         Ok((
-            bytes,
+            remaining_bytes,
             Self::from_bytes(&inner)
                 .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -106,7 +106,7 @@ impl NomDecode for Fr {
         Ok((
             bytes,
             fr_from_bytes(&inner)
-                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
     }
 }
@@ -156,7 +156,7 @@ impl NomDecode for Ed25519PublicKey {
         Ok((
             bytes,
             Self::from_bytes(&inner)
-                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
     }
 }

--- a/core/src/mantle/nom/sdp/active/blend.rs
+++ b/core/src/mantle/nom/sdp/active/blend.rs
@@ -22,9 +22,9 @@ impl NomDecode for ProofOfQuota {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (bytes, value) = ProofOfQuotaNom::decode(bytes)?;
+        let (remaining_bytes, value) = ProofOfQuotaNom::decode(bytes)?;
         Ok((
-            bytes,
+            remaining_bytes,
             Self::try_from(value)
                 .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
@@ -44,9 +44,9 @@ impl NomDecode for ProofOfSelection {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (bytes, value) = ProofOfSelectionNom::decode(bytes)?;
+        let (remaining_bytes, value) = ProofOfSelectionNom::decode(bytes)?;
         Ok((
-            bytes,
+            remaining_bytes,
             Self::try_from(value)
                 .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))

--- a/core/src/mantle/nom/sdp/active/blend.rs
+++ b/core/src/mantle/nom/sdp/active/blend.rs
@@ -26,7 +26,7 @@ impl NomDecode for ProofOfQuota {
         Ok((
             bytes,
             Self::try_from(value)
-                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
     }
 }
@@ -48,7 +48,7 @@ impl NomDecode for ProofOfSelection {
         Ok((
             bytes,
             Self::try_from(value)
-                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
     }
 }

--- a/core/src/mantle/nom/sdp/active/blend.rs
+++ b/core/src/mantle/nom/sdp/active/blend.rs
@@ -2,7 +2,10 @@ use lb_blend_proofs::{
     quota::{PROOF_OF_QUOTA_SIZE, ProofOfQuota},
     selection::{PROOF_OF_SELECTION_SIZE, ProofOfSelection},
 };
-use nom::{IResult, Parser as _, combinator::map_res};
+use nom::{
+    IResult,
+    error::{Error, ErrorKind},
+};
 
 use crate::mantle::nom::{NomArray, NomDecode, NomEncode};
 
@@ -19,7 +22,12 @@ impl NomDecode for ProofOfQuota {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map_res(ProofOfQuotaNom::decode, Self::try_from).parse(bytes)
+        let (bytes, value) = ProofOfQuotaNom::decode(bytes)?;
+        Ok((
+            bytes,
+            Self::try_from(value)
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+        ))
     }
 }
 
@@ -36,6 +44,11 @@ impl NomDecode for ProofOfSelection {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map_res(ProofOfSelectionNom::decode, Self::try_from).parse(bytes)
+        let (bytes, value) = ProofOfSelectionNom::decode(bytes)?;
+        Ok((
+            bytes,
+            Self::try_from(value)
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+        ))
     }
 }

--- a/core/src/mantle/nom/sdp/declare.rs
+++ b/core/src/mantle/nom/sdp/declare.rs
@@ -3,6 +3,7 @@ use lb_utils::bounded_vec::BoundedVec;
 use nom::{
     IResult, Parser as _,
     combinator::{map, map_res},
+    error::{Error, ErrorKind},
 };
 
 use crate::{
@@ -27,7 +28,12 @@ impl NomDecode for ServiceType {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map_res(u8::decode, Self::try_from).parse(bytes)
+        let (bytes, value) = u8::decode(bytes)?;
+        Ok((
+            bytes,
+            Self::try_from(value)
+                .map_err(|()| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+        ))
     }
 }
 
@@ -45,7 +51,12 @@ impl NomDecode for Locator {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        map_res(NomLocator::decode, Self::try_from).parse(bytes)
+        let (bytes, value) = NomLocator::decode(bytes)?;
+        Ok((
+            bytes,
+            Self::try_from(value)
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+        ))
     }
 }
 
@@ -61,7 +72,8 @@ impl NomDecode for Locators {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        map(NomLocators::decode, Self::from).parse(bytes)
+        let (bytes, value) = NomLocators::decode(bytes)?;
+        Ok((bytes, value))
     }
 }
 
@@ -75,7 +87,8 @@ impl NomDecode for ProviderId {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        map(Ed25519PublicKey::decode, Self).parse(bytes)
+        let (bytes, value) = Ed25519PublicKey::decode(bytes)?;
+        Ok((bytes, Self(value)))
     }
 }
 

--- a/core/src/mantle/nom/sdp/declare.rs
+++ b/core/src/mantle/nom/sdp/declare.rs
@@ -27,9 +27,9 @@ impl NomDecode for ServiceType {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (bytes, value) = u8::decode(bytes)?;
+        let (remaining_bytes, value) = u8::decode(bytes)?;
         Ok((
-            bytes,
+            remaining_bytes,
             Self::try_from(value)
                 .map_err(|()| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
@@ -50,9 +50,9 @@ impl NomDecode for Locator {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self> {
-        let (bytes, value) = NomLocator::decode(bytes)?;
+        let (remaining_bytes, value) = NomLocator::decode(bytes)?;
         Ok((
-            bytes,
+            remaining_bytes,
             Self::try_from(value)
                 .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))

--- a/core/src/mantle/nom/sdp/declare.rs
+++ b/core/src/mantle/nom/sdp/declare.rs
@@ -1,8 +1,7 @@
 use lb_key_management_system_keys::keys::{Ed25519PublicKey, ZkPublicKey};
 use lb_utils::bounded_vec::BoundedVec;
 use nom::{
-    IResult, Parser as _,
-    combinator::{map, map_res},
+    IResult,
     error::{Error, ErrorKind},
 };
 
@@ -32,7 +31,7 @@ impl NomDecode for ServiceType {
         Ok((
             bytes,
             Self::try_from(value)
-                .map_err(|()| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+                .map_err(|()| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
     }
 }
@@ -55,7 +54,7 @@ impl NomDecode for Locator {
         Ok((
             bytes,
             Self::try_from(value)
-                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::Fail)))?,
+                .map_err(|_| nom::Err::Error(Error::new(bytes, ErrorKind::MapRes)))?,
         ))
     }
 }

--- a/core/src/mantle/nom/sdp/mod.rs
+++ b/core/src/mantle/nom/sdp/mod.rs
@@ -1,7 +1,10 @@
 use lb_blend_proofs::{quota::ProofOfQuota, selection::ProofOfSelection};
 use lb_cryptarchia_engine::Epoch;
 use lb_key_management_system_keys::keys::Ed25519PublicKey;
-use nom::{IResult, Parser as _, combinator::map, error::Error};
+use nom::{
+    IResult,
+    error::{Error, ErrorKind},
+};
 
 use crate::{
     mantle::nom::{NomArray, NomDecode, NomEncode},
@@ -22,7 +25,8 @@ impl NomDecode for DeclarationId {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        map(NomArray::<u8, 32>::decode, Self).parse(bytes)
+        let (bytes, value) = NomArray::<u8, _>::decode(bytes)?;
+        Ok((bytes, Self(value)))
     }
 }
 
@@ -50,10 +54,7 @@ impl NomDecode for ActivityMetadata {
                 let (bytes, blend_activity_proof) = blend::ActivityProof::decode(bytes)?;
                 Ok((bytes, Self::Blend(Box::new(blend_activity_proof))))
             }
-            _ => Err(nom::Err::Error(Error::new(
-                bytes,
-                nom::error::ErrorKind::Fail,
-            ))),
+            _ => Err(nom::Err::Error(Error::new(bytes, ErrorKind::Fail))),
         }
     }
 }
@@ -77,10 +78,7 @@ impl NomDecode for blend::ActivityProof {
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
         let (bytes, proof_version) = u8::decode(bytes)?;
         if proof_version != BLEND_ACTIVE_METADATA_VERSION_BYTE {
-            return Err(nom::Err::Error(Error::new(
-                bytes,
-                nom::error::ErrorKind::Fail,
-            )));
+            return Err(nom::Err::Error(Error::new(bytes, ErrorKind::Fail)));
         }
         let (bytes, epoch) = Epoch::decode(bytes)?;
         let (bytes, signing_key) = Ed25519PublicKey::decode(bytes)?;

--- a/core/src/mantle/nom/sdp/mod.rs
+++ b/core/src/mantle/nom/sdp/mod.rs
@@ -48,10 +48,10 @@ impl NomDecode for ActivityMetadata {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (bytes, metadata_type) = u8::decode(bytes)?;
+        let (remaining_bytes, metadata_type) = u8::decode(bytes)?;
         match metadata_type {
             ACTIVE_METADATA_BLEND_TYPE => {
-                let (bytes, blend_activity_proof) = blend::ActivityProof::decode(bytes)?;
+                let (bytes, blend_activity_proof) = blend::ActivityProof::decode(remaining_bytes)?;
                 Ok((bytes, Self::Blend(Box::new(blend_activity_proof))))
             }
             _ => Err(nom::Err::Error(Error::new(bytes, ErrorKind::Fail))),
@@ -76,11 +76,11 @@ impl NomDecode for blend::ActivityProof {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (bytes, proof_version) = u8::decode(bytes)?;
+        let (remaining_bytes, proof_version) = u8::decode(bytes)?;
         if proof_version != BLEND_ACTIVE_METADATA_VERSION_BYTE {
             return Err(nom::Err::Error(Error::new(bytes, ErrorKind::Fail)));
         }
-        let (bytes, epoch) = Epoch::decode(bytes)?;
+        let (bytes, epoch) = Epoch::decode(remaining_bytes)?;
         let (bytes, signing_key) = Ed25519PublicKey::decode(bytes)?;
         let (bytes, proof_of_quota) = ProofOfQuota::decode(bytes)?;
         let (bytes, proof_of_selection) = ProofOfSelection::decode(bytes)?;

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -59,12 +59,12 @@ impl NomDecode for InscriptionOp {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (input, channel_id) = ChannelId::decode(bytes)?;
-        let (input, inscription) = NomInscription::decode(input)?;
-        let (input, parent) = MsgId::decode(input)?;
-        let (input, signer) = Ed25519PublicKey::decode(input)?;
+        let (bytes, channel_id) = ChannelId::decode(bytes)?;
+        let (bytes, inscription) = NomInscription::decode(bytes)?;
+        let (bytes, parent) = MsgId::decode(bytes)?;
+        let (bytes, signer) = Ed25519PublicKey::decode(bytes)?;
         Ok((
-            input,
+            bytes,
             Self {
                 channel_id,
                 inscription,

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -167,7 +167,7 @@ impl NomDecode for Op {
     type Output = Self;
 
     fn decode(bytes: &[u8]) -> IResult<&[u8], Self::Output> {
-        let (input, opcode) = u8::decode(bytes)?;
+        let (bytes, opcode) = u8::decode(bytes)?;
 
         match opcode {
             INSCRIBE => {
@@ -191,9 +191,9 @@ impl NomDecode for Op {
                 SDPActiveOp::decode(bytes).map(|(bytes, op)| (bytes, Self::SDPActive(op)))
             }
             // TODO: Use `.decode()` once implemented for all other ops
-            LEADER_CLAIM => map(decode_leader_claim, Self::LeaderClaim).parse(input),
-            TRANSFER => map(decode_transfer, Self::Transfer).parse(input),
-            _ => Err(nom::Err::Error(Error::new(input, ErrorKind::Fail))),
+            LEADER_CLAIM => map(decode_leader_claim, Self::LeaderClaim).parse(bytes),
+            TRANSFER => map(decode_transfer, Self::Transfer).parse(bytes),
+            _ => Err(nom::Err::Error(Error::new(bytes, ErrorKind::Fail))),
         }
     }
 }

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -170,13 +170,26 @@ impl NomDecode for Op {
         let (input, opcode) = u8::decode(bytes)?;
 
         match opcode {
-            INSCRIBE => map(InscriptionOp::decode, Self::ChannelInscribe).parse(input),
-            CHANNEL_CONFIG => map(ChannelConfigOp::decode, Self::ChannelConfig).parse(input),
-            CHANNEL_DEPOSIT => map(DepositOp::decode, Self::ChannelDeposit).parse(input),
-            CHANNEL_WITHDRAW => map(ChannelWithdrawOp::decode, Self::ChannelWithdraw).parse(input),
-            SDP_DECLARE => map(SDPDeclareOp::decode, Self::SDPDeclare).parse(input),
-            SDP_WITHDRAW => map(SDPWithdrawOp::decode, Self::SDPWithdraw).parse(input),
-            SDP_ACTIVE => map(SDPActiveOp::decode, Self::SDPActive).parse(input),
+            INSCRIBE => {
+                InscriptionOp::decode(bytes).map(|(bytes, op)| (bytes, Self::ChannelInscribe(op)))
+            }
+            CHANNEL_CONFIG => {
+                ChannelConfigOp::decode(bytes).map(|(bytes, op)| (bytes, Self::ChannelConfig(op)))
+            }
+            CHANNEL_DEPOSIT => {
+                DepositOp::decode(bytes).map(|(bytes, op)| (bytes, Self::ChannelDeposit(op)))
+            }
+            CHANNEL_WITHDRAW => ChannelWithdrawOp::decode(bytes)
+                .map(|(bytes, op)| (bytes, Self::ChannelWithdraw(op))),
+            SDP_DECLARE => {
+                SDPDeclareOp::decode(bytes).map(|(bytes, op)| (bytes, Self::SDPDeclare(op)))
+            }
+            SDP_WITHDRAW => {
+                SDPWithdrawOp::decode(bytes).map(|(bytes, op)| (bytes, Self::SDPWithdraw(op)))
+            }
+            SDP_ACTIVE => {
+                SDPActiveOp::decode(bytes).map(|(bytes, op)| (bytes, Self::SDPActive(op)))
+            }
             // TODO: Use `.decode()` once implemented for all other ops
             LEADER_CLAIM => map(decode_leader_claim, Self::LeaderClaim).parse(input),
             TRANSFER => map(decode_transfer, Self::Transfer).parse(input),


### PR DESCRIPTION
## 1. What does this PR implement?

Built on top of https://github.com/logos-blockchain/logos-blockchain/pull/2974.

This PR removes all calls to `parse` from the types and delegates that to the primitive types, encapsulating the logic. The overall checks should be performed at the serialization/deserialization boundary, which will be a whole `SignedMantleTx`, when we get to the point of implementing `NomEncode` and `NomDecode` on that type.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.