### PR TITLE
fix(wallet): don't add an input when the tx is already funded

### DIFF
--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -183,6 +183,22 @@ impl WalletState {
         // Consume large valued notes first to ensure we converge.
         utxos.sort_by_key(|utxo| -i128::from(utxo.note.value));
 
+        // The transaction may already be funded before we add any of the
+        // wallet's UTXOs, for example when it pays no fee or the caller already
+        // supplied inputs. In that case we must not pull in an extra input (and
+        // the change note it would require).
+        match tx_builder.funding_delta::<G>()?.cmp(&0) {
+            Ordering::Equal => return Ok(tx_builder.clone()),
+            Ordering::Greater => {
+                if let Some(tx_with_change) = tx_builder.clone().return_change::<G>(change_pk)? {
+                    return Ok(tx_with_change);
+                }
+                // The change note costs more than the surplus covers, so fall
+                // through and pull in more UTXO's below.
+            }
+            Ordering::Less => {}
+        }
+
         for i in 0..utxos.len() {
             let funded_tx_builder = tx_builder
                 .clone()
@@ -868,6 +884,56 @@ mod tests {
     }
 
     #[test]
+    fn test_fund_tx_no_fee_adds_no_input() {
+        let alice = pk(1);
+        // The wallet has a spendable note available...
+        let utxo = Utxo::new(tx_hash(0), 0, Note::new(5000, alice));
+        let ledger_state = LedgerState::from_utxos([utxo], &ledger_config());
+        let wallet_state =
+            WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
+
+        // ...but with zero gas prices a transfer-less transaction owes no fee,
+        // so it needs no funding at all.
+        let mut tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(0, 0),
+            ),
+            leader_reward_amount: 0,
+        });
+
+        let signing_key = Ed25519Key::from_bytes(&[1; 32]);
+        tx_builder = tx_builder
+            .push_op(Op::ChannelInscribe(InscriptionOp {
+                channel_id: ChannelId::from([0xAA; 32]),
+                inscription: [0xAB; 8].into(),
+                parent: MsgId::from([0xBB; 32]),
+                signer: signing_key.public_key(),
+            }))
+            .unwrap();
+
+        assert_eq!(0, tx_builder.funding_delta::<Gas>().unwrap());
+
+        let funded_tx_builder = wallet_state
+            .fund_tx::<Gas>(&tx_builder, alice, [alice])
+            .unwrap();
+
+        // No input was pulled in (an added input would push the net balance to
+        // 5000) and therefore no change note was added.
+        assert_eq!(0, funded_tx_builder.net_balance());
+
+        // The empty transfer is dropped, so the built tx carries no transfer op.
+        let funded_tx = funded_tx_builder.build().unwrap();
+        assert!(
+            !funded_tx
+                .ops()
+                .iter()
+                .any(|op| matches!(op, Op::Transfer(_))),
+            "a fee-less transaction must not contain a transfer op"
+        );
+    }
+
+    #[test]
     fn test_fund_tx_insufficient_funds() {
         let alice = pk(1);
         let ledger_state = LedgerState::from_utxos(
@@ -920,7 +986,15 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1)]), &ledger_state);
 
-        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context());
+        // Use non-zero gas prices so the transaction actually owes a fee and
+        // therefore needs funding.
+        let tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        });
 
         // Fund the transaction
         let fund_attempt = wallet_state.fund_tx::<Gas>(&tx_builder, alice, [alice]);
@@ -942,7 +1016,15 @@ mod tests {
         // Lock `utxo` deliberately to ensure that `fund_tx` excludes locked notes
         wallet_state.locked_notes = wallet_state.locked_notes.insert(utxo.id());
 
-        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context());
+        // Use non-zero gas prices so the transaction actually owes a fee and
+        // therefore needs funding.
+        let tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        });
 
         // Fund the transaction
         let fund_attempt = wallet_state.fund_tx::<Gas>(&tx_builder, alice, [alice]);
@@ -965,7 +1047,15 @@ mod tests {
         let wallet_state =
             WalletState::from_ledger(&HashMap::from_iter([(alice, 1), (bob, 2)]), &ledger_state);
 
-        let tx_builder = MantleTxBuilder::new(ledger_state.tx_context());
+        // Use non-zero gas prices so the transaction actually owes a fee and
+        // therefore needs funding.
+        let tx_builder = MantleTxBuilder::new(MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        });
 
         // Attempt to fund the transaction with Alice's notes.
         let fund_attempt = wallet_state.fund_tx::<Gas>(&tx_builder, alice, [alice]);


### PR DESCRIPTION
## 1. What does this PR implement?

`WalletState::fund_tx` always pulled in at least one of the wallet's UTXOs as an input *before* checking whether funding was needed. The loop starts at the first UTXO and only evaluates `funding_delta` after `extend_ledger_inputs`, so the zero-input state is never tested. Consequences:

- A transaction that needs no funding — e.g. it pays no fee (gas prices are `0` today, see #2490), or the caller already balanced it — still pulled in an input and then added a change note to hand that value straight back: an unnecessary **self-transfer**. (This is the bundled Transfer op we see on SDP Active txs.)
- If no funding was needed but the wallet held no spare notes, `fund_tx` returned `InsufficientFunds` even though nothing needed funding.

This PR checks the funding delta of the transaction *as supplied* first:
- `== 0` → return it untouched (no input, no change),
- `> 0` → add only a change note (no new input),
- `< 0` → fall back to the existing loop that pulls in UTXOs.

## 2. Does the code have enough context to be clearly understood?

The change is local to `WalletState::fund_tx` in `wallet/src/lib.rs`. `funding_delta = (Σinputs − Σoutputs) − gas_cost`, so a non-positive delta means the tx is already funded.

**Stacked on #2970** (`fix/skip-empty-transfer-op`). When the tx is already funded with no inputs/outputs (the no-fee case), `fund_tx` now returns a builder with an empty pending transfer; #2970 is what makes `build()` omit that empty transfer so the resulting tx is valid. This PR targets that branch and should merge after it.

Three existing tests (`test_fund_tx_zero_funds`, `test_fund_tx_all_locked_notes`, `test_fund_tx_respects_pk_list`) asserted `InsufficientFunds` using zero gas prices on an empty tx — which no longer needs funding. They now use `GasPrices::new(1, 1)` so they still exercise the underfunded path (and the locked-note / pk-list filtering they were written to check). New test `test_fund_tx_no_fee_adds_no_input` covers the no-fee path: no input pulled in, no transfer op in the built tx.

## 3. Who are the specification authors and who is accountable for this PR?

@davidrusu (accountable). Reviewers TBD.

## 4. Is the specification accurate and complete?

N/A — wallet funding-logic correctness fix; no specification change.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the logging guidelines. (No log changes.)
