### PR TITLE
test(cucumber): start devnet wallet feed after sync

### DIFF
--- a/tests/cucumber_tests/features/manual_control.feature
+++ b/tests/cucumber_tests/features/manual_control.feature
@@ -228,14 +228,15 @@ Feature: Manual control of transactions
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
-    And I request 3 rounds of faucet funds for all user wallets
     And I have public cryptarchia endpoint peers:
       | public_cryptarchia_endpoint               | username               | password              |
       | https://devnet.blockchain.logos.co/node/0 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/1 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/2 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/3 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
-#    When I wait for all nodes to be synced to the chain
+    When I wait for all nodes to be synced to the chain
+    And I request 3 rounds of faucet funds for all user wallets
+    And I verify each wallet has minimum 1 outputs "available" in 300 seconds
     When node NODE_1 is at height 2000 in 3000 seconds
     When I perform manual control of transactions for all wallets no time-out
     Then I stop all nodes
@@ -274,7 +275,6 @@ Feature: Manual control of transactions
       | NODE_8    | 8             | WALLET_8A   | NODE_7       |
       | NODE_9    | 9             | WALLET_9A   | NODE_8       |
       | NODE_10   | 10            | WALLET_10A  | NODE_9       |
-    And I request 3 rounds of faucet funds for all user wallets
     And I have public cryptarchia endpoint peers:
       | public_cryptarchia_endpoint               | username               | password              |
       | https://devnet.blockchain.logos.co/node/0 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
@@ -282,5 +282,7 @@ Feature: Manual control of transactions
       | https://devnet.blockchain.logos.co/node/2 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/3 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
     When I wait for all nodes to be synced to the chain
+    And I request 3 rounds of faucet funds for all user wallets
+    And I verify each wallet has minimum 1 outputs "available" in 300 seconds
     When I perform manual control of transactions for all wallets no time-out
     Then I stop all nodes

--- a/tests/cucumber_tests/features/manual_control.feature
+++ b/tests/cucumber_tests/features/manual_control.feature
@@ -236,7 +236,6 @@ Feature: Manual control of transactions
       | https://devnet.blockchain.logos.co/node/2 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/3 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
     When I wait for all nodes to be synced to the chain
-    And I verify each wallet has minimum 1 outputs "available" in 300 seconds
     When node NODE_1 is at height 2000 in 3000 seconds
     When I perform manual control of transactions for all wallets no time-out
     Then I stop all nodes
@@ -283,6 +282,5 @@ Feature: Manual control of transactions
       | https://devnet.blockchain.logos.co/node/2 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/3 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
     When I wait for all nodes to be synced to the chain
-    And I verify each wallet has minimum 1 outputs "available" in 300 seconds
     When I perform manual control of transactions for all wallets no time-out
     Then I stop all nodes

--- a/tests/cucumber_tests/features/manual_control.feature
+++ b/tests/cucumber_tests/features/manual_control.feature
@@ -228,6 +228,7 @@ Feature: Manual control of transactions
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
       | NODE_2    | 2             | WALLET_2A   | NODE_1       |
+    And I request 3 rounds of faucet funds for all user wallets
     And I have public cryptarchia endpoint peers:
       | public_cryptarchia_endpoint               | username               | password              |
       | https://devnet.blockchain.logos.co/node/0 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
@@ -235,7 +236,6 @@ Feature: Manual control of transactions
       | https://devnet.blockchain.logos.co/node/2 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/3 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
     When I wait for all nodes to be synced to the chain
-    And I request 3 rounds of faucet funds for all user wallets
     And I verify each wallet has minimum 1 outputs "available" in 300 seconds
     When node NODE_1 is at height 2000 in 3000 seconds
     When I perform manual control of transactions for all wallets no time-out
@@ -275,6 +275,7 @@ Feature: Manual control of transactions
       | NODE_8    | 8             | WALLET_8A   | NODE_7       |
       | NODE_9    | 9             | WALLET_9A   | NODE_8       |
       | NODE_10   | 10            | WALLET_10A  | NODE_9       |
+    And I request 3 rounds of faucet funds for all user wallets
     And I have public cryptarchia endpoint peers:
       | public_cryptarchia_endpoint               | username               | password              |
       | https://devnet.blockchain.logos.co/node/0 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
@@ -282,7 +283,6 @@ Feature: Manual control of transactions
       | https://devnet.blockchain.logos.co/node/2 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
       | https://devnet.blockchain.logos.co/node/3 | env(CCMBR_DEVNET_USER) | env(CCMBR_DEVNET_PWD) |
     When I wait for all nodes to be synced to the chain
-    And I request 3 rounds of faucet funds for all user wallets
     And I verify each wallet has minimum 1 outputs "available" in 300 seconds
     When I perform manual control of transactions for all wallets no time-out
     Then I stop all nodes

--- a/tests/src/common/wallet/chain/feed.rs
+++ b/tests/src/common/wallet/chain/feed.rs
@@ -42,6 +42,11 @@ pub enum WalletBlockFeedTrackerError {
         source_node_name: String,
         height: u64,
     },
+    #[error(
+        "cannot start wallet tracking from observed tip for `{source_node_name}` before source \
+        has advanced past genesis"
+    )]
+    SourceAtGenesis { source_node_name: String },
     #[error(transparent)]
     TrackedKeys(#[from] TrackedWalletKeysError),
 }
@@ -243,6 +248,42 @@ impl WalletBlockFeedTracker {
         Ok(tracking)
     }
 
+    /// Start wallet tracking from the currently observed feed tip.
+    ///
+    /// This is for live-chain scenarios that intentionally begin tracking
+    /// before new wallet-relevant transactions are submitted. It does not
+    /// reconstruct historical wallet state.
+    pub fn track_wallets_from_observed_tip(
+        &mut self,
+        wallets: &mut TrackedWallets,
+        tracking_batches: &[WalletFeedTrackingBatch],
+        feed: &BlockFeed,
+        genesis_utxos: &[Utxo],
+    ) -> Result<(), WalletBlockFeedTrackerError> {
+        self.remember_block_bodies(&feed.history());
+
+        let Some(observation) = feed.latest_observation() else {
+            return Ok(());
+        };
+
+        for batch in tracking_batches {
+            self.prepare_tracking_batch_from_observed_tip(wallets, batch, genesis_utxos)?;
+        }
+
+        let view = WalletFeedChainView::new(observation, &self.block_bodies_by_header);
+
+        for batch in tracking_batches {
+            Self::start_prepared_tracking_batch_from_observed_tip(
+                wallets,
+                &mut self.source_trackers,
+                batch,
+                &view,
+            )?;
+        }
+
+        Ok(())
+    }
+
     /// Apply all newly observed canonical blocks from the feed.
     pub fn apply_feed(
         &mut self,
@@ -328,6 +369,75 @@ impl WalletBlockFeedTracker {
         );
 
         Ok(WalletSourceTracking::Ready)
+    }
+
+    fn prepare_tracking_batch_from_observed_tip(
+        &mut self,
+        wallets: &mut TrackedWallets,
+        batch: &WalletFeedTrackingBatch,
+        genesis_utxos: &[Utxo],
+    ) -> Result<(), WalletBlockFeedTrackerError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+
+        wallets.ensure_wallets_from_tracked_keys(batch.wallet_keys());
+        self.ensure_observed_tip_source_tracker(
+            batch.source_node_name(),
+            batch.wallet_keys(),
+            genesis_utxos,
+        )?;
+
+        Ok(())
+    }
+
+    fn start_prepared_tracking_batch_from_observed_tip(
+        wallets: &mut TrackedWallets,
+        source_trackers: &mut HashMap<String, WalletSourceTracker>,
+        batch: &WalletFeedTrackingBatch,
+        view: &WalletFeedChainView<'_>,
+    ) -> Result<(), WalletBlockFeedTrackerError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+
+        let source_tracker = source_trackers
+            .get_mut(batch.source_node_name())
+            .ok_or_else(|| WalletBlockFeedTrackerError::MissingSource {
+                source_node_name: batch.source_node_name().to_owned(),
+            })?;
+
+        source_tracker.start_at_observed_tip(wallets, view, batch.source_node_name())?;
+        wallets.replace_current_wallets_utxos(source_tracker.wallet_utxos());
+
+        Ok(())
+    }
+
+    fn ensure_observed_tip_source_tracker(
+        &mut self,
+        source_node_name: &str,
+        wallet_keys: &[TrackedWalletKeys],
+        genesis_utxos: &[Utxo],
+    ) -> Result<(), WalletBlockFeedTrackerError> {
+        let Some(source_tracker) = self.source_trackers.get(source_node_name) else {
+            self.source_trackers.insert(
+                source_node_name.to_owned(),
+                WalletSourceTracker::new(wallet_keys, genesis_utxos)?,
+            );
+
+            return Ok(());
+        };
+
+        if source_tracker.covers_wallet_keys(wallet_keys) {
+            return Ok(());
+        }
+
+        self.source_trackers.insert(
+            source_node_name.to_owned(),
+            source_tracker.with_added_wallet_keys(wallet_keys, genesis_utxos)?,
+        );
+
+        Ok(())
     }
 
     fn advance_source_trackers(
@@ -452,6 +562,29 @@ impl WalletSourceTracker {
             .collect()
     }
 
+    fn with_added_wallet_keys(
+        &self,
+        wallet_keys: &[TrackedWalletKeys],
+        genesis_utxos: &[Utxo],
+    ) -> Result<Self, TrackedWalletKeysError> {
+        let merged_wallet_keys = self.merged_wallet_keys(wallet_keys);
+
+        let Some((applied_tip, applied_height)) = self.applied_position() else {
+            return Self::new(&merged_wallet_keys, genesis_utxos);
+        };
+
+        Self::from_wallet_utxos(
+            &merged_wallet_keys,
+            self.wallet_utxos(),
+            applied_tip,
+            applied_height,
+        )
+    }
+
+    fn applied_position(&self) -> Option<(HeaderId, u64)> {
+        Some((self.applied_tip?, self.applied_height?))
+    }
+
     fn advance_to_observed_tip(
         &mut self,
         wallets: &mut TrackedWallets,
@@ -482,6 +615,36 @@ impl WalletSourceTracker {
                 )
             })
             .collect())
+    }
+
+    fn start_at_observed_tip(
+        &mut self,
+        wallets: &mut TrackedWallets,
+        view: &WalletFeedChainView<'_>,
+        source_node_name: &str,
+    ) -> Result<(), WalletBlockFeedTrackerError> {
+        let tip_height = view.source_tip_height(source_node_name)?;
+        if tip_height == 0 {
+            return Err(WalletBlockFeedTrackerError::SourceAtGenesis {
+                source_node_name: source_node_name.to_owned(),
+            });
+        }
+
+        let tip_header = view.header_at_height(source_node_name, tip_height)?;
+        let tip_header_string = tip_header.to_string();
+
+        self.applied_tip = Some(tip_header);
+        self.applied_height = Some(tip_height);
+
+        wallets.record_header_height(source_node_name, &tip_header_string, tip_height);
+        wallets.record_observed_wallets_utxos(
+            tip_header_string,
+            self.chain_state
+                .wallet_utxos()
+                .map(|(wallet_id, utxos)| (wallet_id.clone(), utxos)),
+        );
+
+        Ok(())
     }
 
     fn next_unapplied_height(

--- a/tests/src/common/wallet/chain/feed.rs
+++ b/tests/src/common/wallet/chain/feed.rs
@@ -42,11 +42,6 @@ pub enum WalletBlockFeedTrackerError {
         source_node_name: String,
         height: u64,
     },
-    #[error(
-        "cannot start wallet tracking from observed tip for `{source_node_name}` before source \
-        has advanced past genesis"
-    )]
-    SourceAtGenesis { source_node_name: String },
     #[error(transparent)]
     TrackedKeys(#[from] TrackedWalletKeysError),
 }
@@ -248,42 +243,6 @@ impl WalletBlockFeedTracker {
         Ok(tracking)
     }
 
-    /// Start wallet tracking from the currently observed feed tip.
-    ///
-    /// This is for live-chain scenarios that intentionally begin tracking
-    /// before new wallet-relevant transactions are submitted. It does not
-    /// reconstruct historical wallet state.
-    pub fn track_wallets_from_observed_tip(
-        &mut self,
-        wallets: &mut TrackedWallets,
-        tracking_batches: &[WalletFeedTrackingBatch],
-        feed: &BlockFeed,
-        genesis_utxos: &[Utxo],
-    ) -> Result<(), WalletBlockFeedTrackerError> {
-        self.remember_block_bodies(&feed.history());
-
-        let Some(observation) = feed.latest_observation() else {
-            return Ok(());
-        };
-
-        for batch in tracking_batches {
-            self.prepare_tracking_batch_from_observed_tip(wallets, batch, genesis_utxos)?;
-        }
-
-        let view = WalletFeedChainView::new(observation, &self.block_bodies_by_header);
-
-        for batch in tracking_batches {
-            Self::start_prepared_tracking_batch_from_observed_tip(
-                wallets,
-                &mut self.source_trackers,
-                batch,
-                &view,
-            )?;
-        }
-
-        Ok(())
-    }
-
     /// Apply all newly observed canonical blocks from the feed.
     pub fn apply_feed(
         &mut self,
@@ -369,75 +328,6 @@ impl WalletBlockFeedTracker {
         );
 
         Ok(WalletSourceTracking::Ready)
-    }
-
-    fn prepare_tracking_batch_from_observed_tip(
-        &mut self,
-        wallets: &mut TrackedWallets,
-        batch: &WalletFeedTrackingBatch,
-        genesis_utxos: &[Utxo],
-    ) -> Result<(), WalletBlockFeedTrackerError> {
-        if batch.is_empty() {
-            return Ok(());
-        }
-
-        wallets.ensure_wallets_from_tracked_keys(batch.wallet_keys());
-        self.ensure_observed_tip_source_tracker(
-            batch.source_node_name(),
-            batch.wallet_keys(),
-            genesis_utxos,
-        )?;
-
-        Ok(())
-    }
-
-    fn start_prepared_tracking_batch_from_observed_tip(
-        wallets: &mut TrackedWallets,
-        source_trackers: &mut HashMap<String, WalletSourceTracker>,
-        batch: &WalletFeedTrackingBatch,
-        view: &WalletFeedChainView<'_>,
-    ) -> Result<(), WalletBlockFeedTrackerError> {
-        if batch.is_empty() {
-            return Ok(());
-        }
-
-        let source_tracker = source_trackers
-            .get_mut(batch.source_node_name())
-            .ok_or_else(|| WalletBlockFeedTrackerError::MissingSource {
-                source_node_name: batch.source_node_name().to_owned(),
-            })?;
-
-        source_tracker.start_at_observed_tip(wallets, view, batch.source_node_name())?;
-        wallets.replace_current_wallets_utxos(source_tracker.wallet_utxos());
-
-        Ok(())
-    }
-
-    fn ensure_observed_tip_source_tracker(
-        &mut self,
-        source_node_name: &str,
-        wallet_keys: &[TrackedWalletKeys],
-        genesis_utxos: &[Utxo],
-    ) -> Result<(), WalletBlockFeedTrackerError> {
-        let Some(source_tracker) = self.source_trackers.get(source_node_name) else {
-            self.source_trackers.insert(
-                source_node_name.to_owned(),
-                WalletSourceTracker::new(wallet_keys, genesis_utxos)?,
-            );
-
-            return Ok(());
-        };
-
-        if source_tracker.covers_wallet_keys(wallet_keys) {
-            return Ok(());
-        }
-
-        self.source_trackers.insert(
-            source_node_name.to_owned(),
-            source_tracker.with_added_wallet_keys(wallet_keys, genesis_utxos)?,
-        );
-
-        Ok(())
     }
 
     fn advance_source_trackers(
@@ -562,29 +452,6 @@ impl WalletSourceTracker {
             .collect()
     }
 
-    fn with_added_wallet_keys(
-        &self,
-        wallet_keys: &[TrackedWalletKeys],
-        genesis_utxos: &[Utxo],
-    ) -> Result<Self, TrackedWalletKeysError> {
-        let merged_wallet_keys = self.merged_wallet_keys(wallet_keys);
-
-        let Some((applied_tip, applied_height)) = self.applied_position() else {
-            return Self::new(&merged_wallet_keys, genesis_utxos);
-        };
-
-        Self::from_wallet_utxos(
-            &merged_wallet_keys,
-            self.wallet_utxos(),
-            applied_tip,
-            applied_height,
-        )
-    }
-
-    fn applied_position(&self) -> Option<(HeaderId, u64)> {
-        Some((self.applied_tip?, self.applied_height?))
-    }
-
     fn advance_to_observed_tip(
         &mut self,
         wallets: &mut TrackedWallets,
@@ -615,36 +482,6 @@ impl WalletSourceTracker {
                 )
             })
             .collect())
-    }
-
-    fn start_at_observed_tip(
-        &mut self,
-        wallets: &mut TrackedWallets,
-        view: &WalletFeedChainView<'_>,
-        source_node_name: &str,
-    ) -> Result<(), WalletBlockFeedTrackerError> {
-        let tip_height = view.source_tip_height(source_node_name)?;
-        if tip_height == 0 {
-            return Err(WalletBlockFeedTrackerError::SourceAtGenesis {
-                source_node_name: source_node_name.to_owned(),
-            });
-        }
-
-        let tip_header = view.header_at_height(source_node_name, tip_height)?;
-        let tip_header_string = tip_header.to_string();
-
-        self.applied_tip = Some(tip_header);
-        self.applied_height = Some(tip_height);
-
-        wallets.record_header_height(source_node_name, &tip_header_string, tip_height);
-        wallets.record_observed_wallets_utxos(
-            tip_header_string,
-            self.chain_state
-                .wallet_utxos()
-                .map(|(wallet_id, utxos)| (wallet_id.clone(), utxos)),
-        );
-
-        Ok(())
     }
 
     fn next_unapplied_height(

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -8,7 +8,7 @@ use std::{
 use cucumber::gherkin::Table;
 use futures::future::try_join_all;
 use hex::ToHex as _;
-use lb_chain_service::{ChainServiceMode, CryptarchiaInfo, State};
+use lb_chain_service::{ChainServiceInfo, ChainServiceMode, CryptarchiaInfo, State};
 use lb_core::mantle::{GenesisTx as _, Utxo, ops::OpId as _};
 use lb_http_api_common::paths::CRYPTARCHIA_INFO;
 use lb_libp2p::PeerId;
@@ -422,8 +422,9 @@ async fn fetch_public_peer_consensus(
         .send()
         .await?
         .error_for_status()?
-        .json::<CryptarchiaInfo>()
+        .json::<ChainServiceInfo>()
         .await
+        .map(|info| info.cryptarchia_info)
         .map_err(Into::into)
 }
 

--- a/tests/src/cucumber/steps/manual_transactions/faucet.rs
+++ b/tests/src/cucumber/steps/manual_transactions/faucet.rs
@@ -1,5 +1,6 @@
 use std::{num::NonZero, time::Duration};
 
+use lb_chain_service::ChainServiceInfo;
 use lb_http_api_common::paths::CRYPTARCHIA_INFO;
 use reqwest::Client;
 use tokio::{task::JoinHandle, time::sleep};
@@ -145,20 +146,9 @@ impl FaucetTask {
                         continue;
                     }
 
-                    match response.json::<serde_json::Value>().await {
+                    match response.json::<ChainServiceInfo>().await {
                         Ok(data) => {
-                            if let Some(height) =
-                                data.get("height").and_then(serde_json::Value::as_u64)
-                            {
-                                return Ok(height);
-                            }
-                            last_err = Some(
-                                format!(
-                                    "[check_block_height] Missing or invalid `height` in JSON \
-                                        from {url}",
-                                )
-                                .into(),
-                            );
+                            return Ok(data.cryptarchia_info.height);
                         }
                         Err(e) => {
                             last_err = Some(Box::new(e));

--- a/tests/src/cucumber/steps/manual_transactions/steps.rs
+++ b/tests/src/cucumber/steps/manual_transactions/steps.rs
@@ -31,10 +31,7 @@ use crate::{
             },
         },
         utils::resolve_literal_or_env,
-        wallet::{
-            best_node::get_best_node_info,
-            sync::start_current_wallet_feed_tracking_from_observed_tip,
-        },
+        wallet::best_node::get_best_node_info,
         world::{CucumberWorld, WalletInfo},
     },
     non_zero,
@@ -679,15 +676,7 @@ async fn step_request_faucet_funds_for_wallet(
 
     let wallet_pk_hex = wallet.public_key_hex();
 
-    start_current_wallet_feed_tracking_from_observed_tip(
-        world,
-        &step.value,
-        std::slice::from_ref(&wallet),
-    )
-    .await
-    .inspect_err(|error| {
-        warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-    })?;
+    track_wallets_before_faucet_request(world, step).await?;
 
     utils::request_faucet_funds(
         world,
@@ -704,17 +693,13 @@ async fn step_request_faucet_funds_for_all_wallets(
     step: &Step,
     number_of_rounds: usize,
 ) -> StepResult {
-    let wallets = world.wallet_info.values().cloned().collect::<Vec<_>>();
-    let all_wallets_pk_hex = wallets
-        .iter()
+    let all_wallets_pk_hex = world
+        .wallet_info
+        .values()
         .map(WalletInfo::public_key_hex)
         .collect::<Vec<_>>();
 
-    start_current_wallet_feed_tracking_from_observed_tip(world, &step.value, &wallets)
-        .await
-        .inspect_err(|error| {
-            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-        })?;
+    track_wallets_before_faucet_request(world, step).await?;
 
     utils::request_faucet_funds(
         world,
@@ -731,23 +716,14 @@ async fn step_request_faucet_funds_for_all_user_wallets(
     step: &Step,
     number_of_rounds: usize,
 ) -> StepResult {
-    let wallets = world
+    let all_wallets_pk_hex = world
         .wallet_info
         .values()
         .filter(|w| w.is_user_wallet())
-        .cloned()
-        .collect::<Vec<_>>();
-
-    let all_wallets_pk_hex = wallets
-        .iter()
         .map(WalletInfo::public_key_hex)
         .collect::<Vec<_>>();
 
-    start_current_wallet_feed_tracking_from_observed_tip(world, &step.value, &wallets)
-        .await
-        .inspect_err(|error| {
-            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-        })?;
+    track_wallets_before_faucet_request(world, step).await?;
 
     utils::request_faucet_funds(
         world,
@@ -764,23 +740,14 @@ async fn step_request_faucet_funds_for_all_funding_wallets(
     step: &Step,
     number_of_rounds: usize,
 ) -> StepResult {
-    let wallets = world
+    let all_wallets_pk_hex = world
         .wallet_info
         .values()
         .filter(|w| w.is_funding_wallet())
-        .cloned()
-        .collect::<Vec<_>>();
-
-    let all_wallets_pk_hex = wallets
-        .iter()
         .map(WalletInfo::public_key_hex)
         .collect::<Vec<_>>();
 
-    start_current_wallet_feed_tracking_from_observed_tip(world, &step.value, &wallets)
-        .await
-        .inspect_err(|error| {
-            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
-        })?;
+    track_wallets_before_faucet_request(world, step).await?;
 
     utils::request_faucet_funds(
         world,
@@ -788,4 +755,20 @@ async fn step_request_faucet_funds_for_all_funding_wallets(
         non_zero!("number of rounds", number_of_rounds)?,
         &all_wallets_pk_hex,
     )
+}
+
+async fn track_wallets_before_faucet_request(world: &mut CucumberWorld, step: &Step) -> StepResult {
+    world
+        .ensure_wallet_block_feed()
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
+
+    world
+        .track_known_wallets_with_block_feed()
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })
 }

--- a/tests/src/cucumber/steps/manual_transactions/steps.rs
+++ b/tests/src/cucumber/steps/manual_transactions/steps.rs
@@ -31,7 +31,10 @@ use crate::{
             },
         },
         utils::resolve_literal_or_env,
-        wallet::best_node::get_best_node_info,
+        wallet::{
+            best_node::get_best_node_info,
+            sync::start_current_wallet_feed_tracking_from_observed_tip,
+        },
         world::{CucumberWorld, WalletInfo},
     },
     non_zero,
@@ -664,28 +667,27 @@ fn step_faucet_details(
 
 #[given(expr = "I request {int} rounds of faucet funds for wallet {string}")]
 #[when(expr = "I request {int} rounds of faucet funds for wallet {string}")]
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "Required by cucumber expression"
-)]
-fn step_request_faucet_funds_for_wallet(
+async fn step_request_faucet_funds_for_wallet(
     world: &mut CucumberWorld,
     step: &Step,
     number_of_rounds: usize,
     wallet_name: String,
 ) -> StepResult {
-    let wallet_pk_hex = if let Ok(wallet) = world.resolve_wallet(&wallet_name) {
-        wallet.public_key_hex()
-    } else {
-        warn!(
-            target: TARGET,
-            "Step `{}` error: Wallet `{wallet_name}` not found.",
-            step.value
-        );
-        return Err(StepError::LogicalError {
-            message: format!("Wallet `{wallet_name}` not found"),
-        });
-    };
+    let wallet = world.resolve_wallet(&wallet_name).inspect_err(|error| {
+        warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+    })?;
+
+    let wallet_pk_hex = wallet.public_key_hex();
+
+    start_current_wallet_feed_tracking_from_observed_tip(
+        world,
+        &step.value,
+        std::slice::from_ref(&wallet),
+    )
+    .await
+    .inspect_err(|error| {
+        warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+    })?;
 
     utils::request_faucet_funds(
         world,
@@ -697,16 +699,22 @@ fn step_request_faucet_funds_for_wallet(
 
 #[given(expr = "I request {int} rounds of faucet funds for all wallets")]
 #[when(expr = "I request {int} rounds of faucet funds for all wallets")]
-fn step_request_faucet_funds_for_all_wallets(
+async fn step_request_faucet_funds_for_all_wallets(
     world: &mut CucumberWorld,
     step: &Step,
     number_of_rounds: usize,
 ) -> StepResult {
-    let all_wallets_pk_hex = world
-        .wallet_info
-        .values()
+    let wallets = world.wallet_info.values().cloned().collect::<Vec<_>>();
+    let all_wallets_pk_hex = wallets
+        .iter()
         .map(WalletInfo::public_key_hex)
         .collect::<Vec<_>>();
+
+    start_current_wallet_feed_tracking_from_observed_tip(world, &step.value, &wallets)
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
 
     utils::request_faucet_funds(
         world,
@@ -718,17 +726,28 @@ fn step_request_faucet_funds_for_all_wallets(
 
 #[given(expr = "I request {int} rounds of faucet funds for all user wallets")]
 #[when(expr = "I request {int} rounds of faucet funds for all user wallets")]
-fn step_request_faucet_funds_for_all_user_wallets(
+async fn step_request_faucet_funds_for_all_user_wallets(
     world: &mut CucumberWorld,
     step: &Step,
     number_of_rounds: usize,
 ) -> StepResult {
-    let all_wallets_pk_hex = world
+    let wallets = world
         .wallet_info
         .values()
         .filter(|w| w.is_user_wallet())
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let all_wallets_pk_hex = wallets
+        .iter()
         .map(WalletInfo::public_key_hex)
         .collect::<Vec<_>>();
+
+    start_current_wallet_feed_tracking_from_observed_tip(world, &step.value, &wallets)
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
 
     utils::request_faucet_funds(
         world,
@@ -740,17 +759,28 @@ fn step_request_faucet_funds_for_all_user_wallets(
 
 #[given(expr = "I request {int} rounds of faucet funds for all funding wallets")]
 #[when(expr = "I request {int} rounds of faucet funds for all funding wallets")]
-fn step_request_faucet_funds_for_all_funding_wallets(
+async fn step_request_faucet_funds_for_all_funding_wallets(
     world: &mut CucumberWorld,
     step: &Step,
     number_of_rounds: usize,
 ) -> StepResult {
-    let all_wallets_pk_hex = world
+    let wallets = world
         .wallet_info
         .values()
         .filter(|w| w.is_funding_wallet())
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let all_wallets_pk_hex = wallets
+        .iter()
         .map(WalletInfo::public_key_hex)
         .collect::<Vec<_>>();
+
+    start_current_wallet_feed_tracking_from_observed_tip(world, &step.value, &wallets)
+        .await
+        .inspect_err(|error| {
+            warn!(target: TARGET, "Step `{}` error: {error}", step.value);
+        })?;
 
     utils::request_faucet_funds(
         world,

--- a/tests/src/cucumber/wallet/sync.rs
+++ b/tests/src/cucumber/wallet/sync.rs
@@ -52,6 +52,34 @@ pub async fn current_available_utxos_for_user_wallets(
     .await
 }
 
+pub async fn start_current_wallet_feed_tracking_from_observed_tip(
+    world: &mut CucumberWorld,
+    step: &str,
+    wallets: &[WalletInfo],
+) -> Result<(), StepError> {
+    world.ensure_wallet_block_feed().await?;
+    let feed = world.wallet_block_feed()?;
+    let genesis_utxos = world.genesis_block_utxos.clone();
+    let feed_requirements = wallet_feed_source_requirements(world, wallets).await?;
+    let wallet_keys = build_tracked_wallet_keys(world, step, wallets)?;
+    let tracking_batches = wallet_feed_tracking_batches(world, &wallet_keys, &feed_requirements);
+
+    wait_for_wallet_feed_sources(world, &feed, feed_requirements).await?;
+
+    world
+        .with_wallet_feed_state_mut(|tracker, wallets| {
+            tracker.track_wallets_from_observed_tip(
+                wallets,
+                &tracking_batches,
+                &feed,
+                &genesis_utxos,
+            )
+        })?
+        .map_err(wallet_feed_error)?;
+
+    Ok(())
+}
+
 pub async fn current_available_utxos_for_funding_wallets(
     world: &mut CucumberWorld,
     step: &str,

--- a/tests/src/cucumber/wallet/sync.rs
+++ b/tests/src/cucumber/wallet/sync.rs
@@ -52,34 +52,6 @@ pub async fn current_available_utxos_for_user_wallets(
     .await
 }
 
-pub async fn start_current_wallet_feed_tracking_from_observed_tip(
-    world: &mut CucumberWorld,
-    step: &str,
-    wallets: &[WalletInfo],
-) -> Result<(), StepError> {
-    world.ensure_wallet_block_feed().await?;
-    let feed = world.wallet_block_feed()?;
-    let genesis_utxos = world.genesis_block_utxos.clone();
-    let feed_requirements = wallet_feed_source_requirements(world, wallets).await?;
-    let wallet_keys = build_tracked_wallet_keys(world, step, wallets)?;
-    let tracking_batches = wallet_feed_tracking_batches(world, &wallet_keys, &feed_requirements);
-
-    wait_for_wallet_feed_sources(world, &feed, feed_requirements).await?;
-
-    world
-        .with_wallet_feed_state_mut(|tracker, wallets| {
-            tracker.track_wallets_from_observed_tip(
-                wallets,
-                &tracking_batches,
-                &feed,
-                &genesis_utxos,
-            )
-        })?
-        .map_err(wallet_feed_error)?;
-
-    Ok(())
-}
-
 pub async fn current_available_utxos_for_funding_wallets(
     world: &mut CucumberWorld,
     step: &str,
@@ -248,7 +220,9 @@ async fn current_wallet_state_views(
     let started_at = Instant::now();
 
     loop {
-        let observations = current_wallet_state_views_from_feed(world, wallet_keys, &feed)?;
+        apply_latest_wallet_feed_state(world, &feed, &tracking_batches, &genesis_utxos).await?;
+
+        let observations = current_wallet_state_views_from_state(world, wallet_keys)?;
 
         if !wallet_states_waiting_for_reserved_outputs(&observations)
             || started_at.elapsed() >= CURRENT_WALLET_STATE_CATCH_UP_TIMEOUT
@@ -260,13 +234,10 @@ async fn current_wallet_state_views(
     }
 }
 
-fn current_wallet_state_views_from_feed(
+fn current_wallet_state_views_from_state(
     world: &CucumberWorld,
     wallet_keys: &TrackedWalletKeysBySource,
-    feed: &BlockFeed,
 ) -> Result<BTreeMap<WalletId, WalletStateView>, StepError> {
-    apply_latest_wallet_feed_state(world, feed)?;
-
     let mut observations = world.with_wallets(|wallets| {
         wallets.current_wallet_states(wallet_keys.wallet_keys().cloned())
     })?;
@@ -412,7 +383,11 @@ async fn wait_for_wallet_feed_sources(
         .map_or(0, |observation| observation.cycle());
 
     loop {
-        apply_latest_wallet_feed_state(world, feed)?;
+        if let Some(status) =
+            update_wallet_feed_state_status(world, feed, &world.genesis_block_utxos)?
+        {
+            debug!(target: TARGET, "{status}");
+        }
 
         if let Some(observation) = feed.latest_observation() {
             let pending_sources = pending_wallet_feed_sources(&observation, &requirements);
@@ -498,16 +473,21 @@ fn wallet_feed_timeout_message(feed: &BlockFeed, details: &str) -> String {
     )
 }
 
-fn apply_latest_wallet_feed_state(
+async fn apply_latest_wallet_feed_state(
     world: &CucumberWorld,
     feed: &BlockFeed,
+    tracking_batches: &[WalletFeedTrackingBatch],
+    genesis_utxos: &[Utxo],
 ) -> Result<(), StepError> {
-    if let Some(status) = update_wallet_feed_state_status(world, feed, &world.genesis_block_utxos)?
-    {
-        debug!(target: TARGET, "{status}");
-    }
+    match update_wallet_feed_state(world, feed, genesis_utxos)? {
+        Ok(()) => Ok(()),
+        Err(error) if error.requires_direct_backfill() => {
+            debug!(target: TARGET, "wallet feed state needs backfill: {error}");
 
-    Ok(())
+            backfill_wallet_feed_batches(world, tracking_batches, genesis_utxos).await
+        }
+        Err(error) => Err(wallet_feed_error(error)),
+    }
 }
 
 fn build_tracked_wallet_keys(


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes devnet manual-control wallet tracking when scenarios join an already running live devnet and request faucet funds during the test.

Wallet tracking now handles the live-devnet ordering more robustly: wallets can be registered before faucet funds are requested, and their state is populated as the local nodes catch up and observe the relevant blocks through the normal block-feed path.

Previously wallet tracking could start from the wrong point for a long-running devnet, which meant faucet outputs requested by the scenario were not reliably reflected in wallet state.

After this change, devnet scenarios no longer need manual balance-refresh commands. Wallet outputs are verified from the tracked block-feed-backed wallet state before manual transaction control starts.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal @hansieodendaal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
