### PR TITLE
refactor(sdp): rename `Declaration::withdrawn` to `withdraw_at`

### DIFF
--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -40,13 +40,13 @@ impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
         };
 
         // Check the declaration hasn't been withdrawn
-        // (Return error if `withdrawn` epoch has passed)
-        if let Some(withdrawn) = declaration.withdrawn
-            && withdrawn <= ctx.epoch
+        // (Return error if `scheduled_withdrawal_epoch` epoch has passed)
+        if let Some(withdraw_at) = declaration.withdraw_at
+            && withdraw_at <= ctx.epoch
         {
             return Err(SdpError::DeclarationWithdrawn {
                 declaration_id: self.declaration_id,
-                withdrawn_epoch: withdrawn,
+                withdraw_at,
             });
         }
 

--- a/core/src/mantle/ops/sdp/mod.rs
+++ b/core/src/mantle/ops/sdp/mod.rs
@@ -41,11 +41,11 @@ pub enum SdpError {
     #[error("Sdp declaration id not found: {0:?}")]
     DeclarationNotFound(DeclarationId),
     #[error(
-        "Sdp declaration has been already withdrawn: {declaration_id:?} at epoch {withdrawn_epoch:?}"
+        "Sdp declaration has been already scheduled to be withdrawn: {declaration_id:?} at epoch {withdraw_at:?}"
     )]
     DeclarationWithdrawn {
         declaration_id: DeclarationId,
-        withdrawn_epoch: Epoch,
+        withdraw_at: Epoch,
     },
     #[error(
         "Invalid sdp message nonce: message_nonce={message_nonce:?}, declaration_nonce={declaration_nonce:?}"

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -42,11 +42,11 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
         };
 
-        // Check that the declaration hasn't been withdrawn
-        if let Some(withdrawn) = declaration.withdrawn {
+        // Check that the declaration hasn't been already scheduled to be withdrawn.
+        if let Some(withdraw_at) = declaration.withdraw_at {
             return Err(SdpError::DeclarationWithdrawn {
                 declaration_id: self.declaration_id,
-                withdrawn_epoch: withdrawn,
+                withdraw_at,
             });
         }
 
@@ -110,13 +110,13 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
         // withdrawal because SDP uses the snapshot from `SNAPSHOT_FINALIZATION_DELAY`
         // epochs ago.
         // The note will be unlocked once the withdrawn epoch set here is reached.
-        declaration.withdrawn = Some(ctx.epoch.strict_add(sdp::SNAPSHOT_FINALIZATION_DELAY));
+        declaration.withdraw_at = Some(ctx.epoch.strict_add(sdp::SNAPSHOT_FINALIZATION_DELAY));
         declaration.nonce = self.nonce;
 
         debug!(
             target: LOG_TARGET,
             provider_id = ?declaration.provider_id,
-            withdrawn = ?declaration.withdrawn,
+            withdraw_at = ?declaration.withdraw_at,
             nonce = ?declaration.nonce,
             "updated declaration with withdraw message"
         );

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -368,8 +368,8 @@ pub struct Declaration {
     /// snapshot logic.
     // TODO: Use Option<Epoch> with a better name.
     pub active: Epoch,
-    /// The epoch at which the declaration must be withdrawn
-    pub withdrawn: Option<Epoch>,
+    /// The epoch at which the declaration is scheduled to be withdrawn.
+    pub withdraw_at: Option<Epoch>,
     pub nonce: Nonce,
 }
 
@@ -392,7 +392,7 @@ impl Declaration {
             zk_id: declaration_msg.zk_id,
             created: epoch,
             active: epoch.strict_add(SNAPSHOT_FINALIZATION_DELAY),
-            withdrawn: None,
+            withdraw_at: None,
             nonce: 0,
         }
     }
@@ -645,7 +645,7 @@ mod tests {
         assert_eq!(declaration.zk_id, msg.zk_id);
         assert_eq!(declaration.created, Epoch::new(10));
         assert_eq!(declaration.active, Epoch::new(12)); // created + SNAPSHOT_FINALIZATION_DELAY
-        assert_eq!(declaration.withdrawn, None);
+        assert_eq!(declaration.withdraw_at, None);
         assert_eq!(declaration.nonce, 0);
     }
 }

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -213,8 +213,8 @@ impl<R: Rewards> ServiceState<R> {
         epoch: Epoch,
     ) {
         self.declarations.iter().for_each(|(_, declaration)| {
-            if let Some(withdrawn) = declaration.withdrawn
-                && epoch >= withdrawn
+            if let Some(withdraw_at) = declaration.withdraw_at
+                && epoch >= withdraw_at
                 && locked_notes
                     .is_locked_for_service(&declaration.locked_note_id, &declaration.service_type)
             {
@@ -254,9 +254,9 @@ impl<R: Rewards> ServiceState<R> {
         current_epoch: Epoch,
         config: &ServiceParameters,
     ) -> bool {
-        let withdrawn = declaration
-            .withdrawn
-            .is_some_and(|withdrawn| withdrawn.strict_add(config.retention_period) < current_epoch);
+        let withdrawn = declaration.withdraw_at.is_some_and(|withdraw_at| {
+            withdraw_at.strict_add(config.retention_period) < current_epoch
+        });
         let inactive = declaration
             .active
             .strict_add(config.inactivity_period.into_inner())
@@ -288,8 +288,8 @@ fn is_active(declaration: &Declaration, current_epoch: Epoch, config: &ServicePa
         .strict_add(config.inactivity_period.into_inner())
         >= current_epoch
         && declaration
-            .withdrawn
-            .is_none_or(|withdrawn| withdrawn > current_epoch)
+            .withdraw_at
+            .is_none_or(|withdraw_at| withdraw_at > current_epoch)
 }
 
 /// A SDP state of the mantle ledger
@@ -950,12 +950,12 @@ mod tests {
         };
         let ledger =
             apply_withdraw_with_dummies(ledger, withdraw_op, utxo_sk, zk_key, &config).unwrap();
-        let withdrawn_epoch = ledger
+        let withdraw_at = ledger
             .get_declaration(&declaration_id)
             .unwrap()
-            .withdrawn
-            .expect("withdraw must set the withdrawn epoch");
-        assert_eq!(withdrawn_epoch, Epoch::new(3));
+            .withdraw_at
+            .expect("withdraw must set the withdraw_at");
+        assert_eq!(withdraw_at, Epoch::new(3));
 
         // The declaration is still in the live SDP ledger — cleanup runs only
         // when the ledger advances past `withdrawn_epoch`.
@@ -963,7 +963,7 @@ mod tests {
 
         // Snapshot at any epoch strictly less than `withdrawn_epoch` must
         // include the declaration.
-        for epoch in 0..withdrawn_epoch.into_inner() {
+        for epoch in 0..withdraw_at.into_inner() {
             assert!(
                 ledger
                     .active_declarations(epoch.into(), &config.service_params)
@@ -974,7 +974,7 @@ mod tests {
         }
 
         // Snapshot at `withdrawn_epoch` (and beyond) must exclude it.
-        for epoch in withdrawn_epoch.into_inner()..=withdrawn_epoch.into_inner() + 2 {
+        for epoch in withdraw_at.into_inner()..=withdraw_at.into_inner() + 2 {
             assert!(
                 ledger
                     .active_declarations(epoch.into(), &config.service_params)
@@ -1203,8 +1203,8 @@ mod tests {
 
         let withdrawn_epoch = sdp_ledger.get_declaration(&declaration_id)
             .expect("declaration must still exist even after withdrawal because GC shouldn't remove it immediately")
-            .withdrawn
-            .expect("withdraw epoch must be set after withdraw tx is accepted");
+            .withdraw_at
+            .expect("withdraw_at must be set after withdraw tx is accepted");
 
         // Move forward epochs until withdrawn_epoch is reached,
         // and check that the note has been unlocked.

--- a/ledger/src/mantle/sdp/rewards/test_utils.rs
+++ b/ledger/src/mantle/sdp/rewards/test_utils.rs
@@ -30,7 +30,7 @@ pub fn create_epoch_state(
                 zk_id: ZkPublicKey::new(BigUint::from(i as u64).into()),
                 created: 0.into(),
                 active: 2.into(),
-                withdrawn: None,
+                withdraw_at: None,
                 nonce: 0,
             };
             (DeclarationId([i as u8; 32]), declaration)

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -207,8 +207,8 @@ async fn sdp_ops_e2e() {
         .await
         .expect("API must succeed")
         .expect("declaration must still exist even after withdrawal because GC shouldn't remove it immediately")
-        .withdrawn
-        .expect("withdraw epoch must be set after withdraw tx is accepted");
+        .withdraw_at
+        .expect("withdraw_at must be set after withdraw tx is accepted");
 
     // Wait for the snapshot finalization delay and the retention period to pass.
     wait_for_tip_slot(


### PR DESCRIPTION
## 1. What does this PR implement?

The `Declaration` struct was having a field `withdrawn` as defined in the [spec](https://app.notion.com/p/nomos-tech/1-0-0-Service-Declaration-Protocol-33d261aa09df808f834bc728ae0c5e0f?source=copy_link#33d261aa09df80658da9ee2232b92692). But, it could be misleading. Declarations are not withdrawn immediately as soon as the withdraw message is accepted. Instead, they are scheduled to be withdrawn at the epoch `current + 2` (since [this RFC](https://app.notion.com/p/nomos-tech/RFC-Remove-Concept-of-a-Session-f39261aa09df826db83e81613bb454dc?source=copy_link#357261aa09df80d79dcbeccd5487b5a5) and PR #2855). This was also pointed out in https://github.com/logos-blockchain/logos-blockchain/pull/2943/changes#r3418331695.

So, this PR renames the `withdrawn` field to `withdraw_at`, which is much clearer, I think.
And I’ll also propose updating the RFC accordingly to Marcin.

The `Declaration` struct also has another field `active` which is also not so clear, I think. I will propose a new name in a separate PR. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

Yes, although it would be great to reflect this naming update in the spec as well.

## 5. Does the implementation introduce changes in the specification?

Yes, as mentioned above.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
