### PR TITLE
fix(config): give the SDP service its own recovery file (was colliding with mempool)

### DIFF
--- a/nodes/node/binary/src/config/sdp/mod.rs
+++ b/nodes/node/binary/src/config/sdp/mod.rs
@@ -15,7 +15,7 @@ impl ServiceConfig {
     pub fn into_sdp_service_settings(self, state_config: &StateConfig) -> SdpSettings {
         let recovery_path = state_config.get_path_for_recovery_state(
             PathBuf::new()
-                .join("mempool")
+                .join("sdp")
                 .join("recovery")
                 .with_extension("json")
                 .as_path(),

--- a/nodes/node/binary/src/config/tests.rs
+++ b/nodes/node/binary/src/config/tests.rs
@@ -19,7 +19,10 @@ use crate::{
         },
         mempool::ServiceConfig as MempoolServiceConfig,
         parse_log_filter_layer,
-        sdp::serde::{Config as SdpConfig, RequiredValues as SdpRequiredValues},
+        sdp::{
+            ServiceConfig as SdpServiceConfig,
+            serde::{Config as SdpConfig, RequiredValues as SdpRequiredValues},
+        },
         storage::{
             ServiceConfig as StorageServiceConfig,
             serde::{Config as StorageConfig, RocksDbSettings},
@@ -122,6 +125,22 @@ fn common_recovery_folder() {
         mempool_service_settings
             .recovery_path
             .starts_with(Path::new(STATE_PATH).join("recovery").join("mempool"))
+    );
+
+    // The SDP service must own its recovery file under `recovery/sdp`. If it
+    // shares a path with another service (e.g. the mempool), that service
+    // overwrites the persisted `declaration_id`, so a restarted blend core node
+    // loses its declaration and silently drops out of the blend network.
+    let sdp_service_settings = SdpServiceConfig {
+        user: user_config.sdp.clone(),
+    }
+    .into_sdp_service_settings(&user_config.state);
+    assert!(
+        sdp_service_settings
+            .recovery_path
+            .starts_with(Path::new(STATE_PATH).join("recovery").join("sdp")),
+        "SDP recovery path must live under recovery/sdp, but was {:?} (collides with another service's recovery file)",
+        sdp_service_settings.recovery_path
     );
 
     let storage_service_settings = StorageServiceConfig {


### PR DESCRIPTION
## Problem

The SDP service and the TX-mempool service write to the **same** recovery file: `recovery/mempool/recovery.json`.

`into_sdp_service_settings` builds its `recovery_path` with the `mempool` path component — copy-pasted from `into_mempool_service_settings`:

```rust
// config/sdp/mod.rs (before)
let recovery_path = state_config.get_path_for_recovery_state(
    PathBuf::new().join("mempool").join("recovery").with_extension("json").as_path(),
);
```

The mempool rewrites that file on every transaction, overwriting the `SdpState` the SDP service persists via `state_updater.update(SdpState::from(declaration_id))`. On restart, `SdpService::init` reads the file, fails to recover a valid `SdpState`, and falls back to `from_settings` → `declaration_id = settings.declaration_id`.

For a node whose declaration was created at **runtime** (blend `JoinAsCore` / `/blend/join`, where config `sdp.declaration_id` is `None`), that means `declaration_id` is lost on every restart:

- `handle_post_activity` logs `No declaration_id set. Cannot post activity without declaration.`
- the node stops submitting per-epoch SDP activity (active) messages,
- its blend declaration goes inactive and is pruned after `inactivity_period + retention_period` epochs,
- the node silently drops from blend **core → edge** (`/blend/info` `core_info: null`, blend UDP port unbound), while chain sync stays healthy.

Nodes whose `declaration_id` is provided via config (e.g. genesis providers) are unaffected, because `init` recovers it from settings — which is why the existing e2e/genesis tests never exposed this.

### Observed in the wild

On a devnet core node, after an OS reboot:

```
recovery/  ->  consensus/  blend/  wallet/  mempool/      # no sdp/
recovery/mempool/recovery.json  ->  {"pool":{"pending_items":[...]}}   # mempool state, no declaration_id
```

…followed by repeated `No declaration_id set` and eventual `Local node is not part of new membership. Retiring from core.`

## Fix

One line — give the SDP service its own `recovery/sdp/recovery.json`:

```rust
// config/sdp/mod.rs (after)
PathBuf::new().join("sdp").join("recovery").with_extension("json")
```

## Test

`config::tests::common_recovery_folder` already asserts the recovery path of every service (blend, consensus, wallet, mempool, storage) — **except SDP**. That gap is why the bug shipped. This PR adds the missing assertion (commit 1, fails before the fix) and applies the one-line fix (commit 2, makes it pass):

```
SDP recovery path must live under recovery/sdp, but was
"./state/recovery/mempool/recovery.json" (collides with another service's recovery file)
```

## Notes

- No migration logic: a node that already lost its `declaration_id` re-establishes it on its next `/blend/join`; after this fix the persisted id survives restarts.
- Persistence/recovery itself (`handle_post_declaration` → `state_updater.update`, `init` recovery, `Loaded declaration from ledger`) was already correct — only the file path was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)