### PR TITLE
fix: zone sdk stale last_msg_id bug

### DIFF
--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -830,12 +830,13 @@ where
         data: Inscription,
     ) -> Result<(MantleTx, MsgId, Ed25519Signature), Error> {
         self.ensure_ready()?;
+        let parent = self.compute_publish_parent();
         Ok(build_prepare_tx(
             ops,
             self.channel_id,
             &self.signing_key,
             data,
-            self.last_msg_id,
+            parent,
         ))
     }
 


### PR DESCRIPTION

## 1. What does this PR implement?

Fixed a Zone SDK stale-parent bug in prepare_tx.

- `ZoneSequencer::do_prepare_tx` previously used `self.last_msg_id` directly when building a parented channel inscription bundle. That diverged from the normal publish path, which uses `compute_publish_parent()` to derive
  the current safe parent from sequencer state.

- This could produce stale-parent transactions after checkpoint restore or after another command advanced the channel tip. In the manual TUI flow, a multi-signature withdraw prepared after a config update could be
  accepted locally but never land on-chain because the prepared bundle was still parented to an older message.

- The fix makes `prepare_tx` use the same parent-selection path as publish, so manually prepared transactions follow the current channel lineage instead of trusting checkpoint-derived `last_msg_id`.

- Normal interactive publish did not hit this because it already used `compute_publish_parent()`; the bug was isolated to SDK callers using the “prepare but don’t fully publish now” API path.

**Note:** This bug surfaced in #2938.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal @pradovic 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
