### PR TITLE
fix(wallet): track channel withdraw outputs

### DIFF
--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -93,6 +93,11 @@ pub enum EventPayload {
         voucher_nullifier: VoucherNullifier,
         utxo: Utxo,
     },
+    Withdraw {
+        channel_id: ChannelId,
+        amount: Value,
+        utxos: Vec<Utxo>,
+    },
 }
 
 impl TryFrom<Bytes> for Events {

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -461,6 +461,7 @@ mod tests {
             .execute(WithdrawExecutionContext {
                 channels,
                 utxos: utxo_tree,
+                tx_hash: [1; 32].into(),
             })
             .expect("execution should succeed");
 
@@ -468,7 +469,31 @@ mod tests {
             updated.channels.channel_state(&channel_id).unwrap().balance,
             4
         );
-        assert!(events.is_empty());
+        assert_eq!(events.len(), 1);
+        let Event::Tx {
+            tx_hash,
+            op_id,
+            payload,
+        } = events.iter().next().cloned().unwrap()
+        else {
+            panic!("expected Tx event")
+        };
+        assert_eq!(tx_hash, [1; 32].into());
+        assert_eq!(op_id, withdraw_op.op_id());
+        let EventPayload::Withdraw {
+            channel_id,
+            amount,
+            utxos,
+        } = payload
+        else {
+            panic!("expected Withdraw event")
+        };
+        assert_eq!(channel_id, withdraw_op.channel_id);
+        assert_eq!(amount, 6);
+        assert_eq!(
+            utxos,
+            withdraw_op.outputs.utxos(&withdraw_op).collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -492,6 +517,7 @@ mod tests {
         let result = withdraw_op.execute(WithdrawExecutionContext {
             channels,
             utxos: utxo_tree,
+            tx_hash: [0; 32].into(),
         });
 
         assert!(matches!(result, Err(Error::InsufficientFunds)));
@@ -517,6 +543,7 @@ mod tests {
         let result = withdraw_op.execute(WithdrawExecutionContext {
             channels,
             utxos: utxo_tree,
+            tx_hash: [0; 32].into(),
         });
 
         assert!(matches!(result, Err(Error::ChannelNotFound { .. })));

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -2,7 +2,7 @@ use nom::IResult;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    events::Events,
+    events::{Event, EventPayload, Events},
     mantle::{
         TxHash,
         channel::{Channels, Error},
@@ -64,6 +64,7 @@ pub struct WithdrawValidationContext<'a> {
 pub struct WithdrawExecutionContext {
     pub channels: Channels,
     pub utxos: Utxos,
+    pub tx_hash: TxHash,
 }
 
 impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
@@ -151,9 +152,21 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
             })
         }?;
 
-        // Add the ouputs to the ledger
+        // Add the outputs to the ledger
+        let output_utxos = self.outputs.utxos(self).collect::<Vec<_>>();
         ctx.utxos = self.outputs.execute(ctx.utxos, self);
 
-        Ok((ctx, Events::new()))
+        let events = Event::from_tx(
+            ctx.tx_hash,
+            self.op_id(),
+            EventPayload::Withdraw {
+                channel_id: self.channel_id,
+                amount: amount_withdraw,
+                utxos: output_utxos,
+            },
+        )
+        .into();
+
+        Ok((ctx, events))
     }
 }

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -153,9 +153,9 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
         }?;
 
         // Add the outputs to the ledger
-        let output_utxos = self.outputs.utxos(self).collect::<Vec<_>>();
         ctx.utxos = self.outputs.execute(ctx.utxos, self);
 
+        let output_utxos = self.outputs.utxos(self).collect::<Vec<_>>();
         let events = Event::from_tx(
             ctx.tx_hash,
             self.op_id(),

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -623,6 +623,7 @@ impl LedgerState {
                         .execute(WithdrawExecutionContext {
                             channels: channels.clone(),
                             utxos: utxos.clone(),
+                            tx_hash,
                         })
                         .map_err(mantle::Error::Channel)?;
                     self.mantle_ledger = self.mantle_ledger.update_channels(result.channels);
@@ -1237,7 +1238,28 @@ mod tests {
             .expect("withdraw should have at least one utxo")
             .id();
         assert!(new_state.latest_utxos().contains(&withdraw_utxo));
-        assert!(events.is_empty());
+        assert_eq!(events.len(), 1);
+        let Event::Tx {
+            tx_hash,
+            op_id,
+            payload,
+        } = events.iter().next().unwrap().clone()
+        else {
+            panic!("expected a Tx event")
+        };
+        assert_eq!(tx_hash, withdraw_tx_hash);
+        assert_eq!(op_id, withdraw.op_id());
+        let EventPayload::Withdraw {
+            channel_id,
+            amount,
+            utxos,
+        } = payload
+        else {
+            panic!("expected Withdraw event")
+        };
+        assert_eq!(channel_id, withdraw.channel_id);
+        assert_eq!(amount, withdraw_note.value);
+        assert_eq!(utxos, withdraw.outputs.utxos(&withdraw).collect::<Vec<_>>());
     }
 
     #[test]
@@ -1784,6 +1806,7 @@ mod tests {
                     reward_amount: leaders.reward_amount(),
                     claimable_rewards: leaders.claimable_rewards(),
                     utxos: Utxos::new(),
+                    tx_hash: TxHash::from([0u8; 32]),
                 })
                 .unwrap();
             leaders.update_nullifiers(result.nullifiers);
@@ -1822,6 +1845,7 @@ mod tests {
                 reward_amount: leaders.reward_amount(),
                 claimable_rewards: leaders.claimable_rewards(),
                 utxos: Utxos::new(),
+                tx_hash: TxHash::from([0u8; 32]),
             })
             .unwrap();
         leaders.update_nullifiers(result.nullifiers);

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -1,21 +1,29 @@
 use std::{num::NonZero, path::PathBuf, time::Duration};
 
 use futures::StreamExt as _;
+use lb_common_http_client::ProcessedBlockEvent;
 use lb_core::{
     events::{Event, EventPayload, Events},
     header::HeaderId,
     mantle::{
-        GenesisTx as _, NoteId, Transaction as _,
+        GenesisTx as _, MantleTx, Note, NoteId, OpProof, SignedMantleTx, Transaction as _, TxHash,
         gas::GasCost,
-        ledger::Inputs,
-        ops::channel::{ChannelId, deposit::DepositOp},
+        ledger::{Inputs, Outputs},
+        ops::{
+            Op,
+            channel::{
+                ChannelId, MsgId, deposit::DepositOp, inscribe::InscriptionOp,
+                withdraw::ChannelWithdrawOp,
+            },
+        },
     },
+    proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
 };
 use lb_http_api_common::bodies::{
     channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
     wallet::balance::WalletBalanceResponseBody,
 };
-use lb_key_management_system_service::keys::ZkPublicKey;
+use lb_key_management_system_service::keys::{Ed25519Key, ZkPublicKey};
 use lb_node::config::RunConfig;
 use lb_testing_framework::{
     DeploymentBuilder, NodeHttpClient, TopologyConfig as TfTopologyConfig,
@@ -187,6 +195,133 @@ async fn channel_deposit() {
     );
 }
 
+/// End-to-end test for the channel withdraw wallet path:
+///
+/// 1. Spawn validators that produce blocks.
+/// 2. Create a channel with a known signer.
+/// 3. Deposit funds into that channel.
+/// 4. Submit a signed channel withdraw transaction.
+/// 5. Verify the block containing the withdraw tx exposes a matching `Withdraw`
+///    event via the `/cryptarchia/blocks/:id/events` endpoint.
+/// 6. Verify the recipient wallet balance increases.
+/// 7. Verify the channel balance decreases.
+#[tokio::test]
+#[serial]
+async fn channel_withdraw_updates_wallet_balance() {
+    let deposit_amount = 5;
+    let withdraw_amount = 2;
+    let (wallet_config, funding_pk) = channel_deposit_wallet_config(deposit_amount, 100);
+    let (_base, nodes) = start_local_manual_cluster_with_layout(
+        "channel-withdraw-wallet-balance",
+        "mantle-channel",
+        DeploymentBuilder::new(
+            TfTopologyConfig::with_node_numbers(2)
+                .with_allow_multiple_genesis_tokens(true)
+                .with_test_context(Some("channel_withdraw_updates_wallet_balance".to_owned())),
+        )
+        .with_wallet_config(wallet_config),
+        2,
+        ManualNodeLayout::SelectNodeSeed(0),
+        |config| Ok::<_, DynError>(channel_test_config(config)),
+        Some(PathBuf::from(E2E_ARTIFACTS_DIR)),
+    )
+    .await;
+
+    let validator = &nodes[0];
+
+    wait_for_nodes_height(
+        nodes
+            .iter()
+            .map(|node| &node.client)
+            .collect::<Vec<_>>()
+            .as_slice(),
+        3,
+        Duration::from_mins(5),
+    )
+    .await;
+
+    let channel_id = ChannelId::from([42; 32]);
+    let channel_signing_key = Ed25519Key::from_bytes(&[7; 32]);
+    let signed_inscription_tx = signed_channel_inscription(channel_id, &channel_signing_key);
+
+    let mut block_stream = validator.client.blocks_stream().await.unwrap();
+    let inscription_tx_hash = signed_inscription_tx.hash();
+
+    validator
+        .client
+        .submit_transaction(&signed_inscription_tx)
+        .await
+        .expect("inscription transaction should be submitted");
+
+    wait_for_tx_inclusion(&mut block_stream, inscription_tx_hash, "inscription").await;
+
+    let (deposit_op, deposit_tx_hash) =
+        submit_channel_deposit(&validator.client, channel_id, funding_pk, deposit_amount).await;
+    wait_for_tx_inclusion(&mut block_stream, deposit_tx_hash, "deposit").await;
+
+    let balance_after_deposit =
+        wait_for_wallet_balance(&validator.client, funding_pk, 100, Duration::from_mins(2)).await;
+    let channel_balance_after_deposit = get_channel_balance(&validator.client, channel_id).await;
+    assert_eq!(
+        channel_balance_after_deposit, deposit_amount,
+        "channel balance should increase after deposit: after={channel_balance_after_deposit}, deposit_amount={deposit_amount}",
+    );
+
+    let withdraw = ChannelWithdrawOp {
+        channel_id,
+        outputs: Outputs::new([Note::new(withdraw_amount, funding_pk)]),
+        withdraw_nonce: 0,
+    };
+    let signed_withdraw_tx = signed_channel_withdraw(withdraw.clone(), &channel_signing_key);
+    let withdraw_tx_hash = signed_withdraw_tx.hash();
+
+    validator
+        .client
+        .submit_transaction(&signed_withdraw_tx)
+        .await
+        .expect("withdraw transaction should be submitted");
+
+    let withdraw_block_id =
+        wait_for_tx_inclusion(&mut block_stream, withdraw_tx_hash, "withdraw").await;
+
+    let events = fetch_block_events(&validator.client, withdraw_block_id).await;
+    let payload = find_tx_payload(&events, withdraw_tx_hash)
+        .expect("block events should include the withdraw tx");
+    let EventPayload::Withdraw {
+        channel_id,
+        amount,
+        utxos,
+    } = payload
+    else {
+        panic!("expected Withdraw event")
+    };
+    assert_eq!(channel_id, withdraw.channel_id);
+    assert_eq!(amount, withdraw_amount);
+    assert_eq!(utxos, withdraw.outputs.utxos(&withdraw).collect::<Vec<_>>());
+
+    let balance_after_withdraw = wait_for_wallet_balance(
+        &validator.client,
+        funding_pk,
+        balance_after_deposit + withdraw_amount,
+        Duration::from_mins(2),
+    )
+    .await;
+    assert_eq!(
+        balance_after_withdraw,
+        balance_after_deposit + withdraw_amount,
+        "wallet balance should increase after withdraw: before={balance_after_deposit}, after={balance_after_withdraw}, withdraw_amount={withdraw_amount}",
+    );
+
+    let channel_balance_after_withdraw = get_channel_balance(&validator.client, channel_id).await;
+    assert_eq!(
+        channel_balance_after_withdraw,
+        channel_balance_after_deposit - withdraw_amount,
+        "channel balance should decrease after withdraw: before={channel_balance_after_deposit}, after={channel_balance_after_withdraw}, withdraw_amount={withdraw_amount}",
+    );
+
+    assert_eq!(deposit_op.channel_id, withdraw.channel_id);
+}
+
 fn channel_deposit_wallet_config(
     deposit_note_amount: u64,
     fee_note_amount: u64,
@@ -212,6 +347,113 @@ fn channel_test_config(mut config: RunConfig) -> RunConfig {
     config.deployment.cryptarchia.slot_activation_coeff =
         NonNegativeRatio::new(1, 2.try_into().unwrap());
     config
+}
+
+async fn submit_channel_deposit(
+    node: &NodeHttpClient,
+    channel_id: ChannelId,
+    funding_pk: ZkPublicKey,
+    deposit_amount: u64,
+) -> (DepositOp, TxHash) {
+    let (note_id, selected_deposit_amount) =
+        get_wallet_note(node, funding_pk, deposit_amount).await;
+    assert_eq!(selected_deposit_amount, deposit_amount);
+    let deposit_op = DepositOp {
+        channel_id,
+        inputs: Inputs::new([note_id]),
+        metadata: format!("Mint {deposit_amount} to Alice in Zone")
+            .into_bytes()
+            .try_into()
+            .expect("Metadata too large for deposit op."),
+    };
+    let body = ChannelDepositRequestBody {
+        tip: None,
+        deposit: deposit_op.clone(),
+        change_public_key: funding_pk,
+        funding_public_keys: vec![funding_pk],
+        max_tx_fee: GasCost::new(10),
+    };
+    let response = reqwest::Client::new()
+        .post(api_url(node, "channel/deposit"))
+        .json(&body)
+        .send()
+        .await
+        .expect("request should not fail");
+
+    assert!(
+        response.status().is_success(),
+        "request should succeed, got status: {} body: {}",
+        response.status(),
+        response.text().await.unwrap_or_default(),
+    );
+
+    let deposit_tx_hash = response
+        .json::<ChannelDepositResponseBody>()
+        .await
+        .expect("deposit response should be valid JSON")
+        .hash;
+
+    (deposit_op, deposit_tx_hash)
+}
+
+fn signed_channel_inscription(channel_id: ChannelId, signing_key: &Ed25519Key) -> SignedMantleTx {
+    let inscription = InscriptionOp {
+        channel_id,
+        inscription: b"channel withdraw wallet balance test"
+            .to_vec()
+            .try_into()
+            .expect("inscription payload should fit"),
+        parent: MsgId::root(),
+        signer: signing_key.public_key(),
+    };
+    let mantle_tx = MantleTx([Op::ChannelInscribe(inscription)].into());
+    let tx_hash = mantle_tx.hash();
+    let inscription_proof =
+        OpProof::Ed25519Sig(signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref()));
+
+    SignedMantleTx::new(mantle_tx, vec![inscription_proof])
+        .expect("inscription transaction should be valid")
+}
+
+fn signed_channel_withdraw(
+    withdraw: ChannelWithdrawOp,
+    signing_key: &Ed25519Key,
+) -> SignedMantleTx {
+    let mantle_tx = MantleTx([Op::ChannelWithdraw(withdraw)].into());
+    let tx_hash = mantle_tx.hash();
+    let withdraw_proof = ChannelMultiSigProof::new(vec![IndexedSignature::new(
+        0,
+        signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref()),
+    )])
+    .expect("withdraw proof should be valid");
+
+    SignedMantleTx::new(
+        mantle_tx,
+        vec![OpProof::ChannelMultiSigProof(withdraw_proof)],
+    )
+    .expect("withdraw transaction should be valid")
+}
+
+async fn wait_for_tx_inclusion(
+    block_stream: &mut (impl futures::Stream<Item = ProcessedBlockEvent> + Unpin),
+    tx_hash: TxHash,
+    label: &str,
+) -> HeaderId {
+    timeout(Duration::from_mins(5), async {
+        while let Some(event) = block_stream.next().await {
+            if event
+                .block
+                .transactions
+                .iter()
+                .any(|tx| tx.hash() == tx_hash)
+            {
+                return event.block.header.id;
+            }
+        }
+        panic!("blocks stream ended before {label} tx was observed");
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for the {label} tx to be included in a block"))
 }
 
 async fn get_wallet_note(node: &NodeHttpClient, pk: ZkPublicKey, min_value: u64) -> (NoteId, u64) {
@@ -242,6 +484,27 @@ async fn get_wallet_note(node: &NodeHttpClient, pk: ZkPublicKey, min_value: u64)
         .expect("should find a note with sufficient balance for deposit")
 }
 
+async fn wait_for_wallet_balance(
+    node: &NodeHttpClient,
+    pk: ZkPublicKey,
+    expected: u64,
+    wait: Duration,
+) -> u64 {
+    let start = tokio::time::Instant::now();
+    let mut last_balance = get_wallet_balance(node, pk).await;
+
+    while start.elapsed() < wait {
+        if last_balance == expected {
+            return last_balance;
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        last_balance = get_wallet_balance(node, pk).await;
+    }
+
+    panic!("timed out waiting for wallet balance {expected}, last balance was {last_balance}");
+}
+
 async fn fetch_block_events(node: &NodeHttpClient, block_id: HeaderId) -> Events {
     let url = api_url(node, &format!("cryptarchia/blocks/{block_id}/events"));
     let response = reqwest::Client::new()
@@ -261,6 +524,15 @@ async fn fetch_block_events(node: &NodeHttpClient, block_id: HeaderId) -> Events
         .json::<Events>()
         .await
         .expect("block events response should be valid JSON")
+}
+
+fn find_tx_payload(events: &Events, expected_tx_hash: TxHash) -> Option<EventPayload> {
+    events.iter().find_map(|event| match event {
+        Event::Tx {
+            tx_hash, payload, ..
+        } => (tx_hash == &expected_tx_hash).then(|| payload.clone()),
+        Event::Ledger(_) => None,
+    })
 }
 
 async fn get_channel_balance(node: &NodeHttpClient, channel_id: ChannelId) -> u64 {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -257,11 +257,11 @@ impl WalletState {
             remove_spent_utxo(spent_id, &mut utxos, &mut pk_index);
         }
 
-        for utxo in &block.leader_reward_utxos {
-            insert_utxo_if_owned(*utxo, known_keys, &mut utxos, &mut pk_index);
-        }
-
-        for utxo in &block.channel_withdraw_utxos {
+        for utxo in block
+            .leader_reward_utxos
+            .iter()
+            .chain(&block.channel_withdraw_utxos)
+        {
             insert_utxo_if_owned(*utxo, known_keys, &mut utxos, &mut pk_index);
         }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -45,6 +45,7 @@ pub struct WalletBlock {
     pub voucher_cm: VoucherCm,
     pub spent_notes: Vec<NoteId>,
     pub leader_reward_utxos: Vec<Utxo>,
+    pub channel_withdraw_utxos: Vec<Utxo>,
     pub transfers: Vec<TransferOp>,
     pub locked_notes: HashSet<NoteId>,
     pub unlocked_notes: HashSet<NoteId>,
@@ -59,6 +60,7 @@ impl WalletBlock {
         // TODO: handle inputs/outputs of ALL operations: https://github.com/logos-blockchain/logos-blockchain/issues/2627
         let mut spent_notes = Vec::new();
         let mut leader_reward_utxos = Vec::new();
+        let mut channel_withdraw_utxos = Vec::new();
         let mut transfers = Vec::new();
         let mut locked_notes = HashSet::new();
         let mut unlocked_notes = HashSet::new();
@@ -85,6 +87,7 @@ impl WalletBlock {
         }
 
         leader_reward_utxos.extend(leader_reward_utxos_from_events(events));
+        channel_withdraw_utxos.extend(channel_withdraw_utxos_from_events(events));
 
         Self {
             id: block.header().id(),
@@ -93,6 +96,7 @@ impl WalletBlock {
             voucher_cm: *block.header().leader_proof().voucher_cm(),
             spent_notes,
             leader_reward_utxos,
+            channel_withdraw_utxos,
             transfers,
             locked_notes,
             unlocked_notes,
@@ -257,6 +261,10 @@ impl WalletState {
             insert_utxo_if_owned(*utxo, known_keys, &mut utxos, &mut pk_index);
         }
 
+        for utxo in &block.channel_withdraw_utxos {
+            insert_utxo_if_owned(*utxo, known_keys, &mut utxos, &mut pk_index);
+        }
+
         for transfer in &block.transfers {
             // Add new UTXOs (outputs) - only if they belong to our known keys
             for utxo in transfer.outputs.utxos(transfer) {
@@ -369,6 +377,19 @@ fn leader_reward_utxos_from_events(events: &Events) -> impl Iterator<Item = Utxo
         } => Some(*utxo),
         _ => None,
     })
+}
+
+fn channel_withdraw_utxos_from_events(events: &Events) -> impl Iterator<Item = Utxo> + '_ {
+    events
+        .iter()
+        .flat_map(|event| match event {
+            Event::Tx {
+                payload: EventPayload::Withdraw { utxos, .. },
+                ..
+            } => utxos.as_slice(),
+            _ => &[],
+        })
+        .copied()
 }
 
 fn remove_spent_utxo(
@@ -753,6 +774,7 @@ mod tests {
             voucher_cm: v1_cm,
             spent_notes: vec![],
             leader_reward_utxos: vec![],
+            channel_withdraw_utxos: vec![],
             transfers: vec![transfer1.clone()],
             locked_notes: HashSet::from([locked_note]),
             // Unknown unlocked note that will be ignored
@@ -776,6 +798,7 @@ mod tests {
             voucher_cm: v2_cm,
             spent_notes: vec![alice_100_nmo_utxo.id()],
             leader_reward_utxos: vec![],
+            channel_withdraw_utxos: vec![],
             transfers: vec![TransferOp {
                 inputs: Inputs::new([alice_100_nmo_utxo.id()]),
                 outputs: Outputs::new([Note::new(20, bob), Note::new(80, alice)]),
@@ -826,6 +849,7 @@ mod tests {
             voucher_cm: v3_cm,
             spent_notes: vec![alice_80_nmo_utxo.id()],
             leader_reward_utxos: vec![Utxo::new(tx_hash(9), 0, Note::new(38, alice))],
+            channel_withdraw_utxos: vec![],
             transfers: vec![],
             locked_notes: HashSet::new(),
             unlocked_notes: HashSet::new(),
@@ -879,6 +903,45 @@ mod tests {
         let utxos = leader_reward_utxos_from_events(&events).collect::<Vec<_>>();
 
         assert_eq!(utxos, vec![alice_utxo, bob_utxo]);
+    }
+
+    #[test]
+    fn test_channel_withdraw_outputs_update_balance() {
+        let alice = pk(1);
+        let bob = pk(2);
+        let genesis = HeaderId::from([0; 32]);
+        let ledger = LedgerState::from_utxos([], &ledger_config());
+        let (voucher_cm, _voucher_nf) = voucher(1, 0);
+        let alice_withdraw_utxo = Utxo::new(tx_hash(1), 0, Note::new(42, alice));
+        let bob_withdraw_utxo = Utxo::new(tx_hash(1), 1, Note::new(7, bob));
+
+        let mut wallet = Wallet::<_, TestVoucherId>::from_lib_ledger_state(
+            [(alice, 1)],
+            Vouchers::default(),
+            genesis,
+            &ledger,
+        );
+
+        let block = WalletBlock {
+            id: HeaderId::from([1; 32]),
+            parent: genesis,
+            epoch: 1.into(),
+            voucher_cm,
+            spent_notes: vec![],
+            leader_reward_utxos: vec![],
+            channel_withdraw_utxos: vec![alice_withdraw_utxo, bob_withdraw_utxo],
+            transfers: vec![],
+            locked_notes: HashSet::new(),
+            unlocked_notes: HashSet::new(),
+        };
+
+        wallet.apply_block(&block).unwrap();
+
+        assert_eq!(
+            wallet.balance(block.id, alice).unwrap().unwrap().balance,
+            42
+        );
+        assert_eq!(wallet.balance(block.id, bob).unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

This fixes wallet balance tracking after channel withdraws.

Withdraw outputs are now passed to the wallet through block events, using the same approach as leader reward claims instead of reconstructing them in wallet code. This fixes the stale balance shown in the UI after a withdraw.

Includes focused wallet coverage and an e2e check for the balance update.

Related [Discord](https://discord.com/channels/973324189794697286/1518016374897643710)

---

One possible follow-up is to keep moving wallet sync toward typed block events.

At the moment wallet balance tracking is a bit mixed: some data comes from parsing operations directly, while leader rewards and channel withdraws now come from events. It might be cleaner over time if each relevant operation event carried the wallet-visible data it already knows about, and then the matching wallet-side operation parsing could be removed.

For example:
- `Deposit` could include spent note IDs
- `Withdraw` already includes created UTXOs
- `Transfer` could include spent note IDs and created UTXOs
- `LeaderRewardClaimed` already includes the reward UTXO
- SDP events could include locked/unlocked note IDs


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
