### PR TITLE
refactor(ledger): remove dead code in leader claim

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -726,7 +726,7 @@ mod tests {
             MantleTx, Note, SignedMantleTx, Transaction as _, TxHash,
             encoding::Ops,
             gas::MainnetGasConstants,
-            ledger::{Inputs, Outputs},
+            ledger::{Inputs, Outputs, Utxos},
             ops::{
                 OpId as _,
                 channel::{
@@ -736,21 +736,29 @@ mod tests {
                     inscribe::InscriptionOp,
                     withdraw::ChannelWithdrawOp,
                 },
+                leader_claim::{LeaderClaimError, LeaderClaimOp},
                 sdp::SDPActiveOp,
                 transfer::TransferOp,
             },
         },
-        proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
+        proofs::{
+            channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
+            leader_claim_proof::Groth16LeaderClaimProof,
+        },
         sdp::{ActivityMetadata, DeclarationId, Nonce, blend::ActivityProof},
     };
     use lb_cryptarchia_engine::Epoch;
+    use lb_groth16::{CompressedGroth16Proof, Field as _};
     use lb_key_management_system_keys::keys::{Ed25519Key, Ed25519PublicKey, ZkKey, ZkPublicKey};
     use num_bigint::BigUint;
 
     use super::*;
-    use crate::cryptarchia::tests::{
-        apply_and_add_utxo, apply_and_add_utxo_and_declaration, declaration_in_snapshot, ledger,
-        update_ledger, utxo_with_sk,
+    use crate::{
+        cryptarchia::tests::{
+            apply_and_add_utxo, apply_and_add_utxo_and_declaration, declaration_in_snapshot,
+            ledger, update_ledger, utxo_with_sk,
+        },
+        mantle::leader::LeaderState,
     };
 
     fn create_test_keys() -> (Ed25519Key, Ed25519PublicKey) {
@@ -1733,5 +1741,99 @@ mod tests {
                 .get_pending_rewards()
         );
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_leader_claim_operation() {
+        let leaders = LeaderState::new();
+        // Add 3 vouchers (blocks) at epoch 1
+        let leaders = leaders.try_apply_header(1.into(), Fr::ZERO.into()).unwrap();
+        let leaders = leaders.try_apply_header(1.into(), Fr::ONE.into()).unwrap();
+        let leaders = leaders
+            .try_apply_header(1.into(), Fr::from(2u64).into())
+            .unwrap();
+        // Advance to epoch 2 by adding a voucher (block)
+        let mut leaders = leaders
+            .try_apply_header(2.into(), Fr::from(3u64).into())
+            .unwrap();
+        // Set rewards to 300 which can be distributed to the 3 vouchers
+        // collected so far (during epoch 1).
+        leaders.update_rewards(300);
+
+        // For each of the 3 vouchers, claim the reward.
+        for nf in [Fr::ZERO, Fr::ONE, Fr::from(2u64)] {
+            assert_eq!(leaders.reward_amount(), 100);
+            let op = LeaderClaimOp {
+                rewards_root: leaders.vouchers_snapshot_root(),
+                voucher_nullifier: nf.into(),
+                pk: ZkPublicKey::zero(),
+            };
+            // Skip `op.validate` in this test to avoid having to generate a valid proof
+            let (result, _events) = op
+                .execute(LeaderClaimExecutionContext {
+                    nullifiers: leaders.nullifiers_cloned(),
+                    reward_amount: leaders.reward_amount(),
+                    claimable_rewards: leaders.claimable_rewards(),
+                    utxos: Utxos::new(),
+                })
+                .unwrap();
+            leaders.update_nullifiers(result.nullifiers);
+            leaders.update_rewards(result.claimable_rewards);
+
+            assert_eq!(result.utxos.size(), 1);
+            let (_, (utxo, _)) = result.utxos.utxos().iter().next().unwrap();
+            assert_eq!(utxo.note.value, 100);
+        }
+
+        // All rewards have been claimed.
+        assert_eq!(leaders.claimable_rewards(), 0);
+    }
+
+    #[test]
+    fn test_duplicate_leader_claim_is_rejected() {
+        let leaders = LeaderState::new();
+        // Add a voucher (block) at epoch 1
+        let leaders = leaders.try_apply_header(1.into(), Fr::ZERO.into()).unwrap();
+        // Advance to epoch 2 by adding a voucher (block)
+        let mut leaders = leaders.try_apply_header(2.into(), Fr::ONE.into()).unwrap();
+        // Set rewards to 100 which can be distributed to the vouchers
+        // collected so far (during epoch 1).
+        leaders.update_rewards(100);
+
+        // Claim the reward for the 1st voucher.
+        let op = LeaderClaimOp {
+            rewards_root: leaders.vouchers_snapshot_root(),
+            voucher_nullifier: Fr::ZERO.into(), // nf of the 1st voucher
+            pk: ZkPublicKey::zero(),
+        };
+        // Skip `op.validate` in this test to avoid having to generate a valid proof
+        let (result, _events) = op
+            .execute(LeaderClaimExecutionContext {
+                nullifiers: leaders.nullifiers_cloned(),
+                reward_amount: leaders.reward_amount(),
+                claimable_rewards: leaders.claimable_rewards(),
+                utxos: Utxos::new(),
+            })
+            .unwrap();
+        leaders.update_nullifiers(result.nullifiers);
+        leaders.update_rewards(result.claimable_rewards);
+        assert_eq!(result.utxos.size(), 1);
+        let (_, (utxo, _)) = result.utxos.utxos().iter().next().unwrap();
+        assert_eq!(utxo.note.value, 100);
+
+        // Try to claim the reward using the same nullifier.
+        let err = op
+            .validate(&LeaderClaimValidationContext {
+                nullifiers: leaders.nullifiers(),
+                claimable_vouchers_root: &leaders.vouchers_snapshot_root(),
+                // Use a dummy proof since duplication is detected before proof verification
+                proof_of_claim: &Groth16LeaderClaimProof::new(
+                    CompressedGroth16Proof::from_bytes(&[0u8; 128]),
+                    Fr::ZERO.into(),
+                ),
+                tx_hash: &TxHash::from([0u8; 32]),
+            })
+            .unwrap_err();
+        assert_eq!(err, LeaderClaimError::DuplicatedVoucherNullifier);
     }
 }

--- a/ledger/src/mantle/leader.rs
+++ b/ledger/src/mantle/leader.rs
@@ -4,7 +4,7 @@ use lb_core::{
     crypto::ZkHasher,
     mantle::{
         Value,
-        ops::leader_claim::{LeaderClaimOp, RewardsRoot, VoucherCm, VoucherNullifier},
+        ops::leader_claim::{RewardsRoot, VoucherCm, VoucherNullifier},
     },
 };
 use lb_cryptarchia_engine::Epoch;
@@ -17,16 +17,16 @@ use serde::{Deserialize, Serialize};
 /// since we keep a copy of this state for each block.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeaderState {
-    /// current epoch
+    /// Current epoch
     epoch: Epoch,
     /// A snapshot of voucher commitments, updated once at each epoch start.
     vouchers_snapshot: VouchersSnapshot,
-    /// nullifiers of vouchers that have been claimed since genesis
+    /// Nullifiers of vouchers that have been claimed since genesis
     nfs: rpds::HashTrieSetSync<VoucherNullifier>,
-    /// rewards to be distributed
-    /// at the start of each epoch this is increased by the amount of rewards
+    /// Rewards to be distributed.
+    /// At the start of each epoch this is increased by the amount of rewards
     /// that have been collected in the previous epoch.
-    /// unclaimed rewards are carried over to the next epoch.
+    /// Unclaimed rewards are carried over to the next epoch.
     claimable_rewards: Value,
     /// Rewards that are being collected during the current epoch.
     /// This will be added to the `claimable_rewards` when a new epoch starts.
@@ -40,10 +40,10 @@ pub struct LeaderState {
 struct VouchersSnapshot {
     /// Root of voucher commitment tree
     root: RewardsRoot,
-    /// Number of voucher commitments in the tree
+    /// Number of voucher commitments in the tree.
     /// This includes voucher commitments that have been already claimed
-    /// because claiming is done by nullifier that is transparently coupled
-    /// with commitment.
+    /// because claims are done by nullifiers that is not transparently
+    /// linked to commitments.
     count: u64,
 }
 
@@ -181,88 +181,19 @@ impl LeaderState {
             .checked_div(n_unclaimed_vouchers)
             .unwrap_or(0)
     }
-
-    /// Claim the reward associated with a voucher.
-    /// Any cryptographic proof of correct derivation of the voucher nullifier
-    /// and membership proof in the merkle tree is expected to happen
-    /// outside of this function.
-    pub fn claim(&self, op: &LeaderClaimOp) -> Result<(Self, Value), Error> {
-        if self.nfs.contains(&op.voucher_nullifier) {
-            return Err(Error::DuplicatedVoucherNullifier);
-        }
-
-        if self.vouchers_snapshot_root() != op.rewards_root {
-            return Err(Error::VoucherNotFound);
-        }
-
-        let reward_amount = self.reward_amount();
-        let nfs = self.nfs.insert(op.voucher_nullifier);
-        let claimable_rewards = self.claimable_rewards - reward_amount;
-        Ok((
-            Self {
-                nfs,
-                claimable_rewards,
-                ..self.clone()
-            },
-            reward_amount,
-        ))
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use lb_groth16::{AdditiveGroup as _, Field as _, Fr};
-    use lb_key_management_system_keys::keys::ZkPublicKey;
 
     use super::*;
 
     impl LeaderState {
-        #[cfg(test)]
         #[must_use]
         pub fn get_pending_rewards(&self) -> Value {
             self.pending_rewards
         }
-    }
-
-    #[test]
-    fn test_reward_amounts() {
-        let state = LeaderState::new();
-        let state = state.try_apply_header(1.into(), Fr::ZERO.into()).unwrap();
-        let state = state.try_apply_header(1.into(), Fr::ONE.into()).unwrap();
-        let state = state
-            .try_apply_header(1.into(), Fr::from(2u64).into())
-            .unwrap();
-        let state = state
-            .try_apply_header(2.into(), Fr::from(3u64).into())
-            .unwrap();
-        let state = LeaderState {
-            claimable_rewards: 300,
-            ..state
-        };
-        let op1 = LeaderClaimOp {
-            rewards_root: state.vouchers_snapshot_root(),
-            voucher_nullifier: Fr::ZERO.into(),
-            pk: ZkPublicKey::zero(),
-        };
-        let (state, bal) = state.claim(&op1).unwrap();
-        assert_eq!(bal, 100);
-        assert_eq!(state.claimable_rewards, 200);
-        let op2 = LeaderClaimOp {
-            rewards_root: state.vouchers_snapshot_root(),
-            voucher_nullifier: Fr::ONE.into(),
-            pk: ZkPublicKey::zero(),
-        };
-        let (state, bal) = state.claim(&op2).unwrap();
-        assert_eq!(bal, 100);
-        assert_eq!(state.claimable_rewards, 100);
-        let op3 = LeaderClaimOp {
-            rewards_root: state.vouchers_snapshot_root(),
-            voucher_nullifier: Fr::from(2u64).into(),
-            pk: ZkPublicKey::zero(),
-        };
-        let (state, bal) = state.claim(&op3).unwrap();
-        assert_eq!(bal, 100);
-        assert_eq!(state.claimable_rewards, 0);
     }
 
     #[test]
@@ -300,19 +231,5 @@ mod tests {
             .unwrap();
         assert_eq!(state.epoch, 4);
         assert_eq!(state.vouchers_snapshot.count, 4);
-    }
-
-    #[test]
-    fn test_cannot_claim_reward_twice() {
-        let state = LeaderState::new();
-        let op = LeaderClaimOp {
-            voucher_nullifier: Fr::ZERO.into(),
-            rewards_root: state.vouchers_snapshot_root(),
-            pk: ZkPublicKey::zero(),
-        };
-        let (state, balance) = state.claim(&op).unwrap();
-        assert_eq!(balance, 0);
-        let err = state.claim(&op).unwrap_err();
-        assert_eq!(err, Error::DuplicatedVoucherNullifier);
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Since PR https://github.com/logos-blockchain/logos-blockchain/pull/2579 was merged, the `LeaderState` has had a dead function, `claim`. The actual validation/execution logic is implemented in [`LeaderClaimOp`](https://github.com/logos-blockchain/logos-blockchain/blob/c6dd2ac69609f45581131481fa541b8e1db27dba/core/src/mantle/ops/leader_claim.rs#L173). 

This PR removes the dead code and reorganize the tests.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
