### PR TITLE
fix(ledger): add missing leader claim tx hashes in tests

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1784,6 +1784,7 @@ mod tests {
                     reward_amount: leaders.reward_amount(),
                     claimable_rewards: leaders.claimable_rewards(),
                     utxos: Utxos::new(),
+                    tx_hash: TxHash::from([0u8; 32]),
                 })
                 .unwrap();
             leaders.update_nullifiers(result.nullifiers);
@@ -1822,6 +1823,7 @@ mod tests {
                 reward_amount: leaders.reward_amount(),
                 claimable_rewards: leaders.claimable_rewards(),
                 utxos: Utxos::new(),
+                tx_hash: TxHash::from([0u8; 32]),
             })
             .unwrap();
         leaders.update_nullifiers(result.nullifiers);


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes the current `master` clippy failure after #2978 was merged.

#2978 added `tx_hash` to `LeaderClaimExecutionContext`. Around the same time, #2998 added new ledger tests that also construct `LeaderClaimExecutionContext`.

Both PRs passed on their own, but after they were merged together on `master`, those new tests also needed to provide `tx_hash`.

This PR adds the missing test `tx_hash` values.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
