### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 to fix RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6803,9 +6803,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
Fixes the new `cargo-deny` advisory failure on `master`:

- **RUSTSEC-2026-0185** — Remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly. Fixed upstream in `0.11.15`.

Resolved with `cargo update -p quinn-proto` (0.11.14 → 0.11.15), a semver-compatible, lockfile-only bump.

## Verification
Full `cargo-deny check` with the same flags/config as CI (`code-check.yml`, cargo-deny 0.19.0) now passes clean:

```
advisories ok: 0 errors, 0 warnings, 16 notes
      bans ok: 0 errors
  licenses ok: 0 errors
   sources ok: 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)