### PR TITLE
fix(mantle): bind LeaderClaim voucher nullifier via the proof's public input

### DIFF
--- a/core/src/mantle/encoding.rs
+++ b/core/src/mantle/encoding.rs
@@ -157,11 +157,8 @@ fn decode_op_proof<'a>(input: &'a [u8], op: &Op) -> IResult<&'a [u8], OpProof> {
         }
 
         // ProofOfClaimProof = Groth16
-        Op::LeaderClaim(leader_claim_op) => map(decode_groth16, |proof| {
-            OpProof::PoC(Groth16LeaderClaimProof::new(
-                proof,
-                leader_claim_op.voucher_nullifier,
-            ))
+        Op::LeaderClaim(_) => map(decode_groth16, |proof| {
+            OpProof::PoC(Groth16LeaderClaimProof::new(proof))
         })
         .parse(input),
 
@@ -1253,18 +1250,14 @@ mod tests {
             pk: ZkPublicKey::from(BigUint::from(0u64)),
         };
 
-        let mantle_tx = MantleTx(Ops::new_unchecked(vec![Op::LeaderClaim(
-            leader_claim_op.clone(),
-        )]));
+        let mantle_tx = MantleTx(Ops::new_unchecked(vec![Op::LeaderClaim(leader_claim_op)]));
 
         let empty_gas_context =
             MantleTxGasContext::new(HashMap::new(), HashMap::new(), GasPrices::new(0, 0));
         let predicted_size = predict_signed_mantle_tx_size(&mantle_tx, &empty_gas_context);
 
-        let poc_proof = Groth16LeaderClaimProof::new(
-            CompressedGroth16Proof::from_bytes(&[0u8; 128]),
-            leader_claim_op.voucher_nullifier,
-        );
+        let poc_proof =
+            Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
 
         // Construct directly to skip proof verification (dummy proof won't verify)
         let signed_tx = SignedMantleTx {
@@ -1281,15 +1274,12 @@ mod tests {
         use crate::proofs::leader_claim_proof::Groth16LeaderClaimProof;
 
         let proof_bytes: [u8; 128] = core::array::from_fn(|i| i as u8);
-        let voucher_nf = VoucherNullifier::default();
-        let poc_proof = Groth16LeaderClaimProof::new(
-            CompressedGroth16Proof::from_bytes(&proof_bytes),
-            voucher_nf,
-        );
+        let poc_proof =
+            Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(&proof_bytes));
 
         let leader_claim_op = LeaderClaimOp {
             rewards_root: RewardsRoot::default(),
-            voucher_nullifier: voucher_nf,
+            voucher_nullifier: VoucherNullifier::default(),
             pk: ZkPublicKey::from(BigUint::from(0u64)),
         };
         let op = Op::LeaderClaim(leader_claim_op);
@@ -1303,7 +1293,6 @@ mod tests {
             decoded,
             OpProof::PoC(Groth16LeaderClaimProof::new(
                 CompressedGroth16Proof::from_bytes(&proof_bytes),
-                voucher_nf,
             ))
         );
     }

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -191,6 +191,7 @@ impl Operation<LeaderClaimValidationContext<'_>> for LeaderClaimOp {
 
         // Check the proof of claim
         if !ctx.proof_of_claim.verify(&LeaderClaimPublic {
+            voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: ctx.claimable_vouchers_root.0,
             mantle_tx_hash: ctx.tx_hash.to_fr(),
         }) {
@@ -247,7 +248,11 @@ mod tests {
         let voucher_root = RewardsRoot::from(mmr.frontier_root());
         let tx_hash = TxHash::from([11u8; 32]);
         let proof = Groth16LeaderClaimProof::prove(LeaderClaimPrivate::new(
-            LeaderClaimPublic::new(voucher_root.into(), tx_hash.to_fr()),
+            LeaderClaimPublic::new(
+                VoucherNullifier::from_secret(voucher_secret).into(),
+                voucher_root.into(),
+                tx_hash.to_fr(),
+            ),
             &voucher_path,
             voucher_secret,
         ))
@@ -315,5 +320,56 @@ mod tests {
         assert_eq!(*voucher_nullifier, op.voucher_nullifier);
         assert_eq!(*utxo, op.utxo(reward_amount));
         assert!(events.next().is_none());
+    }
+
+    /// Regression test for #2990 (reward double-claim).
+    ///
+    /// The op's `voucher_nullifier` is fed in as the proof's public input, so a
+    /// claim that supplies a nullifier other than the one the proof commits to
+    /// fails verification (`InvalidPoC`). This is what prevents re-claiming a
+    /// voucher under a different, unused nullifier to bypass the double-spend
+    /// set: the op's dedup key is bound to the proven voucher.
+    #[test]
+    fn validate_rejects_op_nullifier_not_matching_proof() {
+        let voucher_secret = VoucherSecret::from(Fr::from(7u64));
+        let voucher_cm = VoucherCm::from_secret(voucher_secret);
+        let (mmr, voucher_path) = MerkleMountainRange::<VoucherCm, ZkHasher>::new()
+            .push_with_paths(voucher_cm, &mut [])
+            .expect("MMR shouldn't be full");
+        let voucher_root = RewardsRoot::from(mmr.frontier_root());
+        let tx_hash = TxHash::from([11u8; 32]);
+        // Proof proves ownership of the voucher whose nullifier is
+        // `from_secret(voucher_secret)`.
+        let proof = Groth16LeaderClaimProof::prove(LeaderClaimPrivate::new(
+            LeaderClaimPublic::new(
+                VoucherNullifier::from_secret(voucher_secret).into(),
+                voucher_root.into(),
+                tx_hash.to_fr(),
+            ),
+            &voucher_path,
+            voucher_secret,
+        ))
+        .expect("proof generation should succeed");
+
+        // The claim supplies a DIFFERENT nullifier than the one the proof proves.
+        let bogus_nf = VoucherNullifier::from_secret(VoucherSecret::from(Fr::from(999u64)));
+        assert_ne!(bogus_nf, VoucherNullifier::from_secret(voucher_secret));
+        let op = LeaderClaimOp {
+            rewards_root: voucher_root,
+            voucher_nullifier: bogus_nf,
+            pk: ZkPublicKey::zero(),
+        };
+        let nullifiers = rpds::HashTrieSetSync::new_sync();
+        let ctx = LeaderClaimValidationContext {
+            nullifiers: &nullifiers,
+            claimable_vouchers_root: &voucher_root,
+            proof_of_claim: &proof,
+            tx_hash: &tx_hash,
+        };
+
+        // The proof is verified against `op.voucher_nullifier`, which does not
+        // match the proven voucher -> rejected. A voucher cannot be claimed under
+        // a substituted nullifier.
+        assert_eq!(op.validate(&ctx), Err(LeaderClaimError::InvalidPoC));
     }
 }

--- a/core/src/mantle/tx.rs
+++ b/core/src/mantle/tx.rs
@@ -436,6 +436,7 @@ impl SignedMantleTx {
                 }
                 (Op::LeaderClaim(leader_claim_op), OpProof::PoC(poc)) => {
                     let ok = poc.verify(&LeaderClaimPublic {
+                        voucher_nullifier: leader_claim_op.voucher_nullifier.into(),
                         voucher_root: leader_claim_op.rewards_root.into(),
                         mantle_tx_hash: tx_hash.to_fr(),
                     });

--- a/core/src/proofs/leader_claim_proof.rs
+++ b/core/src/proofs/leader_claim_proof.rs
@@ -5,10 +5,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
 
-use crate::{
-    mantle::ops::leader_claim::{VoucherNullifier, VoucherSecret},
-    proofs::merkle::mmr_path_to_witness,
-};
+use crate::{mantle::ops::leader_claim::VoucherSecret, proofs::merkle::mmr_path_to_witness};
 
 const LOG_TARGET: &str = proofs::LEADER_CLAIM;
 
@@ -16,7 +13,6 @@ const LOG_TARGET: &str = proofs::LEADER_CLAIM;
 pub struct Groth16LeaderClaimProof {
     #[serde(with = "proof_serde")]
     proof: lb_poc::PoCProof,
-    voucher_nf: VoucherNullifier,
 }
 
 #[derive(Debug, Error)]
@@ -28,19 +24,16 @@ pub enum Error {
 impl Groth16LeaderClaimProof {
     pub fn prove(witness: LeaderClaimPrivate) -> Result<Self, Error> {
         let start_t = std::time::Instant::now();
-        let (proof, voucher_nf) = Self::generate_proof(witness)?;
+        let proof = Self::generate_proof(witness)?;
         tracing::debug!(target: LOG_TARGET, "PoC groth16 prover time: {:.2?}", start_t.elapsed());
 
-        Ok(Self {
-            proof,
-            voucher_nf: voucher_nf.into(),
-        })
+        Ok(Self { proof })
     }
 
-    fn generate_proof(private: LeaderClaimPrivate) -> Result<(lb_poc::PoCProof, Fr), Error> {
-        let (proof, verif_inputs) =
+    fn generate_proof(private: LeaderClaimPrivate) -> Result<lb_poc::PoCProof, Error> {
+        let (proof, _verif_inputs) =
             lb_poc::prove(private.input.into()).map_err(Error::PoCProofFailed)?;
-        Ok((proof, verif_inputs.voucher_nullifier.into_inner()))
+        Ok(proof)
     }
 
     #[must_use]
@@ -49,16 +42,14 @@ impl Groth16LeaderClaimProof {
     }
 
     #[must_use]
-    pub const fn new(proof: lb_poc::PoCProof, voucher_nf: VoucherNullifier) -> Self {
-        Self { proof, voucher_nf }
+    pub const fn new(proof: lb_poc::PoCProof) -> Self {
+        Self { proof }
     }
 }
 
 pub trait LeaderClaimProof {
     /// Verify the proof against the public inputs.
     fn verify(&self, public_inputs: &LeaderClaimPublic) -> bool;
-
-    fn voucher_nf(&self) -> &VoucherNullifier;
 }
 
 impl LeaderClaimProof for Groth16LeaderClaimProof {
@@ -66,7 +57,7 @@ impl LeaderClaimProof for Groth16LeaderClaimProof {
         lb_poc::verify(
             &self.proof,
             &lb_poc::PoCVerifierInput::new(
-                (*self.voucher_nf()).into(),
+                public_inputs.voucher_nullifier,
                 public_inputs.voucher_root,
                 public_inputs.mantle_tx_hash,
             ),
@@ -76,14 +67,12 @@ impl LeaderClaimProof for Groth16LeaderClaimProof {
             false
         })
     }
-
-    fn voucher_nf(&self) -> &VoucherNullifier {
-        &self.voucher_nf
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeaderClaimPublic {
+    #[serde(with = "serde_fr")]
+    pub voucher_nullifier: Fr,
     #[serde(with = "serde_fr")]
     pub voucher_root: Fr,
     #[serde(with = "serde_fr")]
@@ -92,8 +81,9 @@ pub struct LeaderClaimPublic {
 
 impl LeaderClaimPublic {
     #[must_use]
-    pub const fn new(voucher_root: Fr, mantle_tx_hash: Fr) -> Self {
+    pub const fn new(voucher_nullifier: Fr, voucher_root: Fr, mantle_tx_hash: Fr) -> Self {
         Self {
+            voucher_nullifier,
             voucher_root,
             mantle_tx_hash,
         }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1838,10 +1838,9 @@ mod tests {
                 nullifiers: leaders.nullifiers(),
                 claimable_vouchers_root: &leaders.vouchers_snapshot_root(),
                 // Use a dummy proof since duplication is detected before proof verification
-                proof_of_claim: &Groth16LeaderClaimProof::new(
-                    CompressedGroth16Proof::from_bytes(&[0u8; 128]),
-                    Fr::ZERO.into(),
-                ),
+                proof_of_claim: &Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(
+                    &[0u8; 128],
+                )),
                 tx_hash: &TxHash::from([0u8; 32]),
             })
             .unwrap_err();

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -970,6 +970,7 @@ where
     ) -> Result<Groth16LeaderClaimProof, WalletServiceError> {
         Ok(Groth16LeaderClaimProof::prove(LeaderClaimPrivate::new(
             LeaderClaimPublic {
+                voucher_nullifier: VoucherNullifier::from_secret(voucher_secret).into(),
                 voucher_root: rewards_root.into(),
                 mantle_tx_hash: tx_hash.to_fr(),
             },


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes #2990 (**Critical** — reward-pool drain).

The bug: the Proof-of-Claim was verified against a `voucher_nf` **stored in `Groth16LeaderClaimProof`**, while the double-spend set was keyed on the `LeaderClaimOp`'s **separate** `voucher_nullifier` field — two copies of the same value, with nothing forcing them equal. The JSON path's derived `Deserialize` let them diverge: an attacker proves voucher `N` but dedups under an unused `M`, re-claiming the same voucher under fresh nullifiers and draining `claimable_rewards`. (See #2990 for the quantified exploit.)

**We fix the bug by making the bad state unrepresentable.** Instead of carrying the nullifier twice and checking the copies agree, we remove the duplicate: `Groth16LeaderClaimProof` becomes just `{ proof }`, and `op.voucher_nullifier` is fed in as the PoC verifier's public input (via `LeaderClaimPublic`). There is now exactly **one** nullifier — the one on the op — so "a proof whose nullifier differs from the op's" is no longer a representable state. The proof verifies only when `op.voucher_nullifier` is the value the circuit derived from the proven voucher, which is what binds the dedup key to the voucher. A forged/mismatched nullifier simply fails verification (`InvalidPoC`); the separate equality check (and its error variant) is gone because there is nothing left to keep in sync.

## 2. Does the code have enough context to be clearly understood?

- The binary wire already never carried the nullifier twice (`decode` reconstructed it from the op); this removes the redundant in-memory/JSON copy and unifies the two paths.
- Regression test `validate_rejects_op_nullifier_not_matching_proof`: a claim supplying a nullifier other than the proven voucher's fails verification. `validate_accepts_valid_proof_of_claim` still passes.
- Spec: [Proof of Leadership](https://lip.logos.co/blockchain/raw/cryptarchia-proof-of-leadership.html) / [Anonymous Leaders Reward](https://lip.logos.co/blockchain/raw/bedrock-anonymous-leaders-reward.html).

## 3. Who are the specification authors and who is accountable for this PR?

> PoL / anonymous-leaders-reward spec authors: please add as reviewers. Author accountable for resolution.

## 4. Is the specification accurate and complete?

Yes — one-nullifier-per-voucher dedup is implied by the spec; the implementation had decoupled the dedup key from the proof.

## 5. Does the implementation introduce changes in the specification?

No (it removes a redundant on-wire/in-memory field; the proof statement is unchanged).

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are in sync.
* [ ] 6. Link PR to a specific milestone.
* [x] 7. New/changed logs reviewed (none added).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

