### PR TITLE
fix(cryptarchia-sync): bound chainsync message length before allocating

### DIFF
--- a/consensus/cryptarchia-sync/src/libp2p/packing.rs
+++ b/consensus/cryptarchia-sync/src/libp2p/packing.rs
@@ -62,6 +62,15 @@ where
     R: AsyncReadExt + Unpin,
 {
     let data_length = read_data_length(reader).await?;
+    // Bound the peer-supplied length before allocating, otherwise a malicious
+    // peer can send a ~4 GiB length prefix and OOM the node. `MAX_MSG_LEN` is the
+    // same cap `pack_to_writer` enforces on the send side.
+    if data_length > MAX_MSG_LEN {
+        return Err(PackingError::MessageTooLarge {
+            max: MAX_MSG_LEN,
+            actual: data_length,
+        });
+    }
     let mut data = vec![0u8; data_length];
     reader.read_exact(&mut data).await?;
     Ok(Message::from_bytes(&data)?)


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes #2991 (**High** — remotely-triggerable OOM / DoS).

The chainsync wire decoder `unpack_from_reader` read a 4-byte little-endian length prefix from a peer and immediately did `vec![0u8; data_length]` with **no upper bound**. The `MAX_MSG_LEN` (16 MiB) constant existed but was only used in a `pack_to_writer` error message — never enforced on the read path. Any connected peer (server side via `Provider::process_request`, or a peer being synced from via `Downloader`) could send the prefix `0xFFFFFFFF` (~4 GiB) and OOM-kill the node.

This PR enforces `data_length <= MAX_MSG_LEN` before allocating, matching the cap already applied on the send side.

## 2. Does the code have enough context to be clearly understood?

- The gossipsub path is already bounded by `max_transmit_size(DATA_LIMIT = 16 MiB)`; only this custom chainsync framing lacked the bound. The fix reuses the existing `MAX_MSG_LEN` constant and `PackingError::MessageTooLarge`. Verified the crate compiles clean.
- No spec governs the wire framing; this is an implementation hardening of untrusted-input handling.

## 3. Who are the specification authors and who is accountable for this PR?

> Sync/networking owners: please add as reviewers. Author accountable for resolution.

## 4. Is the specification accurate and complete?

N/A — wire-framing/transport hardening, not spec-governed.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [x] 3. Context added (transport-level; no spec doc).
* [x] 4. Main contact(s) added
* [x] 5. Implementation and Specification in sync (N/A).
* [x] 6. Link PR to a specific milestone.
* [x] 7. New/changed logs reviewed (none added).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
