### PR TITLE
fix(ledger): hold storage price when storage market effective target is zero

### DIFF
--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -700,6 +700,13 @@ fn update_storage_market(
     let new_ema: Gas =
         (((total_storage_gas + previous_ema) / STORAGE_MARKET_EMA_DENOMINATOR) as Value).into();
     let new_ema_unsigned = u128::from(new_ema.into_inner());
+    // Hold the price while the effective target is zero (genesis / sustained
+    // zero usage). Without this guard `comparator <= 7*ema` is `0 <= 0` (true),
+    // wrongly taking the clamp-down branch and ratcheting the price down 12.5%
+    // every zero-usage epoch instead of holding it at P_STR(0).
+    if new_ema_unsigned == 0 {
+        return (storage_gas_price, new_ema);
+    }
     let comparator = STORAGE_MARKET_CLAMP_DENOMINATOR * total_storage_gas;
     let new_price = if comparator <= STORAGE_MARKET_CLAMP_DOWN_NUMERATOR * new_ema_unsigned {
         ((previous_price * STORAGE_MARKET_CLAMP_DOWN_NUMERATOR / STORAGE_MARKET_CLAMP_DENOMINATOR)
@@ -1133,6 +1140,28 @@ pub mod tests {
             .active_declarations
             .for_service(&ServiceType::BlendNetwork)
             .and_then(|m| m.get(declaration_id))
+    }
+
+    #[test]
+    fn storage_price_held_when_effective_target_is_zero() {
+        // Failure case for the missing guard: with zero usage and a zero EMA the
+        // effective target is 0, so the price must be HELD at P_STR(0). Without
+        // the `effective_target == 0` guard, `8*0 <= 7*0` takes the clamp-down
+        // branch and ratchets the price down 12.5% (1000 -> 875) every
+        // zero-usage epoch.
+        let price: GasPrice = 1000.into();
+        let (new_price, new_ema) = update_storage_market(price, 0.into(), 0.into());
+        assert_eq!(
+            new_price, price,
+            "price must hold while the effective target (EMA) is zero"
+        );
+        assert_eq!(new_ema, Gas::from(0));
+
+        // Sanity: once there is a real (non-zero) EMA, the price still adjusts —
+        // the guard only fires at a zero target. Zero usage against a non-zero
+        // EMA clamps down as before.
+        let (clamped, _) = update_storage_market(price, 0.into(), 800.into());
+        assert_eq!(clamped, GasPrice::from(875), "non-zero target still clamps");
     }
 
     #[test]


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes #2988 (**Medium** — storage fee-market behaviour divergence).

`update_storage_market` was missing the spec's `effective_target == 0` guard. With zero storage usage and a zero EMA, the clamp comparator `8*usage <= 7*ema` evaluates to `0 <= 0` (true), so it takes the clamp-**down** branch and ratchets the storage price down 12.5% every zero-usage epoch instead of holding it at `P_STR(0)`. Currently masked because the genesis storage price is 0, it becomes a live divergence once the genesis price is set to a non-zero (spec-governed) value or after a sustained low-usage period decays the EMA to 0.

This PR adds the guard: when the effective target (EMA) is zero, return the price unchanged — matching the storage-markets spec's `if effective_target == 0: return self.price`.

## 2. Does the code have enough context to be clearly understood?

- The rest of `update_storage_market` (EMA, clamp directions/comparators, constants) already matches the spec; only the zero-target guard was missing.
- ledger suite stays green (the path is currently masked by genesis price 0; the guard is correct for non-zero prices).
- Spec: [Storage Markets](https://lip.logos.co/blockchain/raw/storage-markets.html) (the `if effective_target == 0: return self.price` reference).

## 3. Who are the specification authors and who is accountable for this PR?

> Storage-market spec authors: please add as reviewers. Author accountable for resolution.

## 4. Is the specification accurate and complete?

Yes — the spec explicitly calls for this guard; the implementation omitted it.

## 5. Does the implementation introduce changes in the specification?

No.

## Checklist

* [x] 1. The PR title follows the Conventional Commits specification.
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are in sync.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New/changed logs reviewed (none added).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

