### PR TITLE
fix(mempool): preserve requested transaction order

### DIFF
--- a/services/tx-service/src/lib.rs
+++ b/services/tx-service/src/lib.rs
@@ -19,7 +19,8 @@ pub use tx::{service::TxMempoolService, settings::TxMempoolSettings};
 /// Response for `GetTransactionsByHashes` request
 #[derive(Debug, Clone)]
 pub struct TransactionsByHashesResponse<Item, Key> {
-    /// Transactions that were found in the mempool
+    /// Transactions that were found in the mempool, ordered like the requested
+    /// hashes.
     found: Vec<Item>,
     /// Hashes of transactions that were not found in the mempool
     not_found: BTreeSet<Key>,

--- a/services/tx-service/src/tx/service.rs
+++ b/services/tx-service/src/tx/service.rs
@@ -5,7 +5,7 @@ pub mod openapi {
 }
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Display},
     marker::PhantomData,
     pin::Pin,
@@ -453,28 +453,33 @@ where
         pool: &Pool,
         hashes: Vec<Pool::Key>,
     ) -> Result<TransactionsByHashesResponse<Pool::Item, Pool::Key>, MempoolError> {
-        let keys_set: BTreeSet<Pool::Key> = hashes.into_iter().collect();
+        let unique_hashes: BTreeSet<Pool::Key> = hashes.iter().cloned().collect();
 
-        let items_stream = pool
-            .get_items_by_keys(keys_set.iter().cloned())
-            .await
-            .map_err(|e| {
-                MempoolError::StorageError(format!("Failed to get items by keys: {e:?}"))
-            })?;
+        let items_stream = pool.get_items_by_keys(unique_hashes).await.map_err(|e| {
+            MempoolError::StorageError(format!("Failed to get items by keys: {e:?}"))
+        })?;
 
-        let found_transactions: Vec<Pool::Item> = items_stream.collect().await;
+        let mut fetched_by_hash = items_stream
+            .map(|tx| (Transaction::hash(&tx), tx))
+            .collect::<BTreeMap<_, _>>()
+            .await;
 
-        if found_transactions.len() == keys_set.len() {
-            return Ok(TransactionsByHashesResponse::new(
-                found_transactions,
-                BTreeSet::new(),
-            ));
+        let mut seen_hashes = BTreeSet::new();
+        let mut found_transactions = Vec::new();
+        let mut not_found_hashes = BTreeSet::new();
+
+        for hash in hashes {
+            if !seen_hashes.insert(hash.clone()) {
+                continue;
+            }
+
+            match fetched_by_hash.remove(&hash) {
+                Some(tx) => found_transactions.push(tx),
+                None => {
+                    not_found_hashes.insert(hash);
+                }
+            }
         }
-
-        let found_hashes: BTreeSet<Pool::Key> =
-            found_transactions.iter().map(Transaction::hash).collect();
-
-        let not_found_hashes: BTreeSet<Pool::Key> = &keys_set - &found_hashes;
 
         Ok(TransactionsByHashesResponse::new(
             found_transactions,

--- a/services/tx-service/tests/mock.rs
+++ b/services/tx-service/tests/mock.rs
@@ -162,6 +162,26 @@ async fn pending_txs(
         .await
 }
 
+async fn txs_by_hashes(
+    mempool_outbound: &OutboundRelay<<MockMempoolService as ServiceData>::Message>,
+    hashes: Vec<MockTxId>,
+) -> Vec<MockTransaction<MockMessage>> {
+    let (reply_channel, reply) = tokio::sync::oneshot::channel();
+    mempool_outbound
+        .send(MempoolMsg::GetTransactionsByHashes {
+            hashes,
+            reply_channel,
+        })
+        .await
+        .unwrap();
+
+    reply
+        .await
+        .expect("mempool should reply to tx lookup")
+        .expect("tx lookup should succeed")
+        .into_found()
+}
+
 #[derive(Clone, Default)]
 struct InMemoryStorageAdapter {
     items: Arc<Mutex<BTreeMap<MockTxId, MockTransaction<MockMessage>>>>,
@@ -441,6 +461,70 @@ fn local_submission_rejects_oversized_tx() {
                 .block_on(pending_txs(&mempool_outbound))
                 .is_empty()
         );
+
+        drop(app.runtime().handle().block_on(app.handle().shutdown()));
+        app.blocking_wait_finished();
+    });
+}
+
+#[test]
+fn get_transactions_by_hashes_preserves_request_order() {
+    let recovery_file_path = get_test_random_path();
+    run_with_recovery_teardown(&recovery_file_path, || {
+        let (settings, _temp_dir) = mock_pool_node_settings(&recovery_file_path, Vec::new());
+        let app = OverwatchRunner::<MockPoolNode>::run(settings, None)
+            .map_err(|e| eprintln!("Error encountered: {e}"))
+            .unwrap();
+
+        drop(
+            app.runtime()
+                .handle()
+                .block_on(app.handle().start_all_services()),
+        );
+
+        let mempool_outbound = app
+            .runtime()
+            .handle()
+            .block_on(async { app.handle().relay::<MockMempoolService>().await.unwrap() });
+
+        let first_tx = MockTransaction::new(MockMessage {
+            payload: "first".to_owned(),
+            content_topic: MOCK_TX_CONTENT_TOPIC,
+            version: 0,
+            timestamp: 1,
+        });
+
+        let second_tx = MockTransaction::new(MockMessage {
+            payload: "second".to_owned(),
+            content_topic: MOCK_TX_CONTENT_TOPIC,
+            version: 0,
+            timestamp: 2,
+        });
+
+        app.runtime()
+            .handle()
+            .block_on(add_tx(&mempool_outbound, first_tx.clone()))
+            .expect("first tx should be added");
+
+        app.runtime()
+            .handle()
+            .block_on(add_tx(&mempool_outbound, second_tx.clone()))
+            .expect("second tx should be added");
+
+        let requested_txs = if first_tx.id() < second_tx.id() {
+            vec![second_tx, first_tx]
+        } else {
+            vec![first_tx, second_tx]
+        };
+
+        let requested_hashes = requested_txs.iter().map(MockTransaction::id).collect();
+
+        let fetched_txs = app
+            .runtime()
+            .handle()
+            .block_on(txs_by_hashes(&mempool_outbound, requested_hashes));
+
+        assert_eq!(fetched_txs, requested_txs);
 
         drop(app.runtime().handle().block_on(app.handle().shutdown()));
         app.blocking_wait_finished();


### PR DESCRIPTION
## 1. What does this PR implement?

This PR fixes mempool transaction lookup by preserving the order requested by the caller.

This matters for block proposal reconstruction, where validators must rebuild the block using the same transaction order as the leader-provided transaction references. A focused tx-service test was added to cover this contract.

Closes #2989

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
