### PR TITLE
feat(c-bindings): Pack txid with txs on c block subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "logos-blockchain-wallet-service",
  "multiaddr",
  "overwatch",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -22,6 +22,7 @@ lb-utils                      = { workspace = true }
 lb-wallet-service             = { workspace = true }
 multiaddr                     = { workspace = true }
 overwatch                     = { workspace = true }
+serde                         = { features = ["derive"], workspace = true }
 serde_json                    = { workspace = true }
 tempfile                      = { workspace = true }
 tokio                         = { features = ["rt-multi-thread"], workspace = true }

--- a/c-bindings/src/api/subscriptions.rs
+++ b/c-bindings/src/api/subscriptions.rs
@@ -2,11 +2,15 @@ use std::ffi::c_char;
 
 use lb_api_service::http::storage::StorageAdapter as _;
 use lb_chain_service::api::CryptarchiaServiceApi;
-use lb_core::block::Block as CoreBlock;
+use lb_core::{
+    block::Block as CoreBlock,
+    mantle::{StorageSize, Transaction, TransactionHasher, TxHash},
+};
 use lb_node::{
     ApiStorageAdapter, RuntimeServiceId, SignedMantleTx, StorageService,
     generic_services::CryptarchiaService,
 };
+use serde::Serialize;
 
 use crate::{
     LogosBlockchainNode, OperationStatus,
@@ -14,6 +18,29 @@ use crate::{
     callbacks::{BoxedCallback, CCallback, into_boxed_callback},
     logging, return_error_if_null_pointer,
 };
+
+#[derive(Serialize)]
+#[serde(rename = "SignedMantleTx")]
+pub struct TxWithId {
+    id: TxHash,
+    #[serde(flatten)]
+    tx: SignedMantleTx,
+}
+
+impl Transaction for TxWithId {
+    const HASHER: TransactionHasher<Self> = |tx| <SignedMantleTx as Transaction>::HASHER(&tx.tx);
+    type Hash = <SignedMantleTx as Transaction>::Hash;
+
+    fn as_signing(&self) -> Vec<u8> {
+        self.tx.as_signing()
+    }
+}
+
+impl StorageSize for TxWithId {
+    fn storage_size(&self) -> usize {
+        self.tx.storage_size()
+    }
+}
 
 pub fn subscribe_to_new_blocks_sync(
     node: &LogosBlockchainNode,
@@ -52,6 +79,19 @@ pub fn subscribe_to_new_blocks_sync(
                             ApiStorageAdapter::<RuntimeServiceId>::get_block(relay, event.block_id)
                                 .await;
                         if let Ok(Some(block)) = res {
+                            let txs_with_id: Vec<TxWithId> = block
+                                .transactions()
+                                .map(|tx| TxWithId {
+                                    id: tx.hash(),
+                                    tx: tx.clone(),
+                                })
+                                .collect();
+                            let block: CoreBlock<TxWithId> = CoreBlock::reconstruct(
+                                block.header().clone(),
+                                txs_with_id,
+                                *block.signature(),
+                            )
+                            .expect("Block should always build from valid block");
                             callback_per_block(Block::from(block).as_ptr());
                         } else {
                             logging::error!(

--- a/c-bindings/src/api/types/block.rs
+++ b/c-bindings/src/api/types/block.rs
@@ -1,6 +1,8 @@
 use std::ffi::{CString, c_char};
 
-use lb_core::{block::Block as CoreBlock, mantle::SignedMantleTx};
+use lb_core::block::Block as CoreBlock;
+
+use crate::api::subscriptions::TxWithId;
 
 #[repr(C)]
 pub struct Block(CString); // JSON representation of a block
@@ -11,8 +13,8 @@ impl Block {
     }
 }
 
-impl From<CoreBlock<SignedMantleTx>> for Block {
-    fn from(value: CoreBlock<SignedMantleTx>) -> Self {
+impl From<CoreBlock<TxWithId>> for Block {
+    fn from(value: CoreBlock<TxWithId>) -> Self {
         Self(
             CString::new(
                 serde_json::to_string(&value)


### PR DESCRIPTION
## 1. What does this PR implement?

Serialize txs ids (hash) on block subscriptions in the bindings. This avoids having to recompute the hash on the consumer side.

## 2. Does the code have enough context to be clearly understood?

Small change that doesn't affect outside of the bindings

## 3. Who are the specification authors and who is accountable for this PR?

@danielSanchezQ @strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
