### PR TITLE
refactor(core): drop `EventPayload::Withdraw` identical to `ChannelWithdraw` op

### DIFF
--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -93,11 +93,6 @@ pub enum EventPayload {
         voucher_nullifier: VoucherNullifier,
         utxo: Utxo,
     },
-    Withdraw {
-        channel_id: ChannelId,
-        amount: Value,
-        utxos: Vec<Utxo>,
-    },
 }
 
 impl TryFrom<Bytes> for Events {

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -469,31 +469,7 @@ mod tests {
             updated.channels.channel_state(&channel_id).unwrap().balance,
             4
         );
-        assert_eq!(events.len(), 1);
-        let Event::Tx {
-            tx_hash,
-            op_id,
-            payload,
-        } = events.iter().next().cloned().unwrap()
-        else {
-            panic!("expected Tx event")
-        };
-        assert_eq!(tx_hash, [1; 32].into());
-        assert_eq!(op_id, withdraw_op.op_id());
-        let EventPayload::Withdraw {
-            channel_id,
-            amount,
-            utxos,
-        } = payload
-        else {
-            panic!("expected Withdraw event")
-        };
-        assert_eq!(channel_id, withdraw_op.channel_id);
-        assert_eq!(amount, 6);
-        assert_eq!(
-            utxos,
-            withdraw_op.outputs.utxos(&withdraw_op).collect::<Vec<_>>()
-        );
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -2,7 +2,7 @@ use nom::IResult;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    events::{Event, EventPayload, Events},
+    events::Events,
     mantle::{
         TxHash,
         channel::{Channels, Error},
@@ -155,18 +155,6 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
         // Add the outputs to the ledger
         ctx.utxos = self.outputs.execute(ctx.utxos, self);
 
-        let output_utxos = self.outputs.utxos(self).collect::<Vec<_>>();
-        let events = Event::from_tx(
-            ctx.tx_hash,
-            self.op_id(),
-            EventPayload::Withdraw {
-                channel_id: self.channel_id,
-                amount: amount_withdraw,
-                utxos: output_utxos,
-            },
-        )
-        .into();
-
-        Ok((ctx, events))
+        Ok((ctx, Events::new()))
     }
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1238,28 +1238,7 @@ mod tests {
             .expect("withdraw should have at least one utxo")
             .id();
         assert!(new_state.latest_utxos().contains(&withdraw_utxo));
-        assert_eq!(events.len(), 1);
-        let Event::Tx {
-            tx_hash,
-            op_id,
-            payload,
-        } = events.iter().next().unwrap().clone()
-        else {
-            panic!("expected a Tx event")
-        };
-        assert_eq!(tx_hash, withdraw_tx_hash);
-        assert_eq!(op_id, withdraw.op_id());
-        let EventPayload::Withdraw {
-            channel_id,
-            amount,
-            utxos,
-        } = payload
-        else {
-            panic!("expected Withdraw event")
-        };
-        assert_eq!(channel_id, withdraw.channel_id);
-        assert_eq!(amount, withdraw_note.value);
-        assert_eq!(utxos, withdraw.outputs.utxos(&withdraw).collect::<Vec<_>>());
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -201,10 +201,8 @@ async fn channel_deposit() {
 /// 2. Create a channel with a known signer.
 /// 3. Deposit funds into that channel.
 /// 4. Submit a signed channel withdraw transaction.
-/// 5. Verify the block containing the withdraw tx exposes a matching `Withdraw`
-///    event via the `/cryptarchia/blocks/:id/events` endpoint.
-/// 6. Verify the recipient wallet balance increases.
-/// 7. Verify the channel balance decreases.
+/// 5. Verify the recipient wallet balance increases.
+/// 6. Verify the channel balance decreases.
 #[tokio::test]
 #[serial]
 async fn channel_withdraw_updates_wallet_balance() {
@@ -281,23 +279,7 @@ async fn channel_withdraw_updates_wallet_balance() {
         .await
         .expect("withdraw transaction should be submitted");
 
-    let withdraw_block_id =
-        wait_for_tx_inclusion(&mut block_stream, withdraw_tx_hash, "withdraw").await;
-
-    let events = fetch_block_events(&validator.client, withdraw_block_id).await;
-    let payload = find_tx_payload(&events, withdraw_tx_hash)
-        .expect("block events should include the withdraw tx");
-    let EventPayload::Withdraw {
-        channel_id,
-        amount,
-        utxos,
-    } = payload
-    else {
-        panic!("expected Withdraw event")
-    };
-    assert_eq!(channel_id, withdraw.channel_id);
-    assert_eq!(amount, withdraw_amount);
-    assert_eq!(utxos, withdraw.outputs.utxos(&withdraw).collect::<Vec<_>>());
+    wait_for_tx_inclusion(&mut block_stream, withdraw_tx_hash, "withdraw").await;
 
     let balance_after_withdraw = wait_for_wallet_balance(
         &validator.client,
@@ -524,15 +506,6 @@ async fn fetch_block_events(node: &NodeHttpClient, block_id: HeaderId) -> Events
         .json::<Events>()
         .await
         .expect("block events response should be valid JSON")
-}
-
-fn find_tx_payload(events: &Events, expected_tx_hash: TxHash) -> Option<EventPayload> {
-    events.iter().find_map(|event| match event {
-        Event::Tx {
-            tx_hash, payload, ..
-        } => (tx_hash == &expected_tx_hash).then(|| payload.clone()),
-        Event::Ledger(_) => None,
-    })
 }
 
 async fn get_channel_balance(node: &NodeHttpClient, channel_id: ChannelId) -> u64 {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -441,12 +441,13 @@ fn transform_op(op: &Op, event: Option<EventPayload>) -> Option<WalletOp> {
         Op::SDPWithdraw(withdrawal) => Some(WalletOp::Unlock(withdrawal.locked_note_id)),
         Op::LeaderClaim(_) => match event.expect("event for LeaderClaim op must exist") {
             EventPayload::LeaderRewardClaimed { utxo, .. } => Some(WalletOp::LeaderClaim(utxo)),
-            _ => None,
+            EventPayload::Deposit { .. } => {
+                panic!("event for LeaderClaim op must be LeaderRewardClaimed")
+            }
         },
-        Op::ChannelWithdraw(_) => match event.expect("event for ChannelWithdraw op must exist") {
-            EventPayload::Withdraw { utxos, .. } => Some(WalletOp::ChannelWithdraw(utxos)),
-            _ => None,
-        },
+        Op::ChannelWithdraw(withdraw) => Some(WalletOp::ChannelWithdraw(
+            withdraw.outputs.utxos(withdraw).collect(),
+        )),
         Op::ChannelInscribe(_) | Op::ChannelConfig(_) | Op::SDPActive(_) => None,
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

(Stacked on PR #3000)

Since PR https://github.com/logos-blockchain/logos-blockchain/pull/2997 was merged, we've been emitting/persisting a `Withdraw` event per `ChannelWithdraw` operation. But, we don't actually need the event because it is 100% identical to `ChannelWithdraw` operation. The `ChannelWithdraw` operation already contains all useful information for users and the wallet. 

This PR removes the redundant `Withdraw` event and simplify the wallet tracking the `ChannelWithdraw` operation.


## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
