### PR TITLE
chore: remove unnecessary serde machinery

### DIFF
--- a/core/src/mantle/encoding.rs
+++ b/core/src/mantle/encoding.rs
@@ -227,7 +227,7 @@ fn decode_channel_multi_sig_proof(input: &[u8]) -> IResult<&[u8], ChannelMultiSi
         .map(|(signature, index)| IndexedSignature::from((index, signature)))
         .collect();
 
-    ChannelMultiSigProof::new(signatures)
+    ChannelMultiSigProof::try_from(signatures)
         .map(|proof| (input, proof))
         .map_err(|_| nom::Err::Failure(Error::new(input, ErrorKind::Verify)))
 }
@@ -708,7 +708,7 @@ mod tests {
 
         // ChannelConfig creates the channel just-in-time, so no signatures are
         // required for validation — empty proof is well-formed.
-        let config_proof = ChannelMultiSigProof::new(vec![]).unwrap();
+        let config_proof = ChannelMultiSigProof::try_from(vec![]).unwrap();
 
         // Encode and decode roundtrip test (no hardcoded test vector since signatures
         // are deterministic)
@@ -922,7 +922,7 @@ mod tests {
 
         // Create a signed tx and encode it to get actual size. New channel
         // → empty proof (no signatures required for just-in-time create).
-        let config_proof = ChannelMultiSigProof::new(vec![]).unwrap();
+        let config_proof = ChannelMultiSigProof::try_from(vec![]).unwrap();
         let signed_tx =
             SignedMantleTx::new(mantle_tx, vec![OpProof::ChannelMultiSigProof(config_proof)])
                 .unwrap();
@@ -1110,7 +1110,7 @@ mod tests {
         let op_sig = signing_key.sign_payload(&txhash.as_signing_bytes());
         // Create a signed tx and encode it to get actual size. ChannelConfig
         // creates the channel here, so its proof has no signatures.
-        let config_proof = ChannelMultiSigProof::new(vec![]).unwrap();
+        let config_proof = ChannelMultiSigProof::try_from(vec![]).unwrap();
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
             vec![
@@ -1223,7 +1223,7 @@ mod tests {
         // creates the channel here, so its proof has no signatures.
         let txhash = mantle_tx.hash();
         let op_ed25519_sig = signing_key1.sign_payload(&txhash.as_signing_bytes());
-        let config_proof = ChannelMultiSigProof::new(vec![]).unwrap();
+        let config_proof = ChannelMultiSigProof::try_from(vec![]).unwrap();
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
             vec![
@@ -1340,7 +1340,7 @@ mod tests {
             },
         )]));
         let tx_hash = mantle_tx.hash();
-        let proof = ChannelMultiSigProof::new(vec![IndexedSignature::new(
+        let proof = ChannelMultiSigProof::try_from(vec![IndexedSignature::new(
             0,
             signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref()),
         )])

--- a/core/src/mantle/tx.rs
+++ b/core/src/mantle/tx.rs
@@ -770,7 +770,7 @@ mod tests {
             withdraw_nonce: 0,
         })]);
         let tx_hash = mantle_tx.hash();
-        let signatures = signing_keys
+        let signatures: Vec<_> = signing_keys
             .iter()
             .enumerate()
             .map(|(index, key)| {
@@ -780,7 +780,7 @@ mod tests {
                 )
             })
             .collect();
-        let proof = ChannelMultiSigProof::new(signatures).unwrap();
+        let proof = ChannelMultiSigProof::try_from(signatures).unwrap();
         SignedMantleTx::new(mantle_tx, vec![OpProof::ChannelMultiSigProof(proof)]).unwrap()
     }
 

--- a/core/src/proofs/channel_multi_sig_proof.rs
+++ b/core/src/proofs/channel_multi_sig_proof.rs
@@ -53,7 +53,7 @@ pub enum Error {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "Vec<IndexedSignature>")]
+#[serde(try_from = "Vec<IndexedSignature>", into = "Vec<IndexedSignature>")]
 pub struct ChannelMultiSigProof {
     // Invariant: signature indices are strictly increasing (hence ordered and
     // unique), as required by the spec.
@@ -100,6 +100,12 @@ impl TryFrom<Vec<IndexedSignature>> for ChannelMultiSigProof {
     fn try_from(value: Vec<IndexedSignature>) -> Result<Self, Self::Error> {
         Self::validate_well_formedness(&value)?;
         Ok(Self { signatures: value })
+    }
+}
+
+impl From<ChannelMultiSigProof> for Vec<IndexedSignature> {
+    fn from(value: ChannelMultiSigProof) -> Self {
+        value.signatures
     }
 }
 
@@ -179,10 +185,6 @@ mod tests {
         ])
         .expect("distinct indices are well-formed");
         let serialized = serde_json::to_string(&ok).expect("serialize proof");
-        assert!(
-            serialized.starts_with("{\"signatures\":"),
-            "expected the `{{ signatures: [..] }}` shape, got {serialized}"
-        );
         let round_tripped: ChannelMultiSigProof =
             serde_json::from_str(&serialized).expect("well-formed proof round-trips");
         assert_eq!(round_tripped, ok);

--- a/core/src/proofs/channel_multi_sig_proof.rs
+++ b/core/src/proofs/channel_multi_sig_proof.rs
@@ -53,52 +53,14 @@ pub enum Error {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-// Serde goes through `ChannelMultiSigProofRepr` via `try_from`/`into`: `Deserialize`
-// routes through `new`, so the well-formedness invariant (strictly-increasing
-// indices) is upheld on every serde path too — a non-monotonic proof is
-// unrepresentable no matter how it is constructed, and no consumer needs to
-// re-check. The repr keeps the `{ "signatures": [..] }` wire form.
-#[serde(
-    try_from = "ChannelMultiSigProofRepr",
-    into = "ChannelMultiSigProofRepr"
-)]
+#[serde(try_from = "Vec<IndexedSignature>")]
 pub struct ChannelMultiSigProof {
     // Invariant: signature indices are strictly increasing (hence ordered and
     // unique), as required by the spec.
     signatures: Vec<IndexedSignature>,
 }
 
-/// Serde wire representation of [`ChannelMultiSigProof`] — a struct with a
-/// `signatures` field. Kept separate so the public type's (de)serialization
-/// is forced through `new` (via the `TryFrom`/`From` impls below) while
-/// preserving the `{ "signatures": [..] }` JSON shape.
-#[derive(Serialize, Deserialize)]
-struct ChannelMultiSigProofRepr {
-    signatures: Vec<IndexedSignature>,
-}
-
-impl TryFrom<ChannelMultiSigProofRepr> for ChannelMultiSigProof {
-    type Error = Error;
-
-    fn try_from(repr: ChannelMultiSigProofRepr) -> Result<Self, Self::Error> {
-        Self::new(repr.signatures)
-    }
-}
-
-impl From<ChannelMultiSigProof> for ChannelMultiSigProofRepr {
-    fn from(proof: ChannelMultiSigProof) -> Self {
-        Self {
-            signatures: proof.signatures,
-        }
-    }
-}
-
 impl ChannelMultiSigProof {
-    pub fn new(signatures: Vec<IndexedSignature>) -> Result<Self, Error> {
-        Self::validate_well_formedness(&signatures)?;
-        Ok(Self { signatures })
-    }
-
     /// Validates that the proof is structurally well-formed: signature indices
     /// must be strictly increasing (so they are ordered and unique, per the
     /// `CHANNEL_CONFIG` / `CHANNEL_WITHDRAW` spec), and the count must not
@@ -136,7 +98,8 @@ impl TryFrom<Vec<IndexedSignature>> for ChannelMultiSigProof {
     type Error = Error;
 
     fn try_from(value: Vec<IndexedSignature>) -> Result<Self, Self::Error> {
-        Self::new(value)
+        Self::validate_well_formedness(&value)?;
+        Ok(Self { signatures: value })
     }
 }
 
@@ -156,7 +119,7 @@ mod tests {
             IndexedSignature::new(0, sig(2)),
         ];
         assert!(matches!(
-            ChannelMultiSigProof::new(signatures),
+            ChannelMultiSigProof::try_from(signatures),
             Err(Error::IndicesNotStrictlyIncreasing(_))
         ));
     }
@@ -170,7 +133,7 @@ mod tests {
             IndexedSignature::new(0, sig(2)),
         ];
         assert!(matches!(
-            ChannelMultiSigProof::new(signatures),
+            ChannelMultiSigProof::try_from(signatures),
             Err(Error::IndicesNotStrictlyIncreasing(_))
         ));
     }
@@ -181,7 +144,7 @@ mod tests {
             IndexedSignature::new(0, sig(1)),
             IndexedSignature::new(1, sig(2)),
         ];
-        let proof = ChannelMultiSigProof::new(signatures)
+        let proof = ChannelMultiSigProof::try_from(signatures)
             .expect("strictly-increasing indices are well-formed");
         assert_eq!(proof.signatures().len(), 2);
     }
@@ -210,7 +173,7 @@ mod tests {
 
         // A well-formed proof still round-trips, and keeps the `{ "signatures": [..] }`
         // JSON shape.
-        let ok = ChannelMultiSigProof::new(vec![
+        let ok = ChannelMultiSigProof::try_from(vec![
             IndexedSignature::new(0, sig(1)),
             IndexedSignature::new(1, sig(2)),
         ])

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1039,7 +1039,7 @@ mod tests {
 
         let config_tx = MantleTx([Op::ChannelConfig(config_op.clone())].into());
         let config_tx_hash = config_tx.hash();
-        let config_proof = ChannelMultiSigProof::new(vec![IndexedSignature::new(
+        let config_proof = ChannelMultiSigProof::try_from(vec![IndexedSignature::new(
             0,
             signing_key.sign_payload(config_tx_hash.as_signing_bytes().as_ref()),
         )])
@@ -1205,7 +1205,7 @@ mod tests {
         };
         let withdraw_tx = MantleTx([Op::ChannelWithdraw(withdraw.clone())].into());
         let withdraw_tx_hash = withdraw_tx.hash();
-        let withdraw_proof = ChannelMultiSigProof::new(vec![IndexedSignature::new(
+        let withdraw_proof = ChannelMultiSigProof::try_from(vec![IndexedSignature::new(
             0,
             signing_key.sign_payload(withdraw_tx_hash.as_signing_bytes().as_ref()),
         )])
@@ -1293,7 +1293,7 @@ mod tests {
         let wrong_key = Ed25519Key::from_bytes(&[42; 32]);
         let withdraw_tx = MantleTx([Op::ChannelWithdraw(withdraw.clone())].into());
         let withdraw_tx_hash = withdraw_tx.hash();
-        let invalid_proof = ChannelMultiSigProof::new(vec![IndexedSignature::new(
+        let invalid_proof = ChannelMultiSigProof::try_from(vec![IndexedSignature::new(
             0,
             wrong_key.sign_payload(withdraw_tx_hash.as_signing_bytes().as_ref()),
         )])
@@ -1510,7 +1510,7 @@ mod tests {
         ];
         let config_tx = MantleTx(Ops::new_unchecked(ops.clone()));
         let config_tx_hash = config_tx.hash();
-        let config_proof = ChannelMultiSigProof::new(vec![IndexedSignature::new(
+        let config_proof = ChannelMultiSigProof::try_from(vec![IndexedSignature::new(
             0,
             sk1.sign_payload(config_tx_hash.as_signing_bytes().as_ref()),
         )])

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -1330,7 +1330,7 @@ pub async fn submit_zone_withdraw(
             })?;
 
     let withdraw_proof =
-        match ChannelMultiSigProof::new(vec![IndexedSignature::new(0, withdraw_sig)]) {
+        match ChannelMultiSigProof::try_from(vec![IndexedSignature::new(0, withdraw_sig)]) {
             Ok(proof) => proof,
             Err(error) => {
                 return Err(ZoneTestError::SubmitWithdraw {

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -29,7 +29,7 @@ pub(super) fn build_atomic_withdraw_ops_proofs(
     own_sig: Ed25519Signature,
 ) -> Result<Vec<OpProof>, Error> {
     let withdraw_proof =
-        ChannelMultiSigProof::new(vec![IndexedSignature::new(own_key_index, own_sig)])
+        ChannelMultiSigProof::try_from(vec![IndexedSignature::new(own_key_index, own_sig)])
             .map_err(|e| Error::Network(format!("multi-sig proof assembly failed: {e:?}")))?;
     let mut ops_proofs = Vec::with_capacity(tx.ops().len());
     for op in tx.ops() {
@@ -116,7 +116,7 @@ pub(super) fn create_channel_config_tx(
     let config_tx = MantleTx([Op::ChannelConfig(config_op)].into());
 
     let tx_hash = config_tx.hash();
-    let signatures = signing_keys
+    let signatures: Vec<_> = signing_keys
         .iter()
         .enumerate()
         .map(|(index, key)| {
@@ -126,7 +126,7 @@ pub(super) fn create_channel_config_tx(
             )
         })
         .collect();
-    let proof = ChannelMultiSigProof::new(signatures).unwrap();
+    let proof = ChannelMultiSigProof::try_from(signatures).unwrap();
 
     SignedMantleTx {
         ops_proofs: vec![OpProof::ChannelMultiSigProof(proof)],


### PR DESCRIPTION
## 1. What does this PR implement?

Remove the unnecessary serde machinery when deserializing `ChannelMultiSigProof`, and remove the fallible `new` method in favor of a single `TryFrom<Vec>` implementation. This code will be updated once we migrate to bounded vectors for proofs as well.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.