### PR TITLE
feat(wallet): add `locked` field in the balance API response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4602,6 +4602,7 @@ dependencies = [
  "logos-blockchain-key-management-system-keys",
  "logos-blockchain-log-targets",
  "logos-blockchain-tracing",
+ "logos-blockchain-wallet",
  "pprof",
  "serde",
  "serde_json",

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -485,9 +485,16 @@ pub(crate) fn get_wallet_notes_sync(
                 .await
                 .map(|tip_response| {
                     let resolved_tip = tip_response.tip;
-                    tip_response
-                        .response
-                        .map(|balance| (resolved_tip, balance.notes.into_iter().collect()))
+                    tip_response.response.map(|balance| {
+                        (
+                            resolved_tip,
+                            balance
+                                .notes
+                                .into_iter()
+                                .map(|(id, note)| (id, note.value))
+                                .collect(),
+                        )
+                    })
                 })
         })
         .map_err(|_| OperationStatus::DynError)
@@ -1263,7 +1270,13 @@ pub(crate) fn channel_deposit_sync(
             })?;
         let notes: Vec<(CoreNoteId, Value)> = balance
             .response
-            .map(|balance| balance.notes.into_iter().collect())
+            .map(|balance| {
+                balance
+                    .notes
+                    .into_iter()
+                    .map(|(id, note)| (id, note.value))
+                    .collect()
+            })
             .ok_or_else(|| {
                 logging::error!("channel_deposit_sync", "Unknown funding address.");
                 OperationStatus::NotFound

--- a/nodes/api-common/Cargo.toml
+++ b/nodes/api-common/Cargo.toml
@@ -18,6 +18,7 @@ lb-core                       = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-log-targets                = { workspace = true }
 lb-tracing                    = { workspace = true }
+lb-wallet                     = { workspace = true }
 serde                         = { features = ["alloc", "derive"], workspace = true }
 serde_json                    = { workspace = true }
 serde_urlencoded              = { workspace = true }

--- a/nodes/api-common/src/bodies/wallet.rs
+++ b/nodes/api-common/src/bodies/wallet.rs
@@ -11,6 +11,7 @@ pub mod balance {
     };
     use lb_key_management_system_keys::keys::ZkPublicKey;
     use lb_log_targets::api;
+    use lb_wallet::WalletNote;
     use serde::{Deserialize, Serialize};
     use tracing::error;
 
@@ -20,7 +21,7 @@ pub mod balance {
     pub struct WalletBalanceResponseBody {
         pub tip: HeaderId,
         pub balance: Value,
-        pub notes: HashMap<NoteId, Value>,
+        pub notes: HashMap<NoteId, WalletNote>,
         pub address: ZkPublicKey,
     }
 

--- a/tests/src/tests/mantle/channel.rs
+++ b/tests/src/tests/mantle/channel.rs
@@ -460,8 +460,8 @@ async fn get_wallet_note(node: &NodeHttpClient, pk: ZkPublicKey, min_value: u64)
         .expect("balance response should be valid JSON");
 
     body.notes
-        .into_iter()
-        .filter(|(_, value)| *value >= min_value)
+        .into_values()
+        .filter_map(|note| (note.value >= min_value).then_some((note.id, note.value)))
         .min_by_key(|(_, value)| *value)
         .expect("should find a note with sufficient balance for deposit")
 }

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -230,6 +230,17 @@ async fn sdp_ops_e2e() {
             .iter()
             .any(|declaration| declaration.provider_id == provider_id)
     );
+
+    // Check that the note has been unlocked in the wallet.
+    let resp = node0
+        .get_wallet_balance(spare_note_secret_key.to_public_key(), None)
+        .await
+        .expect("balance request should succeed");
+    let note = resp
+        .notes
+        .get(&locked_note_id)
+        .expect("the previously-locked note should be tracked by the wallet");
+    assert!(!note.locked);
 }
 
 /// Test that SDP declaration is correctly restored after validator restart.

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -24,7 +24,7 @@ use lb_core::{
         WithdrawMessage,
     },
 };
-use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature, ZkKey};
+use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature, ZkKey, ZkPublicKey};
 use lb_node::config::{
     RunConfig, blend::deployment::MinimumNetworkSize, cryptarchia::deployment::EpochConfig,
 };
@@ -80,6 +80,7 @@ async fn sdp_ops_e2e() {
         spare_note_id,
         slots_per_epoch,
     ) = start_sdp_manual_cluster("sdp-ops").await;
+    let spare_note_pk = spare_note_secret_key.to_public_key();
 
     let inclusion_timeout = Duration::from_mins(1);
 
@@ -160,6 +161,9 @@ async fn sdp_ops_e2e() {
         .expect("API must succeed")
         .expect("declaration should appear after submission");
 
+    // Check that the note has been locked in the wallet.
+    assert!(is_note_locked(&node0, spare_note_pk, locked_note_id).await);
+
     // Submit an withdraw tx immediately.
     let withdraw_message = WithdrawMessage {
         declaration_id,
@@ -232,15 +236,7 @@ async fn sdp_ops_e2e() {
     );
 
     // Check that the note has been unlocked in the wallet.
-    let resp = node0
-        .get_wallet_balance(spare_note_secret_key.to_public_key(), None)
-        .await
-        .expect("balance request should succeed");
-    let note = resp
-        .notes
-        .get(&locked_note_id)
-        .expect("the previously-locked note should be tracked by the wallet");
-    assert!(!note.locked);
+    assert!(!is_note_locked(&node0, spare_note_pk, locked_note_id).await);
 }
 
 /// Test that SDP declaration is correctly restored after validator restart.
@@ -530,4 +526,13 @@ async fn fund_sdp_transaction(
             .expect("funded mixed-op builder should build"),
         signing_keys,
     )
+}
+
+async fn is_note_locked(node: &NodeHttpClient, pk: ZkPublicKey, note_id: NoteId) -> bool {
+    let resp = node
+        .get_wallet_balance(pk, None)
+        .await
+        .expect("balance request should succeed");
+    let note = resp.notes.get(&note_id).expect("note should exist");
+    note.locked
 }

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -14,7 +14,10 @@ use lb_core::{
 use lb_http_api_common::{
     bodies::{
         blend::JoinBlendRequestBody,
-        wallet::transfer_funds::{WalletTransferFundsRequestBody, WalletTransferFundsResponseBody},
+        wallet::{
+            balance::WalletBalanceResponseBody,
+            transfer_funds::{WalletTransferFundsRequestBody, WalletTransferFundsResponseBody},
+        },
     },
     paths::{
         BLEND_NETWORK_INFO, DIAL_PEER, MANTLE_METRICS, MANTLE_SDP_DECLARATIONS, MEMPOOL_VIEW,
@@ -22,6 +25,7 @@ use lb_http_api_common::{
     },
     queries::BlocksStreamQuery,
 };
+use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_libp2p::{Multiaddr, PeerId};
 use lb_network_service::backends::libp2p::Libp2pInfo;
 use lb_tx_service::MempoolMetrics;
@@ -152,6 +156,19 @@ impl NodeHttpClient {
         self.with_timeout(
             "Transfer funds request",
             self.http_client.transfer_funds(self.base_url.clone(), body),
+        )
+        .await
+    }
+
+    pub async fn get_wallet_balance(
+        &self,
+        pk: ZkPublicKey,
+        tip: Option<HeaderId>,
+    ) -> Result<WalletBalanceResponseBody, Error> {
+        self.with_timeout(
+            "Get wallet balance request",
+            self.http_client
+                .get_wallet_balance(self.base_url.clone(), pk, tip),
         )
         .await
     }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -244,7 +244,14 @@ impl WalletState {
         self.pk_index.get(&pk)?.iter().for_each(|id| {
             let value = self.utxos[id].note.value;
             balance.balance += value;
-            balance.notes.insert(*id, value);
+            balance.notes.insert(
+                *id,
+                WalletNote {
+                    id: *id,
+                    value,
+                    locked: self.locked_notes.contains(id),
+                },
+            );
         });
 
         Some(balance)
@@ -715,7 +722,14 @@ where
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WalletBalance {
     pub balance: Value,
-    pub notes: HashMap<NoteId, Value>,
+    pub notes: HashMap<NoteId, WalletNote>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WalletNote {
+    pub id: NoteId,
+    pub value: Value,
+    pub locked: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 1. What does this PR implement?

This is a follow-up PR of https://github.com/logos-blockchain/logos-blockchain/pull/3017.

This PR improves the `sdp_ops_e2e` test to check if the note has been actually unlocked in the end.

For that, we need to extend the `GET wallet/<pk>/balance` API. Previously it was returning the value of each note. This PR extend it to return the `locked: bool` for each note, so that the e2e test can check if the note has been unlocked.

No client in this repo (e.g. faucet, c-binding) is not broken. The faucet is interested in only the total balance. The c-binding simply ignores the `locked: bool` field, as before (i.e., it doesn't distinguish locked notes from other notes).

Any JSON consumers outside of this repo may be broken. Please let me know if there's any.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
