### PR TITLE
fix(storage): store block data atomically

### DIFF
--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -1040,20 +1040,24 @@ where
 
         let tx_count = block.transactions().count();
 
-        relays
-            .storage_adapter()
-            .store_block(header.id(), header.parent(), block.clone(), events)
-            .await
-            .map_err(|e| Error::Storage(format!("Failed to store block: {e}")))?;
-
-        Self::store_immutable_blocks_index(
+        let immutable_blocks = Self::immutable_blocks_index(
             &pruned_blocks,
             Some(prev_lib),
             new_lib,
             candidate.consensus.lib_branch().slot(),
-            relays.storage_adapter(),
-        )
-        .await?;
+        );
+
+        relays
+            .storage_adapter()
+            .store_block_data(
+                header.id(),
+                header.parent(),
+                block.clone(),
+                events,
+                immutable_blocks,
+            )
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to store block data: {e}")))?;
 
         *cryptarchia = candidate;
         metrics::emit_block_transactions_metric(tx_count);
@@ -1133,6 +1137,21 @@ where
         new_lib_slot: Slot,
         storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
     ) -> Result<(), Error> {
+        let immutable_blocks =
+            Self::immutable_blocks_index(pruned_blocks, prev_lib, new_lib, new_lib_slot);
+
+        storage_adapter
+            .store_immutable_block_ids(immutable_blocks)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to store immutable block ids: {e}")))
+    }
+
+    fn immutable_blocks_index(
+        pruned_blocks: &PrunedBlocks<HeaderId>,
+        prev_lib: Option<HeaderId>,
+        new_lib: HeaderId,
+        new_lib_slot: Slot,
+    ) -> BTreeMap<Slot, HeaderId> {
         let mut immutable_blocks = pruned_blocks.immutable_blocks().clone();
         // The new LIB is also immutable and should be immediately queryable by slot.
         // prune_immutable_blocks() only returns blocks older than the new LIB,
@@ -1140,10 +1159,8 @@ where
         if prev_lib.is_none_or(|prev| prev != new_lib) {
             immutable_blocks.insert(new_lib_slot, new_lib);
         }
-        storage_adapter
-            .store_immutable_block_ids(immutable_blocks)
-            .await
-            .map_err(|e| Error::Storage(format!("Failed to store immutable block ids: {e}")))
+
+        immutable_blocks
     }
 
     /// Returns block IDs from descendant (inclusive) to ancestor

--- a/services/chain/chain-service/src/storage/adapters/storage.rs
+++ b/services/chain/chain-service/src/storage/adapters/storage.rs
@@ -94,32 +94,40 @@ where
         }
     }
 
-    async fn store_block(
+    async fn store_block_data(
         &self,
         header_id: HeaderId,
         parent_id: HeaderId,
         block: Self::Block,
         events: Self::Events,
+        immutable_ids: BTreeMap<Slot, HeaderId>,
     ) -> Result<(), overwatch::DynError> {
         let block = block
             .try_into()
             .map_err(|_| "Failed to convert block to storage format")?;
+
         let events = events
             .try_into()
             .map_err(|_| "Failed to convert events to storage format")?;
+
         let (sender, receiver) = oneshot::channel();
 
         self.storage_relay
-            .send(StorageMsg::store_block_request(
-                header_id, parent_id, block, events, sender,
+            .send(StorageMsg::store_block_data_request(
+                header_id,
+                parent_id,
+                block,
+                events,
+                immutable_ids,
+                sender,
             ))
             .await
-            .map_err(|_| "Failed to send store block request to storage relay")?;
+            .map_err(|_| "Failed to send store block data request to storage relay")?;
 
         receiver
             .await
-            .map_err(|e| format!("Failed to receive store block response from storage: {e}"))?
-            .map_err(|e| format!("Failed to store block in storage: {e}").into())
+            .map_err(|e| format!("Failed to receive store block data response from storage: {e}"))?
+            .map_err(|e| format!("Failed to store block data in storage: {e}").into())
     }
 
     async fn get_block_parent(&self, header_id: &HeaderId) -> Option<HeaderId> {

--- a/services/chain/chain-service/src/storage/mod.rs
+++ b/services/chain/chain-service/src/storage/mod.rs
@@ -32,12 +32,13 @@ pub trait StorageAdapter<RuntimeServiceId> {
     /// The block with the given header id. If no block is found, returns None.
     async fn get_block(&self, key: &HeaderId) -> Option<Self::Block>;
 
-    async fn store_block(
+    async fn store_block_data(
         &self,
         header_id: HeaderId,
         parent_id: HeaderId,
         block: Self::Block,
         events: Self::Events,
+        immutable_ids: BTreeMap<Slot, HeaderId>,
     ) -> Result<(), overwatch::DynError>;
 
     async fn get_block_parent(&self, header_id: &HeaderId) -> Option<HeaderId>;

--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -918,11 +918,12 @@ mod tests {
             let (sender, receiver) = oneshot::channel();
 
             self.storage_relay
-                .send(StorageMsg::store_block_request(
+                .send(StorageMsg::store_block_data_request(
                     header_id,
                     parent_id,
                     store_result.unwrap(),
                     Events::new().try_into().unwrap(),
+                    BTreeMap::new(),
                     sender,
                 ))
                 .await

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -25,7 +25,6 @@ use lb_ledger::{
 };
 use lb_storage_service::{
     StorageMsg, StorageService,
-    api::{StorageApiRequest, chain::requests::ChainApiRequest},
     backends::{
         StorageBackend as _,
         rocksdb::{RocksBackend, RocksBackendSettings},
@@ -244,8 +243,8 @@ async fn get_block_ids() {
 async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
     let (storage_tx, storage_rx) = mpsc::channel(10);
-    // Close the storage relay before processing so the initial StoreBlock request
-    // fails.
+    // Close the storage relay before processing so the initial combined store
+    // request fails.
     drop(storage_rx);
     let (time_tx, _time_rx) = mpsc::channel(10);
     let relays =
@@ -276,87 +275,6 @@ async fn process_block_does_not_mutate_state_when_storage_send_fails() {
         &lib_tx,
     )
     .await;
-
-    match &result {
-        Err(Error::Storage(_)) => {}
-        Err(e) => panic!("expected storage error, got {e:?}"),
-        Ok(_) => panic!("expected storage error, got Ok"),
-    }
-    assert_eq!(cryptarchia.info(), initial_info);
-    assert!(new_block_rx.try_recv().is_err());
-    assert!(lib_rx.try_recv().is_err());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn process_block_does_not_mutate_state_when_immutable_index_write_fails() {
-    let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
-    let (storage_tx, mut storage_rx) = mpsc::channel(10);
-    let (time_tx, _time_rx) = mpsc::channel(10);
-    let relays =
-        CryptarchiaConsensusRelays::<SignedMantleTx, RocksBackend, TestRuntimeServiceId>::new(
-            OutboundRelay::new(broadcast_tx),
-            OutboundRelay::new(storage_tx),
-            OutboundRelay::new(time_tx),
-        )
-        .await;
-    let (new_block_tx, mut new_block_rx) = broadcast::channel(10);
-    let (lib_tx, mut lib_rx) = broadcast::channel(10);
-
-    let storage_task = tokio::spawn(async move {
-        while let Some(msg) = storage_rx.recv().await {
-            match msg {
-                StorageMsg::Api {
-                    request:
-                        StorageApiRequest::Chain(ChainApiRequest::StoreBlock { response_tx, .. }),
-                } => {
-                    response_tx
-                        .send(Ok(()))
-                        .map_err(|_| "store block reply receiver dropped")?;
-                }
-                StorageMsg::Api {
-                    request:
-                        StorageApiRequest::Chain(ChainApiRequest::StoreImmutableBlockIds {
-                            response_tx,
-                            ..
-                        }),
-                } => {
-                    response_tx
-                        .send(Err(
-                            "StoreImmutableBlockIds is rejected by this test".to_owned()
-                        ))
-                        .map_err(|_| "immutable index reply receiver dropped")?;
-
-                    return Ok(());
-                }
-                _ => return Err("unexpected storage request"),
-            }
-        }
-
-        Err("expected immutable index write request, storage channel closed")
-    });
-
-    let (mut cryptarchia, block) = test_chain_with_next_block();
-    let initial_info = cryptarchia.info();
-    let block_slot = block.header().slot();
-
-    let result = CryptarchiaConsensus::<
-        _,
-        RocksBackend,
-        SystemTimeBackend,
-        TestRuntimeServiceId,
-    >::process_block(
-        &mut cryptarchia,
-        block,
-        block_slot,
-        &relays,
-        &new_block_tx,
-        &lib_tx,
-    )
-    .await;
-    storage_task
-        .await
-        .expect("storage task should not panic")
-        .expect("storage task should reject immutable index write");
 
     match &result {
         Err(Error::Storage(_)) => {}

--- a/services/storage/src/api/backend/rocksdb/chain.rs
+++ b/services/storage/src/api/backend/rocksdb/chain.rs
@@ -42,18 +42,18 @@ impl StorageChainApi for RocksBackend {
         self.load(&key).await.map_err(Into::into)
     }
 
-    async fn store_block(
+    async fn store_block_data(
         &mut self,
         header_id: HeaderId,
         parent_id: HeaderId,
         block: Self::Block,
         events: Self::Events,
+        immutable_ids: BTreeMap<Slot, HeaderId>,
     ) -> Result<(), Self::Error> {
-        let header_bytes: [u8; 32] = header_id.into();
+        let header_bytes = <[u8; 32]>::from(header_id);
         let block_key = Bytes::copy_from_slice(&header_bytes);
         let parent_key = key_bytes(BLOCK_PARENT_PREFIX, header_bytes);
-        let parent_bytes: [u8; 32] = parent_id.into();
-        let parent_value = Bytes::copy_from_slice(&parent_bytes);
+        let parent_value = Bytes::copy_from_slice(&<[u8; 32]>::from(parent_id));
         let events_key = key_bytes(BLOCK_EVENTS_PREFIX, header_bytes);
 
         let db_transaction = self.txn(move |db| {
@@ -61,6 +61,7 @@ impl StorageChainApi for RocksBackend {
             batch.put(block_key, block);
             batch.put(parent_key, parent_value);
             batch.put(events_key, events);
+            insert_immutable_block_ids(&mut batch, immutable_ids);
             db.write(batch)?;
             Ok(None)
         });
@@ -119,12 +120,7 @@ impl StorageChainApi for RocksBackend {
     ) -> Result<(), Self::Error> {
         let db_transaction = self.txn(move |db| {
             let mut batch = WriteBatch::default();
-            for (slot, header_id) in ids {
-                // use be_bytes to keep prefix ordering
-                let key = key_bytes(IMMUTABLE_BLOCK_PREFIX, slot.to_be_bytes());
-                let header_id: [u8; 32] = header_id.into();
-                batch.put(key, Bytes::copy_from_slice(&header_id));
-            }
+            insert_immutable_block_ids(&mut batch, ids);
             db.write(batch)?;
             Ok(None)
         });
@@ -256,6 +252,15 @@ impl StorageChainApi for RocksBackend {
     }
 }
 
+fn insert_immutable_block_ids(batch: &mut WriteBatch, ids: BTreeMap<Slot, HeaderId>) {
+    for (slot, header_id) in ids {
+        // Use big-endian bytes to keep prefix ordering.
+        let key = key_bytes(IMMUTABLE_BLOCK_PREFIX, slot.to_be_bytes());
+        let header_id = <[u8; 32]>::from(header_id);
+        batch.put(key, Bytes::copy_from_slice(&header_id));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter;
@@ -269,6 +274,48 @@ mod tests {
         },
         backends::rocksdb::RocksBackendSettings,
     };
+
+    #[tokio::test]
+    async fn store_block_data_stores_block_and_indexes() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut backend = RocksBackend::new(RocksBackendSettings {
+            db_path: temp_dir.path().to_path_buf(),
+            read_only: false,
+            column_family: None,
+        })
+        .unwrap();
+
+        let header_id = HeaderId::from([1u8; 32]);
+        let parent_id = HeaderId::from([0u8; 32]);
+        let block = Bytes::from_static(b"block");
+        let events = Bytes::from_static(b"events");
+        let immutable_id = HeaderId::from([2u8; 32]);
+
+        backend
+            .store_block_data(
+                header_id,
+                parent_id,
+                block.clone(),
+                events.clone(),
+                [(Slot::new(7), immutable_id)].into(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(backend.get_block(header_id).await.unwrap(), Some(block));
+        assert_eq!(
+            backend.get_block_parent(header_id).await.unwrap(),
+            Some(parent_id)
+        );
+        assert_eq!(
+            backend.get_block_events(header_id).await.unwrap(),
+            Some(events)
+        );
+        assert_eq!(
+            backend.get_immutable_block_id(Slot::new(7)).await.unwrap(),
+            Some(immutable_id)
+        );
+    }
 
     #[tokio::test]
     async fn immutable_block_ids() {

--- a/services/storage/src/api/chain/mod.rs
+++ b/services/storage/src/api/chain/mod.rs
@@ -25,12 +25,13 @@ pub trait StorageChainApi {
 
     async fn get_block(&mut self, header_id: HeaderId) -> Result<Option<Self::Block>, Self::Error>;
 
-    async fn store_block(
+    async fn store_block_data(
         &mut self,
         header_id: HeaderId,
         parent_id: HeaderId,
         block: Self::Block,
         events: Self::Events,
+        immutable_ids: BTreeMap<Slot, HeaderId>,
     ) -> Result<(), Self::Error>;
 
     async fn remove_block(

--- a/services/storage/src/api/chain/requests.rs
+++ b/services/storage/src/api/chain/requests.rs
@@ -26,11 +26,12 @@ pub enum ChainApiRequest<Backend: StorageBackend> {
         header_id: HeaderId,
         response_tx: Sender<Option<<Backend as StorageChainApi>::Block>>,
     },
-    StoreBlock {
+    StoreBlockData {
         header_id: HeaderId,
         parent_id: HeaderId,
         block: <Backend as StorageChainApi>::Block,
         events: <Backend as StorageChainApi>::Events,
+        immutable_ids: BTreeMap<Slot, HeaderId>,
         response_tx: Sender<Result<(), String>>,
     },
     RemoveBlock {
@@ -85,14 +86,24 @@ where
                 header_id,
                 response_tx,
             } => handle_get_block(backend, header_id, response_tx).await,
-            Self::StoreBlock {
+            Self::StoreBlockData {
                 header_id,
                 parent_id,
                 block,
                 events,
+                immutable_ids,
                 response_tx,
             } => {
-                handle_store_block(backend, header_id, parent_id, block, events, response_tx).await
+                handle_store_block_data(
+                    backend,
+                    header_id,
+                    parent_id,
+                    block,
+                    events,
+                    immutable_ids,
+                    response_tx,
+                )
+                .await
             }
             Self::RemoveBlock {
                 header_id,
@@ -161,16 +172,17 @@ async fn handle_get_block<Backend: StorageBackend>(
     Ok(())
 }
 
-async fn handle_store_block<Backend: StorageBackend>(
+async fn handle_store_block_data<Backend: StorageBackend>(
     backend: &mut Backend,
     header_id: HeaderId,
     parent_id: HeaderId,
     block: Backend::Block,
     events: Backend::Events,
+    immutable_ids: BTreeMap<Slot, HeaderId>,
     response_tx: Sender<Result<(), String>>,
 ) -> Result<(), StorageServiceError> {
     let result = backend
-        .store_block(header_id, parent_id, block, events)
+        .store_block_data(header_id, parent_id, block, events, immutable_ids)
         .await
         .map_err(|e| StorageServiceError::BackendError(e.into()));
 
@@ -180,7 +192,7 @@ async fn handle_store_block<Backend: StorageBackend>(
         .send(response)
         .map_err(|_| StorageServiceError::ReplyError {
             message: format!(
-                "Failed to send reply for store block request by header_id: {header_id}"
+                "Failed to send reply for store block data request by header_id: {header_id}"
             ),
         })?;
 
@@ -339,19 +351,21 @@ impl<Api: StorageBackend> StorageMsg<Api> {
         }
     }
 
-    pub const fn store_block_request(
+    pub const fn store_block_data_request(
         header_id: HeaderId,
         parent_id: HeaderId,
         block: <Api as StorageChainApi>::Block,
         events: <Api as StorageChainApi>::Events,
+        immutable_ids: BTreeMap<Slot, HeaderId>,
         response_tx: Sender<Result<(), String>>,
     ) -> Self {
         Self::Api {
-            request: StorageApiRequest::Chain(ChainApiRequest::StoreBlock {
+            request: StorageApiRequest::Chain(ChainApiRequest::StoreBlockData {
                 header_id,
                 parent_id,
                 block,
                 events,
+                immutable_ids,
                 response_tx,
             }),
         }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR is related to the recovery failure in #2569.

That issue shows the node can fail to restart when chain data in RocksDB is incomplete after an unclean shutdown. One risk in the current write path is that accepting a block stores the block body/parent/events first, then stores immutable block indexes in a separate request. If the process dies between those writes, RocksDB can contain only part of the chain data.

This PR writes the block body, parent link, block events, and immutable block index in one RocksDB batch, so block storage cannot succeed with only part of that state updated.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
