### PR TITLE
feat(ibd): DRAFT: retry tip requests

### DIFF
--- a/nodes/node/binary/src/config/cryptarchia/mod.rs
+++ b/nodes/node/binary/src/config/cryptarchia/mod.rs
@@ -107,6 +107,16 @@ impl ServiceConfig {
             bootstrap: lb_chain_network_service::BootstrapConfig {
                 ibd: lb_chain_network_service::IbdConfig {
                     trusted_peers: self.user.network.bootstrap.ibd.trusted_peers,
+                    tips_fetch: lb_chain_network_service::TipsFetchConfig {
+                        attempts: self.user.network.bootstrap.ibd.tips_fetch.attempts,
+                        delay_between_attempts: self
+                            .user
+                            .network
+                            .bootstrap
+                            .ibd
+                            .tips_fetch
+                            .delay_between_attempts,
+                    },
                 },
             },
             network: LibP2pAdapterSettings {

--- a/nodes/node/binary/src/config/cryptarchia/serde/network.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/network.rs
@@ -1,4 +1,7 @@
-use core::num::{NonZeroU64, NonZeroUsize};
+use core::{
+    num::{NonZeroU64, NonZeroUsize},
+    time::Duration,
+};
 use std::collections::HashSet;
 
 use libp2p::PeerId;
@@ -25,6 +28,26 @@ pub struct BootstrapConfig {
 pub struct IbdConfig {
     /// Peers to query for the chain tip during IBD.
     pub trusted_peers: HashSet<PeerId>,
+    /// Retry policy for tip-fetch batches.
+    pub tips_fetch: TipsFetchConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TipsFetchConfig {
+    /// Total number of attempts.
+    pub attempts: NonZeroUsize,
+    /// Fixed delay between attempts.
+    pub delay_between_attempts: Duration,
+}
+
+impl Default for TipsFetchConfig {
+    fn default() -> Self {
+        Self {
+            attempts: NonZeroUsize::new(3).unwrap(),
+            delay_between_attempts: Duration::from_secs(1),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/nodes/node/standalone-node-config.yaml
+++ b/nodes/node/standalone-node-config.yaml
@@ -124,6 +124,11 @@ cryptarchia:
     bootstrap:
       ibd:
         trusted_peers: []
+        tips_fetch:
+          attempts: 3
+          delay_between_attempts:
+            secs: 1
+            nanos: 0
     sync:
       orphan:
         max_orphan_cache_size: 1000

--- a/services/chain/chain-network/src/bootstrap/config.rs
+++ b/services/chain/chain-network/src/bootstrap/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, hash::Hash};
+use std::{collections::HashSet, hash::Hash, num::NonZeroUsize, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -19,4 +19,15 @@ where
 {
     /// Trusted peers to query for the chain tip during IBD.
     pub trusted_peers: HashSet<NodeId>,
+    /// Retry policy for tip-fetch batches.
+    pub tips_fetch: TipsFetchConfig,
+}
+
+/// Retry policy for tip-fetch batches at the start of each IBD round.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub struct TipsFetchConfig {
+    /// Total number of attempts.
+    pub attempts: NonZeroUsize,
+    /// Fixed delay between attempts.
+    pub delay_between_attempts: Duration,
 }

--- a/services/chain/chain-network/src/bootstrap/ibd.rs
+++ b/services/chain/chain-network/src/bootstrap/ibd.rs
@@ -16,7 +16,8 @@ use overwatch::DynError;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    Error as ChainError, IbdConfig, mempool::adapter::MempoolAdapter, network::NetworkAdapter,
+    Error as ChainError, IbdConfig, bootstrap::config::TipsFetchConfig,
+    mempool::adapter::MempoolAdapter, network::NetworkAdapter,
     sync::orphan_handler::OrphanBlocksDownloader,
 };
 
@@ -142,7 +143,9 @@ where
         loop {
             self.drain_downloader(&mut downloader).await;
 
-            let unsynced_tips = self.collect_unsynced_tips(&config.trusted_peers).await?;
+            let unsynced_tips = self
+                .collect_unsynced_tips(&config.trusted_peers, config.tips_fetch)
+                .await?;
             if unsynced_tips.is_empty() {
                 info!("IBD complete: all trusted peer tips are present in the local tree");
                 return Ok(self.block_processor);
@@ -183,14 +186,19 @@ where
     }
 
     /// Fetches tips from the trusted peers and returns those not yet in the
-    /// local tree. Returns [`Error::AllPeersFailed`] if no peer responded.
+    /// local tree. Returns [`Error::AllPeersFailed`] if no peer responded
+    /// across every configured attempt.
     async fn collect_unsynced_tips(
         &self,
         peers: &HashSet<NetAdapter::PeerId>,
+        config: TipsFetchConfig,
     ) -> Result<HashSet<HeaderId>, Error> {
-        let tips = fetch_tips(&self.network, peers.iter().copied()).await;
+        let tips = fetch_tips_with_retry(&self.network, peers, config).await;
         if tips.is_empty() {
-            error!("IBD: no trusted peer returned a tip this round");
+            error!(
+                "IBD: no trusted peer returned a tip after {} attempts",
+                config.attempts
+            );
             return Err(Error::AllPeersFailed);
         }
 
@@ -202,6 +210,34 @@ where
         }
         Ok(unsynced)
     }
+}
+
+/// Calls [`fetch_tips`] up to [`TipsFetchConfig::attempts`] times, sleeping
+/// [`TipsFetchConfig::delay_between_attempts`] between attempts. Returns the
+/// first non-empty batch, or an empty set if every attempt returned nothing.
+///
+/// The retry uses a fixed delay rather than exponential backoff because
+/// tip requests are very lightweight.
+async fn fetch_tips_with_retry<NetAdapter, RuntimeServiceId>(
+    network: &NetAdapter,
+    peers: &HashSet<NetAdapter::PeerId>,
+    config: TipsFetchConfig,
+) -> HashSet<HeaderId>
+where
+    NetAdapter: NetworkAdapter<RuntimeServiceId> + Sync,
+    NetAdapter::PeerId: Copy + Debug + Send + Sync,
+    RuntimeServiceId: Sync,
+{
+    for attempt in 0..config.attempts.get() {
+        if attempt > 0 {
+            tokio::time::sleep(config.delay_between_attempts).await;
+        }
+        let tips = fetch_tips(network, peers.iter().copied()).await;
+        if !tips.is_empty() {
+            return tips;
+        }
+    }
+    HashSet::new()
 }
 
 /// Concurrently asks every peer for its current chain tip, returning the tips
@@ -263,7 +299,7 @@ mod tests {
     use std::{
         collections::HashMap,
         iter::empty,
-        num::{NonZero, NonZeroU64},
+        num::{NonZero, NonZeroU64, NonZeroUsize},
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -485,6 +521,26 @@ mod tests {
         assert!(matches!(result, Err(Error::AllPeersFailed)));
     }
 
+    /// If a peer's first tip request fails but a later attempt within the
+    /// same round succeeds, IBD recovers via the configured retry instead of
+    /// aborting with `AllPeersFailed`.
+    #[tokio::test]
+    async fn tip_fetch_retries_after_transient_failure() {
+        let chain = vec![Block::genesis(), Block::new(1, GENESIS_ID, 1, 1)];
+        // First tip request fails, second succeeds: only the retry can make
+        // this scenario pass.
+        let peer = BlockProvider::with_tips(
+            chain.clone(),
+            vec![Err(()), Ok(Block::new(1, GENESIS_ID, 1, 1))],
+        );
+        let block_processor = run_ibd(HashMap::from([(NodeId(0), peer)]), [NodeId(0)].into())
+            .await
+            .unwrap();
+
+        let cryptarchia = block_processor.cryptarchia;
+        assert!(chain.iter().all(|b| cryptarchia.has_block(&b.id)));
+    }
+
     async fn run_ibd(
         providers: HashMap<NodeId, BlockProvider>,
         peers: HashSet<NodeId>,
@@ -540,7 +596,13 @@ mod tests {
     struct NodeId(usize);
 
     fn config(trusted_peers: HashSet<NodeId>) -> IbdConfig<NodeId> {
-        IbdConfig { trusted_peers }
+        IbdConfig {
+            trusted_peers,
+            tips_fetch: TipsFetchConfig {
+                attempts: NonZeroUsize::new(3).unwrap(),
+                delay_between_attempts: Duration::from_secs(1),
+            },
+        }
     }
 
     const GENESIS_ID: u8 = 0;

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -49,7 +49,7 @@ use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 use tracing_futures::Instrument as _;
 
 pub use crate::{
-    bootstrap::config::{BootstrapConfig, IbdConfig},
+    bootstrap::config::{BootstrapConfig, IbdConfig, TipsFetchConfig},
     sync::config::{OrphanConfig, SyncConfig, TipPollConfig},
 };
 use crate::{

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -635,6 +635,7 @@ fn build_cryptarchia_user_config(
             bootstrap: network::BootstrapConfig {
                 ibd: network::IbdConfig {
                     trusted_peers: HashSet::new(),
+                    tips_fetch: network::TipsFetchConfig::default(),
                 },
             },
             network: network::NetworkConfig {


### PR DESCRIPTION
## 1. What does this PR implement?

Stacked on PR #3019 

This PR adds a retry mechanism for requesting tips to the trusted peers.

IBD basically fails if none of the trusted peers fail to return their tip (e.g., due to `max_inbound_requests`). This failure can happen if all nodes in the network send tip requests to the same trusted nodes. 

To avoid giving up on IBD too early, we are adding a retry mechanism.

Tip requests themselves are very lightweight. However, the current chainsync implementation uses the common `max_inbound_requests` limit for both tip requests and download requests. As a result, if trusted nodes are busy serving many download requests, they may reject incoming tip requests as well, causing IBD failures for other nodes. In a follow-up PR, I will introduce separate limits for tip requests and download requests.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?
Yes

## 5. Does the implementation introduce changes in the specification?

No. This is an implementation detail.

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
