### PR TITLE
test(e2e): speed up manual wallet balance reads

### DIFF
--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -979,10 +979,6 @@ async fn step_all_nodes_agree_on_lib(
 
 #[when("I wait for all nodes to be synced to the chain")]
 #[then("I wait for all nodes to be synced to the chain")]
-#[expect(
-    clippy::needless_pass_by_ref_mut,
-    reason = "Cucumber step functions require the world as the first `&mut` argument"
-)]
 async fn step_wait_for_all_nodes_to_be_synced_to_the_chain(
     world: &mut CucumberWorld,
     step: &Step,

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -38,6 +38,7 @@ use crate::cucumber::{
         display_last_path_components, extract_child_dir_name, funding_wallet_pk_from_node_yaml,
         matching_child_dirs, peer_id_from_node_yaml, track_progress, truncate_hash,
     },
+    wallet::sync::current_wallet_states_for_wallets,
     world::{
         ChainInfoMap, ConfigOverride, CucumberWorld, ManualNodeConfigOverrides, NodeInfo,
         PublicCryptarchiaEndpointPeer, WalletInfo, WalletInfoMap, WalletType,
@@ -308,7 +309,7 @@ pub(crate) fn ensure_fee_sponsorship_and_fork_groups_are_not_mixed(
 }
 
 pub(crate) async fn wait_for_all_nodes_to_be_synced_to_chain(
-    world: &CucumberWorld,
+    world: &mut CucumberWorld,
     step: &str,
 ) -> StepResult {
     let public_cryptarchia_endpoint_peers = world
@@ -347,6 +348,9 @@ pub(crate) async fn wait_for_all_nodes_to_be_synced_to_chain(
                 "All nodes synced to the chain in {:.2?}",
                 start.elapsed()
             );
+
+            catch_up_known_wallet_tracking_after_chain_sync(world, step).await?;
+
             return Ok(());
         }
 
@@ -363,6 +367,27 @@ pub(crate) async fn wait_for_all_nodes_to_be_synced_to_chain(
 
         sleep(CHAIN_SYNC_POLL_INTERVAL).await;
     }
+}
+
+async fn catch_up_known_wallet_tracking_after_chain_sync(
+    world: &mut CucumberWorld,
+    step: &str,
+) -> StepResult {
+    let wallets = world.wallet_info.values().cloned().collect::<Vec<_>>();
+    if wallets.is_empty() {
+        return Ok(());
+    }
+
+    let started_at = Instant::now();
+    current_wallet_states_for_wallets(world, step, &wallets).await?;
+
+    info!(
+        target: TARGET,
+        "Wallet state refreshed after chain sync in {:.2?}",
+        started_at.elapsed()
+    );
+
+    Ok(())
 }
 
 pub(crate) fn parse_url(raw: &str) -> Result<String, String> {

--- a/tests/src/cucumber/steps/manual_transactions/command_file_utils.rs
+++ b/tests/src/cucumber/steps/manual_transactions/command_file_utils.rs
@@ -42,7 +42,7 @@ use tokio::time::{Instant, sleep};
 use tracing::{info, warn};
 
 use crate::{
-    common::wallet::WalletUtxos,
+    common::wallet::{WalletStateView, WalletUtxos},
     cucumber::{
         error::{StepError, StepResult},
         steps::{
@@ -518,8 +518,19 @@ async fn log_wallet_balances(
     step: &str,
     wallets: Vec<WalletInfo>,
 ) -> StepResult {
-    for wallet in wallets {
-        log_wallet_balance(world, step, &wallet.wallet_name).await?;
+    let states = utils::current_wallet_states_for_wallets(world, step, &wallets).await?;
+
+    for wallet in &wallets {
+        let state =
+            states
+                .get(wallet.wallet_name.as_str())
+                .ok_or_else(|| StepError::LogicalError {
+                    message: format!(
+                        "Wallet `{}` balance state is not tracked",
+                        wallet.wallet_name
+                    ),
+                })?;
+        log_wallet_state_balance(&wallet.wallet_name, state);
     }
 
     Ok(())
@@ -530,16 +541,14 @@ async fn log_wallet_balance(
     step: &str,
     wallet_name: &str,
 ) -> StepResult {
-    let available =
-        utils::current_wallet_balance(world, step, wallet_name, WalletOutputState::Available)
-            .await?;
+    let wallet = world.resolve_wallet(wallet_name)?;
+    log_wallet_balances(world, step, vec![wallet]).await
+}
 
-    let reserved =
-        utils::current_wallet_balance(world, step, wallet_name, WalletOutputState::Reserved)
-            .await?;
-
-    let on_chain =
-        utils::current_wallet_balance(world, step, wallet_name, WalletOutputState::OnChain).await?;
+fn log_wallet_state_balance(wallet_name: &str, state: &WalletStateView) {
+    let available = state.balance(WalletOutputState::Available);
+    let reserved = state.balance(WalletOutputState::Reserved);
+    let on_chain = state.balance(WalletOutputState::OnChain);
 
     info!(
         target: TARGET,
@@ -552,8 +561,6 @@ async fn log_wallet_balance(
         on_chain.output_count,
         on_chain.value,
     );
-
-    Ok(())
 }
 
 fn clear_wallet_encumbrances(

--- a/tests/src/cucumber/steps/manual_transactions/utils.rs
+++ b/tests/src/cucumber/steps/manual_transactions/utils.rs
@@ -18,7 +18,7 @@ pub use crate::cucumber::wallet::{
     sync::{
         current_available_utxos_for_all_wallets, current_available_utxos_for_funding_wallets,
         current_available_utxos_for_user_wallets, current_available_utxos_for_wallet,
-        current_wallet_available_state, current_wallet_balance,
+        current_wallet_available_state, current_wallet_balance, current_wallet_states_for_wallets,
     },
 };
 pub(crate) use crate::cucumber::wallet::{

--- a/tests/src/cucumber/wallet/sync.rs
+++ b/tests/src/cucumber/wallet/sync.rs
@@ -104,6 +104,17 @@ pub async fn current_wallet_balance(
         .balance(wallet_state_type))
 }
 
+pub async fn current_wallet_states_for_wallets(
+    world: &mut CucumberWorld,
+    step: &str,
+    wallets: &[WalletInfo],
+) -> Result<BTreeMap<WalletId, WalletStateView>, StepError> {
+    let feed_requirements = wallet_feed_source_requirements(world, wallets).await?;
+    let wallet_keys = build_tracked_wallet_keys(world, step, wallets)?;
+
+    current_wallet_state_views(world, &wallet_keys, feed_requirements).await
+}
+
 pub async fn current_wallet_available_state(
     world: &mut CucumberWorld,
     wallet_name: &str,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR makes manual wallet balance checks faster.

`BALANCE_ALL_USER_WALLETS` used to resolve each wallet separately, and for every wallet it resolved available, reserved, and on-chain balances separately too. With 10 wallets this meant up to 30 repeated wallet-state reads.

Now it resolves current state for all requested wallets once, then prints all balance types from that state.

In devnet manual-control testing, once wallet tracking was caught up, `BALANCE_ALL_USER_WALLETS` dropped from roughly 1-3 minutes to about 15-20ms.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
