### PR TITLE
feat(chain-network): cache rejected blocks to short-circuit orphan downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "logos-blockchain-tracing",
  "logos-blockchain-tx-service",
  "logos-blockchain-utils",
+ "lru",
  "overwatch",
  "rand 0.8.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ libp2p                             = { default-features = false, version = "0.55
 libp2p-stream                      = { default-features = false, version = "0.3.0-alpha" }
 libp2p-swarm-test                  = { default-features = false, version = "0.5" }
 log                                = { default-features = false, version = "0.4" }
+lru                                = { default-features = false, version = "0.12" }
 multiaddr                          = { default-features = false, version = "0.18" }
 natpmp                             = { default-features = false, version = "0.5" }
 netdev                             = { default-features = false, version = "0.31" }

--- a/nodes/node/binary/src/config/cryptarchia/mod.rs
+++ b/nodes/node/binary/src/config/cryptarchia/mod.rs
@@ -131,6 +131,7 @@ impl ServiceConfig {
             sync: lb_chain_network_service::SyncConfig {
                 orphan: lb_chain_network_service::OrphanConfig {
                     max_orphan_cache_size: self.user.network.sync.orphan.max_orphan_cache_size,
+                    max_rejected_cache_size: self.user.network.sync.orphan.max_rejected_cache_size,
                 },
                 tip_poll: lb_chain_network_service::TipPollConfig {
                     enabled: self.user.network.sync.tip_poll.enabled,

--- a/nodes/node/binary/src/config/cryptarchia/serde/network.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/network.rs
@@ -54,12 +54,17 @@ pub struct SyncConfig {
 pub struct OrphanConfig {
     /// The maximum number of pending orphans to keep in the cache.
     pub max_orphan_cache_size: NonZeroUsize,
+    /// The maximum number of block IDs to remember in the rejected-blocks
+    /// negative cache. The orphan pipeline consults this cache to short-circuit
+    /// known-bad/older-than-LIB blocks before enqueuing or downloading them.
+    pub max_rejected_cache_size: NonZeroUsize,
 }
 
 impl Default for OrphanConfig {
     fn default() -> Self {
         Self {
             max_orphan_cache_size: NonZeroUsize::new(1000).unwrap(),
+            max_rejected_cache_size: NonZeroUsize::new(1000).unwrap(),
         }
     }
 }

--- a/nodes/node/binary/src/config/cryptarchia/serde/network.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/network.rs
@@ -57,14 +57,16 @@ pub struct OrphanConfig {
     /// The maximum number of block IDs to remember in the rejected-blocks
     /// negative cache. The orphan pipeline consults this cache to short-circuit
     /// known-bad/older-than-LIB blocks before enqueuing or downloading them.
-    pub max_rejected_cache_size: NonZeroUsize,
+    ///
+    /// Setting this to `0` disables the cache entirely.
+    pub max_rejected_cache_size: usize,
 }
 
 impl Default for OrphanConfig {
     fn default() -> Self {
         Self {
             max_orphan_cache_size: NonZeroUsize::new(1000).unwrap(),
-            max_rejected_cache_size: NonZeroUsize::new(1000).unwrap(),
+            max_rejected_cache_size: 1000,
         }
     }
 }

--- a/nodes/node/standalone-node-config.yaml
+++ b/nodes/node/standalone-node-config.yaml
@@ -130,6 +130,7 @@ cryptarchia:
     sync:
       orphan:
         max_orphan_cache_size: 1000
+        max_rejected_cache_size: 1000
     network:
       max_connected_peers_to_try_download: 16
       max_discovered_peers_to_try_download: 16

--- a/services/chain/chain-network/Cargo.toml
+++ b/services/chain/chain-network/Cargo.toml
@@ -26,6 +26,7 @@ lb-services-utils       = { workspace = true }
 lb-time-service         = { workspace = true }
 lb-tracing              = { workspace = true }
 lb-tx-service           = { workspace = true }
+lru                     = { workspace = true }
 overwatch               = { workspace = true }
 rand                    = { workspace = true }
 serde                   = { workspace = true }

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -392,15 +392,19 @@ where
                         let header_id = block.header().id();
                         info!("Processing block from orphan downloader: {header_id:?}");
 
-                        if !should_process_block(
+                        match should_process_block(
                             relays.cryptarchia(),
                             block.header().id(),
                             block.header().slot(),
                         )
                         .await
                         {
-                            orphan_downloader.insert_rejected_block(header_id);
-                            continue;
+                            Ok(()) => {}
+                            Err(DoNotProcessBlock::OlderThanLib) => {
+                                orphan_downloader.insert_rejected_block(header_id);
+                                continue;
+                            }
+                            Err(DoNotProcessBlock::AlreadyApplied) => continue,
                         }
 
                         Self::log_received_block(&block);
@@ -531,10 +535,17 @@ where
         let block_slot = proposal.header().slot();
         metrics::consensus_proposals_received_total("network");
 
-        if !should_process_block(relays.cryptarchia(), block_id, block_slot).await {
-            metrics::consensus_proposals_ignored_total("already_processed", "network");
-            orphan_downloader.insert_rejected_block(block_id);
-            return;
+        match should_process_block(relays.cryptarchia(), block_id, block_slot).await {
+            Ok(()) => {}
+            Err(DoNotProcessBlock::OlderThanLib) => {
+                metrics::consensus_proposals_ignored_total("older_than_lib", "network");
+                orphan_downloader.insert_rejected_block(block_id);
+                return;
+            }
+            Err(DoNotProcessBlock::AlreadyApplied) => {
+                metrics::consensus_proposals_ignored_total("already_processed", "network");
+                return;
+            }
         }
 
         let reconstruct_started_at = Instant::now();
@@ -745,28 +756,32 @@ async fn should_process_block<Cryptarchia, RuntimeServiceId>(
     cryptarchia: &CryptarchiaServiceApi<Cryptarchia, RuntimeServiceId>,
     block_id: HeaderId,
     block_slot: Slot,
-) -> bool
+) -> Result<(), DoNotProcessBlock>
 where
     Cryptarchia: CryptarchiaServiceData,
     Cryptarchia::Tx: AuthenticatedMantleTx + Debug + Clone + Send + Sync,
     RuntimeServiceId: Send + Sync,
 {
     if !is_after_lib(cryptarchia, block_id, block_slot).await {
-        return false;
+        return Err(DoNotProcessBlock::OlderThanLib);
     }
 
     match cryptarchia.get_ledger_state(block_id).await {
-        Ok(Some(_)) => false,
-        Ok(None) => {
-            // block has not been processed
-            true
-        }
+        Ok(Some(_)) => Err(DoNotProcessBlock::AlreadyApplied),
+        Ok(None) => Ok(()),
         Err(err) => {
             error!(target: LOG_TARGET, err = ?err, "Failure when checking if block already processed");
             // block processing is idempotent, so we can safely re-process a block
-            true
+            Ok(())
         }
     }
+}
+
+/// Errors that indicate why a block should not be processed.
+#[derive(Debug)]
+enum DoNotProcessBlock {
+    OlderThanLib,
+    AlreadyApplied,
 }
 
 async fn is_after_lib<Cryptarchia, RuntimeServiceId>(
@@ -809,6 +824,9 @@ fn is_at_or_before_lib(block_slot: Slot, lib_slot: Slot) -> bool {
 /// Apply-time errors that must NOT mark the block as rejected:
 /// - `ParentMissing` / `FutureBlock`: transient — the block may become
 ///   applicable once an ancestor arrives or the local clock catches up.
+/// - `AlreadyApplied`: the block is already in the chain; re-processing is
+///   unnecessary. Rejecting would also block its valid descendants from
+///   entering the orphan pipeline.
 /// - `CommsFailure`: relay failure has nothing to do with block validity; a
 ///   blanket "reject" here would poison the cache whenever chain-service is
 ///   temporarily unreachable.
@@ -821,6 +839,7 @@ const fn is_recoverable_apply_error(err: &Error) -> bool {
         Error::Cryptarchia(
             lb_chain_service::api::ApiError::ParentMissing { .. }
                 | lb_chain_service::api::ApiError::FutureBlock { .. }
+                | lb_chain_service::api::ApiError::AlreadyApplied(_)
                 | lb_chain_service::api::ApiError::CommsFailure(_),
         ),
     )

--- a/services/chain/chain-network/src/lib.rs
+++ b/services/chain/chain-network/src/lib.rs
@@ -314,6 +314,7 @@ where
         let mut orphan_downloader = Box::pin(OrphanBlocksDownloader::new(
             network_adapter,
             sync_config.orphan.max_orphan_cache_size,
+            sync_config.orphan.max_rejected_cache_size,
         ));
 
         // Set up the proactive tip-poll lag watchdog: subscribe to slot ticks and
@@ -398,6 +399,7 @@ where
                         )
                         .await
                         {
+                            orphan_downloader.insert_rejected_block(header_id);
                             continue;
                         }
 
@@ -411,6 +413,9 @@ where
                             }
                             Err(e) => {
                                 error!(target: LOG_TARGET, "Error processing orphan downloader block: {e:?}");
+                                if !is_recoverable_apply_error(&e) {
+                                    orphan_downloader.insert_rejected_block(header_id);
+                                }
                                 orphan_downloader.cancel_active_download();
                             }
                         }
@@ -528,6 +533,7 @@ where
 
         if !should_process_block(relays.cryptarchia(), block_id, block_slot).await {
             metrics::consensus_proposals_ignored_total("already_processed", "network");
+            orphan_downloader.insert_rejected_block(block_id);
             return;
         }
 
@@ -595,6 +601,9 @@ where
                     target: LOG_TARGET, %err, ?block_id,
                     "Error processing reconstructed block",
                 );
+                if !is_recoverable_apply_error(&err) {
+                    orphan_downloader.insert_rejected_block(block_id);
+                }
             }
         }
     }
@@ -795,6 +804,26 @@ where
 
 fn is_at_or_before_lib(block_slot: Slot, lib_slot: Slot) -> bool {
     block_slot <= lib_slot
+}
+
+/// Apply-time errors that must NOT mark the block as rejected:
+/// - `ParentMissing` / `FutureBlock`: transient — the block may become
+///   applicable once an ancestor arrives or the local clock catches up.
+/// - `CommsFailure`: relay failure has nothing to do with block validity; a
+///   blanket "reject" here would poison the cache whenever chain-service is
+///   temporarily unreachable.
+///
+/// Other apply errors (e.g. validation failures surfaced as
+/// `ApiError::Unexpected`) are treated as terminal for the orphan pipeline.
+const fn is_recoverable_apply_error(err: &Error) -> bool {
+    matches!(
+        err,
+        Error::Cryptarchia(
+            lb_chain_service::api::ApiError::ParentMissing { .. }
+                | lb_chain_service::api::ApiError::FutureBlock { .. }
+                | lb_chain_service::api::ApiError::CommsFailure(_),
+        ),
+    )
 }
 
 /// Retry applying a block when `Cryptarchia` reports it as a `FutureBlock`.

--- a/services/chain/chain-network/src/metrics.rs
+++ b/services/chain/chain-network/src/metrics.rs
@@ -97,6 +97,23 @@ pub fn orphan_blocks_fetch_failed_total() {
     lb_tracing::increase_counter_u64!(orphan_blocks_fetch_failed_total, 1);
 }
 
+/// Enqueue was refused because the block (or its parent) is in the
+/// rejected-blocks negative cache.
+pub fn orphan_blocks_enqueue_rejected_total() {
+    lb_tracing::increase_counter_u64!(orphan_blocks_enqueue_rejected_total, 1);
+}
+
+/// A queued orphan was dropped at dequeue time because it had been marked
+/// rejected after enqueue.
+pub fn orphan_blocks_dequeue_rejected_total() {
+    lb_tracing::increase_counter_u64!(orphan_blocks_dequeue_rejected_total, 1);
+}
+
+/// A block id was inserted into the rejected-blocks negative cache.
+pub fn orphan_blocks_rejected_inserted_total() {
+    lb_tracing::increase_counter_u64!(orphan_blocks_rejected_inserted_total, 1);
+}
+
 pub fn tip_poll_triggered_total() {
     lb_tracing::increase_counter_u64!(tip_poll_triggered_total, 1);
 }

--- a/services/chain/chain-network/src/sync/config.rs
+++ b/services/chain/chain-network/src/sync/config.rs
@@ -19,6 +19,10 @@ pub struct OrphanConfig {
     /// The maximum number of pending orphans to keep in the cache.
     #[serde(default = "default_max_orphan_cache_size")]
     pub max_orphan_cache_size: NonZeroUsize,
+    /// The maximum number of block IDs to remember in the rejected-blocks
+    /// negative cache. The orphan pipeline consults this cache to short-circuit
+    /// known-bad/older-than-LIB blocks before enqueuing or downloading them.
+    pub max_rejected_cache_size: NonZeroUsize,
 }
 
 /// Configuration for the proactive tip-polling lag watchdog.

--- a/services/chain/chain-network/src/sync/config.rs
+++ b/services/chain/chain-network/src/sync/config.rs
@@ -22,7 +22,9 @@ pub struct OrphanConfig {
     /// The maximum number of block IDs to remember in the rejected-blocks
     /// negative cache. The orphan pipeline consults this cache to short-circuit
     /// known-bad/older-than-LIB blocks before enqueuing or downloading them.
-    pub max_rejected_cache_size: NonZeroUsize,
+    ///
+    /// Setting this to `0` disables the cache entirely.
+    pub max_rejected_cache_size: usize,
 }
 
 /// Configuration for the proactive tip-polling lag watchdog.

--- a/services/chain/chain-network/src/sync/mod.rs
+++ b/services/chain/chain-network/src/sync/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod orphan_handler;
+pub mod rejected_blocks;
 pub mod tip_poll;
 
 const LOG_TARGET: &str = "chain_network::service::sync";

--- a/services/chain/chain-network/src/sync/orphan_handler.rs
+++ b/services/chain/chain-network/src/sync/orphan_handler.rs
@@ -125,7 +125,7 @@ where
     pub fn new(
         network_adapter: NetAdapter,
         max_pending_orphans: NonZeroUsize,
-        max_rejected_cache_size: NonZeroUsize,
+        max_rejected_cache_size: usize,
     ) -> Self {
         Self {
             pending_orphans_queue: HashMap::new(),
@@ -717,11 +717,28 @@ mod tests {
     const ORPHAN_CACHE_SIZE: NonZeroUsize =
         NonZeroUsize::new(5).expect("ORPHAN_CACHE_SIZE must be non-zero");
 
-    const REJECTED_CACHE_SIZE: NonZeroUsize =
-        NonZeroUsize::new(16).expect("REJECTED_CACHE_SIZE must be non-zero");
+    const REJECTED_CACHE_SIZE: usize = 16;
 
     const TEST_TIP: [u8; 32] = [10u8; 32];
     const TEST_LIB: [u8; 32] = [11u8; 32];
+
+    #[tokio::test]
+    async fn test_disabled_rejected_cache_is_noop() {
+        // capacity = 0 disables the cache: inserts and lookups must be no-ops.
+        let network = MockNetworkAdapter::new();
+        let mut downloader: OrphanBlocksDownloader<_, usize> =
+            OrphanBlocksDownloader::new(network, ORPHAN_CACHE_SIZE, 0);
+
+        let block: HeaderId = [1u8; 32].into();
+        downloader.insert_rejected_block(block);
+
+        // Even though we just "inserted", the disabled cache should not block
+        // the enqueue.
+        downloader
+            .enqueue_orphan(block, None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+        assert!(downloader.pending_orphans_queue.contains_key(&block));
+    }
 
     #[tokio::test]
     async fn test_enqueue_rejects_block_in_rejected_cache() {

--- a/services/chain/chain-network/src/sync/orphan_handler.rs
+++ b/services/chain/chain-network/src/sync/orphan_handler.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, warn};
 use crate::{
     metrics,
     network::{BoxedStream, NetworkAdapter},
-    sync::LOG_TARGET,
+    sync::{LOG_TARGET, rejected_blocks::RejectedBlocks},
 };
 
 type PendingNetworkRequest<Block> =
@@ -44,6 +44,9 @@ where
     state: DownloaderState<NetAdapter::Block>,
     /// Maximum number of orphans to queue
     max_pending_orphans: NonZeroUsize,
+    /// Negative cache of block IDs the orphan pipeline should skip
+    /// (known-invalid or older-than-LIB).
+    rejected_blocks: RejectedBlocks,
     /// Waker to notify when new work is available
     waker: Option<Waker>,
     _phantom: std::marker::PhantomData<RuntimeServiceId>,
@@ -54,6 +57,10 @@ where
 pub struct OrphanInfo {
     /// The orphan block ID we're fetching ancestors for
     orphan_id: HeaderId,
+    /// The orphan block's parent, when known to the enqueueing caller.
+    /// `None` for orphans enqueued from a peer-polled tip where the parent is
+    /// not yet known locally.
+    parent_id: Option<HeaderId>,
     /// Local tip
     tip: HeaderId,
     /// The latest immutable block
@@ -61,9 +68,15 @@ pub struct OrphanInfo {
 }
 
 impl OrphanInfo {
-    const fn new(block_id: HeaderId, local_tip: HeaderId, lib: HeaderId) -> Self {
+    const fn new(
+        block_id: HeaderId,
+        parent_id: Option<HeaderId>,
+        local_tip: HeaderId,
+        lib: HeaderId,
+    ) -> Self {
         Self {
             orphan_id: block_id,
+            parent_id,
             tip: local_tip,
             lib,
         }
@@ -109,15 +122,27 @@ where
     NetAdapter::Block: Clone + Send + Sync + 'static,
     RuntimeServiceId: Send + Sync + 'static,
 {
-    pub fn new(network_adapter: NetAdapter, max_pending_orphans: NonZeroUsize) -> Self {
+    pub fn new(
+        network_adapter: NetAdapter,
+        max_pending_orphans: NonZeroUsize,
+        max_rejected_cache_size: NonZeroUsize,
+    ) -> Self {
         Self {
             pending_orphans_queue: HashMap::new(),
             network_adapter,
             state: DownloaderState::Idle,
             max_pending_orphans,
+            rejected_blocks: RejectedBlocks::new(max_rejected_cache_size),
             waker: None,
             _phantom: std::marker::PhantomData,
         }
+    }
+
+    /// Marks a block as rejected so the orphan pipeline will refuse to
+    /// re-enqueue it (or any descendant whose parent is this block) and will
+    /// drop it if it surfaces from the queue later.
+    pub fn insert_rejected_block(&mut self, block_id: HeaderId) {
+        self.rejected_blocks.insert(block_id);
     }
 
     #[expect(
@@ -131,6 +156,19 @@ where
         current_tip: HeaderId,
         lib: HeaderId,
     ) -> Result<(), OrphanEnqueueError> {
+        if self
+            .rejected_blocks
+            .contains_block_or_parent(&block_id, parent_id.as_ref())
+        {
+            debug!(
+                target: LOG_TARGET, ?block_id, ?parent_id,
+                "Orphan block (or its parent) is in the rejected cache, skipping enqueue"
+            );
+            self.insert_rejected_block(block_id);
+            metrics::orphan_blocks_enqueue_rejected_total();
+            return Err(OrphanEnqueueError::Rejected);
+        }
+
         if let DownloaderState::Downloading(download) = &self.state
             && download.orphan_block_id() == block_id
         {
@@ -173,8 +211,10 @@ where
             });
         }
 
-        self.pending_orphans_queue
-            .insert(block_id, OrphanInfo::new(block_id, current_tip, lib));
+        self.pending_orphans_queue.insert(
+            block_id,
+            OrphanInfo::new(block_id, parent_id, current_tip, lib),
+        );
         debug!(
             target: LOG_TARGET,
             ?block_id, ?current_tip, ?lib, queue_size = self.pending_orphans_queue.len(),
@@ -191,8 +231,23 @@ where
     }
 
     fn dequeue_next_orphan(&mut self) -> Option<OrphanInfo> {
-        let block_id = self.pending_orphans_queue.keys().next().copied()?;
-        self.remove_orphan(&block_id)
+        loop {
+            let block_id = self.pending_orphans_queue.keys().next().copied()?;
+            let orphan_info = self.remove_orphan(&block_id)?;
+            if self
+                .rejected_blocks
+                .contains_block_or_parent(&block_id, orphan_info.parent_id.as_ref())
+            {
+                debug!(
+                    target: LOG_TARGET, ?block_id, parent_id = ?orphan_info.parent_id,
+                    "dropping queued orphan: block (or its parent) is in the rejected cache"
+                );
+                self.insert_rejected_block(block_id);
+                metrics::orphan_blocks_dequeue_rejected_total();
+                continue;
+            }
+            return Some(orphan_info);
+        }
     }
 
     async fn request_blocks_stream(
@@ -433,6 +488,8 @@ pub enum OrphanEnqueueError {
     AlreadyDownloading,
     #[error("orphan block is already in the queue")]
     AlreadyInQueue,
+    #[error("orphan block (or its parent) is in the rejected cache")]
+    Rejected,
 }
 
 #[cfg(test)]
@@ -456,7 +513,7 @@ mod tests {
 
     fn create_downloader() -> OrphanBlocksDownloader<MockNetworkAdapter, usize> {
         let network = MockNetworkAdapter::new();
-        OrphanBlocksDownloader::new(network, ORPHAN_CACHE_SIZE)
+        OrphanBlocksDownloader::new(network, ORPHAN_CACHE_SIZE, REJECTED_CACHE_SIZE)
     }
 
     fn create_downloader_with_responses<T>(
@@ -486,7 +543,7 @@ mod tests {
             }
         }
 
-        OrphanBlocksDownloader::new(network, ORPHAN_CACHE_SIZE)
+        OrphanBlocksDownloader::new(network, ORPHAN_CACHE_SIZE, REJECTED_CACHE_SIZE)
     }
 
     trait IntoBlockResult {
@@ -660,8 +717,78 @@ mod tests {
     const ORPHAN_CACHE_SIZE: NonZeroUsize =
         NonZeroUsize::new(5).expect("ORPHAN_CACHE_SIZE must be non-zero");
 
+    const REJECTED_CACHE_SIZE: NonZeroUsize =
+        NonZeroUsize::new(16).expect("REJECTED_CACHE_SIZE must be non-zero");
+
     const TEST_TIP: [u8; 32] = [10u8; 32];
     const TEST_LIB: [u8; 32] = [11u8; 32];
+
+    #[tokio::test]
+    async fn test_enqueue_rejects_block_in_rejected_cache() {
+        let mut downloader = create_downloader();
+        let block: HeaderId = [1u8; 32].into();
+
+        downloader.insert_rejected_block(block);
+
+        assert!(matches!(
+            downloader.enqueue_orphan(block, None, TEST_TIP.into(), TEST_LIB.into()),
+            Err(OrphanEnqueueError::Rejected)
+        ));
+        assert!(downloader.pending_orphans_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_rejects_block_whose_parent_is_in_rejected_cache() {
+        let mut downloader = create_downloader();
+        let parent: HeaderId = [1u8; 32].into();
+        let child: HeaderId = [2u8; 32].into();
+
+        downloader.insert_rejected_block(parent);
+
+        assert!(matches!(
+            downloader.enqueue_orphan(child, Some(parent), TEST_TIP.into(), TEST_LIB.into()),
+            Err(OrphanEnqueueError::Rejected)
+        ));
+        assert!(downloader.pending_orphans_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_dequeue_skips_rejected_blocks() {
+        let chain = create_chain(4);
+        // Stream covers only block index 3 (chain[3]); the other two enqueued
+        // orphans get marked rejected after being enqueued.
+        // Those two should be skipped at dequeue time.
+        let mut downloader =
+            create_downloader_with_responses(&chain, vec![(3, vec![vec![0, 1, 2, 3]])]);
+        downloader
+            .enqueue_orphan(chain[0], None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+        downloader.insert_rejected_block(chain[0]);
+        downloader
+            .enqueue_orphan(chain[1], None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+        downloader.insert_rejected_block(chain[1]);
+        downloader
+            .enqueue_orphan(chain[3], None, TEST_TIP.into(), TEST_LIB.into())
+            .unwrap();
+
+        let mut downloader = pin::pin!(downloader);
+        let received_blocks = receive_blocks(&mut downloader, 4).await;
+        assert_eq!(&received_blocks, &chain[0..=3]);
+
+        // Only one request should have fired — the one for the non-rejected
+        // orphan. The two rejected entries are dropped at dequeue.
+        let requests = downloader
+            .as_mut()
+            .get_mut()
+            .network_adapter
+            .requests
+            .lock()
+            .unwrap()
+            .clone();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].target, chain[3]);
+    }
 
     #[tokio::test]
     async fn test_orphan_cache_limit() {
@@ -794,7 +921,11 @@ mod tests {
         // download stays in `Downloading` waiting for `parent`.
         let network =
             MockNetworkAdapter::new().with_stream(parent, None, vec![Ok(ancestor), Ok(parent)]);
-        let downloader = OrphanBlocksDownloader::<_, usize>::new(network, ORPHAN_CACHE_SIZE);
+        let downloader = OrphanBlocksDownloader::<_, usize>::new(
+            network,
+            ORPHAN_CACHE_SIZE,
+            REJECTED_CACHE_SIZE,
+        );
         let mut downloader = pin::pin!(downloader);
 
         downloader

--- a/services/chain/chain-network/src/sync/rejected_blocks.rs
+++ b/services/chain/chain-network/src/sync/rejected_blocks.rs
@@ -8,30 +8,43 @@ use crate::{metrics, sync::LOG_TARGET};
 
 /// Bounded LRU of block IDs that the orphan pipeline should skip
 /// (known-invalid or older-than-LIB).
+///
+/// A capacity of `0` disables the cache: all queries return `false` and all
+/// insertions are no-ops. This allows operators to turn the feature off via
+/// config without conditional logic at every call site.
 pub struct RejectedBlocks {
-    cache: LruCache<HeaderId, ()>,
+    cache: Option<LruCache<HeaderId, ()>>,
 }
 
 impl RejectedBlocks {
-    pub fn new(capacity: NonZeroUsize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
-            cache: LruCache::new(capacity),
+            cache: NonZeroUsize::new(capacity).map(LruCache::new),
         }
     }
 
     /// Returns `true` if either the block itself or its parent (when known) is
     /// in the cache. Touches matching entries on hit so frequently-checked
     /// rejections stay in the cache.
+    ///
+    /// Always returns `false` when the cache is disabled.
     pub fn contains_block_or_parent(
         &mut self,
         block_id: &HeaderId,
         parent_id: Option<&HeaderId>,
     ) -> bool {
-        self.cache.get(block_id).is_some() || parent_id.is_some_and(|p| self.cache.get(p).is_some())
+        let Some(cache) = self.cache.as_mut() else {
+            return false;
+        };
+        cache.get(block_id).is_some() || parent_id.is_some_and(|p| cache.get(p).is_some())
     }
 
+    /// No-op when the cache is disabled.
     pub fn insert(&mut self, block_id: HeaderId) {
-        if self.cache.put(block_id, ()).is_none() {
+        let Some(cache) = self.cache.as_mut() else {
+            return;
+        };
+        if cache.put(block_id, ()).is_none() {
             debug!(target: LOG_TARGET, ?block_id, "inserted rejected block into cache");
             metrics::orphan_blocks_rejected_inserted_total();
         }

--- a/services/chain/chain-network/src/sync/rejected_blocks.rs
+++ b/services/chain/chain-network/src/sync/rejected_blocks.rs
@@ -2,8 +2,9 @@ use std::num::NonZeroUsize;
 
 use lb_core::header::HeaderId;
 use lru::LruCache;
+use tracing::debug;
 
-use crate::metrics;
+use crate::{metrics, sync::LOG_TARGET};
 
 /// Bounded LRU of block IDs that the orphan pipeline should skip
 /// (known-invalid or older-than-LIB).
@@ -31,6 +32,7 @@ impl RejectedBlocks {
 
     pub fn insert(&mut self, block_id: HeaderId) {
         if self.cache.put(block_id, ()).is_none() {
+            debug!(target: LOG_TARGET, ?block_id, "inserted rejected block into cache");
             metrics::orphan_blocks_rejected_inserted_total();
         }
     }

--- a/services/chain/chain-network/src/sync/rejected_blocks.rs
+++ b/services/chain/chain-network/src/sync/rejected_blocks.rs
@@ -1,0 +1,37 @@
+use std::num::NonZeroUsize;
+
+use lb_core::header::HeaderId;
+use lru::LruCache;
+
+use crate::metrics;
+
+/// Bounded LRU of block IDs that the orphan pipeline should skip
+/// (known-invalid or older-than-LIB).
+pub struct RejectedBlocks {
+    cache: LruCache<HeaderId, ()>,
+}
+
+impl RejectedBlocks {
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            cache: LruCache::new(capacity),
+        }
+    }
+
+    /// Returns `true` if either the block itself or its parent (when known) is
+    /// in the cache. Touches matching entries on hit so frequently-checked
+    /// rejections stay in the cache.
+    pub fn contains_block_or_parent(
+        &mut self,
+        block_id: &HeaderId,
+        parent_id: Option<&HeaderId>,
+    ) -> bool {
+        self.cache.get(block_id).is_some() || parent_id.is_some_and(|p| self.cache.get(p).is_some())
+    }
+
+    pub fn insert(&mut self, block_id: HeaderId) {
+        if self.cache.put(block_id, ()).is_none() {
+            metrics::orphan_blocks_rejected_inserted_total();
+        }
+    }
+}

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -34,6 +34,8 @@ pub enum ApiError {
         block_slot: Slot,
         current_slot: Slot,
     },
+    #[error("Block {0} has already been applied")]
+    AlreadyApplied(HeaderId),
     #[error("Failed to establish connection to chain-service: {0}")]
     CommsFailure(String),
     #[error("Unexpected Error: {0}")]
@@ -273,6 +275,7 @@ where
                     block_slot,
                     current_slot,
                 },
+                crate::Error::AlreadyApplied(block_id) => ApiError::AlreadyApplied(block_id),
                 err => ApiError::Unexpected(format!("Failure while applying block: {err:?}")),
             })
     }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -87,6 +87,8 @@ pub enum Error {
         block_slot: Slot,
         current_slot: Slot,
     },
+    #[error("Block {0} has already been applied")]
+    AlreadyApplied(HeaderId),
     #[error("Ledger error: {0}")]
     Ledger(#[from] lb_ledger::LedgerError<HeaderId>),
     #[error("Consensus error: {0}")]
@@ -354,6 +356,10 @@ impl Cryptarchia {
         let id = header.id();
         let parent = header.parent();
         let slot = header.slot();
+
+        if self.ledger.state(&id).is_some() {
+            return Err(Error::AlreadyApplied(id));
+        }
 
         // Reject blocks from future slots
         if slot > current_slot {

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -646,8 +646,7 @@ fn build_cryptarchia_user_config(
                 orphan: network::OrphanConfig {
                     max_orphan_cache_size: NonZeroUsize::new(1000)
                         .expect("max orphan cache size must be non-zero"),
-                    max_rejected_cache_size: NonZeroUsize::new(1000)
-                        .expect("max rejected cache size must be non-zero"),
+                    max_rejected_cache_size: 1000,
                 },
                 tip_poll: network::TipPollConfig::default(),
             },

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -646,6 +646,8 @@ fn build_cryptarchia_user_config(
                 orphan: network::OrphanConfig {
                     max_orphan_cache_size: NonZeroUsize::new(1000)
                         .expect("max orphan cache size must be non-zero"),
+                    max_rejected_cache_size: NonZeroUsize::new(1000)
+                        .expect("max rejected cache size must be non-zero"),
                 },
                 tip_poll: network::TipPollConfig::default(),
             },


### PR DESCRIPTION
## 1. What does this PR implement?

### Issues 

We found that a significant portion of the blocks inserted into the orphan queue had parents that had previously been rejected by the local chain (e.g., invalid block, or older than LIB).

The orphan downloader will dequeue them one by one and download ancestors of them from remote peers, without any filtering. We will detect that they have to be rejected only when we apply the downloaded blocks. That is, we are wasting network resource and queue capacity.

### Solution

This PR is introducing a LRU cache, `RejectedBlocks`, in the orphan downloader.

The chain-network service inserts blocks to the cache in the following cases, in order to help the orphan downloader:
- The `should_process_block` pre-check returns `false`, meaning that the block is older than LIB or has been already applied in the local chain.
- The chain service returns an non-recoverable error (not missing-parent). 

Then, the orphan downloader uses the cache in the following scenarios:
- Don't enqueue an orphan block if the block (or its parent) is in the cache.
- Don't start download if the dequeued block (or its parent) is in the cache.

### Notes

- The cache lives only inside the orphan downloader because it is used only to avoid initiating unnecessary block downloads.
  - The chain-network service only inserted blocks to the cache, but doesn't use the cache to reject blocks, because it processes only a single block at once. That block will be rejected by the chain service immediately.   

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?
@youngjoon-lee 


## 4. Is the specification accurate and complete?

Yes. This is an implementation detail.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
