### PR TITLE
feat(chain-service): make block-provider batch size configurable

### DIFF
--- a/nodes/node/binary/src/config/cryptarchia/mod.rs
+++ b/nodes/node/binary/src/config/cryptarchia/mod.rs
@@ -102,6 +102,11 @@ impl ServiceConfig {
                     .as_path(),
             ),
             starting_state: self.deployment.genesis_block.into(),
+            sync: lb_chain_service::SyncConfig {
+                block_provider: lb_chain_service::BlockProviderConfig {
+                    batch_size: self.user.service.sync.block_provider.batch_size,
+                },
+            },
         };
         let chain_network_settings = lb_chain_network_service::ChainNetworkSettings {
             bootstrap: lb_chain_network_service::BootstrapConfig {

--- a/nodes/node/binary/src/config/cryptarchia/serde/service.rs
+++ b/nodes/node/binary/src/config/cryptarchia/serde/service.rs
@@ -1,4 +1,4 @@
-use core::time::Duration;
+use core::{num::NonZeroUsize, time::Duration};
 
 use lb_utils::bounded_duration::{MinimalBoundedDuration, SECOND};
 use serde::{Deserialize, Serialize};
@@ -8,6 +8,29 @@ use serde_with::serde_as;
 #[serde(default)]
 pub struct Config {
     pub bootstrap: BootstrapConfig,
+    pub sync: SyncConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct SyncConfig {
+    pub block_provider: BlockProviderConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct BlockProviderConfig {
+    /// Upper bound on blocks returned per `send_blocks` request handled by
+    /// the chain-service `BlockProvider`.
+    pub batch_size: NonZeroUsize,
+}
+
+impl Default for BlockProviderConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: NonZeroUsize::new(1000).unwrap(),
+        }
+    }
 }
 
 #[serde_as]

--- a/nodes/node/standalone-node-config.yaml
+++ b/nodes/node/standalone-node-config.yaml
@@ -120,6 +120,9 @@ cryptarchia:
       offline_grace_period:
         grace_period: '5.000000000'
         state_recording_interval: '60.000000000'
+    sync:
+      block_provider:
+        batch_size: 1000
   network:
     bootstrap:
       ibd:

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -5,7 +5,7 @@ mod notifier;
 mod relays;
 mod states;
 pub mod storage;
-pub mod sync;
+mod sync;
 #[cfg(test)]
 mod tests;
 

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -5,7 +5,7 @@ mod notifier;
 mod relays;
 mod states;
 pub mod storage;
-mod sync;
+pub mod sync;
 #[cfg(test)]
 mod tests;
 
@@ -60,7 +60,10 @@ use tokio::{
 use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 use tracing_futures::Instrument as _;
 
-pub use crate::bootstrap::config::{BootstrapConfig, OfflineGracePeriodConfig};
+pub use crate::{
+    bootstrap::config::{BootstrapConfig, OfflineGracePeriodConfig},
+    sync::config::{BlockProviderConfig, SyncConfig},
+};
 use crate::{
     bootstrap::state::choose_engine_state,
     notifier::ChainOnlineNotifier,
@@ -474,6 +477,7 @@ pub struct CryptarchiaSettings {
     pub starting_state: StartingState,
     pub recovery_file: PathBuf,
     pub bootstrap: BootstrapConfig,
+    pub sync: SyncConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -588,6 +592,7 @@ where
             config: ledger_config,
             bootstrap: bootstrap_config,
             starting_state,
+            sync: sync_config,
             ..
         } = self
             .service_resources_handle
@@ -636,8 +641,10 @@ where
             );
         }
 
-        let sync_blocks_provider: BlockProvider<_, _> =
-            BlockProvider::new(relays.storage_adapter().storage_relay.clone());
+        let sync_blocks_provider: BlockProvider<_, _> = BlockProvider::new(
+            relays.storage_adapter().storage_relay.clone(),
+            sync_config.block_provider,
+        );
 
         // Chain start timer will prevent the chain service to process and produce
         // blocks if the starting state is GenesisBlock and has chain start time

--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -18,9 +18,7 @@ use thiserror::Error;
 use tokio::sync::{mpsc::Sender, oneshot};
 use tracing::{debug, error};
 
-use crate::relays::StorageRelay;
-
-const MAX_NUMBER_OF_BLOCKS: usize = 1000;
+use crate::{relays::StorageRelay, sync::config::BlockProviderConfig};
 
 #[derive(Debug, Error, Clone)]
 pub enum GetBlocksError {
@@ -57,6 +55,7 @@ where
     Tx: Clone + Eq,
 {
     storage_relay: StorageRelay<Storage>,
+    config: BlockProviderConfig,
     _phantom: PhantomData<Tx>,
 }
 
@@ -66,9 +65,11 @@ where
     <Storage as StorageChainApi>::Block: TryInto<Block<Tx>> + Into<Bytes>,
     Tx: Serialize + Clone + Eq + Send + Sync + 'static,
 {
-    pub const fn new(storage_relay: StorageRelay<Storage>) -> Self {
+    #[must_use]
+    pub const fn new(storage_relay: StorageRelay<Storage>, config: BlockProviderConfig) -> Self {
         Self {
             storage_relay,
+            config,
             _phantom: PhantomData,
         }
     }
@@ -123,7 +124,7 @@ where
     /// Creates a block stream that leads from one of the [`known_blocks`]
     /// to the [`target_block`], in parent-to-child order.
     ///
-    /// The stream includes at most [`MAX_NUMBER_OF_BLOCKS`] blocks.
+    /// The stream includes at most `batch_size` blocks.
     /// The stream may or may not reach the [`target_block`].
     ///
     /// In any error case, [`GetBlocksError`] is returned.
@@ -329,9 +330,11 @@ where
         target_info: BlockInfo,
     ) -> Result<Vec<HeaderId>, GetBlocksError> {
         // Add 1 because we remove first(known block) from the path
-        let limit = (MAX_NUMBER_OF_BLOCKS + 1)
-            .try_into()
-            .expect("MAX_NUMBER_OF_BLOCKS should be > 0");
+        let limit = self
+            .config
+            .batch_size
+            .checked_add(1)
+            .expect("batch_size + 1 must not overflow");
 
         match start_info.location {
             BlockLocation::Engine => {
@@ -728,7 +731,7 @@ mod tests {
     async fn test_path_length_limit() {
         let mut env = TestEnv::new().await;
 
-        let long_chain = env.setup_chain_with_blocks(MAX_NUMBER_OF_BLOCKS + 1).await;
+        let long_chain = env.setup_chain_with_blocks(TEST_BATCH_SIZE.get() + 1).await;
 
         let known_blocks = HashSet::from([long_chain[0]]);
         let target_block = *long_chain.last().unwrap();
@@ -739,10 +742,13 @@ mod tests {
 
         assert_eq!(
             retrieved_blocks.len(),
-            MAX_NUMBER_OF_BLOCKS,
-            "Retrieved blocks should not exceed MAX_NUMBER_OF_BLOCKS minus the skipped known block"
+            TEST_BATCH_SIZE.get(),
+            "Retrieved blocks should not exceed batch_size minus the skipped known block"
         );
     }
+
+    const TEST_BATCH_SIZE: NonZeroUsize =
+        NonZeroUsize::new(1000).expect("TEST_BATCH_SIZE must be non-zero");
 
     #[derive_services]
     pub struct TestServices {
@@ -766,7 +772,12 @@ mod tests {
                 NonNegativeRatio::new(1, 10.try_into().unwrap()),
             );
             let proof = Self::make_test_proof(&cryptarchia);
-            let provider = BlockProvider::new(storage_relay.clone());
+            let provider = BlockProvider::new(
+                storage_relay.clone(),
+                BlockProviderConfig {
+                    batch_size: TEST_BATCH_SIZE,
+                },
+            );
 
             Self {
                 service,

--- a/services/chain/chain-service/src/sync/config.rs
+++ b/services/chain/chain-service/src/sync/config.rs
@@ -1,0 +1,15 @@
+use std::num::NonZeroUsize;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SyncConfig {
+    pub block_provider: BlockProviderConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BlockProviderConfig {
+    /// Upper bound on blocks returned per `send_blocks` request handled by
+    /// the `BlockProvider`.
+    pub batch_size: NonZeroUsize,
+}

--- a/services/chain/chain-service/src/sync/mod.rs
+++ b/services/chain/chain-service/src/sync/mod.rs
@@ -1,1 +1,2 @@
 pub mod block_provider;
+pub mod config;

--- a/tests/testing_framework/src/framework/local/provisioning.rs
+++ b/tests/testing_framework/src/framework/local/provisioning.rs
@@ -659,6 +659,12 @@ fn build_cryptarchia_user_config(
                 },
                 prolonged_bootstrap_period: consensus.prolonged_bootstrap_period,
             },
+            sync: service::SyncConfig {
+                block_provider: service::BlockProviderConfig {
+                    batch_size: NonZeroUsize::new(1000)
+                        .expect("block_provider batch_size must be non-zero"),
+                },
+            },
         },
         leader: LeaderConfig {
             wallet: leader::WalletConfig {


### PR DESCRIPTION
## 1. What does this PR implement?

### Issues

We had `MAX_NUMBER_OF_BLOCKS = 1000` hardcoded in the chain-sync block provider. It is the max number of blocks returned by a block download response. I will call it "batch size" in this PR. 

Because of that, the requester has to send a new download request to the provider, after consuming the 1000 blocks. Then, the provider has to compute the block path **again** based on the starting/end points that the request provides. This path computation is expensive if the chain is long. That's why we see some time delay (~1min) between every 1000 blocks when we catch up the network.

### Solution

This PR makes the value configurable. The default value is still 1000, but we can increase it.

The impacts of increasing the batch size are:
- The provider will keep a bigger `Vec<HeaderId>` as a result of path computation. But that is not huge.
- The provider loads blocks from storage one by one and stream it to the requester. So, no memory pressure in this step.
- The provider will consume much network egress.
- The provider will perform path computations much less. The cost of path computation is the same if the starting/end points are the same between two block download requests.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @youngjoon-lee 

## 4. Is the specification accurate and complete?

This is an implementation detail.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
