### PR TITLE
fix(blend): stop reporting core peers count after core swarm is shut down

### DIFF
--- a/services/blend/src/core/backends/libp2p/mod.rs
+++ b/services/blend/src/core/backends/libp2p/mod.rs
@@ -185,5 +185,6 @@ impl Drop for Libp2pBlendBackend {
             ..
         } = self;
         swarm_task_abort_handle.abort();
+        metrics::peers_negotiated_stop_reporting();
     }
 }

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -22,7 +22,11 @@ mod imp {
     }
 
     pub fn core_peers_negotiated(count: usize) {
-        lb_tracing::metric_gauge_u64!(blend_core_peers_negotiated, count as u64);
+        lb_tracing::metric_observable_gauge_u64_set!(blend_core_peers_negotiated, count as u64);
+    }
+
+    pub fn peers_negotiated_stop_reporting() {
+        lb_tracing::metric_observable_gauge_u64_clear!(blend_core_peers_negotiated);
     }
 
     pub fn outbound_publish_ok() {

--- a/tracing/src/lib.rs
+++ b/tracing/src/lib.rs
@@ -31,6 +31,20 @@ macro_rules! metric_gauge_u64 {
 }
 
 #[macro_export]
+macro_rules! metric_observable_gauge_u64_set {
+    ($name:ident, $value:expr) => {{
+        $crate::metrics::emit::observable_gauge_u64_set(stringify!($name), $value);
+    }};
+}
+
+#[macro_export]
+macro_rules! metric_observable_gauge_u64_clear {
+    ($name:ident) => {{
+        $crate::metrics::emit::observable_gauge_u64_clear(stringify!($name));
+    }};
+}
+
+#[macro_export]
 macro_rules! metric_histogram_u64 {
     ($name:ident, $value:expr $(, $k:ident = $v:expr)* $(,)?) => {{
         let attributes = &[$($crate::metrics::emit::key_value(stringify!($k), $v),)*];

--- a/tracing/src/metrics/emit.rs
+++ b/tracing/src/metrics/emit.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::HashMap,
-    sync::{LazyLock, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use opentelemetry::{
     KeyValue, Value, global,
-    metrics::{Counter, Gauge, Histogram, Meter},
+    metrics::{AsyncInstrument, Counter, Gauge, Histogram, Meter},
 };
 
 fn meter() -> Meter {
@@ -21,6 +21,10 @@ static U64_GAUGES: LazyLock<Mutex<HashMap<&'static str, Gauge<u64>>>> =
 static U64_HISTOGRAMS: LazyLock<Mutex<HashMap<&'static str, Histogram<u64>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static F64_HISTOGRAMS: LazyLock<Mutex<HashMap<&'static str, Histogram<f64>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+type ObservableGaugeCell = Arc<Mutex<Option<u64>>>;
+static OBSERVABLE_U64_GAUGES: LazyLock<Mutex<HashMap<&'static str, ObservableGaugeCell>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub fn reset_cached_instruments() {
@@ -40,6 +44,10 @@ pub fn reset_cached_instruments() {
     F64_HISTOGRAMS
         .lock()
         .expect("f64 histogram lock poisoned")
+        .clear();
+    OBSERVABLE_U64_GAUGES
+        .lock()
+        .expect("observable u64 gauge lock poisoned")
         .clear();
 }
 
@@ -117,6 +125,23 @@ macro_rules! get_instrument {
             }
         }
     }};
+    // Support for optional callback for observable gauges.
+    ($map:expr, $name:expr, $method:ident, $callback_for_cell:expr) => {{
+        match $map.lock() {
+            Ok(mut map) => Some(Arc::clone(map.entry($name).or_insert_with(|| {
+                let cell = Arc::new(Mutex::new(None));
+                meter()
+                    .$method($name)
+                    .with_callback(($callback_for_cell)(Arc::clone(&cell)))
+                    .build();
+                cell
+            }))),
+            Err(e) => {
+                tracing::error!("Instrument '{}' lock poisoned: {e:?}", $name);
+                None
+            }
+        }
+    }};
 }
 
 pub fn increase_counter_u64(
@@ -138,6 +163,48 @@ pub fn counter_f64(name: &'static str, value: f64, attributes: &[KeyValue]) {
 pub fn gauge_u64(name: &'static str, value: impl IntoMetricU64, attributes: &[KeyValue]) {
     if let Some(gauge) = get_instrument!(U64_GAUGES, name, u64_gauge) {
         gauge.record(value.into_metric_u64(), attributes);
+    }
+}
+
+pub fn observable_gauge_u64_set(name: &'static str, value: impl IntoMetricU64) {
+    if let Some(cell) = get_instrument!(
+        OBSERVABLE_U64_GAUGES,
+        name,
+        u64_observable_gauge,
+        observe_cell_u64
+    ) {
+        match cell.lock() {
+            Ok(mut current) => *current = Some(value.into_metric_u64()),
+            Err(e) => tracing::error!("Observable gauge '{name}' value lock poisoned: {e:?}"),
+        }
+    }
+}
+
+fn observe_cell_u64(
+    cell: ObservableGaugeCell,
+) -> impl Fn(&dyn AsyncInstrument<u64>) + Send + Sync + 'static {
+    move |observer| {
+        if let Ok(value) = cell.lock()
+            && let Some(value) = *value
+        {
+            observer.observe(value, &[]);
+        }
+    }
+}
+
+pub fn observable_gauge_u64_clear(name: &'static str) {
+    match OBSERVABLE_U64_GAUGES.lock() {
+        Ok(map) => {
+            if let Some(cell) = map.get(name) {
+                match cell.lock() {
+                    Ok(mut current) => *current = None,
+                    Err(e) => {
+                        tracing::error!("Observable gauge '{name}' value lock poisoned: {e:?}");
+                    }
+                }
+            }
+        }
+        Err(e) => tracing::error!("Observable gauge '{name}' lock poisoned: {e:?}"),
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Our exporter was re-using the last-written value when exporting Blend peer metrics, so if a node goes from core to edge, the last core count is still reported. We introduce an observable u64 value here which is stopped being reported as soon as the core swarm is dropped. This will result in an interrupted line in the Grafana dashboard.

I chose this solution over setting the value to `0` and keep reporting that (current default behaviour for all gauges) since it creates a weird mixture of a node being non-core but still reporting and showing up in Grafana.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.