### PR TITLE
docs(release): add ZK circuits prerequisite to node quick-start

### DIFF
--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -8,6 +8,17 @@
     tar -xzf logos-blockchain-node-<arch>-<version>.tar.gz
    ```
 
+2. Download and unzip the **ZK circuits**, then point the node at them:
+
+   ```bash
+    tar -xzf logos-blockchain-circuits-<arch>-<version>.tar.gz
+    export LOGOS_BLOCKCHAIN_CIRCUITS="$PWD/logos-blockchain-circuits-<arch>-<version>"
+   ```
+
+   > ⚠️ The node loads proving/verifying keys at launch and **will not start** without
+   > `LOGOS_BLOCKCHAIN_CIRCUITS` pointing at a valid circuits directory. (No circuits
+   > asset is currently attached to the node release — see #3054.)
+
 ### ⚙️ Initialize Your Node
 
 Generate a default configuration by connecting to the bootstrap peers:


### PR DESCRIPTION
## What

Adds a **ZK circuits** prerequisite to the node quick-start (`.github/release/release-content.md`).

## Why

Following the quick-start as written, the node **fails to start** — the Prerequisites only download the *node binary*, but the standalone `logos-blockchain-node` loads proving/verifying keys at launch and aborts without `LOGOS_BLOCKCHAIN_CIRCUITS` pointing at a circuits directory:

```
Error: No such file or directory (os error 2)
  nodes/node/binary/src/main.rs:83
```

Hit while bringing up a 0.2.0 testnet node (Linux x86_64). I had to reuse a `v0.4.2` circuits dir from a prior release to get past it.

## Note / follow-up

There is **no circuits asset attached to the 0.2.0 node release**, so even with this doc fix an operator has nowhere to download the matching circuits — the artifact should be published alongside the node binary (and the exact version pinned). Filed as #3054, which also covers the related issue that the `lgpd` `blockchain_module 0.2.0` is a **devnet** build (`devnet-0.2.0-rc.1`) while the testnet bootstrap peers run `testnet-0.2.0`.

Draft — happy to adjust the wording / circuits version once the artifact + version are confirmed.

*Filed with AI assistance (Claude Code).*