### PR TITLE
docs(release): faucet takes only a public key, not team credentials

### DIFF
--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -70,7 +70,7 @@ Either key can be used.
 
 **2. 🚰 Request funds from the faucet**
 
-Visit the [devnet faucet][devnet-faucet] or [testnet faucet][testnet-faucet] and enter the credentials provided by the Logos Blockchain team (you can reach out to them on [Discord][testnet-discord-public]), then paste your wallet key.
+Visit the [devnet faucet][devnet-faucet] or [testnet faucet][testnet-faucet], paste your wallet key into the **Destination Public Key (Hex)** field, and click **Request Funds**. (Questions? Reach the Logos Blockchain team on [Discord][testnet-discord-public].)
 
 A word of caution - do not _powerclick_ your way through as only one request can be made per block! So if you want to receive funds more than once, wait until your balance increases before requesting new funds.
 


### PR DESCRIPTION
## What

Fixes the **Getting Funds** step in `.github/release/release-content.md`.

## Why

The step said:
> Visit the faucet and **enter the credentials provided by the Logos Blockchain team** … then paste your wallet key.

But the live testnet faucet (https://testnet.blockchain.logos.co/web/faucet/) has **no credentials field** — only `Destination Public Key (Hex)` + `Request Funds`. Pasting a node key and clicking the button works directly (verified: `Success! Transaction hash: d5b087ad…`, balance landed). The credentials wording is a needless onboarding blocker.

Closes #3056. (Same file as #3055, different section — independent.)

*Verified against the live faucet, 2026-06-30.*