### PR TITLE
chore(blend): change reported metric value for peer count

### DIFF
--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -294,6 +294,10 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             .count()
     }
 
+    pub fn num_negotiated_peers(&self) -> usize {
+        self.negotiated_peers.len()
+    }
+
     pub const fn minimum_healthy_peering_degree(&self) -> usize {
         *self.peering_degree.start()
     }

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -366,9 +366,15 @@ where
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. }
             | SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                let negotiated_count = self
+                    .swarm
+                    .behaviour()
+                    .blend
+                    .with_core()
+                    .num_negotiated_peers();
                 let connected_count = self.swarm.connected_peers().count();
-                tracing::trace!(target: LOG_TARGET, "New connection or disconnection with peer {peer_id:?}. Number of currently connected peers: {connected_count}.");
-                metrics::peers_connected(connected_count);
+                tracing::trace!(target: LOG_TARGET, "New connection or disconnection with peer {peer_id:?}. Number of core peers currently negotiated: {negotiated_count}. Number of peers currently connected: {connected_count}.");
+                metrics::core_peers_negotiated(negotiated_count);
             }
             SwarmEvent::Behaviour(BlendBehaviourEvent::Blend(NetworkBehaviourEvent::WithCore(
                 e,

--- a/services/blend/src/metrics.rs
+++ b/services/blend/src/metrics.rs
@@ -21,8 +21,8 @@ mod imp {
         lb_tracing::increase_counter_u64!(blend_mix_packets_processed_total, 1);
     }
 
-    pub fn peers_connected(count: usize) {
-        lb_tracing::metric_gauge_u64!(blend_peers_connected, count as u64);
+    pub fn core_peers_negotiated(count: usize) {
+        lb_tracing::metric_gauge_u64!(blend_core_peers_negotiated, count as u64);
     }
 
     pub fn outbound_publish_ok() {


### PR DESCRIPTION
## 1. What does this PR implement?

Change the value reported as peer count from the number of _connected_ peers, which includes negotiated core peers but also edge peers and core peers that start a negotiation process that will then close, to the number of _negotiated_ peers, which track the actual peering degree of the node.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.