### PR TITLE
Remove stray .claude/worktrees gitlink that breaks cargo/Nix git-dependency builds (#3062)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ services/tx-service/[0-9]*
 
 # testnet cfgsync generated local deployment file
 testnet/cfgsync/deployment-settings.yaml
+
+# Claude Code worktree admin dirs must never be tracked
+/.claude/


### PR DESCRIPTION
Fixes #3062.

`.claude/worktrees/wf_d6259406-6a4-9` is committed as a git submodule gitlink (→ `93b44bd9`) with **no entry in `.gitmodules`**. This makes `cargo`'s libgit2 submodule walk abort on any build that depends on a logos-blockchain crate as a **git dependency**:

```
failed to update submodule `.claude/worktrees/wf_d6259406-6a4-9`
no URL configured for submodule '.claude/worktrees/wf_d6259406-6a4-9'; class=Submodule (17)
```

It also breaks Nix `buildRustPackage` / `fetchgit` of the same revs. Present on `master` and across the v0.2 tags (`0.2.0`, `0.2.0-rc.1`, `0.2.0-rc.2`).

### Reproduce
```
git ls-tree -r master | grep '^160000'   # 160000 commit 93b44bd9... .claude/worktrees/wf_...
git show master:.gitmodules              # no entry for that path
```

### Fix
Removes the stray gitlink and gitignores `/.claude/` so Claude Code worktree admin dirs aren't tracked again. One commit, no code changes.
