### PR TITLE
chore: migrate TransferOp to NomCodec + fixtures

### DIFF
--- a/core/src/mantle/encoding.rs
+++ b/core/src/mantle/encoding.rs
@@ -16,7 +16,7 @@ use crate::{
     mantle::{
         MantleTx, Note, NoteId, SignedMantleTx,
         nom::{NomDecode as _, NomEncode as _},
-        ops::{Op, OpProof, transfer::TransferOp},
+        ops::{Op, OpProof},
     },
     proofs::leader_claim_proof::Groth16LeaderClaimProof,
 };
@@ -61,30 +61,6 @@ pub fn decode_mantle_tx(input: &[u8]) -> IResult<&[u8], MantleTx> {
     let (input, ops) = Ops::decode(input)?;
 
     Ok((input, MantleTx(ops)))
-}
-
-// ==============================================================================
-// Transfer Decoders
-// ==============================================================================
-
-fn decode_inputs(input: &[u8]) -> IResult<&[u8], Inputs> {
-    let (input, bounded_inputs) = BoundedInputs::decode(input)?;
-
-    Ok((input, Inputs::new(bounded_inputs)))
-}
-
-fn decode_outputs(input: &[u8]) -> IResult<&[u8], Outputs> {
-    let (input, bounded_outputs) = BoundedOutputs::decode(input)?;
-
-    Ok((input, Outputs::new(bounded_outputs)))
-}
-
-pub(crate) fn decode_transfer(input: &[u8]) -> IResult<&[u8], TransferOp> {
-    // Transfer = Inputs Outputs
-    let (input, inputs) = decode_inputs(input)?;
-    let (input, outputs) = decode_outputs(input)?;
-
-    Ok((input, TransferOp::new(inputs, outputs)))
 }
 
 // ==============================================================================
@@ -253,12 +229,7 @@ pub(crate) fn decode_unix_timestamp(input: &[u8]) -> IResult<&[u8], OffsetDateTi
 use lb_groth16::fr_to_bytes;
 
 use crate::{
-    mantle::{
-        Utxo,
-        ledger::{Inputs, Outputs},
-        ops::channel::ChannelKeyIndex,
-        tx::MantleTxGasContext,
-    },
+    mantle::{Utxo, ops::channel::ChannelKeyIndex, tx::MantleTxGasContext},
     proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
 };
 
@@ -269,10 +240,6 @@ fn encode_uint16(value: u16) -> Vec<u8> {
 
 pub(crate) fn encode_uint64(value: u64) -> Vec<u8> {
     value.to_le_bytes().to_vec()
-}
-
-fn encode_byte(value: u8) -> Vec<u8> {
-    vec![value]
 }
 
 pub(crate) fn encode_string(s: &String) -> Vec<u8> {
@@ -318,40 +285,6 @@ fn encode_channel_multi_sig_proof(proof: &ChannelMultiSigProof) -> Vec<u8> {
             .into_iter()
             .chain(encode_uint16(signature.channel_key_index))
     }));
-    bytes
-}
-
-/// Encode transfer operation
-fn encode_note(note: &Note) -> Vec<u8> {
-    let mut bytes = Vec::new();
-    bytes.extend(encode_uint64(note.value));
-    bytes.extend(encode_field_element(note.pk.as_fr()));
-    bytes
-}
-
-fn encode_inputs(inputs: &BoundedInputs) -> Vec<u8> {
-    let mut bytes = Vec::new();
-    bytes.extend(encode_byte(inputs.len() as u8));
-    for input in inputs {
-        bytes.extend(encode_field_element(input.as_ref()));
-    }
-    bytes
-}
-
-fn encode_outputs(outputs: &BoundedOutputs) -> Vec<u8> {
-    let mut bytes = Vec::new();
-    bytes.extend(encode_byte(outputs.len() as u8));
-    for output in outputs {
-        bytes.extend(encode_note(output));
-    }
-    bytes
-}
-
-#[must_use]
-pub fn encode_transfer_op(op: &TransferOp) -> Vec<u8> {
-    let mut bytes = Vec::new();
-    bytes.extend(encode_inputs(op.inputs.as_ref()));
-    bytes.extend(encode_outputs(op.outputs.as_ref()));
     bytes
 }
 
@@ -477,6 +410,7 @@ mod tests {
     use crate::{
         mantle::{
             Transaction as _,
+            ledger::{Inputs, Outputs},
             ops::{
                 channel::{
                     ChannelId, MsgId,
@@ -486,6 +420,7 @@ mod tests {
                 },
                 leader_claim::{LeaderClaimOp, RewardsRoot, VoucherNullifier},
                 sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
+                transfer::TransferOp,
             },
             tx::GasPrices,
         },
@@ -1599,14 +1534,14 @@ mod tests {
         let inputs = BoundedInputs::from(inputs);
 
         // Encode should succeed
-        let encoded = encode_inputs(&inputs);
+        let encoded = inputs.encode();
         assert!(
             !encoded.is_empty(),
             "Encoding max input count should produce some output"
         );
 
         // Decode should succeed and produce the same number of inputs
-        let result = decode_inputs(&encoded);
+        let result = BoundedInputs::decode(&encoded);
         assert!(result.is_ok(), "Should decode max input count");
         let (_, decoded_inputs) = result.unwrap();
         assert_eq!(
@@ -1623,14 +1558,14 @@ mod tests {
         let outputs = BoundedOutputs::from(outputs);
 
         // Encode should succeed
-        let encoded = encode_outputs(&outputs);
+        let encoded = outputs.encode();
         assert!(
             !encoded.is_empty(),
             "Encoding max output count should produce some output"
         );
 
         // Decode should succeed and produce the same number of outputs
-        let result = decode_outputs(&encoded);
+        let result = BoundedOutputs::decode(&encoded);
         assert!(result.is_ok(), "Should decode max output count");
         let (_, decoded_outputs) = result.unwrap();
         assert_eq!(
@@ -1651,7 +1586,7 @@ mod tests {
             valid_input.extend_from_slice(&[0x01; 32]);
         }
 
-        let result = decode_inputs(&valid_input);
+        let result = BoundedInputs::decode(&valid_input);
         assert!(result.is_ok(), "Should accept max input count");
         let (_, inputs) = result.unwrap();
         assert_eq!(inputs.len(), u8::MAX as usize);
@@ -1665,7 +1600,7 @@ mod tests {
             valid_output.extend_from_slice(&[0x02; 32]); // public key
         }
 
-        let result = decode_outputs(&valid_output);
+        let result = BoundedOutputs::decode(&valid_output);
         assert!(result.is_ok(), "Should accept max output count");
         let (_, outputs) = result.unwrap();
         assert_eq!(outputs.len(), u8::MAX as usize);

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -161,6 +161,15 @@ impl AsMut<BoundedOutputs> for Outputs {
     }
 }
 
+impl<I> From<I> for Outputs
+where
+    I: Into<BoundedOutputs>,
+{
+    fn from(value: I) -> Self {
+        Self(value.into())
+    }
+}
+
 impl<'output> IntoIterator for &'output Outputs {
     type Item = <&'output BoundedOutputs as IntoIterator>::Item;
     type IntoIter = <&'output BoundedOutputs as IntoIterator>::IntoIter;

--- a/core/src/mantle/nom/fixtures/ops/mod.rs
+++ b/core/src/mantle/nom/fixtures/ops/mod.rs
@@ -1,3 +1,4 @@
 mod channel;
 mod leader_claim;
 mod sdp;
+mod transfer;

--- a/core/src/mantle/nom/fixtures/ops/transfer.rs
+++ b/core/src/mantle/nom/fixtures/ops/transfer.rs
@@ -1,0 +1,12 @@
+use lb_core_macros::nom_wire_fixtures;
+use lb_groth16::{AdditiveGroup as _, Field as _, Fr};
+
+use crate::mantle::{Note, NoteId, ops::transfer::TransferOp};
+
+nom_wire_fixtures!(
+    TransferOp,
+    TransferOp { inputs: [].into(), outputs: [].into() } => "0000",
+    TransferOp { inputs: [NoteId::from(Fr::ONE)].into(), outputs: [].into() } => "01010000000000000000000000000000000000000000000000000000000000000000",
+    TransferOp { inputs: [].into(), outputs: [Note { value: 0, pk: Fr::ZERO.into() }].into() } => "000100000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    TransferOp { inputs: [NoteId::from(Fr::ZERO)].into(), outputs: [Note { value: 0, pk: Fr::ONE.into() }].into() } => "0100000000000000000000000000000000000000000000000000000000000000000100000000000000000100000000000000000000000000000000000000000000000000000000000000",
+);

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -94,7 +94,8 @@ where
         let encoded = fixture.value.encode();
         assert!(
             encoded.as_slice() == expected,
-            "{type_name}: encode(value) drifted from the well-known bytes\n  actual   (hex): {actual}\n  expected (hex): {expected_hex}",
+            "{type_name}: encode(value) drifted from the well-known bytes\n  value: {:?}  actual   (hex): {actual}\n  expected (hex): {expected_hex}",
+            fixture.value,
             actual = hex::encode(&encoded),
             expected_hex = hex::encode(expected),
         );

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -15,8 +15,7 @@ use channel::{
 };
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
 use nom::{
-    IResult, Parser as _,
-    combinator::map,
+    IResult,
     error::{Error, ErrorKind},
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -31,7 +30,6 @@ use super::{
 use crate::{
     crypto::{Digest as _, Hash, Hasher},
     mantle::{
-        encoding::{decode_transfer, encode_transfer_op},
         nom::{NomDecode, NomEncode},
         ops::{
             internal::{OpDe, OpSer},
@@ -154,10 +152,7 @@ impl NomEncode for Op {
             Self::LeaderClaim(op) => {
                 bytes.extend(op.encode());
             }
-            // TODO: Use `.encode()` once implemented for all other ops
-            Self::Transfer(op) => {
-                bytes.extend(encode_transfer_op(op));
-            }
+            Self::Transfer(op) => bytes.extend(op.encode()),
         }
         bytes
     }
@@ -191,8 +186,7 @@ impl NomDecode for Op {
             LEADER_CLAIM => {
                 LeaderClaimOp::decode(bytes).map(|(bytes, op)| (bytes, Self::LeaderClaim(op)))
             }
-            // TODO: Use `.decode()` once implemented for all other ops
-            TRANSFER => map(decode_transfer, Self::Transfer).parse(bytes),
+            TRANSFER => TransferOp::decode(bytes).map(|(bytes, op)| (bytes, Self::Transfer(op))),
             _ => Err(nom::Err::Error(Error::new(bytes, ErrorKind::Fail))),
         }
     }

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -1,3 +1,4 @@
+use lb_core_macros::NomCodec;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -6,14 +7,14 @@ use crate::{
     events::TxEvent,
     mantle::{
         TxHash,
-        encoding::encode_transfer_op,
         ledger::{self, Inputs, Operation, Outputs, Utxos},
+        nom::NomEncode as _,
         ops::OpId,
     },
     sdp::locked_notes::LockedNotes,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, NomCodec)]
 pub struct TransferOp {
     pub inputs: Inputs,
     pub outputs: Outputs,
@@ -46,7 +47,7 @@ impl TransferOp {
 
 impl OpId for TransferOp {
     fn op_bytes(&self) -> Vec<u8> {
-        encode_transfer_op(self)
+        self.encode()
     }
 }
 


### PR DESCRIPTION
Built on top of the [`LeaderClaimOp` migration PR](https://github.com/logos-blockchain/logos-blockchain/pull/3046), currently under review.

Last op. Next will be proofs' turn.