### PR TITLE
chore(blend): minor improvements

### DIFF
--- a/blend/network/src/core/with_core/behaviour/handler/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/handler/mod.rs
@@ -400,7 +400,8 @@ where
                 }
             }
             ConnectionEvent::DialUpgradeError(e) => {
-                tracing::error!(target: LOG_TARGET, "DialUpgradeError for connection {:?}: {:?}", self.connection_details, e);
+                // This error is handled in the swarm, so we just log it at `DEBUG` level here.
+                tracing::debug!(target: LOG_TARGET, "DialUpgradeError for connection {:?}: {:?}", self.connection_details, e);
                 self.close_substreams();
             }
             event => {

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -647,7 +647,7 @@ where
             delay.as_secs()
         );
         self.pending_retries.push(Box::pin(async move {
-            tokio::time::sleep(delay).await;
+            sleep(delay).await;
             (
                 peer_id,
                 DialAttempt {

--- a/services/blend/src/core/backends/libp2p/swarm.rs
+++ b/services/blend/src/core/backends/libp2p/swarm.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{Stream, StreamExt as _, stream::FuturesUnordered};
+use futures::{Stream, StreamExt as _, future::OptionFuture, stream::FuturesUnordered};
 use lb_blend::{
     message::encap::validated::{
         EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
@@ -30,7 +30,10 @@ use lb_chain_service::Epoch;
 use lb_libp2p::{DialOpts, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm, SwarmBuilder, swarm::dial_opts::PeerCondition};
 use rand::RngCore;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::{
+    sync::{broadcast, mpsc, oneshot},
+    time::sleep,
+};
 
 use crate::{
     core::{
@@ -46,6 +49,13 @@ use crate::{
     message::{CoreInfo, NetworkInfo},
     metrics,
 };
+
+/// Cooldown before re-dialing the entire membership after every eligible peer
+/// has been tried and failed in a single cycle. Without it, a node that cannot
+/// reach any peer — e.g. one locked out after an epoch transition because all
+/// peers are already at their maximum peering degree — would re-dial the whole
+/// (rejecting) membership at event-loop speed, wasting CPU and flooding logs.
+const FULL_MEMBERSHIP_RETRY_DELAY: Duration = Duration::from_mins(1);
 
 #[derive(Debug)]
 pub enum BlendSwarmMessage {
@@ -90,6 +100,7 @@ impl DialAttempt {
 }
 
 type PendingRetries = FuturesUnordered<Pin<Box<dyn Future<Output = (PeerId, DialAttempt)> + Send>>>;
+type FullMembershipRetry = Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
 pub struct BlendSwarm<Rng, ObservationWindowProvider>
 where
@@ -104,6 +115,7 @@ where
     max_dial_attempts_per_connection: NonZeroU64,
     ongoing_dials: HashMap<PeerId, DialAttempt>,
     pending_retries: PendingRetries,
+    pending_full_membership_retry: FullMembershipRetry,
     minimum_network_size: NonZeroUsize,
     /// Periodic timer that re-runs peering-degree maintenance to keep the
     /// number of healthy peers at or above the minimum.
@@ -172,6 +184,7 @@ where
                 *config.backend.core_peering_degree.start() as usize
             ),
             pending_retries: FuturesUnordered::new(),
+            pending_full_membership_retry: None,
             minimum_network_size,
             peering_degree_check_clock: config.peering_degree_check_clock(),
         };
@@ -221,19 +234,42 @@ where
         let no_more_peers_to_dial = peers_to_dial.peek().is_none();
 
         // When no membership peer is eligible to be dialed but we still have peers
-        // we gave up on earlier in this dial cycle (`except`), clear that memory and
-        // retry the whole membership from scratch. When `except` is
-        // empty there is genuinely nobody left to dial (everyone is already
-        // negotiated, in-flight, or blocked), so we stop.
+        // we gave up on earlier in this dial cycle (`except`), we want to clear
+        // that memory and retry the whole membership from scratch. Rather than
+        // doing so immediately — which spins at event-loop speed when every peer
+        // keeps rejecting us (e.g. a node locked out after an epoch transition
+        // because all peers are already at their maximum peering degree) — we
+        // schedule a single delayed retry. When `except` is empty there is
+        // genuinely nobody left to dial (everyone is already negotiated,
+        // in-flight, or blocked), so we stop.
         if no_more_peers_to_dial && !except.is_empty() {
-            tracing::debug!(target: LOG_TARGET, "All eligible peers have been tried this cycle. Clearing failed peers memory and retrying from scratch.");
-            self.dial_random_peers_except(amount, &HashSet::new());
+            self.schedule_full_membership_retry();
             return;
         }
 
         for (peer_id, peer_address) in peers_to_dial {
             self.dial(peer_id, peer_address, except.clone());
         }
+    }
+
+    /// Schedule a delayed re-dial of the entire membership, used when every
+    /// eligible peer has already been tried and failed in the current cycle.
+    /// Only one retry is kept pending at a time; when it fires, the peering
+    /// degree is re-checked and dialing starts over from scratch (with an empty
+    /// failed-peers set).
+    fn schedule_full_membership_retry(&mut self) {
+        if self.pending_full_membership_retry.is_some() {
+            // A retry is already pending; don't stack another.
+            return;
+        }
+        tracing::debug!(
+            target: LOG_TARGET,
+            "All eligible peers have been tried this cycle. Scheduling a retry from scratch in {} seconds.",
+            FULL_MEMBERSHIP_RETRY_DELAY.as_secs()
+        );
+        self.pending_full_membership_retry = Some(Box::pin(async {
+            sleep(FULL_MEMBERSHIP_RETRY_DELAY).await;
+        }));
     }
 
     fn check_and_dial_new_peers(&mut self) {
@@ -434,6 +470,7 @@ where
                     .start_new_epoch(self.current_epoch_info.clone());
                 self.ongoing_dials.clear();
                 self.pending_retries.clear();
+                self.pending_full_membership_retry = None;
                 self.check_and_dial_new_peers();
             }
             BlendSwarmMessage::CompleteEpochTransition => {
@@ -479,6 +516,12 @@ where
             }
             Some(()) = self.peering_degree_check_clock.next() => {
                 tracing::trace!(target: LOG_TARGET, "Periodic peering-degree maintenance: re-checking healthy peer count.");
+                self.check_and_dial_new_peers();
+                false
+            }
+            Some(()) = OptionFuture::from(self.pending_full_membership_retry.as_mut()) => {
+                self.pending_full_membership_retry = None;
+                tracing::debug!(target: LOG_TARGET, "Cooldown elapsed: retrying to dial the full membership from scratch.");
                 self.check_and_dial_new_peers();
                 false
             }
@@ -550,6 +593,11 @@ where
     #[cfg(test)]
     pub fn pending_retries_count(&self) -> usize {
         self.pending_retries.len()
+    }
+
+    #[cfg(test)]
+    pub const fn has_pending_full_membership_retry(&self) -> bool {
+        self.pending_full_membership_retry.is_some()
     }
 
     #[cfg(test)]
@@ -796,6 +844,7 @@ where
             max_dial_attempts_per_connection,
             ongoing_dials: HashMap::new(),
             pending_retries: FuturesUnordered::new(),
+            pending_full_membership_retry: None,
             rng,
             swarm: memory_test_swarm(
                 identity,

--- a/services/blend/src/core/backends/libp2p/tests/redials.rs
+++ b/services/blend/src/core/backends/libp2p/tests/redials.rs
@@ -229,10 +229,14 @@ async fn core_remembers_failed_peers_across_retries() {
     );
 }
 
-/// Verifies that when all peers have been tried and failed, the failed peers
-/// memory is cleared and peers are retried from scratch.
+/// Verifies that when all peers have been tried and failed in a cycle, the node
+/// does not immediately re-dial the whole membership (which would spin at
+/// event-loop speed against peers that keep rejecting us). Instead it schedules
+/// a single delayed retry from scratch; when the cooldown elapses,
+/// `check_and_dial_new_peers` re-dials the membership with a cleared
+/// failed-peers set.
 #[test(tokio::test)]
-async fn core_clears_failed_peers_memory_when_all_exhausted() {
+async fn core_schedules_delayed_retry_when_all_peers_exhausted() {
     // Create 3 membership nodes: 1 local + 2 remote unreachable.
     let (mut identities, nodes) = new_nodes_with_empty_address(3);
     let TestSwarm {
@@ -273,17 +277,16 @@ async fn core_clears_failed_peers_memory_when_all_exhausted() {
         })
         .await;
 
-    // Both peers have been tried. The memory should be cleared and a new dial
-    // should be attempted with an empty failed_peers set.
+    // Both peers have been tried this cycle. Instead of an immediate re-dial, a
+    // single delayed retry-from-scratch should be scheduled, with no dial in
+    // flight in the meantime.
     assert!(
-        !dialing_swarm.ongoing_dials().is_empty(),
-        "A new dial should be attempted after clearing failed peers memory"
+        dialing_swarm.ongoing_dials().is_empty(),
+        "No immediate re-dial should happen; the retry from scratch is delayed"
     );
-    let retried_peer = *dialing_swarm.ongoing_dials().keys().next().unwrap();
-    assert_eq!(
-        dialing_swarm.failed_peers_for(&retried_peer),
-        Some(&HashSet::new()),
-        "Failed peers memory should be cleared after all peers have been tried"
+    assert!(
+        dialing_swarm.has_pending_full_membership_retry(),
+        "A delayed retry-from-scratch should be scheduled after all peers have been tried"
     );
 }
 
@@ -414,6 +417,7 @@ async fn core_does_not_give_up_below_minimum_peering_degree() {
         .num_healthy_peers();
     let ongoing = dialing_swarm.ongoing_dials().len();
     let pending = dialing_swarm.pending_retries_count();
+    let full_retry = dialing_swarm.has_pending_full_membership_retry();
 
     // Sanity: the reachable peer connected, so we are genuinely one short of the
     // minimum (not simply failing to connect to anyone).
@@ -423,13 +427,15 @@ async fn core_does_not_give_up_below_minimum_peering_degree() {
     );
 
     // Regression guard: a node below the minimum peering degree must not give up
-    // — it must still be dialing (an ongoing dial or a pending retry). Before the
-    // fix it ended with no ongoing dials and no pending retries, stranded at degree
-    // 1 < 2 until the next epoch.
+    // — it must still be trying to reach the minimum, whether via an ongoing
+    // dial, a pending per-peer retry, or a scheduled retry-from-scratch. Before
+    // the fix it ended with none of these, stranded at degree 1 < 2 until the
+    // next epoch.
     assert!(
-        healthy >= min_peering_degree || ongoing > 0 || pending > 0,
+        healthy >= min_peering_degree || ongoing > 0 || pending > 0 || full_retry,
         "node gave up below the minimum peering degree: healthy={healthy} < {min_peering_degree}, \
-         ongoing_dials={ongoing}, pending_retries={pending} — it will stay stranded until the next epoch"
+         ongoing_dials={ongoing}, pending_retries={pending}, full_membership_retry={full_retry} — \
+         it will stay stranded until the next epoch"
     );
 }
 

--- a/services/blend/src/core/mod.rs
+++ b/services/blend/src/core/mod.rs
@@ -1335,10 +1335,17 @@ where
         .add_unsent_processed_message(processed_message.clone())
         .is_err()
     {
-        tracing::warn!(
-            target: LOG_TARGET,
-            "There should not be another copy of the same locally-generated processed message: {processed_message:?}."
-        );
+        // With a data replication factor greater than `0`, it's expected to have
+        // multiple identical copies of the same data message, so in that case it's not
+        // a warning and should not be logged.
+        // Hence, we only log a warning in the unexpected case of an encapsulated
+        // message seen twice, which should never happen.
+        if matches!(processed_message, ProcessedMessage::Encapsulated(_)) {
+            tracing::warn!(
+                target: LOG_TARGET,
+                "There should not be another copy of the same locally-generated processed message: {processed_message:?}."
+            );
+        }
     }
     state_updater.commit_changes()
 }
@@ -1875,8 +1882,16 @@ where
         .into_iter()
         .inspect(|processed_message_to_release| {
             if let Some(state_updater) = state_updater.as_mut()
-                && state_updater.remove_sent_processed_message(processed_message_to_release).is_err() {
-                tracing::warn!(target: LOG_TARGET, "Previously processed message should be present in the recovery state but was not found.");
+                && state_updater.remove_sent_processed_message(processed_message_to_release).is_err() && matches!(processed_message_to_release, ProcessedMessage::Encapsulated(_)) {
+                    // With a data replication factor greater than `0`, it's expected to have
+                    // multiple identical copies of the same data message, so in that case it's not
+                    // a warning and should not be logged.
+                    // Hence, we only log a warning in the unexpected case of an encapsulated
+                    // message seen twice, which should never happen.
+                    tracing::warn!(
+                            target: LOG_TARGET,
+                            "Previously processed message should be present in the recovery state but was not found."
+                        );
             }
         })
         .map(


### PR DESCRIPTION
## 1. What does this PR implement?

Based on the last devnet run, this PR introduces the following fixes:

* Remove an `ERROR`-level log entry generated by a connection handler, since the same error is handled and logged by the Blend swarm
* Do not log a `WARN` message for duplicate messages in the recovery state if the type of the message is a data message. This is actually the expected behaviour when a data replication factor greater than `0` is used, so it should not be treated as a warning. The warning remains for encapsulated messages, as those are supposed to be unique.
* Add a statically configured cooldown period of 1 minute when a peer fails to dial all other peers in the membership, before retrying again. This can happen if the other peers all reach their maximum peering degree and won't accept any new connections. The cooldown reduces log spamming and load on the node that is not able to join the Blend network. This cooldown is in addition to the regular peering degree check introduced in https://github.com/logos-blockchain/logos-blockchain/pull/2973, as that is entirely a user config and could be disabled by setting it to `None`. So the two are meant to make the node react relatively fast but not too fast to cases in which it falls below the minimum peering degree, and it's in addition to what the spec defines, which is already implemented.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

Yes.

## 5. Does the implementation introduce changes in the specification?

No.