### PR TITLE
feat(cli): Allow overwriting existing user config

### DIFF
--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -41,11 +41,11 @@ pub fn run(args: InitArgs) -> Result<()> {
             .join("keystore.yaml")
     });
 
-    if user_config_path.exists() {
+    if user_config_path.exists() && !args.overwrite {
         return Err(InitError::UserFileExists.into());
     }
 
-    if keystore_path.exists() {
+    if keystore_path.exists() && !args.overwrite {
         return Err(InitError::KeystoreFileExists.into());
     }
 

--- a/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
+++ b/nodes/node/binary/src/cli/config/migrate_0_1_2/mod.rs
@@ -84,6 +84,7 @@ impl From<MigrateArgs> for InitArgs {
             api: migrate.api,
             state: migrate.state,
             storage_path: None,
+            overwrite: false,
         }
     }
 }

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -149,6 +149,10 @@ pub struct InitArgs {
     #[clap(long = "keystore", short = 'k')]
     pub keystore: Option<PathBuf>,
 
+    /// Overwrite existing user config and keystore.
+    #[arg(long, default_value_t = false)]
+    pub overwrite: bool,
+
     #[clap(flatten)]
     pub log: LogArgs,
 
@@ -269,7 +273,7 @@ impl Default for EmbeddedInitArgs {
 #[derive(Parser, Debug)]
 pub struct UpdateArgs {
     /// Output file path for the generated config.
-    #[clap(long = "user-config", short = 'o', default_value = "user_config.yaml")]
+    #[clap(long = "user-config", short = 'u', default_value = "user_config.yaml")]
     pub user_config: PathBuf,
 
     /// Path for the keystore file.
@@ -404,6 +408,7 @@ impl From<MigrateArgs> for InitArgs {
             api: migrate.api,
             state: migrate.state,
             storage_path: migrate.storage_path,
+            overwrite: false,
         }
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

For deploying in remote environments it's useful to generate a new config even if the old one exists. Change add `--overwrite` flag to the `init-config` command. If the flag is not provided the command fails if `user_config.yaml` or `keystore.yaml` already exists.

## 2. Does the code have enough context to be clearly understood?

A flag added for `init-config` command.

## 3. Who are the specification authors and who is accountable for this PR?

N/A

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
