### PR TITLE
chore: strengthen bounded-vec invariant protection

### DIFF
--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -31,8 +31,12 @@ pub enum Error {
     InvalidGenesisTx(#[from] genesis_tx::Error),
     #[error("add_notes called with empty iterator")]
     EmptyNotes,
+    #[error("too few notes for genesis transfer outputs: attempted {actual}, min {min}")]
+    TooFewNotes { actual: usize, min: usize },
     #[error("too many notes for genesis transfer outputs: attempted {actual}, max {max}")]
     TooManyNotes { actual: usize, max: usize },
+    #[error("Index {index} is out of bounds for length {len}")]
+    IndexOutOfBounds { index: usize, len: usize },
 }
 
 /// Convenience [`Result`](core::result::Result) alias for genesis block
@@ -41,9 +45,17 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 const fn map_notes_bounded_error(error: &BoundedError) -> Error {
     match error {
-        BoundedError::TooLong { actual, max } => Error::TooManyNotes {
+        BoundedError::TooManyItems { count: actual, max } => Error::TooManyNotes {
             actual: *actual,
             max: *max,
+        },
+        BoundedError::TooFewItems { count: actual, min } => Error::TooFewNotes {
+            actual: *actual,
+            min: *min,
+        },
+        BoundedError::IndexOutOfBounds { index, len } => Error::IndexOutOfBounds {
+            index: *index,
+            len: *len,
         },
         BoundedError::EmptyInput => Error::EmptyNotes,
     }

--- a/core/src/mantle/encoding.rs
+++ b/core/src/mantle/encoding.rs
@@ -1246,8 +1246,8 @@ mod tests {
         let result = Inscription::try_from(oversized_inscription);
         assert_eq!(
             result,
-            Err(BoundedError::TooLong {
-                actual: inscribe::MAX_BYTES + 1,
+            Err(BoundedError::TooManyItems {
+                count: inscribe::MAX_BYTES + 1,
                 max: inscribe::MAX_BYTES
             })
         );
@@ -1298,8 +1298,8 @@ mod tests {
         let result = Ops::try_from(ops);
         assert_eq!(
             result,
-            Err(BoundedError::TooLong {
-                actual: u8::MAX as usize + 1,
+            Err(BoundedError::TooManyItems {
+                count: u8::MAX as usize + 1,
                 max: u8::MAX as usize
             })
         );

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::LazyLock};
+use std::{collections::HashSet, slice::IterMut, sync::LazyLock};
 
 use ark_ff::PrimeField as _;
 use bytes::Bytes;
@@ -147,6 +147,14 @@ impl Outputs {
     pub fn iter(&self) -> impl Iterator<Item = &Note> {
         <&Self as IntoIterator>::into_iter(self)
     }
+
+    pub fn iter_mut(&mut self) -> IterMut<'_, Note> {
+        self.0.iter_mut()
+    }
+
+    pub fn try_push(&mut self, note: Note) -> Result<(), BoundedError> {
+        self.0.try_push(note)
+    }
 }
 
 impl AsRef<BoundedOutputs> for Outputs {
@@ -155,9 +163,12 @@ impl AsRef<BoundedOutputs> for Outputs {
     }
 }
 
-impl AsMut<BoundedOutputs> for Outputs {
-    fn as_mut(&mut self) -> &mut BoundedOutputs {
-        &mut self.0
+impl<'a> IntoIterator for &'a mut Outputs {
+    type Item = &'a mut Note;
+    type IntoIter = IterMut<'a, Note>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
     }
 }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -167,7 +167,7 @@ mod tests {
         let oversized = vec![0u8; MAX_BYTES + 1];
         let err = Inscription::try_from(oversized).unwrap_err();
         assert!(
-            matches!(err, BoundedError::TooLong { actual, max } if actual == MAX_BYTES + 1 && max == MAX_BYTES)
+            matches!(err, BoundedError::TooManyItems { count, max } if count == MAX_BYTES + 1 && max == MAX_BYTES)
         );
     }
 
@@ -179,11 +179,12 @@ mod tests {
         assert!(
             format!("{err}").contains(
                 format!(
-                    "Length {} exceeds static maximum of {MAX_BYTES}",
+                    "Item count {} exceeds static maximum of {MAX_BYTES}",
                     MAX_BYTES + 1,
                 )
                 .as_str()
-            )
+            ),
+            "{err:?}",
         );
     }
 

--- a/core/src/mantle/tx_builder.rs
+++ b/core/src/mantle/tx_builder.rs
@@ -19,34 +19,29 @@ use crate::{
 
 #[derive(Debug, Error)]
 pub enum TxBuilderError {
-    #[error("Too many operations in transaction: attempted {actual}, max {max}")]
-    TooManyOps { actual: usize, max: usize },
-    #[error("Too many ledger inputs in transfer: attempted {actual}, max {max}")]
-    TooManyInputs { actual: usize, max: usize },
-    #[error("Too many ledger outputs in transfer: attempted {actual}, max {max}")]
-    TooManyOutputs { actual: usize, max: usize },
+    #[error("Invalid operation bounds in transaction: {source}")]
+    InvalidOpsBounds { source: BoundedError },
+    #[error("Invalid ledger input bounds in transfer: {source}")]
+    InvalidInputsBounds { source: BoundedError },
+    #[error("Invalid ledger output bounds in transfer: {source}")]
+    InvalidOutputsBounds { source: BoundedError },
     #[error("Gas computation overflow: {0}")]
     GasOverflow(#[from] GasOverflow),
 }
 
 #[derive(Debug, Clone, Copy)]
-enum TooManyTag {
+enum BoundedTag {
     Ops,
     Inputs,
     Outputs,
 }
 
-impl From<(BoundedError, TooManyTag)> for TxBuilderError {
-    fn from((err, tag): (BoundedError, TooManyTag)) -> Self {
-        let (actual, max) = match err {
-            BoundedError::TooLong { actual, max } => (actual, max),
-            BoundedError::EmptyInput => (0, 0),
-        };
-
+impl From<(BoundedError, BoundedTag)> for TxBuilderError {
+    fn from((err, tag): (BoundedError, BoundedTag)) -> Self {
         match tag {
-            TooManyTag::Ops => Self::TooManyOps { actual, max },
-            TooManyTag::Inputs => Self::TooManyInputs { actual, max },
-            TooManyTag::Outputs => Self::TooManyOutputs { actual, max },
+            BoundedTag::Ops => Self::InvalidOpsBounds { source: err },
+            BoundedTag::Inputs => Self::InvalidInputsBounds { source: err },
+            BoundedTag::Outputs => Self::InvalidOutputsBounds { source: err },
         }
     }
 }
@@ -90,7 +85,7 @@ impl MantleTxBuilder {
             self.mantle_tx
                 .0
                 .try_push(op)
-                .map_err(|err| TxBuilderError::from((err, TooManyTag::Ops)))?;
+                .map_err(|err| TxBuilderError::from((err, BoundedTag::Ops)))?;
         }
         Ok(self)
     }
@@ -120,10 +115,10 @@ impl MantleTxBuilder {
                 .inputs
                 .as_mut()
                 .try_push(utxo.id())
-                .map_err(|err| TxBuilderError::from((err, TooManyTag::Inputs)))?;
+                .map_err(|err| TxBuilderError::from((err, BoundedTag::Inputs)))?;
             self.ledger_inputs
                 .try_push(utxo)
-                .map_err(|err| TxBuilderError::from((err, TooManyTag::Inputs)))?;
+                .map_err(|err| TxBuilderError::from((err, BoundedTag::Inputs)))?;
         }
         Ok(self)
     }
@@ -139,9 +134,8 @@ impl MantleTxBuilder {
         for note in notes {
             self.pending_transfer
                 .outputs
-                .as_mut()
                 .try_push(note)
-                .map_err(|err| TxBuilderError::from((err, TooManyTag::Outputs)))?;
+                .map_err(|err| TxBuilderError::from((err, BoundedTag::Outputs)))?;
         }
         Ok(self)
     }
@@ -257,7 +251,7 @@ impl MantleTxBuilder {
             self.mantle_tx
                 .0
                 .try_push(Op::Transfer(self.pending_transfer))
-                .map_err(|err| TxBuilderError::from((err, TooManyTag::Ops)))?;
+                .map_err(|err| TxBuilderError::from((err, BoundedTag::Ops)))?;
         }
         Ok(self.mantle_tx)
     }

--- a/tests/testing_framework/src/node/configs/postprocess.rs
+++ b/tests/testing_framework/src/node/configs/postprocess.rs
@@ -78,7 +78,7 @@ pub fn apply_wallet_genesis_overrides(
         .expect("Genesis block should have a genesis tx")
         .genesis_transfer()
         .clone();
-    for output in transfer_op.outputs.as_mut().iter_mut() {
+    for output in &mut transfer_op.outputs {
         if leader_keys.contains(&output.pk) {
             output.value = leader_stake;
         }
@@ -86,7 +86,6 @@ pub fn apply_wallet_genesis_overrides(
     for (secret_key, value) in wallet_accounts {
         transfer_op
             .outputs
-            .as_mut()
             .try_push(Note::new(*value, secret_key.to_public_key()))
             .expect("wallet account outputs must fit transfer output bounds");
     }

--- a/utils/src/bounded_vec.rs
+++ b/utils/src/bounded_vec.rs
@@ -1,7 +1,4 @@
-use core::{
-    ops::{Deref, DerefMut},
-    slice::Iter,
-};
+use core::{ops::Deref, slice::Iter};
 use std::{str::FromStr, vec::IntoIter};
 
 use serde::{Deserialize, Serialize};
@@ -11,8 +8,12 @@ use thiserror::Error;
 pub enum BoundedError {
     #[error("Input cannot be empty.")]
     EmptyInput,
-    #[error("Length {actual} exceeds static maximum of {max}")]
-    TooLong { actual: usize, max: usize },
+    #[error("Item count {count} is below minimum of {min}")]
+    TooFewItems { count: usize, min: usize },
+    #[error("Item count {count} exceeds static maximum of {max}")]
+    TooManyItems { count: usize, max: usize },
+    #[error("Index {index} is out of bounds for length {len}")]
+    IndexOutOfBounds { index: usize, len: usize },
 }
 
 /// `Vec<T>` whose length is statically enforced to be in the range `[MIN,
@@ -81,13 +82,52 @@ impl<T, const MIN: usize, const MAX: usize> BoundedVec<T, MIN, MAX> {
 
     pub fn try_push(&mut self, item: T) -> Result<(), BoundedError> {
         if self.len() >= MAX {
-            return Err(BoundedError::TooLong {
-                actual: self.len() + 1,
+            return Err(BoundedError::TooManyItems {
+                count: self.len() + 1,
                 max: MAX,
             });
         }
         self.0.push(item);
         Ok(())
+    }
+
+    pub fn try_pop(&mut self) -> Result<Option<T>, BoundedError> {
+        if self.is_empty() {
+            return Ok(None);
+        }
+
+        let new_len = self.len() - 1;
+        if new_len < MIN {
+            return Err(BoundedError::TooFewItems {
+                count: new_len,
+                min: MIN,
+            });
+        }
+
+        Ok(self.0.pop())
+    }
+
+    pub fn try_remove(&mut self, index: usize) -> Result<T, BoundedError> {
+        if index >= self.len() {
+            return Err(BoundedError::IndexOutOfBounds {
+                index,
+                len: self.len(),
+            });
+        }
+
+        let new_len = self.len() - 1;
+        if new_len < MIN {
+            return Err(BoundedError::TooFewItems {
+                count: new_len,
+                min: MIN,
+            });
+        }
+
+        Ok(self.0.remove(index))
+    }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+        self.0.iter_mut()
     }
 }
 
@@ -107,12 +147,17 @@ impl<T, const MIN: usize, const MAX: usize> TryFrom<Vec<T>> for BoundedVec<T, MI
     type Error = BoundedError;
 
     fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
-        if value.len() < MIN {
+        if value.len() < MIN && value.is_empty() {
             return Err(BoundedError::EmptyInput);
+        } else if value.len() < MIN {
+            return Err(BoundedError::TooFewItems {
+                count: value.len(),
+                min: MIN,
+            });
         }
         if value.len() > MAX {
-            return Err(BoundedError::TooLong {
-                actual: value.len(),
+            return Err(BoundedError::TooManyItems {
+                count: value.len(),
                 max: MAX,
             });
         }
@@ -133,7 +178,8 @@ where
 
 impl<T, const MIN: usize, const MAX: usize> From<T> for BoundedVec<T, MIN, MAX> {
     fn from(value: T) -> Self {
-        const { assert!(MAX >= 1, "Max size cannot be zero.") }
+        const { assert!(MIN <= 1, "Single element is below BoundedVec MIN") }
+        const { assert!(MAX >= 1, "Single element exceeds BoundedVec MAX") }
         Self([value].into())
     }
 }
@@ -186,9 +232,12 @@ impl<T, const MIN: usize, const MAX: usize> Deref for BoundedVec<T, MIN, MAX> {
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> DerefMut for BoundedVec<T, MIN, MAX> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl<'a, T, const MIN: usize, const MAX: usize> IntoIterator for &'a mut BoundedVec<T, MIN, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
     }
 }
 
@@ -296,7 +345,7 @@ mod tests {
         let mut bv = TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(
             bv.try_push(5),
-            Err(BoundedError::TooLong { actual: 5, max: 4 })
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
         );
         // The failed push must not have mutated the vector.
         assert_eq!(bv.as_slice(), &[1, 2, 3, 4]);
@@ -317,7 +366,7 @@ mod tests {
         );
         assert_eq!(
             TestBoundedVector::try_from(vec![1]),
-            Err(BoundedError::EmptyInput)
+            Err(BoundedError::TooFewItems { count: 1, min: 2 })
         );
     }
 
@@ -325,7 +374,7 @@ mod tests {
     fn try_from_rejects_input_above_max() {
         assert_eq!(
             TestBoundedVector::try_from(vec![1, 2, 3, 4, 5]),
-            Err(BoundedError::TooLong { actual: 5, max: 4 })
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
         );
     }
 
@@ -413,7 +462,8 @@ mod tests {
     fn deserialize_rejects_input_below_min() {
         let err = serde_json::from_str::<TestBoundedVector>("[1]").unwrap_err();
         assert!(
-            err.to_string().contains("Input cannot be empty"),
+            err.to_string()
+                .contains("Item count 1 is below minimum of 2"),
             "unexpected error: {err}"
         );
     }
@@ -434,5 +484,72 @@ mod tests {
             err.to_string().contains("exceeds static maximum"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn try_pop_removes_last_item_when_above_min() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+
+        assert_eq!(bv.try_pop(), Ok(Some(3)));
+        assert_eq!(bv.as_slice(), &[1, 2]);
+        assert_eq!(bv.len(), 2);
+    }
+
+    #[test]
+    fn try_pop_rejects_removal_below_min_and_does_not_mutate() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+
+        assert_eq!(
+            bv.try_pop(),
+            Err(BoundedError::TooFewItems { count: 1, min: 2 })
+        );
+
+        assert_eq!(bv.as_slice(), &[1, 2]);
+        assert_eq!(bv.len(), 2);
+    }
+
+    #[test]
+    fn try_pop_returns_none_when_empty_and_min_is_zero() {
+        type EmptyAllowed = BoundedVec<u8, 0, 4>;
+
+        let mut bv = EmptyAllowed::empty();
+
+        assert_eq!(bv.try_pop(), Ok(None));
+        assert!(bv.is_empty());
+    }
+
+    #[test]
+    fn try_remove_removes_item_at_index_when_above_min() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
+
+        assert_eq!(bv.try_remove(1), Ok(2));
+        assert_eq!(bv.as_slice(), &[1, 3, 4]);
+        assert_eq!(bv.len(), 3);
+    }
+
+    #[test]
+    fn try_remove_rejects_removal_below_min_and_does_not_mutate() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+
+        assert_eq!(
+            bv.try_remove(0),
+            Err(BoundedError::TooFewItems { count: 1, min: 2 })
+        );
+
+        assert_eq!(bv.as_slice(), &[1, 2]);
+        assert_eq!(bv.len(), 2);
+    }
+
+    #[test]
+    fn try_remove_rejects_out_of_bounds_and_does_not_mutate() {
+        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+
+        assert_eq!(
+            bv.try_remove(3),
+            Err(BoundedError::IndexOutOfBounds { index: 3, len: 3 })
+        );
+
+        assert_eq!(bv.as_slice(), &[1, 2, 3]);
+        assert_eq!(bv.len(), 3);
     }
 }

--- a/utils/src/bounded_vec.rs
+++ b/utils/src/bounded_vec.rs
@@ -92,7 +92,7 @@ impl<T, const MIN: usize, const MAX: usize> BoundedVec<T, MIN, MAX> {
     }
 
     pub fn try_pop(&mut self) -> Result<Option<T>, BoundedError> {
-        if self.is_empty() {
+        if self.is_empty() || self.len() - 1 < MIN {
             return Ok(None);
         }
 
@@ -524,34 +524,24 @@ mod tests {
     }
 
     #[test]
-    fn try_pop_removes_last_item_when_above_min() {
+    fn try_pop_returns_none_at_or_below_lower_bound_and_is_idempotent() {
         let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
 
         assert_eq!(bv.try_pop(), Ok(Some(3)));
-        assert_eq!(bv.as_slice(), &[1, 2]);
-        assert_eq!(bv.len(), 2);
-    }
-
-    #[test]
-    fn try_pop_rejects_removal_below_min_and_does_not_mutate() {
-        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
-
-        assert_eq!(
-            bv.try_pop(),
-            Err(BoundedError::TooFewItems { count: 1, min: 2 })
-        );
-
-        assert_eq!(bv.as_slice(), &[1, 2]);
-        assert_eq!(bv.len(), 2);
-    }
-
-    #[test]
-    fn try_pop_returns_none_when_empty_and_min_is_zero() {
-        type EmptyAllowed = BoundedVec<u8, 0, 4>;
-
-        let mut bv = EmptyAllowed::empty();
-
         assert_eq!(bv.try_pop(), Ok(None));
+        assert_eq!(bv.try_pop(), Ok(None));
+
+        assert_eq!(bv.as_slice(), &[1, 2]);
+        assert_eq!(bv.len(), 2);
+
+        let mut bv = TestBoundedVectorMin0::try_from(vec![1, 2, 3]).unwrap();
+
+        assert_eq!(bv.try_pop(), Ok(Some(3)));
+        assert_eq!(bv.try_pop(), Ok(Some(2)));
+        assert_eq!(bv.try_pop(), Ok(Some(1)));
+        assert_eq!(bv.try_pop(), Ok(None));
+        assert_eq!(bv.try_pop(), Ok(None));
+
         assert!(bv.is_empty());
     }
 

--- a/utils/src/bounded_vec.rs
+++ b/utils/src/bounded_vec.rs
@@ -1,5 +1,5 @@
 use core::{ops::Deref, slice::Iter};
-use std::{str::FromStr, vec::IntoIter};
+use std::{ops::DerefMut, str::FromStr, vec::IntoIter};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -96,18 +96,12 @@ impl<T, const MIN: usize, const MAX: usize> BoundedVec<T, MIN, MAX> {
             return Ok(None);
         }
 
-        let new_len = self.len() - 1;
-        if new_len < MIN {
-            return Err(BoundedError::TooFewItems {
-                count: new_len,
-                min: MIN,
-            });
-        }
-
-        Ok(self.0.pop())
+        self.try_remove(self.len() - 1).map(Some)
     }
 
     pub fn try_remove(&mut self, index: usize) -> Result<T, BoundedError> {
+        // This check also guards against an empty vec, `index >= 0` and `self.len() =
+        // 0` will return and error
         if index >= self.len() {
             return Err(BoundedError::IndexOutOfBounds {
                 index,
@@ -178,8 +172,18 @@ where
 
 impl<T, const MIN: usize, const MAX: usize> From<T> for BoundedVec<T, MIN, MAX> {
     fn from(value: T) -> Self {
-        const { assert!(MIN <= 1, "Single element is below BoundedVec MIN") }
-        const { assert!(MAX >= 1, "Single element exceeds BoundedVec MAX") }
+        const {
+            assert!(
+                MIN <= 1,
+                "Single-element construction is invalid for minimum bound > 1"
+            );
+        }
+        const {
+            assert!(
+                MAX >= 1,
+                "Single-element construction is invalid for maximum bound < 1"
+            );
+        }
         Self([value].into())
     }
 }
@@ -232,6 +236,12 @@ impl<T, const MIN: usize, const MAX: usize> Deref for BoundedVec<T, MIN, MAX> {
     }
 }
 
+impl<T, const MIN: usize, const MAX: usize> DerefMut for BoundedVec<T, MIN, MAX> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl<'a, T, const MIN: usize, const MAX: usize> IntoIterator for &'a mut BoundedVec<T, MIN, MAX> {
     type Item = &'a mut T;
     type IntoIter = std::slice::IterMut<'a, T>;
@@ -277,64 +287,81 @@ mod tests {
     use crate::bounded_vec::{BoundedError, BoundedVec};
 
     /// Concrete instantiation used across the tests: between 2 and 4 elements.
-    type TestBoundedVector = BoundedVec<u8, 2, 4>;
+    type TestBoundedVectorMin2 = BoundedVec<u8, 2, 4>;
+    type TestBoundedVectorMin1 = BoundedVec<u8, 1, 4>;
+    type TestBoundedVectorMin0 = BoundedVec<u8, 0, 4>;
+
+    #[test]
+    fn from_accepts_single_element_construction() {
+        let single = TestBoundedVectorMin0::from(1);
+        assert_eq!(single.as_slice(), &[1]);
+        let single = TestBoundedVectorMin1::from(1);
+        assert_eq!(single.as_slice(), &[1]);
+
+        /*
+           This does not compile:
+           ```
+           let single = TestBoundedVectorMin2::from(1);
+           ```
+        */
+    }
 
     #[test]
     fn min_max_constants_reflect_the_generic_parameters() {
-        assert_eq!(TestBoundedVector::MIN, 2);
-        assert_eq!(TestBoundedVector::MAX, 4);
+        assert_eq!(TestBoundedVectorMin2::MIN, 2);
+        assert_eq!(TestBoundedVectorMin2::MAX, 4);
     }
 
     #[test]
     fn new_unchecked_wraps_without_validation() {
         // `new_unchecked` deliberately bypasses the bounds, so it accepts
         // inputs that `try_from` would reject.
-        let empty = TestBoundedVector::new_unchecked(vec![]);
+        let empty = TestBoundedVectorMin2::new_unchecked(vec![]);
         assert!(empty.is_empty());
 
-        let too_long = TestBoundedVector::new_unchecked(vec![1, 2, 3, 4, 5]);
+        let too_long = TestBoundedVectorMin2::new_unchecked(vec![1, 2, 3, 4, 5]);
         assert_eq!(too_long.len(), 5);
     }
 
     #[test]
     fn len_and_is_empty() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         assert_eq!(bv.len(), 3);
         assert!(!bv.is_empty());
 
-        assert!(TestBoundedVector::new_unchecked(vec![]).is_empty());
-        assert_eq!(TestBoundedVector::new_unchecked(vec![]).len(), 0);
+        assert!(TestBoundedVectorMin2::new_unchecked(vec![]).is_empty());
+        assert_eq!(TestBoundedVectorMin2::new_unchecked(vec![]).len(), 0);
     }
 
     #[test]
     fn first_returns_the_leading_element() {
-        let bv = TestBoundedVector::try_from(vec![10, 20, 30]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![10, 20, 30]).unwrap();
         assert_eq!(bv.first(), Some(&10));
 
-        assert_eq!(TestBoundedVector::new_unchecked(vec![]).first(), None);
+        assert_eq!(TestBoundedVectorMin2::new_unchecked(vec![]).first(), None);
     }
 
     #[test]
     fn iter_yields_every_element_in_order() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         assert_eq!(bv.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
     }
 
     #[test]
     fn into_inner_returns_the_backing_vec() {
-        let bv = TestBoundedVector::try_from(vec![7, 8]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![7, 8]).unwrap();
         assert_eq!(bv.into_inner(), vec![7, 8]);
     }
 
     #[test]
     fn as_slice_exposes_the_contents() {
-        let bv = TestBoundedVector::try_from(vec![4, 5, 6]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![4, 5, 6]).unwrap();
         assert_eq!(bv.as_slice(), &[4, 5, 6]);
     }
 
     #[test]
     fn try_push_appends_while_under_the_cap() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
         assert_eq!(bv.try_push(3), Ok(()));
         assert_eq!(bv.try_push(4), Ok(()));
         assert_eq!(bv.as_slice(), &[1, 2, 3, 4]);
@@ -342,7 +369,7 @@ mod tests {
 
     #[test]
     fn try_push_rejects_growth_past_max() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(
             bv.try_push(5),
             Err(BoundedError::TooManyItems { count: 5, max: 4 })
@@ -353,19 +380,25 @@ mod tests {
 
     #[test]
     fn try_from_accepts_lengths_within_bounds() {
-        TestBoundedVector::try_from(vec![1, 2]).unwrap();
-        TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
-        TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
+        TestBoundedVectorMin0::try_from(vec![]).unwrap();
+        TestBoundedVectorMin0::try_from(vec![1]).unwrap();
+        TestBoundedVectorMin0::try_from(vec![1, 2]).unwrap();
+        TestBoundedVectorMin0::try_from(vec![1, 2, 3]).unwrap();
+        TestBoundedVectorMin0::try_from(vec![1, 2, 3, 4]).unwrap();
+
+        TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
+        TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
+        TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4]).unwrap();
     }
 
     #[test]
     fn try_from_rejects_input_below_min() {
         assert_eq!(
-            TestBoundedVector::try_from(vec![]),
+            TestBoundedVectorMin2::try_from(vec![]),
             Err(BoundedError::EmptyInput)
         );
         assert_eq!(
-            TestBoundedVector::try_from(vec![1]),
+            TestBoundedVectorMin2::try_from(vec![1]),
             Err(BoundedError::TooFewItems { count: 1, min: 2 })
         );
     }
@@ -373,7 +406,11 @@ mod tests {
     #[test]
     fn try_from_rejects_input_above_max() {
         assert_eq!(
-            TestBoundedVector::try_from(vec![1, 2, 3, 4, 5]),
+            TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4, 5]),
+            Err(BoundedError::TooManyItems { count: 5, max: 4 })
+        );
+        assert_eq!(
+            TestBoundedVectorMin0::try_from(vec![1, 2, 3, 4, 5]),
             Err(BoundedError::TooManyItems { count: 5, max: 4 })
         );
     }
@@ -387,26 +424,26 @@ mod tests {
 
     #[test]
     fn from_owned_array() {
-        let bv: TestBoundedVector = [1, 2, 3].into();
+        let bv: TestBoundedVectorMin2 = [1, 2, 3].into();
         assert_eq!(bv.as_slice(), &[1, 2, 3]);
     }
 
     #[test]
     fn from_array_reference() {
-        let bv: TestBoundedVector = (&[9, 8, 7]).into();
+        let bv: TestBoundedVectorMin2 = (&[9, 8, 7]).into();
         assert_eq!(bv.as_slice(), &[9, 8, 7]);
     }
 
     #[test]
     fn into_vec_unwraps_the_bounded_vec() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         let raw: Vec<u8> = bv.into();
         assert_eq!(raw, vec![1, 2, 3]);
     }
 
     #[test]
     fn as_ref_slice_and_vec() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         let slice: &[u8] = bv.as_ref();
         assert_eq!(slice, &[1, 2, 3]);
         let vec: &Vec<u8> = bv.as_ref();
@@ -415,7 +452,7 @@ mod tests {
 
     #[test]
     fn into_iterator_by_reference() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         let collected: Vec<u8> = (&bv).into_iter().copied().collect();
         assert_eq!(collected, vec![1, 2, 3]);
         // `bv` is still usable after iterating by reference.
@@ -424,43 +461,43 @@ mod tests {
 
     #[test]
     fn into_iterator_by_value() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         let collected: Vec<u8> = bv.into_iter().collect();
         assert_eq!(collected, vec![1, 2, 3]);
     }
 
     #[test]
     fn equality_and_ordering() {
-        let a = TestBoundedVector::try_from(vec![1, 2]).unwrap();
-        let b = TestBoundedVector::try_from(vec![1, 2]).unwrap();
-        let c = TestBoundedVector::try_from(vec![1, 3]).unwrap();
+        let a = TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
+        let b = TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
+        let c = TestBoundedVectorMin2::try_from(vec![1, 3]).unwrap();
         assert_eq!(a, b);
         assert!(a < c);
     }
 
     #[test]
     fn serialize_emits_a_plain_sequence() {
-        let bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
         assert_eq!(serde_json::to_string(&bv).unwrap(), "[1,2,3]");
     }
 
     #[test]
     fn deserialize_accepts_input_within_bounds() {
-        let bv: TestBoundedVector = serde_json::from_str("[1,2,3]").unwrap();
+        let bv: TestBoundedVectorMin2 = serde_json::from_str("[1,2,3]").unwrap();
         assert_eq!(bv.as_slice(), &[1, 2, 3]);
     }
 
     #[test]
     fn serialize_then_deserialize_roundtrips() {
-        let original = TestBoundedVector::try_from(vec![5, 6, 7, 8]).unwrap();
+        let original = TestBoundedVectorMin2::try_from(vec![5, 6, 7, 8]).unwrap();
         let json = serde_json::to_string(&original).unwrap();
-        let restored: TestBoundedVector = serde_json::from_str(&json).unwrap();
+        let restored: TestBoundedVectorMin2 = serde_json::from_str(&json).unwrap();
         assert_eq!(original, restored);
     }
 
     #[test]
     fn deserialize_rejects_input_below_min() {
-        let err = serde_json::from_str::<TestBoundedVector>("[1]").unwrap_err();
+        let err = serde_json::from_str::<TestBoundedVectorMin2>("[1]").unwrap_err();
         assert!(
             err.to_string()
                 .contains("Item count 1 is below minimum of 2"),
@@ -470,7 +507,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_empty_input() {
-        let err = serde_json::from_str::<TestBoundedVector>("[]").unwrap_err();
+        let err = serde_json::from_str::<TestBoundedVectorMin2>("[]").unwrap_err();
         assert!(
             err.to_string().contains("Input cannot be empty"),
             "unexpected error: {err}"
@@ -479,7 +516,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_input_above_max() {
-        let err = serde_json::from_str::<TestBoundedVector>("[1,2,3,4,5]").unwrap_err();
+        let err = serde_json::from_str::<TestBoundedVectorMin2>("[1,2,3,4,5]").unwrap_err();
         assert!(
             err.to_string().contains("exceeds static maximum"),
             "unexpected error: {err}"
@@ -488,7 +525,7 @@ mod tests {
 
     #[test]
     fn try_pop_removes_last_item_when_above_min() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
 
         assert_eq!(bv.try_pop(), Ok(Some(3)));
         assert_eq!(bv.as_slice(), &[1, 2]);
@@ -497,7 +534,7 @@ mod tests {
 
     #[test]
     fn try_pop_rejects_removal_below_min_and_does_not_mutate() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
 
         assert_eq!(
             bv.try_pop(),
@@ -520,7 +557,7 @@ mod tests {
 
     #[test]
     fn try_remove_removes_item_at_index_when_above_min() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3, 4]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3, 4]).unwrap();
 
         assert_eq!(bv.try_remove(1), Ok(2));
         assert_eq!(bv.as_slice(), &[1, 3, 4]);
@@ -529,7 +566,7 @@ mod tests {
 
     #[test]
     fn try_remove_rejects_removal_below_min_and_does_not_mutate() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2]).unwrap();
 
         assert_eq!(
             bv.try_remove(0),
@@ -542,7 +579,7 @@ mod tests {
 
     #[test]
     fn try_remove_rejects_out_of_bounds_and_does_not_mutate() {
-        let mut bv = TestBoundedVector::try_from(vec![1, 2, 3]).unwrap();
+        let mut bv = TestBoundedVectorMin2::try_from(vec![1, 2, 3]).unwrap();
 
         assert_eq!(
             bv.try_remove(3),


### PR DESCRIPTION
## 1. What does this PR implement?

This PR is a defensive refinement that removes mutable escape hatches from `BoundedVec` and wrapper types (`Outputs`, `Inputs`) to enforce stricter bounds checking and encapsulation. All length-changing operations now go through validated
checked methods, preventing clients from accidentally or intentionally violating the `MIN..=MAX` length invariant.

Invariant Safety:

- No client can bypass bounds checks by obtaining mutable slices.
- All length mutations protected by `try_push()`, `try_pop()`, `try_remove()` with `MIN/MAX` validation.
- `new_unchecked()` remains as documented escape hatch for trusted internal code only.

Encapsulation:

- Ledger `Outputs` and `Inputs` now own all mutation policy.
- Single source of truth for length-changing operations per wrapper type.

Clarity:

- Intent is explicit: safe element mutation via iter_mut(), safe insertion via `try_push(), etc.
- Errors are specific: `OutputsError`, `InputsError` instead of generic `BoundedError`.
- API is audit-friendly: all mutable paths are validated in one place.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
