### PR TITLE
feat(api): expose current gas prices via http endpoint

### DIFF
--- a/nodes/api-common/src/bodies/mantle.rs
+++ b/nodes/api-common/src/bodies/mantle.rs
@@ -1,0 +1,10 @@
+use lb_core::{header::HeaderId, mantle::gas::GasPrice};
+use serde::{Deserialize, Serialize};
+
+/// Current gas prices from the ledger state at the given tip.
+#[derive(Serialize, Deserialize)]
+pub struct GasPricesResponseBody {
+    pub tip: HeaderId,
+    pub execution_base_gas_price: GasPrice,
+    pub storage_gas_price: GasPrice,
+}

--- a/nodes/api-common/src/bodies/mod.rs
+++ b/nodes/api-common/src/bodies/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod blend;
 pub mod channel;
+pub mod mantle;
 pub mod wallet;
 
 /// A no-operation body for endpoints that do not require a request or response

--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -1,6 +1,7 @@
 pub const MANTLE_METRICS: &str = "/mantle/metrics";
 pub const MANTLE_STATUS: &str = "/mantle/status";
 pub const MANTLE_SDP_DECLARATIONS: &str = "/mantle/sdp/declarations";
+pub const MANTLE_GAS_PRICES: &str = "/mantle/gas-prices";
 pub const CRYPTARCHIA_INFO: &str = "/cryptarchia/info";
 pub const CRYPTARCHIA_HEADERS: &str = "/cryptarchia/headers";
 pub const CRYPTARCHIA_LIB_STREAM: &str = "/cryptarchia/lib-stream";

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -45,9 +45,9 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use super::handlers::{
     add_tx, blend_info, block, block_events, blocks_range_stream, blocks_stream,
-    cryptarchia_headers, cryptarchia_info, cryptarchia_lib_stream, dial_peer, get_sdp_declarations,
-    immutable_blocks, libp2p_info, mantle_metrics, mantle_status, mempool_view, time_info,
-    transaction, wallet,
+    cryptarchia_headers, cryptarchia_info, cryptarchia_lib_stream, dial_peer, get_gas_prices,
+    get_sdp_declarations, immutable_blocks, libp2p_info, mantle_metrics, mantle_status,
+    mempool_view, time_info, transaction, wallet,
 };
 use crate::{
     BlendBroadcastSettings, BlendService, TracingService, WalletService,
@@ -322,6 +322,10 @@ where
             .route(
                 paths::wallet::BALANCE,
                 routing::get(wallet::get_balance::<WalletService, _>),
+            )
+            .route(
+                paths::MANTLE_GAS_PRICES,
+                routing::get(get_gas_prices::<RuntimeServiceId>),
             )
             .route(
                 paths::wallet::TRANSACTIONS_TRANSFER_FUNDS,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -35,6 +35,7 @@ use lb_http_api_common::{
     bodies::{
         blend::JoinBlendRequestBody,
         channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
+        mantle::GasPricesResponseBody,
         wallet::{
             balance::WalletBalanceResponseBody,
             claimable_vouchers::{
@@ -1345,6 +1346,59 @@ where
         Ok(Some(events)) => (StatusCode::OK, Json(events)).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "Block not found").into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct GasPricesQuery {
+    tip: Option<HeaderId>,
+}
+
+#[utoipa::path(
+    get,
+    path = paths::MANTLE_GAS_PRICES,
+    responses(
+        (status = 200, description = "Get the gas prices from the ledger state at the tip"),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
+pub async fn get_gas_prices<RuntimeServiceId>(
+    State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+    Query(query): Query<GasPricesQuery>,
+) -> Response
+where
+    RuntimeServiceId:
+        AsServiceId<Cryptarchia<RuntimeServiceId>> + Debug + Sync + Display + Send + 'static,
+{
+    let relay = match get_relay_or_500(&handle).await {
+        Ok(relay) => relay,
+        Err(error_response) => return error_response,
+    };
+    let chain_api =
+        CryptarchiaServiceApi::<Cryptarchia<RuntimeServiceId>, RuntimeServiceId>::new(relay);
+
+    let block_id = match query.tip {
+        Some(tip) => tip,
+        None => match consensus::cryptarchia_info::<RuntimeServiceId>(&handle).await {
+            Ok(info) => info.cryptarchia_info.tip,
+            Err(error) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response();
+            }
+        },
+    };
+
+    match chain_api.get_ledger_state(block_id).await {
+        Ok(Some(ledger_state)) => {
+            let gas_prices = ledger_state.get_gas_prices();
+            Json(GasPricesResponseBody {
+                tip: block_id,
+                execution_base_gas_price: gas_prices.execution_base_gas_price,
+                storage_gas_price: gas_prices.storage_gas_price,
+            })
+            .into_response()
+        }
+        Ok(None) => (StatusCode::NOT_FOUND, "Ledger state not found for block").into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
     }
 }
 

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -29,6 +29,7 @@ use utoipa::OpenApi;
         crate::api::handlers::transaction,
         crate::api::handlers::wallet::get_balance,
         crate::api::handlers::wallet::get_claimable_vouchers,
+        crate::api::handlers::get_gas_prices,
         crate::api::handlers::wallet::post_transactions_transfer_funds,
     ),
     components(schemas(schema::Status, schema::MempoolMetrics)),

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -17,6 +17,7 @@ use lb_http_api_common::{
     MAX_BLOCKS_STREAM_BLOCKS, MAX_BLOCKS_STREAM_CHUNK_SIZE,
     bodies::{
         blend::JoinBlendRequestBody,
+        mantle::GasPricesResponseBody,
         wallet::{
             balance::WalletBalanceResponseBody,
             claimable_vouchers::WalletClaimableVouchersResponseBody,
@@ -26,7 +27,7 @@ use lb_http_api_common::{
     paths::{
         BLEND_JOIN_NETWORK, BLOCK_EVENTS, BLOCKS, BLOCKS_DETAIL, BLOCKS_RANGE_STREAM,
         BLOCKS_STREAM, CHANNEL, CRYPTARCHIA_INFO, CRYPTARCHIA_LIB_STREAM, LEADER_CLAIM_VOUCHERS,
-        MEMPOOL_ADD_TX, SDP_POST_DECLARATION, TIME_INFO,
+        MANTLE_GAS_PRICES, MEMPOOL_ADD_TX, SDP_POST_DECLARATION, TIME_INFO,
         wallet::{BALANCE, TRANSACTIONS_TRANSFER_FUNDS},
     },
     queries::BlocksStreamQuery,
@@ -297,6 +298,15 @@ impl CommonHttpClient {
             .join(CRYPTARCHIA_INFO.trim_start_matches('/'))
             .map_err(Error::Url)?;
         self.get::<(), ChainServiceInfo>(request_url, None).await
+    }
+
+    /// Get the current gas prices from the ledger state at the tip.
+    pub async fn gas_prices(&self, base_url: Url) -> Result<GasPricesResponseBody, Error> {
+        let request_url = base_url
+            .join(MANTLE_GAS_PRICES.trim_start_matches('/'))
+            .map_err(Error::Url)?;
+        self.get::<(), GasPricesResponseBody>(request_url, None)
+            .await
     }
 
     /// Get time service info derived from deployment settings.

--- a/tests/cucumber_tests/features/fees.feature
+++ b/tests/cucumber_tests/features/fees.feature
@@ -1,0 +1,14 @@
+Feature: Fees
+
+  @transactions_ci
+  Scenario: Gas prices endpoint returns the genesis prices
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 1           | 1000         |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet resources:
+      | node_name | account_index | wallet_name | connected_to |
+      | NODE_1    | 1             | WALLET_1A   |              |
+    When node "NODE_1" is at height 1 in 180 seconds
+    Then gas prices on node "NODE_1" equal the genesis gas prices
+    Then I stop all nodes

--- a/tests/src/cucumber/steps/fees.rs
+++ b/tests/src/cucumber/steps/fees.rs
@@ -1,0 +1,125 @@
+use std::str::FromStr;
+
+use cucumber::{Parameter, gherkin::Step, then};
+use lb_core::mantle::{
+    gas::GasPrice,
+    transactions::genesis_tx::{GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE},
+};
+use tracing::info;
+
+use crate::cucumber::{
+    error::{StepError, StepResult},
+    steps::TARGET,
+    world::CucumberWorld,
+};
+
+/// Named gas price expectations resolvable from code, so feature files don't
+/// hardcode price values that change with protocol constants.
+#[derive(Debug, Parameter)]
+#[param(name = "gas_prices_reference", regex = "genesis")]
+pub enum GasPricesReference {
+    Genesis,
+}
+
+impl GasPricesReference {
+    const fn expected(&self) -> (GasPrice, GasPrice) {
+        match self {
+            Self::Genesis => (GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE),
+        }
+    }
+}
+
+impl FromStr for GasPricesReference {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "genesis" => Ok(Self::Genesis),
+            other => Err(format!("unknown gas prices reference `{other}`")),
+        }
+    }
+}
+
+#[then(expr = "gas prices on node {string} equal the {gas_prices_reference} gas prices")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber step entrypoints must take `&mut World`"
+)]
+async fn step_gas_prices_equal_reference(
+    world: &mut CucumberWorld,
+    step: &Step,
+    node_name: String,
+    reference: GasPricesReference,
+) -> StepResult {
+    let (expected_execution, expected_storage) = reference.expected();
+    assert_gas_prices(
+        world,
+        step,
+        &node_name,
+        expected_execution,
+        expected_storage,
+    )
+    .await
+}
+
+#[then(expr = "gas prices on node {string} are execution {int} and storage {int}")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber step entrypoints must take `&mut World`"
+)]
+async fn step_gas_prices_are(
+    world: &mut CucumberWorld,
+    step: &Step,
+    node_name: String,
+    execution: u64,
+    storage: u64,
+) -> StepResult {
+    assert_gas_prices(
+        world,
+        step,
+        &node_name,
+        GasPrice::new(execution),
+        GasPrice::new(storage),
+    )
+    .await
+}
+
+async fn assert_gas_prices(
+    world: &CucumberWorld,
+    step: &Step,
+    node_name: &str,
+    expected_execution: GasPrice,
+    expected_storage: GasPrice,
+) -> StepResult {
+    let client = world.resolve_node_http_client(node_name)?;
+
+    let gas_prices = client
+        .gas_prices()
+        .await
+        .map_err(|source| StepError::StepFail {
+            message: format!(
+                "Step `{}` error: gas prices request failed: {source}",
+                step.value
+            ),
+        })?;
+
+    if gas_prices.execution_base_gas_price != expected_execution
+        || gas_prices.storage_gas_price != expected_storage
+    {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: node '{node_name}' reports gas prices execution={:?} \
+                 storage={:?}, expected execution={expected_execution:?} \
+                 storage={expected_storage:?}",
+                step.value, gas_prices.execution_base_gas_price, gas_prices.storage_gas_price,
+            ),
+        });
+    }
+
+    info!(
+        target: TARGET,
+        "Node '{node_name}' reports the expected gas prices at tip {}", gas_prices.tip
+    );
+
+    Ok(())
+}

--- a/tests/src/cucumber/steps/mod.rs
+++ b/tests/src/cucumber/steps/mod.rs
@@ -2,6 +2,7 @@ pub mod run;
 pub mod scenario;
 pub mod workloads;
 
+pub mod fees;
 pub mod manual_cluster;
 pub mod manual_k8s;
 pub mod manual_mempool;

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -14,6 +14,7 @@ use lb_core::{
 use lb_http_api_common::{
     bodies::{
         blend::JoinBlendRequestBody,
+        mantle::GasPricesResponseBody,
         wallet::{
             balance::WalletBalanceResponseBody,
             transfer_funds::{WalletTransferFundsRequestBody, WalletTransferFundsResponseBody},
@@ -71,6 +72,14 @@ impl NodeHttpClient {
         self.with_timeout(
             "Consensus info request",
             self.http_client.consensus_info(self.base_url.clone()),
+        )
+        .await
+    }
+
+    pub async fn gas_prices(&self) -> Result<GasPricesResponseBody, Error> {
+        self.with_timeout(
+            "Gas prices request",
+            self.http_client.gas_prices(self.base_url.clone()),
         )
         .await
     }


### PR DESCRIPTION
## 1. What does this PR implement?

This PR adds `GET /mantle/gas-prices`, exposing the current gas prices from the ledger state:

```json
{ 
"tip": "0x…", 
"execution_base_gas_price": 0, 
"storage_gas_price": 0 
}
```

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
