### PR TITLE
chore(deployment): Persistent grafana and datasources volumes

### DIFF
--- a/deployment/compose.tracing.yml
+++ b/deployment/compose.tracing.yml
@@ -15,6 +15,7 @@ services:
       - ./tracing/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:z
       - ./tracing/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z
       - ./tracing/grafana/dashboards:/var/lib/grafana/dashboards/:z
+      - grafana-data:/var/lib/grafana
     ports:
       - 9091:3000
     restart: on-failure
@@ -39,6 +40,7 @@ services:
       - "24318:4318"
     volumes:
       - ./tracing/loki.yaml:/etc/loki/local-config.yaml
+      - loki-data:/loki
     command: -config.file=/etc/loki/local-config.yaml
 
   prometheus:
@@ -46,6 +48,7 @@ services:
     image: docker.io/prom/prometheus:v3.0.1
     volumes:
       - ./tracing/prometheus.yaml:/etc/prometheus/prometheus.yml:z
+      - prometheus-data:/prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=7d
@@ -53,3 +56,8 @@ services:
     ports:
       - "0.0.0.0:9090:9090"
     restart: on-failure
+
+volumes:
+  grafana-data:
+  prometheus-data:
+  loki-data:

--- a/deployment/compose.tracing.yml
+++ b/deployment/compose.tracing.yml
@@ -40,7 +40,6 @@ services:
       - "24318:4318"
     volumes:
       - ./tracing/loki.yaml:/etc/loki/local-config.yaml
-      - loki-data:/loki
     command: -config.file=/etc/loki/local-config.yaml
 
   prometheus:
@@ -48,7 +47,6 @@ services:
     image: docker.io/prom/prometheus:v3.0.1
     volumes:
       - ./tracing/prometheus.yaml:/etc/prometheus/prometheus.yml:z
-      - prometheus-data:/prometheus
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=7d
@@ -59,5 +57,3 @@ services:
 
 volumes:
   grafana-data:
-  prometheus-data:
-  loki-data:


### PR DESCRIPTION
## 1. What does this PR implement?

Persist data between deployments. Each service has it's own volume incase we'll want to cleanup prometheus and loki but not grafana user defined contents.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@bacv

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
