### PR TITLE
feat(faucet): serialize drips through a queue and add per-key cooldown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "logos-blockchain-key-management-system-keys",
  "logos-blockchain-node",
  "reqwest",
+ "serde_json",
  "serde_yaml",
  "tokio",
 ]
@@ -5015,6 +5016,7 @@ name = "logos-blockchain-tests"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "axum",
  "bincode",
  "cucumber",
  "derivative",
@@ -5029,6 +5031,7 @@ dependencies = [
  "logos-blockchain-common-http-client",
  "logos-blockchain-config",
  "logos-blockchain-core",
+ "logos-blockchain-faucet",
  "logos-blockchain-groth16",
  "logos-blockchain-http-api-common",
  "logos-blockchain-key-management-system-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ lb-cryptarchia-engine              = { default-features = false, package = "logo
 lb-cryptarchia-sync                = { default-features = false, package = "logos-blockchain-cryptarchia-sync", path = "./consensus/cryptarchia-sync" }
 lb-demo-archiver                   = { default-features = false, package = "logos-blockchain-demo-archiver", path = "./deployment/l2-sequencer-archival-demo/archiver" }
 lb-demo-sequencer                  = { default-features = false, package = "logos-blockchain-demo-sequencer", path = "./deployment/l2-sequencer-archival-demo/sequencer" }
+lb-faucet                          = { default-features = false, package = "logos-blockchain-faucet", path = "./deployment/faucet" }
 lb-groth16                         = { default-features = false, package = "logos-blockchain-groth16", path = "./zk/groth16" }
 lb-http-api-common                 = { default-features = false, package = "logos-blockchain-http-api-common", path = "./nodes/api-common" }
 lb-key-management-system-keys      = { default-features = false, package = "logos-blockchain-key-management-system-keys", path = "./kms/keys" }

--- a/deployment/faucet/Cargo.toml
+++ b/deployment/faucet/Cargo.toml
@@ -19,8 +19,9 @@ lb-http-api-common            = { workspace = true }
 lb-key-management-system-keys = { workspace = true }
 lb-node                       = { workspace = true }
 reqwest                       = { workspace = true }
+serde_json                    = { workspace = true }
 serde_yaml                    = { workspace = true }
-tokio                         = { features = ["macros", "net", "rt-multi-thread"], workspace = true }
+tokio                         = { features = ["macros", "net", "rt-multi-thread", "sync", "time"], workspace = true }
 
 [lints]
 workspace = true

--- a/deployment/faucet/src/bin/faucet.rs
+++ b/deployment/faucet/src/bin/faucet.rs
@@ -1,12 +1,17 @@
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, sync::Arc, time::Duration};
 
 use clap::Parser;
 use lb_groth16::fr_from_bytes;
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_node::config::DeploymentSettings;
-use logos_blockchain_faucet::{faucet::Faucet, server::faucet_app};
+use logos_blockchain_faucet::{
+    faucet::{Faucet, run_worker},
+    server::{FaucetServerState, faucet_app},
+};
 use reqwest::Url;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::mpsc};
+
+const DRIP_QUEUE_CAPACITY: usize = 1024;
 
 #[derive(Parser, Debug)]
 #[command(about = "Faucet")]
@@ -21,8 +26,11 @@ struct Args {
     /// Hex-encoded faucet public key.
     #[arg(long, conflicts_with = "deployment_file")]
     faucet_pk: Option<String>,
-    #[arg(short, long)]
+    #[arg(long)]
     drip_amount: u64,
+    /// Minimum number of seconds between drips for the same recipient key.
+    #[arg(long, default_value_t = 300)]
+    cooldown_secs: u64,
 }
 
 #[tokio::main]
@@ -52,7 +60,14 @@ async fn main() {
             .expect("faucet should be created"),
     );
 
-    let app = faucet_app(faucet);
+    let (queue, requests) = mpsc::channel(DRIP_QUEUE_CAPACITY);
+    tokio::spawn(run_worker(Arc::clone(&faucet), requests));
+
+    let state = Arc::new(FaucetServerState::new(
+        queue,
+        Duration::from_secs(args.cooldown_secs),
+    ));
+    let app = faucet_app(state);
 
     println!("Faucet server running on http://0.0.0.0:{}", args.port);
     let listener = TcpListener::bind(&format!("0.0.0.0:{}", args.port))

--- a/deployment/faucet/src/faucet.rs
+++ b/deployment/faucet/src/faucet.rs
@@ -1,9 +1,28 @@
+use std::{sync::Arc, time::Duration};
+
 use lb_common_http_client::CommonHttpClient;
 use lb_http_api_common::bodies::wallet::transfer_funds::{
     WalletTransferFundsRequestBody, WalletTransferFundsResponseBody,
 };
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use reqwest::Url;
+use tokio::sync::mpsc;
+
+/// How often the worker polls the faucet balance while waiting for a
+/// submitted drip to be included in a block.
+const CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(1);
+/// How long the worker waits for a submitted drip to be confirmed before
+/// moving on. Generous compared to expected block times; hitting it means the
+/// transaction was likely dropped, and the next drip resyncs from the current
+/// wallet state either way.
+const CONFIRMATION_TIMEOUT: Duration = Duration::from_mins(2);
+/// Pause between transfer attempts for the same drip request, so transient
+/// node errors are not retried in a tight loop.
+const RETRY_DELAY: Duration = Duration::from_secs(5);
+/// Transfer attempts per drip request before it is dropped. Bounds how long
+/// one failing request can stall the queue: at most
+/// `MAX_TRANSFER_ATTEMPTS * RETRY_DELAY` plus the request timeouts.
+const MAX_TRANSFER_ATTEMPTS: u32 = 5;
 
 pub struct Faucet {
     faucet_pk: ZkPublicKey,
@@ -24,17 +43,19 @@ impl Faucet {
         })
     }
 
+    pub async fn balance(&self) -> Result<u64, String> {
+        self.http_client
+            .get_wallet_balance(self.base_url.clone(), self.faucet_pk, None)
+            .await
+            .map(|info| info.balance)
+            .map_err(|e| format!("Failed to fetch faucet balance: {e}"))
+    }
+
     pub async fn transfer_to_pk(
         &self,
         recipient_pk: ZkPublicKey,
     ) -> Result<WalletTransferFundsResponseBody, String> {
-        let balance_info = self
-            .http_client
-            .get_wallet_balance(self.base_url.clone(), self.faucet_pk, None)
-            .await
-            .map_err(|e| format!("Failed to fetch faucet balance: {e}"))?;
-
-        let current_balance = balance_info.balance;
+        let current_balance = self.balance().await?;
 
         let amount_to_send = std::cmp::min(current_balance, self.drip_amount);
         if amount_to_send == 0 {
@@ -43,10 +64,7 @@ impl Faucet {
             ));
         }
 
-        println!(
-            "Dripping {}% of balance: {amount_to_send} units to {recipient_pk:?}",
-            self.drip_amount
-        );
+        println!("Dripping {amount_to_send} units to {recipient_pk:?}");
 
         let body = WalletTransferFundsRequestBody {
             tip: None,
@@ -61,4 +79,63 @@ impl Faucet {
             .await
             .map_err(|e| format!("Faucet transfer failed: {e}"))
     }
+
+    /// Waits until the faucet balance differs from `balance_before`, which
+    /// signals that the previously submitted drip was included in a block and
+    /// the change note is spendable again.
+    async fn wait_for_confirmation(&self, balance_before: u64) {
+        let deadline = tokio::time::Instant::now() + CONFIRMATION_TIMEOUT;
+        while tokio::time::Instant::now() < deadline {
+            if let Ok(balance) = self.balance().await
+                && balance != balance_before
+            {
+                return;
+            }
+            tokio::time::sleep(CONFIRMATION_POLL_INTERVAL).await;
+        }
+        eprintln!("Timed out waiting for drip confirmation; continuing with next request");
+    }
+}
+
+/// Drains queued drip requests one at a time.
+///
+/// Each drip waits for on-chain confirmation before the next starts. The
+/// faucet wallet holds a single note, so concurrent transfers would conflict
+/// on the same input; serializing on confirmation guarantees each drip funds
+/// from the confirmed change of the previous one.
+pub async fn run_worker(faucet: Arc<Faucet>, mut requests: mpsc::Receiver<ZkPublicKey>) {
+    while let Some(recipient_pk) = requests.recv().await {
+        drip_with_retries(&faucet, recipient_pk).await;
+    }
+}
+
+async fn drip_with_retries(faucet: &Faucet, recipient_pk: ZkPublicKey) {
+    for attempt in 1..=MAX_TRANSFER_ATTEMPTS {
+        let balance_before = match faucet.balance().await {
+            Ok(balance) => balance,
+            Err(e) => {
+                eprintln!("Drip attempt {attempt}/{MAX_TRANSFER_ATTEMPTS}: {e}");
+                tokio::time::sleep(RETRY_DELAY).await;
+                continue;
+            }
+        };
+
+        match faucet.transfer_to_pk(recipient_pk).await {
+            Ok(response) => {
+                println!(
+                    "Drip submitted for {recipient_pk:?}, hash: {:?}",
+                    response.hash
+                );
+                faucet.wait_for_confirmation(balance_before).await;
+                return;
+            }
+            Err(e) => {
+                eprintln!(
+                    "Drip attempt {attempt}/{MAX_TRANSFER_ATTEMPTS} failed for {recipient_pk:?}: {e}"
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+        }
+    }
+    eprintln!("Dropping drip request for {recipient_pk:?} after {MAX_TRANSFER_ATTEMPTS} attempts");
 }

--- a/deployment/faucet/src/server.rs
+++ b/deployment/faucet/src/server.rs
@@ -1,4 +1,8 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use axum::{
     Router,
@@ -9,11 +13,53 @@ use axum::{
 use lb_groth16::fr_from_bytes;
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use reqwest::StatusCode;
+use tokio::sync::mpsc;
 
-use crate::faucet::Faucet;
+pub struct FaucetServerState {
+    queue: mpsc::Sender<ZkPublicKey>,
+    cooldowns: Mutex<HashMap<String, Instant>>,
+    cooldown: Duration,
+}
+
+impl FaucetServerState {
+    #[must_use]
+    pub fn new(queue: mpsc::Sender<ZkPublicKey>, cooldown: Duration) -> Self {
+        Self {
+            queue,
+            cooldowns: Mutex::new(HashMap::new()),
+            cooldown,
+        }
+    }
+
+    /// Registers a drip attempt for `key`. Returns the remaining cooldown if
+    /// the key is still cooling down from a previous request.
+    fn try_start_cooldown(&self, key: &str) -> Result<(), Duration> {
+        let mut cooldowns = self
+            .cooldowns
+            .lock()
+            .expect("cooldown mutex should not be poisoned");
+        let now = Instant::now();
+        cooldowns.retain(|_, expires_at| *expires_at > now);
+
+        if let Some(expires_at) = cooldowns.get(key) {
+            return Err(expires_at.duration_since(now));
+        }
+
+        cooldowns.insert(key.to_owned(), now + self.cooldown);
+        drop(cooldowns);
+        Ok(())
+    }
+
+    fn clear_cooldown(&self, key: &str) {
+        self.cooldowns
+            .lock()
+            .expect("cooldown mutex should not be poisoned")
+            .remove(key);
+    }
+}
 
 async fn transfer_funds(
-    State(faucet): State<Arc<Faucet>>,
+    State(state): State<Arc<FaucetServerState>>,
     Path(key_id): Path<String>,
 ) -> impl IntoResponse {
     let bytes = match hex::decode(&key_id) {
@@ -32,14 +78,44 @@ async fn transfer_funds(
         }
     };
 
-    match faucet.transfer_to_pk(recipient_pk).await {
-        Ok(tx) => (StatusCode::OK, tx).into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+    let cooldown_key = key_id.to_lowercase();
+    if let Err(remaining) = state.try_start_cooldown(&cooldown_key) {
+        let retry_after_secs = remaining.as_secs().max(1);
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            serde_json::json!({
+                "status": "cooldown",
+                "retry_after_secs": retry_after_secs,
+            })
+            .to_string(),
+        )
+            .into_response();
+    }
+
+    if state.queue.try_send(recipient_pk).is_ok() {
+        (
+            StatusCode::ACCEPTED,
+            serde_json::json!({
+                "status": "queued",
+            })
+            .to_string(),
+        )
+            .into_response()
+    } else {
+        state.clear_cooldown(&cooldown_key);
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "status": "queue_full",
+            })
+            .to_string(),
+        )
+            .into_response()
     }
 }
 
-pub fn faucet_app(faucet: Arc<Faucet>) -> Router {
+pub fn faucet_app(state: Arc<FaucetServerState>) -> Router {
     Router::new()
         .route("/faucet/:pk", post(transfer_funds))
-        .with_state(faucet)
+        .with_state(state)
 }

--- a/deployment/faucet/src/server.rs
+++ b/deployment/faucet/src/server.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 
 pub struct FaucetServerState {
     queue: mpsc::Sender<ZkPublicKey>,
-    cooldowns: Mutex<HashMap<String, Instant>>,
+    cooldowns: Mutex<HashMap<ZkPublicKey, Instant>>,
     cooldown: Duration,
 }
 
@@ -33,7 +33,7 @@ impl FaucetServerState {
 
     /// Registers a drip attempt for `key`. Returns the remaining cooldown if
     /// the key is still cooling down from a previous request.
-    fn try_start_cooldown(&self, key: &str) -> Result<(), Duration> {
+    fn try_start_cooldown(&self, key: ZkPublicKey) -> Result<(), Duration> {
         let mut cooldowns = self
             .cooldowns
             .lock()
@@ -41,20 +41,20 @@ impl FaucetServerState {
         let now = Instant::now();
         cooldowns.retain(|_, expires_at| *expires_at > now);
 
-        if let Some(expires_at) = cooldowns.get(key) {
+        if let Some(expires_at) = cooldowns.get(&key) {
             return Err(expires_at.duration_since(now));
         }
 
-        cooldowns.insert(key.to_owned(), now + self.cooldown);
+        cooldowns.insert(key, now + self.cooldown);
         drop(cooldowns);
         Ok(())
     }
 
-    fn clear_cooldown(&self, key: &str) {
+    fn clear_cooldown(&self, key: ZkPublicKey) {
         self.cooldowns
             .lock()
             .expect("cooldown mutex should not be poisoned")
-            .remove(key);
+            .remove(&key);
     }
 }
 
@@ -78,8 +78,7 @@ async fn transfer_funds(
         }
     };
 
-    let cooldown_key = key_id.to_lowercase();
-    if let Err(remaining) = state.try_start_cooldown(&cooldown_key) {
+    if let Err(remaining) = state.try_start_cooldown(recipient_pk) {
         let retry_after_secs = remaining.as_secs().max(1);
         return (
             StatusCode::TOO_MANY_REQUESTS,
@@ -102,7 +101,7 @@ async fn transfer_funds(
         )
             .into_response()
     } else {
-        state.clear_cooldown(&cooldown_key);
+        state.clear_cooldown(recipient_pk);
         (
             StatusCode::SERVICE_UNAVAILABLE,
             serde_json::json!({

--- a/deployment/nginx/static/run/faucet/index.html
+++ b/deployment/nginx/static/run/faucet/index.html
@@ -50,13 +50,18 @@
                 respDiv.style.display = 'block';
                 
                 if (response.ok) {
-                    const data = JSON.parse(text); 
-                    const hash = data.hash;
-
                     respDiv.className = 'success';
                     respDiv.innerHTML = `
-                        <strong>Success!</strong><br>
-                        <p>Transaction hash: <code>${hash.substring(0, 8)}...</code></p>
+                        <strong>Request queued!</strong><br>
+                        <p>Your funds are on the way and should arrive within a few blocks.</p>
+                    `;
+                } else if (response.status === 429) {
+                    const data = JSON.parse(text);
+
+                    respDiv.className = 'error';
+                    respDiv.innerHTML = `
+                        <strong>Cooldown active</strong><br>
+                        <p>Please wait ${data.retry_after_secs} seconds before requesting again.</p>
                     `;
                 } else {
                     respDiv.className = 'error';

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,6 +22,7 @@ lb-utxotree = { workspace = true }
 
 [dependencies]
 async-trait                      = { workspace = true }
+axum                             = { features = ["http1", "json", "tokio"], workspace = true }
 bincode                          = { workspace = true }
 cucumber                         = { features = ["macros", "output-junit"], workspace = true }
 derivative                       = { workspace = true }
@@ -34,6 +35,7 @@ lb-chain-service                 = { workspace = true }
 lb-common-http-client            = { workspace = true }
 lb-config                        = { workspace = true }
 lb-core                          = { workspace = true }
+lb-faucet                        = { workspace = true }
 lb-groth16                       = { workspace = true }
 lb-http-api-common               = { workspace = true }
 lb-key-management-system-service = { workspace = true }
@@ -94,6 +96,10 @@ path = "src/tests/mantle/chain_start.rs"
 [[test]]
 name = "test_mantle_channel"
 path = "src/tests/mantle/channel.rs"
+
+[[test]]
+name = "test_mantle_faucet"
+path = "src/tests/mantle/faucet.rs"
 
 [[test]]
 name              = "test_mantle_sdp_ops"

--- a/tests/src/common/manual_cluster.rs
+++ b/tests/src/common/manual_cluster.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    num::NonZero,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -8,17 +9,19 @@ use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_libp2p::Multiaddr;
 use lb_node::{UserConfig, config::RunConfig};
 use lb_testing_framework::{
-    DeploymentBuilder, LbcEnv, LbcLocalDeployer, LbcManualCluster, NodeHttpClient,
-    USER_CONFIG_FILE, internal::DeploymentPlan, is_truthy_env, record_system_monitor_event,
-    register_system_monitor_output_file, unregister_system_monitor_output_file,
+    DeploymentBuilder, LbcEnv, LbcLocalDeployer, LbcManualCluster, NodeHttpClient, TopologyConfig,
+    USER_CONFIG_FILE, configs::wallet::WalletConfig, internal::DeploymentPlan, is_truthy_env,
+    record_system_monitor_event, register_system_monitor_output_file,
+    unregister_system_monitor_output_file,
 };
+use lb_utils::math::NonNegativeRatio;
 use lb_zone_sdk::Slot;
 use reqwest::Url;
 use tempfile::TempDir;
 use testing_framework_core::scenario::{DynError, PeerSelection, StartNodeOptions, StartedNode};
 use tokio::time::error::Elapsed;
 
-use crate::cucumber::defaults::{E2E_KEEP_LOGS, E2E_TESTS_BASE_DIR_OVERRIDE};
+use crate::cucumber::defaults::{E2E_ARTIFACTS_DIR, E2E_KEEP_LOGS, E2E_TESTS_BASE_DIR_OVERRIDE};
 
 pub struct LocalManualClusterHarnessBase {
     scenario_base_dir: PathBuf,
@@ -156,6 +159,40 @@ where
         .expect("manual cluster should become ready");
 
     (base, nodes)
+}
+
+/// Starts a local cluster of `node_count` nodes with fast blocks (2s slots)
+/// and the given wallet accounts funded at genesis. Artifacts are written
+/// under [`E2E_ARTIFACTS_DIR`].
+pub async fn start_fast_cluster_with_wallet(
+    test_name: &str,
+    prefix: &str,
+    node_count: usize,
+    wallet_config: WalletConfig,
+) -> (LocalManualClusterHarnessBase, Vec<StartedNode<LbcEnv>>) {
+    start_local_manual_cluster_with_layout(
+        test_name,
+        prefix,
+        DeploymentBuilder::new(
+            TopologyConfig::with_node_numbers(node_count)
+                .with_allow_multiple_genesis_tokens(true)
+                .with_test_context(Some(test_name.to_owned())),
+        )
+        .with_wallet_config(wallet_config),
+        node_count,
+        ManualNodeLayout::SelectNodeSeed(0),
+        |config| Ok(fast_chain_config(config)),
+        Some(PathBuf::from(E2E_ARTIFACTS_DIR)),
+    )
+    .await
+}
+
+fn fast_chain_config(mut config: RunConfig) -> RunConfig {
+    config.deployment.time.slot_duration = Duration::from_secs(2);
+    config.deployment.cryptarchia.security_param = NonZero::new(3).expect("nonzero");
+    config.deployment.cryptarchia.slot_activation_coeff =
+        NonNegativeRatio::new(1, 2.try_into().expect("nonzero"));
+    config
 }
 
 pub async fn start_manual_nodes_with_layout<F>(

--- a/tests/src/cucumber/steps/manual_transactions/faucet.rs
+++ b/tests/src/cucumber/steps/manual_transactions/faucet.rs
@@ -200,9 +200,17 @@ impl FaucetTask {
         let json: serde_json::Value = serde_json::from_str(&body)
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
-        json.get("hash").and_then(|v| v.as_str()).map_or_else(
-            || Err(format!("[request_funds] Missing or invalid `hash` in response: {body}").into()),
-            |hash| Ok(hash.to_owned()),
-        )
+        json.get("hash")
+            .or_else(|| json.get("status"))
+            .and_then(|v| v.as_str())
+            .map_or_else(
+                || {
+                    Err(format!(
+                        "[request_funds] Missing or invalid `hash`/`status` in response: {body}"
+                    )
+                    .into())
+                },
+                |hash| Ok(hash.to_owned()),
+            )
     }
 }

--- a/tests/src/tests/mantle/faucet.rs
+++ b/tests/src/tests/mantle/faucet.rs
@@ -1,0 +1,153 @@
+use std::{sync::Arc, time::Duration};
+
+use lb_faucet::{
+    faucet::{Faucet, run_worker},
+    server::{FaucetServerState, faucet_app},
+};
+use lb_key_management_system_service::keys::ZkPublicKey;
+use lb_testing_framework::{
+    NodeHttpClient,
+    configs::wallet::{WalletAccount, WalletConfig},
+};
+use logos_blockchain_tests::common::manual_cluster::{
+    api_url, get_wallet_balance, start_fast_cluster_with_wallet, wait_for_nodes_height,
+};
+use reqwest::StatusCode;
+use serial_test::serial;
+use tokio::{net::TcpListener, sync::mpsc, time::sleep};
+
+const FAUCET_FUNDS: u64 = 2000;
+const DRIP_AMOUNT: u64 = 50;
+const DRIP_QUEUE_CAPACITY: usize = 16;
+const COOLDOWN: Duration = Duration::from_hours(1);
+const BALANCE_TIMEOUT: Duration = Duration::from_mins(3);
+const BALANCE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// End-to-end test for the faucet drip queue:
+///
+/// 1. Spawn validators with a single-note faucet wallet.
+/// 2. Run the faucet (server + worker) in-process against a validator.
+/// 3. Submit two concurrent drip requests for different recipients.
+/// 4. Verify both are accepted and an immediate repeat request is rejected with
+///    the cooldown status.
+/// 5. Verify both recipients are credited on chain, one drip per block, and the
+///    faucet balance decreases by exactly two drips.
+#[tokio::test]
+#[serial]
+async fn faucet_drips_concurrent_requests_in_order() {
+    let faucet_account = WalletAccount::deterministic(0, FAUCET_FUNDS, false).expect("valid");
+    let recipient_a = WalletAccount::deterministic(1, 1, false).expect("valid");
+    let recipient_b = WalletAccount::deterministic(2, 2, false).expect("valid");
+
+    let wallet_config = WalletConfig::new(vec![
+        faucet_account.clone(),
+        recipient_a.clone(),
+        recipient_b.clone(),
+    ]);
+
+    let (_base, nodes) =
+        start_fast_cluster_with_wallet("faucet-drip-queue", "mantle-faucet", 2, wallet_config)
+            .await;
+
+    let validator = &nodes[0];
+    wait_for_nodes_height(&[&validator.client], 3, Duration::from_mins(5)).await;
+
+    let faucet_url = spawn_faucet(&validator.client, faucet_account.public_key()).await;
+    let client = reqwest::Client::new();
+
+    let (resp_a, resp_b) = tokio::join!(
+        client
+            .post(format!(
+                "{faucet_url}/faucet/{}",
+                recipient_a.public_key_hex()
+            ))
+            .send(),
+        client
+            .post(format!(
+                "{faucet_url}/faucet/{}",
+                recipient_b.public_key_hex()
+            ))
+            .send(),
+    );
+
+    let resp_a = resp_a.expect("drip request for A should not fail");
+    let resp_b = resp_b.expect("drip request for B should not fail");
+    assert_eq!(resp_a.status(), StatusCode::ACCEPTED);
+    assert_eq!(resp_b.status(), StatusCode::ACCEPTED);
+
+    let repeat = client
+        .post(format!(
+            "{faucet_url}/faucet/{}",
+            recipient_a.public_key_hex()
+        ))
+        .send()
+        .await
+        .expect("repeat drip request should not fail");
+
+    assert_eq!(repeat.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let repeat_body: serde_json::Value = repeat.json().await.expect("cooldown body is JSON");
+    assert_eq!(repeat_body["status"], "cooldown");
+    assert!(repeat_body["retry_after_secs"].as_u64().is_some());
+
+    wait_for_balance(
+        &validator.client,
+        recipient_a.public_key(),
+        1 + DRIP_AMOUNT,
+        "recipient A",
+    )
+    .await;
+
+    wait_for_balance(
+        &validator.client,
+        recipient_b.public_key(),
+        2 + DRIP_AMOUNT,
+        "recipient B",
+    )
+    .await;
+
+    let faucet_balance = get_wallet_balance(&validator.client, faucet_account.public_key()).await;
+    assert_eq!(
+        faucet_balance,
+        FAUCET_FUNDS - 2 * DRIP_AMOUNT,
+        "faucet should have paid out exactly two drips"
+    );
+}
+
+/// Runs the faucet worker and HTTP server in-process against the given node,
+/// returning the faucet base URL.
+async fn spawn_faucet(node: &NodeHttpClient, faucet_pk: ZkPublicKey) -> String {
+    let faucet = Arc::new(
+        Faucet::new(api_url(node, ""), faucet_pk, DRIP_AMOUNT).expect("faucet should be created"),
+    );
+
+    let (queue, requests) = mpsc::channel(DRIP_QUEUE_CAPACITY);
+    tokio::spawn(run_worker(Arc::clone(&faucet), requests));
+
+    let state = Arc::new(FaucetServerState::new(queue, COOLDOWN));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("faucet listener should bind");
+
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, faucet_app(state))
+            .await
+            .expect("faucet server should not fail");
+    });
+
+    format!("http://{address}")
+}
+
+async fn wait_for_balance(node: &NodeHttpClient, pk: ZkPublicKey, expected: u64, label: &str) {
+    let deadline = tokio::time::Instant::now() + BALANCE_TIMEOUT;
+    let mut last_balance = get_wallet_balance(node, pk).await;
+    while tokio::time::Instant::now() < deadline {
+        if last_balance == expected {
+            return;
+        }
+        sleep(BALANCE_POLL_INTERVAL).await;
+        last_balance = get_wallet_balance(node, pk).await;
+    }
+    panic!("timed out waiting for {label} balance {expected}, last balance was {last_balance}");
+}


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes the faucet silently dropping concurrent requests while returning success.

**Problem**

- All concurrent requests build transactions spending the faucet's single note, so only one can land per block.
- Every caller still gets a 200 with a tx hash — but the losing transactions are dropped at block inclusion, so those hashes never appear on chain and the users never receive funds or an error.

**Change**

- Requests go into a queue; a worker pays them out one per block, in order. Callers get an immediate `202 {"status":"queued"}` and funds arrive a few blocks later.
- Repeat requests for the same key within the cooldown (`--cooldown-secs`, default 5 min) get `429` with the remaining wait.
- The response no longer contains a tx hash — the transaction is built asynchronously.
- Also fixes a debug-build startup panic (duplicate `-d` short flag).

**Relation to #3080**

That PR makes the wallet reserve notes for in-flight transactions, which turns the silent drops into "insufficient funds" errors from a fully funded faucet. With the queue, requests wait their turn instead.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@andrussal

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).