### PR TITLE
chore(utils): introduce a Bounded wrapper and type aliases for String and Multiaddr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5216,6 +5216,7 @@ dependencies = [
  "futures",
  "humantime",
  "logos-blockchain-log-targets",
+ "multiaddr",
  "nistrs",
  "overwatch",
  "rand 0.8.6",

--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 
 use lb_groth16::CompressedGroth16Proof;
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
-use lb_utils::bounded_vec::BoundedError;
+use lb_utils::bounded::BoundedError;
 
 use crate::{
     block::Block,

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use lb_groth16::{Fr, fr_from_bytes, serde::serde_fr};
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_poseidon2::Digest as _;
-use lb_utils::bounded_vec::{BoundedError, UpperBoundedVec};
+use lb_utils::bounded::{BoundedError, UpperBoundedVec};
 use lb_utxotree::UtxoTree;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};

--- a/core/src/mantle/nom/bounded_vec.rs
+++ b/core/src/mantle/nom/bounded_vec.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use lb_utils::bounded_vec::BoundedVec;
+use lb_utils::bounded::BoundedVec;
 use nom::{
     IResult, Parser as _,
     error::{Error, ErrorKind},
@@ -151,7 +151,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use lb_utils::bounded_vec::BoundedVec;
+    use lb_utils::bounded::BoundedVec;
     use nom::error::ErrorKind;
 
     use crate::mantle::nom::{NomDecode as _, NomEncode as _};

--- a/core/src/mantle/nom/fixtures/genesis.rs
+++ b/core/src/mantle/nom/fixtures/genesis.rs
@@ -6,7 +6,7 @@ use crate::mantle::transactions::genesis_tx::{ChainId, CryptarchiaParameter, Gen
 
 nom_wire_fixtures!(
     ChainId,
-    "logos-chain-1".to_owned().try_into().unwrap() => "0d000000000000006c6f676f732d636861696e2d31"
+    "logos-chain-1".to_owned().try_into().unwrap() => "0d6c6f676f732d636861696e2d31"
 );
 
 nom_wire_fixtures!(
@@ -17,5 +17,5 @@ nom_wire_fixtures!(
 
 nom_wire_fixtures!(
     CryptarchiaParameter,
-    Self { chain_id: ChainId::try_from("logos-chain-1".to_owned()).unwrap(), genesis_time: GenesisTime::new(1000), epoch_nonce: Fr::ZERO } => "0d000000000000006c6f676f732d636861696e2d31e80300000000000000000000000000000000000000000000000000000000000000000000"
+    Self { chain_id: ChainId::try_from("logos-chain-1".to_owned()).unwrap(), genesis_time: GenesisTime::new(1000), epoch_nonce: Fr::ZERO } => "0d6c6f676f732d636861696e2d31e80300000000000000000000000000000000000000000000000000000000000000000000"
 );

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 // Both macros are the blessed way to declare a codec: each emits the mandatory
 // `WireExamples` fixtures (see below) alongside the impls.
 pub use lb_core_macros::{NomCodec, nom_wire_fixtures};
-use lb_utils::bounded_vec::LowerBoundedVec;
+use lb_utils::bounded::LowerBoundedVec;
 use nom::IResult;
 
 pub mod array;

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -1,5 +1,5 @@
 use lb_cryptarchia_engine::Slot;
-use lb_utils::bounded_vec::NonEmptyBoundedVec;
+use lb_utils::bounded::NonEmptyBoundedVec;
 use serde::{Deserialize, Serialize};
 
 use super::{ChannelId, Ed25519PublicKey, MsgId};

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -1,5 +1,5 @@
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
-use lb_utils::bounded_vec::UpperBoundedVec;
+use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use lb_cryptarchia_engine::Slot;
 use lb_key_management_system_keys::keys::Ed25519Signature;
-use lb_utils::bounded_vec::UpperBoundedVec;
+use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
 
 use super::{ChannelId, Ed25519PublicKey, MsgId};
@@ -148,7 +148,7 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
 
 #[cfg(test)]
 mod tests {
-    use lb_utils::bounded_vec::BoundedError;
+    use lb_utils::bounded::BoundedError;
 
     use super::*;
     use crate::mantle::nom::NomDecode as _;

--- a/core/src/mantle/transactions/builder.rs
+++ b/core/src/mantle/transactions/builder.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, collections::HashMap};
 
 use lb_key_management_system_keys::keys::ZkPublicKey;
-use lb_utils::bounded_vec::BoundedError;
+use lb_utils::bounded::BoundedError;
 use thiserror::Error;
 
 use crate::{

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -100,7 +100,7 @@ mod tests {
     use lb_blend_proofs::{quota::VerifiedProofOfQuota, selection::VerifiedProofOfSelection};
     use lb_groth16::{CompressedGroth16Proof, Fr};
     use lb_key_management_system_keys::keys::{Ed25519Key, Ed25519Signature, ZkKey, ZkPublicKey};
-    use lb_utils::bounded_vec::BoundedError;
+    use lb_utils::bounded::BoundedError;
     use multiaddr::Multiaddr;
     use num_bigint::BigUint;
 

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -275,7 +275,7 @@ impl<'de> Deserialize<'de> for GenesisTx {
     }
 }
 
-pub const MAX_CHAIN_ID_SIZE: usize = u64::MAX as usize;
+pub const MAX_CHAIN_ID_SIZE: usize = u8::MAX as usize;
 type ChainIdBoundedVec = BoundedVec<u8, 1, MAX_CHAIN_ID_SIZE>;
 /// A chain ID is a UTF-8 string whose byte length is bounded to
 /// `[1, MAX_CHAIN_ID_SIZE]`. The length invariant is owned by [`Bounded`];

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -352,10 +352,10 @@ impl<const MIN: usize, const MAX: usize> TryFrom<BoundedVec<u8, MIN, MAX>> for C
     fn try_from(value: BoundedVec<u8, MIN, MAX>) -> Result<Self, Self::Error> {
         const {
             assert!(MIN >= 1, "Min size cannot be less than 1.");
-            // No need to assert `MAX <= MAX_CHAIN_ID_SIZE` because
-            // `MAX_CHAIN_ID_SIZE` == `u64::MAX` so comparison is
-            // always true, and the compiles throws an error because
-            // of that.
+            assert!(
+                MAX <= MAX_CHAIN_ID_SIZE,
+                "Max size cannot be greater than MAX_CHAIN_ID_SIZE."
+            );
         }
         Self::try_from(value.into_inner())
     }
@@ -748,9 +748,19 @@ mod tests {
 
     #[test]
     fn test_cryptarchia_parameter_decode_errors() {
-        // Too short
+        // A single byte is a complete 1-byte chain_id length prefix of 0, which
+        // is below the chain_id minimum length of 1.
         assert!(matches!(
             CryptarchiaParameter::decode(&[0; 1]).unwrap_err(),
+            nom::Err::Error(NomError {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
+
+        // Genuinely too short: not even the length prefix can be read.
+        assert!(matches!(
+            CryptarchiaParameter::decode(&[]).unwrap_err(),
             nom::Err::Error(NomError {
                 code: ErrorKind::Eof,
                 ..
@@ -768,9 +778,10 @@ mod tests {
             })
         ));
 
-        // Invalid UTF-8 chain_id
+        // Invalid UTF-8 chain_id. The chain_id bytes begin right after its
+        // single-byte length prefix, so index 1 is the first UTF-8 byte.
         let mut encoded = cryptarchia_param().encode();
-        encoded[8] = 0xFF; // corrupt the UTF-8 byte
+        encoded[1] = 0xFF; // corrupt the first chain_id UTF-8 byte
         assert!(matches!(
             CryptarchiaParameter::decode(&encoded).unwrap_err(),
             nom::Err::Error(NomError {

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Display, Formatter};
 
 use lb_core_macros::NomCodec;
 use lb_groth16::Fr;
-use lb_utils::bounded_vec::BoundedVec;
+use lb_utils::bounded::{BoundedString, BoundedVec};
 use nom::{
     IResult,
     error::{Error as NomError, ErrorKind},
@@ -275,74 +275,11 @@ impl<'de> Deserialize<'de> for GenesisTx {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(try_from = "String")]
-struct BoundedString<const MIN_SIZE: usize, const MAX_SIZE: usize>(String);
-
-impl<const MIN_SIZE: usize, const MAX_SIZE: usize> AsRef<str>
-    for BoundedString<MIN_SIZE, MAX_SIZE>
-{
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl<const MIN_SIZE: usize, const MAX_SIZE: usize> Display for BoundedString<MIN_SIZE, MAX_SIZE> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl<const MIN_SIZE: usize, const MAX_SIZE: usize> TryFrom<String>
-    for BoundedString<MIN_SIZE, MAX_SIZE>
-{
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.len() < MIN_SIZE {
-            return Err(format!("String must be at least {MIN_SIZE} bytes: {value}"));
-        }
-        if value.len() > MAX_SIZE {
-            return Err(format!("String must not exceed {MAX_SIZE} bytes: {value}"));
-        }
-
-        Ok(Self(value))
-    }
-}
-
-impl<const MIN_SIZE: usize, const MAX_SIZE: usize> TryFrom<Vec<u8>>
-    for BoundedString<MIN_SIZE, MAX_SIZE>
-{
-    type Error = String;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        let string = String::from_utf8(value).map_err(|e| format!("Invalid UTF-8 string: {e}"))?;
-        Self::try_from(string)
-    }
-}
-
-impl<const MIN_SIZE: usize, const MAX_SIZE: usize, const MIN: usize, const MAX: usize>
-    TryFrom<BoundedVec<u8, MIN, MAX>> for BoundedString<MIN_SIZE, MAX_SIZE>
-{
-    type Error = String;
-
-    fn try_from(value: BoundedVec<u8, MIN, MAX>) -> Result<Self, Self::Error> {
-        const {
-            assert!(
-                MIN >= MIN_SIZE,
-                "Min size cannot be less than the minimum allowed byte size for a chain ID."
-            );
-            assert!(
-                MAX <= MAX_SIZE,
-                "Max size cannot be more than the maximum allowed byte size for a chain ID."
-            );
-        }
-        Self::try_from(value.into_inner())
-    }
-}
-
 pub const MAX_CHAIN_ID_SIZE: usize = u64::MAX as usize;
 type ChainIdBoundedVec = BoundedVec<u8, 1, MAX_CHAIN_ID_SIZE>;
+/// A chain ID is a UTF-8 string whose byte length is bounded to
+/// `[1, MAX_CHAIN_ID_SIZE]`. The length invariant is owned by [`Bounded`];
+/// the UTF-8 and domain rules live on [`ChainId`] below.
 type ChainIdBoundedString = BoundedString<1, MAX_CHAIN_ID_SIZE>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -352,22 +289,22 @@ pub struct ChainId(ChainIdBoundedString);
 impl ChainId {
     #[must_use]
     pub const fn new_unchecked(addr: String) -> Self {
-        Self(BoundedString(addr))
+        Self(BoundedString::new_unchecked(addr))
     }
 
     #[must_use]
     pub fn into_inner(self) -> String {
-        self.0.0
+        self.0.into_inner()
     }
 
     #[must_use]
     pub const fn len(&self) -> usize {
-        self.0.0.len()
+        self.0.as_inner().len()
     }
 
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.0.0.is_empty()
+        self.0.as_inner().is_empty()
     }
 }
 
@@ -379,13 +316,13 @@ impl Display for ChainId {
 
 impl AsRef<str> for ChainId {
     fn as_ref(&self) -> &str {
-        self.0.as_ref()
+        self.0.as_inner().as_str()
     }
 }
 
 impl AsRef<[u8]> for ChainId {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_ref().as_ref()
+        self.0.as_inner().as_bytes()
     }
 }
 

--- a/core/src/mantle/transactions/mod.rs
+++ b/core/src/mantle/transactions/mod.rs
@@ -8,7 +8,7 @@ pub use genesis_tx::{
     CryptarchiaParameter, GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE, GenesisTime,
     GenesisTx,
 };
-use lb_utils::bounded_vec::UpperBoundedVec;
+use lb_utils::bounded::UpperBoundedVec;
 pub use tx::{
     GasPrices, MantleTx, MantleTxContext, MantleTxGasContext, OperationVerificationHelper,
     SignedMantleTx, TxHash, VerificationError,

--- a/core/src/proofs/channel_multi_sig_proof.rs
+++ b/core/src/proofs/channel_multi_sig_proof.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use lb_core_macros::NomCodec;
 use lb_key_management_system_keys::keys::Ed25519Signature;
-use lb_utils::bounded_vec::UpperBoundedVec;
+use lb_utils::bounded::UpperBoundedVec;
 use nom::{
     Err,
     error::{Error as NomError, ErrorKind},

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -11,7 +11,7 @@ use blake2::{Blake2b, Digest as _};
 use bytes::Bytes;
 use lb_cryptarchia_engine::Epoch;
 use lb_key_management_system_keys::keys::ZkPublicKey;
-use lb_utils::bounded::{Bounded, BoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
+use lb_utils::bounded::{BoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
 use multiaddr::{Multiaddr, Protocol};
 use nom::{
     IResult,

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -104,9 +104,10 @@ pub const MAX_LOCATOR_BYTE_SIZE: usize = 329;
 /// A [`Multiaddr`] whose byte length is bounded to `[0,
 /// MAX_LOCATOR_BYTE_SIZE]`.
 ///
-/// `Multiaddr` is foreign to `lb_utils`, so it cannot implement `BoundedLen`;
-/// the byte length is measured here and validated through the shared
-/// [`Bounded::check_len`] gate.
+/// The shared `lb_utils::bounded` wrapper enforces the byte-length invariant
+/// using `Multiaddr::len()`. `Locator::try_from` performs the additional
+/// locator-specific validation below, such as rejecting unspecified, loopback,
+/// multicast, documentation, and link-local addresses.
 type BoundedMultiaddr = lb_utils::bounded::multiaddr::BoundedMultiaddr<0, MAX_LOCATOR_BYTE_SIZE>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -11,7 +11,7 @@ use blake2::{Blake2b, Digest as _};
 use bytes::Bytes;
 use lb_cryptarchia_engine::Epoch;
 use lb_key_management_system_keys::keys::ZkPublicKey;
-use lb_utils::bounded_vec::{BoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
+use lb_utils::bounded::{Bounded, BoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
 use multiaddr::{Multiaddr, Protocol};
 use nom::{
     IResult,
@@ -99,93 +99,51 @@ pub struct InactivityPeriodTooSmall {
     pub period: NumberOfEpochs,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(try_from = "Multiaddr")]
-struct BoundedMultiaddr<const MAX_SIZE: usize>(Multiaddr);
-
-impl<const MAX_SIZE: usize> AsRef<Multiaddr> for BoundedMultiaddr<MAX_SIZE> {
-    fn as_ref(&self) -> &Multiaddr {
-        &self.0
-    }
-}
-
-impl<const MAX_SIZE: usize> TryFrom<Multiaddr> for BoundedMultiaddr<MAX_SIZE> {
-    type Error = String;
-
-    fn try_from(value: Multiaddr) -> Result<Self, Self::Error> {
-        if value.len() > MAX_SIZE {
-            return Err(format!(
-                "Multiaddr must not exceed {MAX_LOCATOR_BYTE_SIZE} bytes: {value}"
-            ));
-        }
-
-        Ok(Self(value))
-    }
-}
-
-impl<const MAX_SIZE: usize> TryFrom<Vec<u8>> for BoundedMultiaddr<MAX_SIZE> {
-    type Error = String;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        let multiaddr =
-            Multiaddr::try_from(value).map_err(|e| format!("Invalid multiaddr: {e}"))?;
-        Self::try_from(multiaddr)
-    }
-}
-
-impl<const MAX_SIZE: usize, const MIN: usize, const MAX: usize> TryFrom<BoundedVec<u8, MIN, MAX>>
-    for BoundedMultiaddr<MAX_SIZE>
-{
-    type Error = String;
-
-    fn try_from(value: BoundedVec<u8, MIN, MAX>) -> Result<Self, Self::Error> {
-        const {
-            assert!(
-                MAX <= MAX_LOCATOR_BYTE_SIZE,
-                "Max size cannot be more than the maximum allowed byte size for a multiaddr."
-            );
-        }
-        Self::try_from(value.into_inner())
-    }
-}
-
 pub const MAX_LOCATOR_BYTE_SIZE: usize = 329;
 
+/// A [`Multiaddr`] whose byte length is bounded to `[0,
+/// MAX_LOCATOR_BYTE_SIZE]`.
+///
+/// `Multiaddr` is foreign to `lb_utils`, so it cannot implement `BoundedLen`;
+/// the byte length is measured here and validated through the shared
+/// [`Bounded::check_len`] gate.
+type BoundedMultiaddr = Bounded<Multiaddr, 0, MAX_LOCATOR_BYTE_SIZE>;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "Multiaddr")]
-pub struct Locator(BoundedMultiaddr<MAX_LOCATOR_BYTE_SIZE>);
+pub struct Locator(BoundedMultiaddr);
 
 impl Locator {
     #[must_use]
     pub const fn new_unchecked(addr: Multiaddr) -> Self {
-        Self(BoundedMultiaddr(addr))
+        Self(Bounded::new_unchecked(addr))
     }
 
     #[must_use]
     pub fn into_inner(self) -> Multiaddr {
-        self.0.0
+        self.0.into_inner()
     }
 
     #[must_use]
     pub fn len(&self) -> usize {
-        self.0.0.len()
+        self.0.as_inner().len()
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.0.0.is_empty()
+        self.0.as_inner().is_empty()
     }
 }
 
 impl AsRef<Multiaddr> for Locator {
     fn as_ref(&self) -> &Multiaddr {
-        self.0.as_ref()
+        self.0.as_inner()
     }
 }
 
 impl AsRef<[u8]> for Locator {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_ref().as_ref()
+        self.0.as_inner().as_ref()
     }
 }
 
@@ -193,10 +151,10 @@ impl TryFrom<Multiaddr> for Locator {
     type Error = String;
 
     fn try_from(value: Multiaddr) -> Result<Self, Self::Error> {
-        let bounded_multiaddr = BoundedMultiaddr::<MAX_LOCATOR_BYTE_SIZE>::try_from(value.clone())
+        BoundedMultiaddr::check_len_against_bounds(value.len())
             .map_err(|e| format!("Invalid multiaddr: {e}"))?;
 
-        for protocol in bounded_multiaddr.as_ref() {
+        for protocol in &value {
             match protocol {
                 Protocol::Ip4(ip) if ip.is_unspecified() => {
                     return Err(format!(
@@ -217,7 +175,7 @@ impl TryFrom<Multiaddr> for Locator {
             }
         }
 
-        Ok(Self(bounded_multiaddr))
+        Ok(Self(Bounded::new_unchecked(value)))
     }
 }
 
@@ -258,7 +216,7 @@ impl FromStr for Locator {
 
 impl Display for Locator {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.0.0.fmt(f)
+        self.0.fmt(f)
     }
 }
 

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -107,7 +107,7 @@ pub const MAX_LOCATOR_BYTE_SIZE: usize = 329;
 /// `Multiaddr` is foreign to `lb_utils`, so it cannot implement `BoundedLen`;
 /// the byte length is measured here and validated through the shared
 /// [`Bounded::check_len`] gate.
-type BoundedMultiaddr = Bounded<Multiaddr, 0, MAX_LOCATOR_BYTE_SIZE>;
+type BoundedMultiaddr = lb_utils::bounded::multiaddr::BoundedMultiaddr<0, MAX_LOCATOR_BYTE_SIZE>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "Multiaddr")]
@@ -116,7 +116,7 @@ pub struct Locator(BoundedMultiaddr);
 impl Locator {
     #[must_use]
     pub const fn new_unchecked(addr: Multiaddr) -> Self {
-        Self(Bounded::new_unchecked(addr))
+        Self(BoundedMultiaddr::new_unchecked(addr))
     }
 
     #[must_use]
@@ -175,7 +175,7 @@ impl TryFrom<Multiaddr> for Locator {
             }
         }
 
-        Ok(Self(Bounded::new_unchecked(value)))
+        Ok(Self(BoundedMultiaddr::new_unchecked(value)))
     }
 }
 

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -115,7 +115,7 @@ pub enum ZoneTestError {
     #[error("zone sequencer event stream stopped before observing the expected event")]
     SequencerStopped,
     #[error(transparent)]
-    BoundedError(#[from] lb_utils::bounded_vec::BoundedError),
+    BoundedError(#[from] lb_utils::bounded::BoundedError),
     #[error(transparent)]
     OutputsError(#[from] OutputsError),
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,6 +20,7 @@ const-hex      = { features = ["alloc"], workspace = true }
 futures        = { optional = true, workspace = true }
 humantime      = { optional = true, workspace = true }
 lb-log-targets = { workspace = true }
+multiaddr      = { workspace = true }
 overwatch      = { workspace = true }
 rand           = { features = ["getrandom"], workspace = true }
 serde          = { features = ["alloc", "derive"], workspace = true }

--- a/utils/src/bounded/mod.rs
+++ b/utils/src/bounded/mod.rs
@@ -13,6 +13,7 @@
 //! can still reuse the bound-checking logic via [`Bounded::check_len`] and
 //! [`Bounded::new_unchecked`].
 
+pub mod multiaddr;
 pub mod string;
 pub mod vec;
 
@@ -44,18 +45,6 @@ pub enum BoundedError {
 /// [`Bounded::check_len`] + [`Bounded::new_unchecked`].
 pub trait BoundedLen {
     fn bounded_len(&self) -> usize;
-}
-
-impl<T> BoundedLen for Vec<T> {
-    fn bounded_len(&self) -> usize {
-        self.len()
-    }
-}
-
-impl BoundedLen for String {
-    fn bounded_len(&self) -> usize {
-        self.len()
-    }
 }
 
 /// A newtype over `T` whose [measured length](BoundedLen) is statically

--- a/utils/src/bounded/mod.rs
+++ b/utils/src/bounded/mod.rs
@@ -1,0 +1,170 @@
+//! A generic newtype whose *measured length* is statically constrained to an
+//! inclusive `[MIN, MAX]` range.
+//!
+//! [`Bounded`] captures the machinery shared by every length-bounded type in
+//! the codebase — bound checking, unchecked/checked construction, transparent
+//! serialization and validating deserialization — so that concrete bounded
+//! types (`BoundedVec`, chain IDs, locators, …) reduce to a type alias plus
+//! whatever operations are natural for the wrapped type.
+//!
+//! What "length" means is delegated to [`BoundedLen`]: element count for
+//! collections, byte length for strings, and so on. Types that cannot
+//! implement [`BoundedLen`] (e.g. foreign types this crate does not depend on)
+//! can still reuse the bound-checking logic via [`Bounded::check_len`] and
+//! [`Bounded::new_unchecked`].
+
+pub mod string;
+pub mod vec;
+
+use core::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+pub use string::BoundedString;
+use thiserror::Error;
+pub use vec::{BoundedVec, LowerBoundedVec, MaxBoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
+
+#[derive(Debug, Error, Eq, PartialEq, Clone)]
+pub enum BoundedError {
+    #[error("Input cannot be empty.")]
+    EmptyInput,
+    #[error("Item count {count} is below minimum of {min}")]
+    TooFewItems { count: usize, min: usize },
+    #[error("Item count {count} exceeds static maximum of {max}")]
+    TooManyItems { count: usize, max: usize },
+    #[error("Index {index} is out of bounds for length {len}")]
+    IndexOutOfBounds { index: usize, len: usize },
+}
+
+/// The measured length of a value, in whatever unit is natural for its type:
+/// element count for collections, byte length for text.
+///
+/// Implementing this for a type unlocks the ergonomic checked constructors on
+/// [`Bounded`] ([`Bounded::new`], `TryFrom`, `Deserialize`, [`Bounded::len`]).
+/// Foreign types that cannot get an impl here can still be bounded manually via
+/// [`Bounded::check_len`] + [`Bounded::new_unchecked`].
+pub trait BoundedLen {
+    fn bounded_len(&self) -> usize;
+}
+
+impl<T> BoundedLen for Vec<T> {
+    fn bounded_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl BoundedLen for String {
+    fn bounded_len(&self) -> usize {
+        self.len()
+    }
+}
+
+/// A newtype over `T` whose [measured length](BoundedLen) is statically
+/// enforced to lie within the inclusive range `[MIN, MAX]`.
+///
+/// The invariant holds at every *checked* construction site ([`Bounded::new`],
+/// the concrete `TryFrom` impls, deserialization). [`Bounded::new_unchecked`]
+/// deliberately bypasses the check and is reserved for callers that have
+/// already validated the length (or measure it out-of-band).
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Bounded<T, const MIN: usize, const MAX: usize>(T);
+
+impl<T, const MIN: usize, const MAX: usize> Bounded<T, MIN, MAX> {
+    pub const MIN: usize = MIN;
+    pub const MAX: usize = MAX;
+
+    /// Wrap `inner` without checking the bound.
+    ///
+    /// Reserved for callers that have already validated the length. Prefer
+    /// [`Self::new`] (or a concrete `TryFrom`) at trust boundaries.
+    #[must_use]
+    pub const fn new_unchecked(inner: T) -> Self {
+        Self(inner)
+    }
+
+    /// Borrow the wrapped value.
+    #[must_use]
+    pub const fn as_inner(&self) -> &T {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the inner value.
+    #[must_use]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    /// Validate a length against the static `[MIN, MAX]` range.
+    ///
+    /// This is the single source of truth for the bound. Types that measure
+    /// themselves out-of-band (because they cannot implement [`BoundedLen`])
+    /// call this directly, then wrap with [`Self::new_unchecked`].
+    pub const fn check_len_against_bounds(len: usize) -> Result<(), BoundedError> {
+        if len < MIN {
+            if len == 0 {
+                return Err(BoundedError::EmptyInput);
+            }
+            return Err(BoundedError::TooFewItems {
+                count: len,
+                min: MIN,
+            });
+        }
+        if len > MAX {
+            return Err(BoundedError::TooManyItems {
+                count: len,
+                max: MAX,
+            });
+        }
+        Ok(())
+    }
+
+    /// Checked constructor for any [measurable](BoundedLen) `T`.
+    ///
+    /// `TryFrom` cannot be blanket-implemented over a bare `T` (it collides
+    /// with the standard-library `TryFrom<U> for T where U: Into<T>` impl),
+    /// so this inherent method is the shared entry point that the concrete
+    /// `TryFrom` impls delegate to.
+    pub fn try_new(inner: T) -> Result<Self, BoundedError>
+    where
+        T: BoundedLen,
+    {
+        Self::check_len_against_bounds(inner.bounded_len())?;
+        Ok(Self(inner))
+    }
+}
+
+impl<T, const MIN: usize, const MAX: usize> AsRef<T> for Bounded<T, MIN, MAX> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T, const MIN: usize, const MAX: usize> Display for Bounded<T, MIN, MAX>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// Transparent serialization: a `Bounded<T, ..>` is wire-identical to its inner
+// `T`, and does not require `T: Clone` (unlike a serde `into = "..."` shim).
+impl<T, const MIN: usize, const MAX: usize> Serialize for Bounded<T, MIN, MAX>
+where
+    T: Serialize,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+// Deserialize the inner `T`, then re-establish the bound before wrapping.
+impl<'de, T, const MIN: usize, const MAX: usize> Deserialize<'de> for Bounded<T, MIN, MAX>
+where
+    T: BoundedLen + Deserialize<'de>,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let inner = T::deserialize(deserializer)?;
+        Self::try_new(inner).map_err(serde::de::Error::custom)
+    }
+}

--- a/utils/src/bounded/multiaddr.rs
+++ b/utils/src/bounded/multiaddr.rs
@@ -1,0 +1,38 @@
+use multiaddr::Multiaddr;
+
+use crate::bounded::{Bounded, BoundedError, BoundedLen};
+
+impl BoundedLen for Multiaddr {
+    fn bounded_len(&self) -> usize {
+        self.len()
+    }
+}
+
+/// A `Multiaddr` whose byte length is statically enforced to be in the range
+/// `[MIN, MAX]`.
+///
+/// A thin alias over [`Bounded`]. Length checking, (de)serialization, `Display`
+/// and unchecked construction all come from the generic wrapper; only the
+/// multiaddr-flavoured conversions live here.
+pub type BoundedMultiaddr<const MIN: usize, const MAX: usize> = Bounded<Multiaddr, MIN, MAX>;
+
+impl<const MIN: usize, const MAX: usize> BoundedMultiaddr<MIN, MAX> {
+    /// Length in bytes (not `char`s), matching `str`/`String` semantics.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.as_inner().len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.as_inner().is_empty()
+    }
+}
+
+impl<const MIN: usize, const MAX: usize> TryFrom<Multiaddr> for BoundedMultiaddr<MIN, MAX> {
+    type Error = BoundedError;
+
+    fn try_from(value: Multiaddr) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}

--- a/utils/src/bounded/multiaddr.rs
+++ b/utils/src/bounded/multiaddr.rs
@@ -17,7 +17,7 @@ impl BoundedLen for Multiaddr {
 pub type BoundedMultiaddr<const MIN: usize, const MAX: usize> = Bounded<Multiaddr, MIN, MAX>;
 
 impl<const MIN: usize, const MAX: usize> BoundedMultiaddr<MIN, MAX> {
-    /// Length in bytes (not `char`s), matching `str`/`String` semantics.
+    /// Length in bytes (not `char`s), matching `Multiaddr` semantics.
     #[must_use]
     pub fn len(&self) -> usize {
         self.as_inner().len()

--- a/utils/src/bounded/string.rs
+++ b/utils/src/bounded/string.rs
@@ -105,6 +105,7 @@ mod tests {
     #[test]
     fn len_measures_bytes_not_chars() {
         // "é" is two UTF-8 bytes, so "éé" is 4 bytes — within [3, 5].
+        #[expect(clippy::non_ascii_literal, reason = "Test case.")]
         let s = Bounded3To5::try_from("éé").unwrap();
         assert_eq!(s.len(), 4);
     }

--- a/utils/src/bounded/string.rs
+++ b/utils/src/bounded/string.rs
@@ -1,4 +1,10 @@
-use crate::bounded::{Bounded, BoundedError};
+use crate::bounded::{Bounded, BoundedError, BoundedLen};
+
+impl BoundedLen for String {
+    fn bounded_len(&self) -> usize {
+        self.len()
+    }
+}
 
 /// A `String` whose byte length is statically enforced to be in the range
 /// `[MIN, MAX]`.
@@ -8,7 +14,7 @@ use crate::bounded::{Bounded, BoundedError};
 /// string-flavoured conversions live here.
 pub type BoundedString<const MIN: usize, const MAX: usize> = Bounded<String, MIN, MAX>;
 
-impl<const MIN: usize, const MAX: usize> Bounded<String, MIN, MAX> {
+impl<const MIN: usize, const MAX: usize> BoundedString<MIN, MAX> {
     /// Length in bytes (not `char`s), matching `str`/`String` semantics.
     #[must_use]
     pub const fn len(&self) -> usize {
@@ -26,7 +32,7 @@ impl<const MIN: usize, const MAX: usize> Bounded<String, MIN, MAX> {
     }
 }
 
-impl<const MIN: usize, const MAX: usize> TryFrom<String> for Bounded<String, MIN, MAX> {
+impl<const MIN: usize, const MAX: usize> TryFrom<String> for BoundedString<MIN, MAX> {
     type Error = BoundedError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
@@ -34,7 +40,7 @@ impl<const MIN: usize, const MAX: usize> TryFrom<String> for Bounded<String, MIN
     }
 }
 
-impl<const MIN: usize, const MAX: usize> TryFrom<&str> for Bounded<String, MIN, MAX> {
+impl<const MIN: usize, const MAX: usize> TryFrom<&str> for BoundedString<MIN, MAX> {
     type Error = BoundedError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/utils/src/bounded/string.rs
+++ b/utils/src/bounded/string.rs
@@ -1,0 +1,105 @@
+use crate::bounded::{Bounded, BoundedError};
+
+/// A `String` whose byte length is statically enforced to be in the range
+/// `[MIN, MAX]`.
+///
+/// A thin alias over [`Bounded`]. Length checking, (de)serialization, `Display`
+/// and unchecked construction all come from the generic wrapper; only the
+/// string-flavoured conversions live here.
+pub type BoundedString<const MIN: usize, const MAX: usize> = Bounded<String, MIN, MAX>;
+
+impl<const MIN: usize, const MAX: usize> Bounded<String, MIN, MAX> {
+    /// Length in bytes (not `char`s), matching `str`/`String` semantics.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.as_inner().len()
+    }
+
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.as_inner().is_empty()
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.as_inner()
+    }
+}
+
+impl<const MIN: usize, const MAX: usize> TryFrom<String> for Bounded<String, MIN, MAX> {
+    type Error = BoundedError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl<const MIN: usize, const MAX: usize> TryFrom<&str> for Bounded<String, MIN, MAX> {
+    type Error = BoundedError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_new(value.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bounded::{BoundedError, BoundedString};
+
+    type Bounded3To5 = BoundedString<3, 5>;
+
+    #[test]
+    fn try_from_accepts_lengths_within_bounds() {
+        assert_eq!(Bounded3To5::try_from("abc".to_owned()).unwrap().len(), 3);
+        assert_eq!(Bounded3To5::try_from("abcde").unwrap().len(), 5);
+    }
+
+    #[test]
+    fn try_from_rejects_too_short() {
+        assert_eq!(
+            Bounded3To5::try_from("ab".to_owned()),
+            Err(BoundedError::TooFewItems { count: 2, min: 3 })
+        );
+    }
+
+    #[test]
+    fn try_from_rejects_empty() {
+        assert_eq!(
+            Bounded3To5::try_from(String::new()),
+            Err(BoundedError::EmptyInput)
+        );
+    }
+
+    #[test]
+    fn try_from_rejects_too_long() {
+        assert_eq!(
+            Bounded3To5::try_from("abcdef"),
+            Err(BoundedError::TooManyItems { count: 6, max: 5 })
+        );
+    }
+
+    #[test]
+    fn serialize_is_transparent() {
+        let s = Bounded3To5::try_from("abcd").unwrap();
+        assert_eq!(serde_json::to_string(&s).unwrap(), "\"abcd\"");
+    }
+
+    #[test]
+    fn deserialize_enforces_bounds() {
+        let ok: Bounded3To5 = serde_json::from_str("\"abcd\"").unwrap();
+        assert_eq!(ok.as_inner(), "abcd");
+
+        let err = serde_json::from_str::<Bounded3To5>("\"ab\"").unwrap_err();
+        assert!(
+            err.to_string().contains("below minimum of 3"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn len_measures_bytes_not_chars() {
+        // "é" is two UTF-8 bytes, so "éé" is 4 bytes — within [3, 5].
+        let s = Bounded3To5::try_from("éé").unwrap();
+        assert_eq!(s.len(), 4);
+    }
+}

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -4,7 +4,13 @@ use core::{
 };
 use std::{ops::DerefMut, str::FromStr, vec::IntoIter};
 
-use crate::bounded::{Bounded, BoundedError};
+use crate::bounded::{Bounded, BoundedError, BoundedLen};
+
+impl<T> BoundedLen for Vec<T> {
+    fn bounded_len(&self) -> usize {
+        self.len()
+    }
+}
 
 /// `Vec<T>` whose length is statically enforced to be in the range `[MIN,
 /// MAX]`.

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -1,83 +1,54 @@
-use core::{ops::Deref, slice::Iter};
+use core::{
+    ops::Deref,
+    slice::{Iter, IterMut},
+};
 use std::{ops::DerefMut, str::FromStr, vec::IntoIter};
 
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-
-#[derive(Debug, Error, Eq, PartialEq, Clone)]
-pub enum BoundedError {
-    #[error("Input cannot be empty.")]
-    EmptyInput,
-    #[error("Item count {count} is below minimum of {min}")]
-    TooFewItems { count: usize, min: usize },
-    #[error("Item count {count} exceeds static maximum of {max}")]
-    TooManyItems { count: usize, max: usize },
-    #[error("Index {index} is out of bounds for length {len}")]
-    IndexOutOfBounds { index: usize, len: usize },
-}
+use crate::bounded::{Bounded, BoundedError};
 
 /// `Vec<T>` whose length is statically enforced to be in the range `[MIN,
 /// MAX]`.
 ///
-/// The invariant is enforced at every construction site (`TryFrom<Vec<T>>`,
-/// deserialization), so an instance can never be empty nor have more than `MAX`
-/// elements.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(
-    into = "Vec<T>",
-    try_from = "Vec<T>",
-    bound(serialize = "T: Clone + Serialize")
-)]
-pub struct BoundedVec<T, const MIN: usize, const MAX: usize>(Vec<T>);
+/// A thin alias over [`Bounded`]: the length checking, (de)serialization and
+/// construction machinery lives on the generic wrapper, while the operations
+/// below are the ones that only make sense for a `Vec`.
+///
+/// The invariant is enforced at every checked construction site
+/// ([`TryFrom<Vec<T>>`](Self::try_from), deserialization), so an instance can
+/// never be shorter than `MIN` nor longer than `MAX`.
+pub type BoundedVec<T, const MIN: usize, const MAX: usize> = Bounded<Vec<T>, MIN, MAX>;
 
-impl<T, const MIN: usize, const MAX: usize> BoundedVec<T, MIN, MAX> {
-    pub const MIN: usize = MIN;
-    pub const MAX: usize = MAX;
-
+impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     #[must_use]
     pub const fn empty() -> Self {
         const { assert!(MIN == 0, "Cannot construct empty BoundedVec when MIN > 0") }
-        Self(Vec::new())
-    }
-
-    /// Construct without checking the cap.
-    ///
-    /// Reserved for callers that have already validated the length. Prefer
-    /// [`Self::try_from<Vec<T>>`] at trust boundaries.
-    #[must_use]
-    pub const fn new_unchecked(items: Vec<T>) -> Self {
-        Self(items)
+        Self::new_unchecked(Vec::new())
     }
 
     #[must_use]
     pub const fn len(&self) -> usize {
-        self.0.len()
+        self.as_inner().len()
     }
 
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.as_inner().is_empty()
     }
 
     #[must_use]
     // TODO: This function should not return an `Option` when `MIN >= 1`, but at the
     // moment this is not possible in the current Rust version.
     pub fn first(&self) -> Option<&T> {
-        self.0.first()
+        self.as_inner().first()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {
-        self.0.iter()
-    }
-
-    #[must_use]
-    pub fn into_inner(self) -> Vec<T> {
-        self.0
+        self.as_inner().iter()
     }
 
     #[must_use]
     pub fn as_slice(&self) -> &[T] {
-        &self.0
+        self.as_inner()
     }
 
     pub fn try_push(&mut self, item: T) -> Result<(), BoundedError> {
@@ -125,7 +96,7 @@ impl<T, const MIN: usize, const MAX: usize> BoundedVec<T, MIN, MAX> {
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> Default for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> Default for Bounded<Vec<T>, MIN, MAX> {
     fn default() -> Self {
         const {
             assert!(
@@ -133,33 +104,19 @@ impl<T, const MIN: usize, const MAX: usize> Default for BoundedVec<T, MIN, MAX> 
                 "Default is only valid for BoundedVec with MIN == 0"
             );
         }
-        Self(Vec::new())
+        Self::new_unchecked(Vec::new())
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> TryFrom<Vec<T>> for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> TryFrom<Vec<T>> for Bounded<Vec<T>, MIN, MAX> {
     type Error = BoundedError;
 
     fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
-        if value.len() < MIN && value.is_empty() {
-            return Err(BoundedError::EmptyInput);
-        } else if value.len() < MIN {
-            return Err(BoundedError::TooFewItems {
-                count: value.len(),
-                min: MIN,
-            });
-        }
-        if value.len() > MAX {
-            return Err(BoundedError::TooManyItems {
-                count: value.len(),
-                max: MAX,
-            });
-        }
-        Ok(Self(value))
+        Self::try_new(value)
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> TryFrom<&[T]> for BoundedVec<T, MIN, MAX>
+impl<T, const MIN: usize, const MAX: usize> TryFrom<&[T]> for Bounded<Vec<T>, MIN, MAX>
 where
     T: Clone,
 {
@@ -170,35 +127,35 @@ where
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> From<T> for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> From<T> for Bounded<Vec<T>, MIN, MAX> {
     fn from(value: T) -> Self {
         const {
             assert!(
                 MIN <= 1,
                 "Single-element construction is invalid for minimum bound > 1"
             );
-        }
-        const {
             assert!(
                 MAX >= 1,
                 "Single-element construction is invalid for maximum bound < 1"
             );
         }
-        Self([value].into())
+        Self::new_unchecked([value].into())
     }
 }
 
 impl<T, const MIN: usize, const MAX: usize, const INPUT_SIZE: usize> From<[T; INPUT_SIZE]>
-    for BoundedVec<T, MIN, MAX>
+    for Bounded<Vec<T>, MIN, MAX>
 {
     fn from(value: [T; INPUT_SIZE]) -> Self {
-        const { assert!(INPUT_SIZE >= MIN, "Array length is below BoundedVec MIN") }
-        const { assert!(INPUT_SIZE <= MAX, "Array length exceeds BoundedVec MAX") }
-        Self(value.into())
+        const {
+            assert!(INPUT_SIZE >= MIN, "Array length is below BoundedVec MIN");
+            assert!(INPUT_SIZE <= MAX, "Array length exceeds BoundedVec MAX");
+        }
+        Self::new_unchecked(value.into())
     }
 }
 
-impl<const MAX: usize> FromStr for BoundedVec<u8, 0, MAX> {
+impl<const MAX: usize> FromStr for Bounded<Vec<u8>, 0, MAX> {
     type Err = BoundedError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -207,7 +164,7 @@ impl<const MAX: usize> FromStr for BoundedVec<u8, 0, MAX> {
 }
 
 impl<T, const MIN: usize, const MAX: usize, const INPUT_SIZE: usize> From<&[T; INPUT_SIZE]>
-    for BoundedVec<T, MIN, MAX>
+    for Bounded<Vec<T>, MIN, MAX>
 where
     T: Clone,
 {
@@ -216,62 +173,56 @@ where
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> From<BoundedVec<T, MIN, MAX>> for Vec<T> {
-    fn from(value: BoundedVec<T, MIN, MAX>) -> Self {
-        value.0
+impl<T, const MIN: usize, const MAX: usize> From<Bounded<Vec<T>, MIN, MAX>> for Vec<T> {
+    fn from(value: Bounded<Vec<T>, MIN, MAX>) -> Self {
+        value.into_inner()
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> AsRef<[T]> for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> AsRef<[T]> for Bounded<Vec<T>, MIN, MAX> {
     fn as_ref(&self) -> &[T] {
-        &self.0
+        self.as_inner()
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> Deref for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> Deref for Bounded<Vec<T>, MIN, MAX> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.as_inner()
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> DerefMut for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> DerefMut for Bounded<Vec<T>, MIN, MAX> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<'a, T, const MIN: usize, const MAX: usize> IntoIterator for &'a mut BoundedVec<T, MIN, MAX> {
+impl<'a, T, const MIN: usize, const MAX: usize> IntoIterator for &'a mut Bounded<Vec<T>, MIN, MAX> {
     type Item = &'a mut T;
-    type IntoIter = std::slice::IterMut<'a, T>;
+    type IntoIter = IterMut<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter_mut()
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> AsRef<Vec<T>> for BoundedVec<T, MIN, MAX> {
-    fn as_ref(&self) -> &Vec<T> {
-        &self.0
-    }
-}
-
-impl<'a, T, const MIN: usize, const MAX: usize> IntoIterator for &'a BoundedVec<T, MIN, MAX> {
+impl<'a, T, const MIN: usize, const MAX: usize> IntoIterator for &'a Bounded<Vec<T>, MIN, MAX> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
+        self.as_inner().iter()
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> IntoIterator for BoundedVec<T, MIN, MAX> {
+impl<T, const MIN: usize, const MAX: usize> IntoIterator for Bounded<Vec<T>, MIN, MAX> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.into_inner().into_iter()
     }
 }
 
@@ -286,7 +237,7 @@ pub type MaxBoundedVec<T> = UpperBoundedVec<T, { usize::MAX }>;
 
 #[cfg(test)]
 mod tests {
-    use crate::bounded_vec::{BoundedError, BoundedVec};
+    use crate::bounded::{BoundedError, BoundedVec};
 
     /// Concrete instantiation used across the tests: between 2 and 4 elements.
     type TestBoundedVectorMin2 = BoundedVec<u8, 2, 4>;

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -97,7 +97,7 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
         Ok(self.0.remove(index))
     }
 
-    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         self.0.iter_mut()
     }
 }
@@ -179,8 +179,8 @@ where
     }
 }
 
-impl<T, const MIN: usize, const MAX: usize> From<Bounded<Vec<T>, MIN, MAX>> for Vec<T> {
-    fn from(value: Bounded<Vec<T>, MIN, MAX>) -> Self {
+impl<T, const MIN: usize, const MAX: usize> From<Bounded<Self, MIN, MAX>> for Vec<T> {
+    fn from(value: Bounded<Self, MIN, MAX>) -> Self {
         value.into_inner()
     }
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod bounded_vec;
+pub mod bounded;
 pub mod fisheryates;
 pub mod math;
 pub mod net;

--- a/wallet/src/error.rs
+++ b/wallet/src/error.rs
@@ -6,7 +6,7 @@ use lb_core::{
         transactions::builder::TxBuilderError,
     },
 };
-use lb_utils::bounded_vec::BoundedError;
+use lb_utils::bounded::BoundedError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## 1. What does this PR implement?

We had very similar logic for `BoundedMultiaddr` and `BoundedString`. So there was room for improvement. We introduce a `Bounded<T, MIN, MAX>` type which wraps around a type `T` and enforces lower and upper bounds. Then we expose aliases for `BoundedMultiaddr` and `BoundedString`, with also some alias-specific implementations.

Unrelated, but still part of the unaddressed comments on the review of https://github.com/logos-blockchain/logos-blockchain/pull/3082, we change the maximum length of chain ID to be `u8::MAX` bytes long, at most, by using the newly-introduced `BoundedString`. Using an alias to the `Bounded` type also made the error case returned an enum and not a `String` anymore.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.