### PR TITLE
fix(api): utoipa annotations

### DIFF
--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -1285,7 +1285,7 @@ where
 }
 
 #[utoipa::path(
-    post,
+    get,
     path = paths::BLOCKS_DETAIL,
     responses(
         (status = 200, description = "Block found"),
@@ -1385,7 +1385,7 @@ where
 
 #[utoipa::path(
     get,
-    path = paths::BLOCKS_STREAM,
+    path = paths::BLOCKS_RANGE_STREAM,
     params(BlocksStreamQuery),
     responses(
         (status = 200, description = "Stream of processed blocks with chain state in slot order. \
@@ -1473,7 +1473,7 @@ where
 }
 
 #[utoipa::path(
-    post,
+    get,
     path = paths::TRANSACTION,
     responses(
         (status = 200, description = "Transaction found"),

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -30,6 +30,7 @@ use utoipa::OpenApi;
         crate::api::handlers::wallet::get_balance,
         crate::api::handlers::wallet::get_claimable_vouchers,
         crate::api::handlers::wallet::post_transactions_transfer_funds,
+        crate::api::tracing::reload_tracing_filter,
     ),
     components(schemas(schema::Status, schema::MempoolMetrics)),
     tags()

--- a/nodes/node/binary/src/api/tracing.rs
+++ b/nodes/node/binary/src/api/tracing.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Display};
 
 use axum::{Json, extract::State, response::Response};
 use lb_api_service::http::DynError;
+use lb_http_api_common::paths;
 use lb_log_targets::node;
 use lb_tracing::filter::envfilter::EnvFilterConfig;
 use lb_tracing_service::TracingMessage;
@@ -11,6 +12,14 @@ use crate::{TracingService, make_request_and_return_response};
 
 const LOG_TARGET: &str = node::api::TRACING;
 
+#[utoipa::path(
+    put,
+    path = paths::admin::TRACING_FILTER,
+    responses(
+        (status = 200, description = "Tracing filter reloaded"),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
 pub async fn reload_tracing_filter<RuntimeServiceId>(
     State(handle): State<OverwatchHandle<RuntimeServiceId>>,
     Json(filter): Json<EnvFilterConfig>,


### PR DESCRIPTION
## 1. What does this PR implement?

Some utopia annotations for our HTTP endpoints were inconsistent with the actual method being served, and some were missing. I fixed those.

Right now, these things are defined in three separate places, and we might want to look into an alternative like `utoipa-axum` that allows us to declare them once instead, avoid drifting like this.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.