### PR TITLE
chore(init): replace `--ibd` with `--skip-ibd`

### DIFF
--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -36,7 +36,7 @@ pub struct GenerateConfigArgs {
     pub state_path: *const c_char,
     pub storage_path: *const c_char,
     pub logs_path: *const c_char,
-    pub ibd: *const bool,
+    pub skip_ibd: *const bool,
     pub log_filter: *const c_char,
     pub kms_file: *const c_char,
 }
@@ -116,9 +116,9 @@ impl From<GenerateConfigArgs> for EmbeddedInitArgs {
             init_args.logs_path = Some(logs_path.to_string_lossy().to_string().into());
         }
 
-        // ---- ibd ----
-        if !value.ibd.is_null() {
-            init_args.ibd = unsafe { *value.ibd };
+        // ---- skip_ibd ----
+        if !value.skip_ibd.is_null() {
+            init_args.skip_ibd = unsafe { *value.skip_ibd };
         }
 
         // ---- log_filter ----

--- a/nodes/node/binary/src/cli/config/init.rs
+++ b/nodes/node/binary/src/cli/config/init.rs
@@ -164,7 +164,7 @@ fn build_cryptarchia_config(
         CryptarchiaConfig::with_required_values(CryptarchiaConfigRequiredValues {
             funding_pk: cryptarchia_funding_key.to_public_key(),
         });
-    if cryptarchia_args.ibd
+    if !cryptarchia_args.skip_ibd
         && let Some(initial_peers) = initial_peers
     {
         cryptarchia_config.network.bootstrap.ibd.peers = initial_peers

--- a/nodes/node/binary/src/cli/config/update.rs
+++ b/nodes/node/binary/src/cli/config/update.rs
@@ -140,7 +140,7 @@ fn update_cryptarchia_config(
         .expect("Cryptarchia funding key set by default");
     cryptarchia_config.set_funding_pk(cryptarchia_funding_key.to_public_key());
 
-    if cryptarchia_args.ibd
+    if !cryptarchia_args.skip_ibd
         && let Some(initial_peers) = initial_peers
     {
         cryptarchia_config.network.bootstrap.ibd.peers = initial_peers

--- a/nodes/node/binary/src/cli/mod.rs
+++ b/nodes/node/binary/src/cli/mod.rs
@@ -183,7 +183,7 @@ pub struct InitArgs {
 #[derive(Debug)]
 pub struct EmbeddedInitArgs {
     /// Trusted peers to bootstrap from (multiaddr format).
-    /// If `--ibd` is set, peers whose multiaddrs include a `PeerId`
+    /// If `--skip-ibd` is not set, peers whose multiaddrs include a `PeerId`
     /// are also used as IBD peers.
     pub initial_peers: Vec<Multiaddr>,
 
@@ -207,9 +207,9 @@ pub struct EmbeddedInitArgs {
     pub storage_path: Option<PathBuf>,
     pub logs_path: Option<PathBuf>,
 
-    /// Enable Initial Block Download (IBD) using peers
-    /// passed via `--initial-peers`/`-p`.
-    pub ibd: bool,
+    /// Disable Initial Block Download (IBD) by leaving the IBD peer list
+    /// empty, regardless of any peers passed via `--initial-peers`/`-p`.
+    pub skip_ibd: bool,
 
     /// Log filter directives to write into the generated config, e.g.
     /// `warn,logos_blockchain=debug,libp2p_gossipsub::behaviour=error`.
@@ -239,7 +239,7 @@ impl From<EmbeddedInitArgs> for InitArgs {
         init_args.blend.blend_addr =
             Some(BlendCoreConfig::default_listening_address(args.blend_port));
 
-        init_args.cryptarchia.ibd = args.ibd;
+        init_args.cryptarchia.skip_ibd = args.skip_ibd;
         init_args.api.addr = Some(args.http_addr);
         init_args.state.path.clone_from(&args.state_path);
         init_args.storage_path.clone_from(&args.storage_path);
@@ -263,7 +263,7 @@ impl Default for EmbeddedInitArgs {
             state_path: None,
             storage_path: None,
             logs_path: None,
-            ibd: false,
+            skip_ibd: false,
             log_filter: None,
             kms_file: None,
         }

--- a/nodes/node/binary/src/config/mod.rs
+++ b/nodes/node/binary/src/config/mod.rs
@@ -263,10 +263,10 @@ pub struct CryptarchiaArgs {
     )]
     pub cryptarchia_funding_pk: Option<ZkPublicKey>,
 
-    /// Enable Initial Block Download (IBD) using peers
-    /// passed via `--net-initial-peers`/`-p`.
-    #[clap(long = "ibd", default_value_t = false)]
-    pub ibd: bool,
+    /// Disable Initial Block Download (IBD) by leaving the IBD peer list
+    /// empty, regardless of any peers passed via `--net-initial-peers`/`-p`.
+    #[clap(long = "skip-ibd", default_value_t = false)]
+    pub skip_ibd: bool,
 }
 
 #[derive(Parser, Debug, Default, Clone, Copy)]


### PR DESCRIPTION
## 1. What does this PR implement?

Now that we've made IBD scalable, this PR changes the `--ibd` flag of `init` command to `--skip-ibd` flag. It means that we're going to enable IBD by default.

(The `init` command extracts peer IDs from `initial_peers` and populates `ibd.peers`.)

This PR is actually a revert change of https://github.com/logos-blockchain/logos-blockchain/pull/2734. Plus, I updated c-bindings. I will update `logos-blockchain-module` as well.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

n/a

## 5. Does the implementation introduce changes in the specification?

n/a

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
