### PR TITLE
chore: implement Nom traits for MantleTx

### DIFF
--- a/core/benches/mantle_tx_components.rs
+++ b/core/benches/mantle_tx_components.rs
@@ -18,6 +18,7 @@ use logos_blockchain_core::{
     crypto::{Hasher, ZkHasher},
     mantle::{
         MantleTx, SignedMantleTx, Transaction as _, TxHash,
+        nom::NomEncode as _,
         ops::{
             Op, OpProof,
             channel::{
@@ -25,7 +26,7 @@ use logos_blockchain_core::{
                 inscribe::{Inscription, InscriptionOp},
             },
         },
-        transactions::codec::{decode_signed_mantle_tx, encode_mantle_tx, encode_signed_mantle_tx},
+        transactions::codec::{decode_signed_mantle_tx, encode_signed_mantle_tx},
     },
 };
 
@@ -84,7 +85,7 @@ fn blake2b(inputs: &[&[u8]]) -> [u8; 32] {
 #[divan::bench(args = SIZES)]
 fn bench_encode_mantle_tx(bencher: Bencher, size: usize) {
     let tx = make_inscription_tx(size);
-    bencher.bench_local(|| black_box(encode_mantle_tx(&tx)));
+    bencher.bench_local(|| black_box(tx.encode()));
 }
 
 // Poseidon2 hash directly over payload field-elements.
@@ -103,7 +104,7 @@ fn bench_blake2b_poseidon2_hash(bencher: Bencher, size: usize) {
         .bench_values(|tx: MantleTx| {
             // Encoding is included here to compare fairly with the Poseidon2 hash function,
             // which includes it.
-            let encoded = encode_mantle_tx(&tx);
+            let encoded = tx.encode();
             let digest = blake2b(&[encoded.as_slice()]);
             let frs: Vec<Fr> = digest
                 .chunks(GROTH16_SAFE_BYTES_SIZE)

--- a/core/src/mantle/nom/fixtures/mod.rs
+++ b/core/src/mantle/nom/fixtures/mod.rs
@@ -14,3 +14,4 @@ mod ledger;
 mod numbers;
 mod ops;
 mod proof_of_quota;
+mod tx;

--- a/core/src/mantle/nom/fixtures/tx.rs
+++ b/core/src/mantle/nom/fixtures/tx.rs
@@ -1,0 +1,12 @@
+use ark_ff::AdditiveGroup as _;
+use lb_core_macros::nom_wire_fixtures;
+use lb_groth16::Fr;
+
+use crate::mantle::{
+    MantleTx, NoteId, Op, ledger::Outputs, ops::transfer::TransferOp, transactions::Ops,
+};
+
+nom_wire_fixtures!(MantleTx,
+    MantleTx(Ops::empty()) => "00",
+    MantleTx([Op::Transfer(TransferOp { inputs: [NoteId(Fr::ZERO)].into(), outputs: Outputs::empty() })].into()) => "010001000000000000000000000000000000000000000000000000000000000000000000"
+);

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -10,21 +10,14 @@ use crate::{
         MantleTx, Op, SignedMantleTx,
         nom::{NomDecode as _, NomEncode as _},
         ops::codec::{decode_ops_proofs, encode_ops_proofs},
-        transactions::{MantleTxGasContext, Ops},
+        transactions::MantleTxGasContext,
     },
     proofs::channel_multi_sig_proof::codec::calculate_channel_multi_sig_proof_byte_size,
 };
 
-pub fn decode_mantle_tx(input: &[u8]) -> IResult<&[u8], MantleTx> {
-    // MantleTx = Ops ExecutionGasPrice StorageGasPrice
-    let (input, ops) = Ops::decode(input)?;
-
-    Ok((input, MantleTx(ops)))
-}
-
 pub fn decode_signed_mantle_tx(input: &[u8]) -> IResult<&[u8], SignedMantleTx> {
     // SignedMantleTx = MantleTx OpsProofs
-    let (input, mantle_tx) = decode_mantle_tx(input)?;
+    let (input, mantle_tx) = MantleTx::decode(input)?;
     let (input, ops_proofs) = decode_ops_proofs(input, mantle_tx.ops())?;
 
     let signed_tx = SignedMantleTx::new(mantle_tx, ops_proofs)
@@ -34,21 +27,16 @@ pub fn decode_signed_mantle_tx(input: &[u8]) -> IResult<&[u8], SignedMantleTx> {
 }
 
 #[must_use]
-pub fn encode_mantle_tx(tx: &MantleTx) -> Vec<u8> {
-    tx.ops().encode()
-}
-
-#[must_use]
 pub fn encode_signed_mantle_tx(tx: &SignedMantleTx) -> Vec<u8> {
     let mut bytes = Vec::new();
-    bytes.extend(encode_mantle_tx(&tx.mantle_tx));
+    bytes.extend(tx.mantle_tx.encode());
     bytes.extend(encode_ops_proofs(&tx.ops_proofs, tx.mantle_tx.ops()));
     bytes
 }
 
 #[must_use]
 pub fn predict_signed_mantle_tx_size(tx: &MantleTx, context: &MantleTxGasContext) -> usize {
-    let mantle_tx_size = encode_mantle_tx(tx).len();
+    let mantle_tx_size = tx.encode().len();
 
     let ops_proofs_size = tx
         .ops()
@@ -113,15 +101,14 @@ mod tests {
                 channel::{
                     ChannelId, MsgId,
                     config::{ChannelConfigOp, Keys},
-                    inscribe,
-                    inscribe::{Inscription, InscriptionOp},
+                    inscribe::{self, Inscription, InscriptionOp},
                     withdraw::ChannelWithdrawOp,
                 },
                 leader_claim::{LeaderClaimOp, RewardsRoot, VoucherNullifier},
                 sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
                 transfer::TransferOp,
             },
-            transactions::GasPrices,
+            transactions::{GasPrices, Ops},
         },
         proofs::{
             channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
@@ -191,14 +178,15 @@ mod tests {
     #[test]
     fn test_decode_signed_mantle_tx_with_inscribe() {
         let signing_key = Ed25519Key::from_bytes(&[4u8; 32]);
-        let mantle_tx = MantleTx(Ops::new_unchecked(vec![Op::ChannelInscribe(
-            InscriptionOp {
+        let mantle_tx = MantleTx(
+            [Op::ChannelInscribe(InscriptionOp {
                 channel_id: ChannelId::from([0xAA; 32]),
                 inscription: b"hello".into(),
                 parent: MsgId::from([0xBB; 32]),
                 signer: signing_key.public_key(),
-            },
-        )]));
+            })]
+            .into(),
+        );
 
         let txhash = mantle_tx.hash();
         let inscribe_sig =
@@ -348,10 +336,10 @@ mod tests {
         let original_tx = MantleTx(Ops::new_unchecked(vec![]));
 
         // Encode
-        let encoded = encode_mantle_tx(&original_tx);
+        let encoded = original_tx.encode();
 
         // Decode
-        let (remaining, decoded_tx) = decode_mantle_tx(&encoded).unwrap();
+        let (remaining, decoded_tx) = MantleTx::decode(&encoded).unwrap();
 
         // Verify
         assert!(remaining.is_empty());
@@ -369,10 +357,10 @@ mod tests {
         let original_tx = MantleTx(Ops::new_unchecked(vec![Op::Transfer(transfer_op)]));
 
         // Encode
-        let encoded = encode_mantle_tx(&original_tx);
+        let encoded = original_tx.encode();
 
         // Decode
-        let (remaining, decoded_tx) = decode_mantle_tx(&encoded).unwrap();
+        let (remaining, decoded_tx) = MantleTx::decode(&encoded).unwrap();
 
         // Verify
         assert!(remaining.is_empty());

--- a/core/src/mantle/transactions/tx.rs
+++ b/core/src/mantle/transactions/tx.rs
@@ -5,6 +5,7 @@ use std::{
 
 use ark_ff::PrimeField as _;
 use bytes::Bytes;
+use lb_core_macros::NomCodec;
 use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::Ed25519PublicKey;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -15,6 +16,7 @@ use crate::{
         AuthenticatedMantleTx, StorageSize, Transaction, TransactionHasher, Value,
         channel::Channels,
         gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow, GasPrice},
+        nom::{NomDecode as _, NomEncode as _},
         ops::{
             Op, OpProof,
             channel::{ChannelId, ChannelKeyIndex, withdraw::ChannelWithdrawOp},
@@ -23,8 +25,7 @@ use crate::{
         transactions::{
             Ops,
             codec::{
-                decode_mantle_tx, decode_signed_mantle_tx, encode_mantle_tx,
-                encode_signed_mantle_tx, predict_signed_mantle_tx_size,
+                decode_signed_mantle_tx, encode_signed_mantle_tx, predict_signed_mantle_tx_size,
             },
             genesis_tx::{GENESIS_EXECUTION_GAS_PRICE, GENESIS_STORAGE_GAS_PRICE},
         },
@@ -173,7 +174,7 @@ impl MantleTxGasContext {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, NomCodec)]
 pub struct MantleTx(pub Ops);
 
 impl From<MantleTxDeSerImpl> for MantleTx {
@@ -197,7 +198,7 @@ impl Serialize for MantleTx {
             let tx_deser: MantleTxDeSerImpl = self.clone().into();
             tx_deser.serialize(serializer)
         } else {
-            let bytes = encode_mantle_tx(self);
+            let bytes = self.encode();
             serializer.serialize_bytes(&bytes)
         }
     }
@@ -212,7 +213,7 @@ impl<'de> Deserialize<'de> for MantleTx {
             <MantleTxDeSerImpl as Deserialize>::deserialize(deserializer).map(Into::into)
         } else {
             let bytes: Vec<u8> = <Vec<u8>>::deserialize(deserializer)?;
-            decode_mantle_tx(&bytes)
+            Self::decode(&bytes)
                 .map(|(_, tx)| tx)
                 .map_err(serde::de::Error::custom)
         }
@@ -292,7 +293,7 @@ impl Transaction for MantleTx {
         // constant and structure as defined in the Mantle specification:
         // https://www.notion.so/nomos-tech/v1-3-Mantle-Specification-31e261aa09df818f9327ee87e5a6d433#31e261aa09df80aea7cff4eb98d61b6e
         let mut buffer = MANTLE_TXHASH_V1_BYTES.to_vec();
-        buffer.extend(encode_mantle_tx(self));
+        buffer.extend(self.encode());
         buffer
     }
 }

--- a/deployment/tui-zone/src/run_commands/run_config.rs
+++ b/deployment/tui-zone/src/run_commands/run_config.rs
@@ -3,11 +3,12 @@ use std::path::PathBuf;
 use lb_core::{
     mantle::{
         Op, OpProof, SignedMantleTx, Transaction as _,
+        nom::NomEncode as _,
         ops::channel::{
             ChannelId, ChannelKeyIndex,
             config::{ChannelConfigOp, Keys},
         },
-        transactions::codec::{encode_mantle_tx, encode_signed_mantle_tx},
+        transactions::codec::encode_signed_mantle_tx,
     },
     proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
 };
@@ -109,7 +110,7 @@ pub(crate) async fn run_config_prepare(args: ConfigPrepareArgs) -> RunResult<()>
         tx_hash: hex::encode(tx_hash.as_ref()),
         msg_id: hex::encode(msg_id.as_ref()),
         required_threshold: channel_state.configuration_threshold,
-        mantle_tx: hex::encode(encode_mantle_tx(&tx)),
+        mantle_tx: hex::encode(tx.encode()),
         new_authorized_keys: authorized_keys
             .iter()
             .map(|key| hex::encode(key.to_bytes()))

--- a/deployment/tui-zone/src/run_commands/run_withdraw.rs
+++ b/deployment/tui-zone/src/run_commands/run_withdraw.rs
@@ -4,10 +4,11 @@ use lb_core::{
     mantle::{
         Note, Op, OpProof, SignedMantleTx, Transaction as _,
         ledger::Outputs,
+        nom::NomEncode as _,
         ops::channel::{
             ChannelId, ChannelKeyIndex, inscribe::Inscription, withdraw::ChannelWithdrawOp,
         },
-        transactions::codec::{encode_mantle_tx, encode_signed_mantle_tx},
+        transactions::codec::encode_signed_mantle_tx,
     },
     proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
 };
@@ -71,7 +72,7 @@ pub(crate) async fn run_withdraw_prepare(args: WithdrawPrepareArgs) -> RunResult
         tx_hash: hex::encode(tx_hash.as_ref()),
         msg_id: hex::encode(msg_id.as_ref()),
         required_threshold: channel_state.withdraw_threshold,
-        mantle_tx: hex::encode(encode_mantle_tx(&tx)),
+        mantle_tx: hex::encode(tx.encode()),
         inscription_signature: encode_hex_bincode(&inscription_signature)?,
         withdraws: vec![WithdrawFileEntry {
             amount: args.amount,

--- a/deployment/tui-zone/src/run_commands/unit_tests.rs
+++ b/deployment/tui-zone/src/run_commands/unit_tests.rs
@@ -9,15 +9,13 @@ mod tests {
     use lb_core::mantle::{
         MantleTx, Note, Op, SignedMantleTx, Transaction as _, Utxo, Value,
         ledger::{Inputs, Outputs},
+        nom::NomEncode as _,
         ops::channel::{
             ChannelId, MsgId,
             inscribe::{Inscription, InscriptionOp},
             withdraw::ChannelWithdrawOp,
         },
-        transactions::{
-            Ops,
-            codec::{encode_mantle_tx, encode_signed_mantle_tx},
-        },
+        transactions::{Ops, codec::encode_signed_mantle_tx},
     };
     use lb_groth16::{Fr, fr_to_bytes};
     use lb_key_management_system_service::keys::{ED25519_SECRET_KEY_SIZE, Ed25519Key, ZkKey};
@@ -115,7 +113,7 @@ mod tests {
     #[test]
     fn mantle_tx_decoders_reject_trailing_bytes_and_hash_mismatches() {
         let tx = empty_mantle_tx();
-        let encoded = hex::encode(encode_mantle_tx(&tx));
+        let encoded = hex::encode(tx.encode());
         assert_eq!(decode_mantle_tx_hex(&encoded).unwrap(), tx);
         assert!(decode_mantle_tx_hex(&format!("{encoded}00")).is_err());
 
@@ -251,7 +249,7 @@ mod tests {
             tx_hash: hex::encode(tx_hash.as_ref()),
             msg_id: hex::encode(msg_id.as_ref()),
             required_threshold: 1,
-            mantle_tx: hex::encode(encode_mantle_tx(&tx)),
+            mantle_tx: hex::encode(tx.encode()),
             inscription_signature: encode_hex_bincode(
                 &inscriber.sign_payload(tx_hash.as_signing_bytes().as_ref()),
             )
@@ -319,7 +317,7 @@ mod tests {
             tx_hash: hex::encode(tx.hash().as_ref()),
             msg_id: hex::encode(MsgId::root().as_ref()),
             required_threshold: 1,
-            mantle_tx: hex::encode(encode_mantle_tx(&tx)),
+            mantle_tx: hex::encode(tx.encode()),
             inscription_signature: encode_hex_bincode(
                 &test_signing_key(4).sign_payload(tx.hash().as_signing_bytes().as_ref()),
             )
@@ -367,7 +365,7 @@ mod tests {
             tx_hash: hex::encode(tx_hash.as_ref()),
             msg_id: hex::encode(MsgId::root().as_ref()),
             required_threshold: 2,
-            mantle_tx: hex::encode(encode_mantle_tx(&tx)),
+            mantle_tx: hex::encode(tx.encode()),
             inscription_signature: encode_hex_bincode(
                 &signer.sign_payload(tx_hash.as_signing_bytes().as_ref()),
             )
@@ -442,7 +440,7 @@ mod tests {
             tx_hash: hex::encode(tx_hash.as_ref()),
             msg_id: hex::encode(MsgId::root().as_ref()),
             required_threshold: 1,
-            mantle_tx: hex::encode(encode_mantle_tx(&tx)),
+            mantle_tx: hex::encode(tx.encode()),
             inscription_signature: encode_hex_bincode(
                 &signer.sign_payload(tx_hash.as_signing_bytes().as_ref()),
             )

--- a/deployment/tui-zone/src/run_commands/utils.rs
+++ b/deployment/tui-zone/src/run_commands/utils.rs
@@ -9,6 +9,7 @@ use lb_core::mantle::{
     MantleTx, Note, SignedMantleTx, TxHash, Utxo, Value,
     channel::ChannelState,
     ledger::{Inputs, Outputs},
+    nom::NomDecode as _,
     ops::{
         channel::{
             ChannelId, MsgId,
@@ -16,7 +17,7 @@ use lb_core::mantle::{
         },
         transfer::TransferOp,
     },
-    transactions::codec::{decode_mantle_tx, decode_signed_mantle_tx},
+    transactions::codec::decode_signed_mantle_tx,
 };
 use lb_key_management_system_service::keys::{
     ED25519_SECRET_KEY_SIZE, Ed25519Key, Ed25519PublicKey, ZkPublicKey,
@@ -227,7 +228,7 @@ pub fn decode_exported_utxos(funds: &WalletFundsExport) -> RunResult<Vec<Utxo>> 
 /// Decode a hex-encoded mantle transaction and reject trailing bytes.
 pub fn decode_mantle_tx_hex(value: &str) -> RunResult<MantleTx> {
     let bytes = decode_hex(value)?;
-    let (remaining, tx) = decode_mantle_tx(&bytes).map_err(|error| format!("{error:?}"))?;
+    let (remaining, tx) = MantleTx::decode(&bytes).map_err(|error| format!("{error:?}"))?;
     if !remaining.is_empty() {
         return Err("mantle tx has trailing bytes".into());
     }


### PR DESCRIPTION
`SignedMantleTx` is the last one and I will leave it for a separate PR to @strinnityk, as we might want to change few things before (e.g., the `Vec<OpProof>` does not implement `NomEncode` and `NomDecode` because it's not bounded, so we need to perhaps represent signed txs as a bounded `Vec<(Op, OpProof)>` instead, so that we can enforce at compile time, as part of the type system, that ops and proofs count match.