### PR TITLE
fix(blend): proper wire encoding without any dynamically sized types

### DIFF
--- a/blend/message/src/codec.rs
+++ b/blend/message/src/codec.rs
@@ -1,0 +1,142 @@
+use lb_blend_proofs::{
+    quota::{PROOF_OF_QUOTA_SIZE, ProofOfQuota},
+    selection::{PROOF_OF_SELECTION_SIZE, ProofOfSelection},
+};
+use lb_key_management_system_keys::keys::{
+    ED25519_PUBLIC_KEY_SIZE, ED25519_SIGNATURE_SIZE, Ed25519PublicKey, Ed25519Signature,
+};
+
+/// Append a message component's fixed-size, prefix-free wire bytes to `out`.
+pub trait WireCodec: Sized {
+    type Context;
+
+    fn encoded_length(context: Self::Context) -> usize;
+    fn encode_into(&self, out: &mut Vec<u8>);
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()>;
+}
+
+impl WireCodec for u8 {
+    type Context = ();
+
+    fn encoded_length(_context: Self::Context) -> usize {
+        1
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.push(*self);
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < 1 {
+            return Err(());
+        }
+        let value = input[0];
+        let remaining = &input[1..];
+        Ok((remaining, value))
+    }
+}
+
+impl WireCodec for bool {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        u8::encoded_length(context)
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        (*self as u8).encode_into(out);
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (remaining, value) = u8::decode(input, context)?;
+        Ok((remaining, Self::try_from(value).map_err(|_| ())?))
+    }
+}
+
+impl WireCodec for Ed25519PublicKey {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        ED25519_PUBLIC_KEY_SIZE
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(self.as_bytes());
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < ED25519_PUBLIC_KEY_SIZE {
+            return Err(());
+        }
+        let (key_bytes, remaining) = input.split_at(ED25519_PUBLIC_KEY_SIZE);
+        let key_array: [u8; _] = key_bytes.try_into().map_err(|_| ())?;
+        let public_key = Self::from_bytes(&key_array).map_err(|_| ())?;
+        Ok((remaining, public_key))
+    }
+}
+
+impl WireCodec for ProofOfQuota {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        PROOF_OF_QUOTA_SIZE
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(self.as_bytes());
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < PROOF_OF_QUOTA_SIZE {
+            return Err(());
+        }
+        let (proof_bytes, remaining) = input.split_at(PROOF_OF_QUOTA_SIZE);
+        let proof_array: [u8; _] = proof_bytes.try_into().map_err(|_| ())?;
+        let proof = Self::from_bytes(&proof_array).map_err(|_| ())?;
+        Ok((remaining, proof))
+    }
+}
+
+impl WireCodec for ProofOfSelection {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        PROOF_OF_SELECTION_SIZE
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(self.as_bytes());
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < PROOF_OF_SELECTION_SIZE {
+            return Err(());
+        }
+        let (proof_bytes, remaining) = input.split_at(PROOF_OF_SELECTION_SIZE);
+        let proof_array: [u8; _] = proof_bytes.try_into().map_err(|_| ())?;
+        let proof = Self::from_bytes(&proof_array).map_err(|_| ())?;
+        Ok((remaining, proof))
+    }
+}
+
+impl WireCodec for Ed25519Signature {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        ED25519_SIGNATURE_SIZE
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(self.as_bytes());
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < ED25519_SIGNATURE_SIZE {
+            return Err(());
+        }
+        let (sig_bytes, remaining) = input.split_at(ED25519_SIGNATURE_SIZE);
+        let sig_array: [u8; _] = sig_bytes.try_into().map_err(|_| ())?;
+        let signature = Self::from_bytes(&sig_array).map_err(|_| ())?;
+        Ok((remaining, signature))
+    }
+}

--- a/blend/message/src/codec.rs
+++ b/blend/message/src/codec.rs
@@ -37,13 +37,13 @@ pub trait WireEncode {
     fn encode_into(&self, out: &mut Vec<u8>);
 }
 
-/// Decode a message component from the front of `input`, returning the value and
-/// the unconsumed remainder (`(rest, value)`, as in `nom`).
+/// Decode a message component from the front of `input`, returning the value
+/// and the unconsumed remainder (`(rest, value)`, as in `nom`).
 ///
 /// Implementations do not check `input`'s length — the caller guarantees it is
-/// large enough (see [`WireDecodeError`]). `Context` carries anything the decoder
-/// needs that is not on the wire (e.g. the layer count); `()` for self-describing
-/// fixed-size components.
+/// large enough (see [`WireDecodeError`]). `Context` carries anything the
+/// decoder needs that is not on the wire (e.g. the layer count); `()` for
+/// self-describing fixed-size components.
 pub trait WireDecode: Sized {
     type Context;
 
@@ -110,9 +110,11 @@ impl WireDecode for Ed25519PublicKey {
 
     fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (key_bytes, remaining) = input.split_at(ED25519_PUBLIC_KEY_SIZE);
-        let key_array: [u8; ED25519_PUBLIC_KEY_SIZE] =
-            key_bytes.try_into().expect("split_at guarantees the length");
-        let public_key = Self::from_bytes(&key_array).map_err(|_| WireDecodeError::InvalidPublicKey)?;
+        let key_array: [u8; ED25519_PUBLIC_KEY_SIZE] = key_bytes
+            .try_into()
+            .expect("split_at guarantees the length");
+        let public_key =
+            Self::from_bytes(&key_array).map_err(|_| WireDecodeError::InvalidPublicKey)?;
         Ok((remaining, public_key))
     }
 }
@@ -128,9 +130,11 @@ impl WireDecode for ProofOfQuota {
 
     fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (proof_bytes, remaining) = input.split_at(PROOF_OF_QUOTA_SIZE);
-        let proof_array: [u8; PROOF_OF_QUOTA_SIZE] =
-            proof_bytes.try_into().expect("split_at guarantees the length");
-        let proof = Self::try_from(proof_array).map_err(|_| WireDecodeError::InvalidProofOfQuota)?;
+        let proof_array: [u8; PROOF_OF_QUOTA_SIZE] = proof_bytes
+            .try_into()
+            .expect("split_at guarantees the length");
+        let proof =
+            Self::try_from(proof_array).map_err(|_| WireDecodeError::InvalidProofOfQuota)?;
         Ok((remaining, proof))
     }
 }
@@ -146,8 +150,9 @@ impl WireDecode for ProofOfSelection {
 
     fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (proof_bytes, remaining) = input.split_at(PROOF_OF_SELECTION_SIZE);
-        let proof_array: [u8; PROOF_OF_SELECTION_SIZE] =
-            proof_bytes.try_into().expect("split_at guarantees the length");
+        let proof_array: [u8; PROOF_OF_SELECTION_SIZE] = proof_bytes
+            .try_into()
+            .expect("split_at guarantees the length");
         let proof =
             Self::try_from(proof_array).map_err(|_| WireDecodeError::InvalidProofOfSelection)?;
         Ok((remaining, proof))
@@ -165,8 +170,9 @@ impl WireDecode for Ed25519Signature {
 
     fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (sig_bytes, remaining) = input.split_at(ED25519_SIGNATURE_SIZE);
-        let sig_array: [u8; ED25519_SIGNATURE_SIZE] =
-            sig_bytes.try_into().expect("split_at guarantees the length");
+        let sig_array: [u8; ED25519_SIGNATURE_SIZE] = sig_bytes
+            .try_into()
+            .expect("split_at guarantees the length");
         // `Ed25519Signature::from_bytes` is infallible (any bytes are a valid
         // signature value; verification happens elsewhere).
         Ok((remaining, Self::from_bytes(&sig_array)))

--- a/blend/message/src/codec.rs
+++ b/blend/message/src/codec.rs
@@ -10,24 +10,24 @@ use lb_key_management_system_keys::keys::{
 pub trait WireCodec: Sized {
     type Context;
 
-    fn encoded_length(context: Self::Context) -> usize;
+    fn encoded_length(_context: Self::Context) -> usize {
+        size_of::<Self>()
+    }
+
     fn encode_into(&self, out: &mut Vec<u8>);
+
     fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()>;
 }
 
 impl WireCodec for u8 {
     type Context = ();
 
-    fn encoded_length(_context: Self::Context) -> usize {
-        1
-    }
-
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.push(*self);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < 1 {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.is_empty() {
             return Err(());
         }
         let value = input[0];
@@ -36,15 +36,28 @@ impl WireCodec for u8 {
     }
 }
 
+impl WireCodec for u16 {
+    type Context = ();
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.to_le_bytes());
+    }
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < size_of::<Self>() {
+            return Err(());
+        }
+        let (bytes, remaining) = input.split_at(size_of::<Self>());
+        let value = Self::from_le_bytes(bytes.try_into().map_err(|_| ())?);
+        Ok((remaining, value))
+    }
+}
+
 impl WireCodec for bool {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        u8::encoded_length(context)
-    }
-
     fn encode_into(&self, out: &mut Vec<u8>) {
-        (*self as u8).encode_into(out);
+        u8::from(*self).encode_into(out);
     }
 
     fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
@@ -56,15 +69,11 @@ impl WireCodec for bool {
 impl WireCodec for Ed25519PublicKey {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        ED25519_PUBLIC_KEY_SIZE
-    }
-
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(self.as_bytes());
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         if input.len() < ED25519_PUBLIC_KEY_SIZE {
             return Err(());
         }
@@ -78,21 +87,17 @@ impl WireCodec for Ed25519PublicKey {
 impl WireCodec for ProofOfQuota {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        PROOF_OF_QUOTA_SIZE
-    }
-
     fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(self.as_bytes());
+        out.extend_from_slice(&<[u8; _]>::from(self)[..]);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         if input.len() < PROOF_OF_QUOTA_SIZE {
             return Err(());
         }
         let (proof_bytes, remaining) = input.split_at(PROOF_OF_QUOTA_SIZE);
         let proof_array: [u8; _] = proof_bytes.try_into().map_err(|_| ())?;
-        let proof = Self::from_bytes(&proof_array).map_err(|_| ())?;
+        let proof = proof_array.try_into().map_err(|_| ())?;
         Ok((remaining, proof))
     }
 }
@@ -100,21 +105,17 @@ impl WireCodec for ProofOfQuota {
 impl WireCodec for ProofOfSelection {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        PROOF_OF_SELECTION_SIZE
-    }
-
     fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(self.as_bytes());
+        out.extend_from_slice(&<[u8; _]>::from(self)[..]);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         if input.len() < PROOF_OF_SELECTION_SIZE {
             return Err(());
         }
         let (proof_bytes, remaining) = input.split_at(PROOF_OF_SELECTION_SIZE);
         let proof_array: [u8; _] = proof_bytes.try_into().map_err(|_| ())?;
-        let proof = Self::from_bytes(&proof_array).map_err(|_| ())?;
+        let proof = proof_array.try_into().map_err(|_| ())?;
         Ok((remaining, proof))
     }
 }
@@ -122,21 +123,17 @@ impl WireCodec for ProofOfSelection {
 impl WireCodec for Ed25519Signature {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        ED25519_SIGNATURE_SIZE
-    }
-
     fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(self.as_bytes());
+        out.extend_from_slice(&self.to_bytes()[..]);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         if input.len() < ED25519_SIGNATURE_SIZE {
             return Err(());
         }
         let (sig_bytes, remaining) = input.split_at(ED25519_SIGNATURE_SIZE);
         let sig_array: [u8; _] = sig_bytes.try_into().map_err(|_| ())?;
-        let signature = Self::from_bytes(&sig_array).map_err(|_| ())?;
+        let signature = sig_array.into();
         Ok((remaining, signature))
     }
 }

--- a/blend/message/src/codec.rs
+++ b/blend/message/src/codec.rs
@@ -69,6 +69,13 @@ impl WireCodec for bool {
 impl WireCodec for Ed25519PublicKey {
     type Context = ();
 
+    // Must be explicit: `size_of::<Ed25519PublicKey>()` is NOT the wire size — a
+    // `VerifyingKey` also caches the decompressed point, so it is far larger than
+    // the 32 bytes `encode_into` actually writes.
+    fn encoded_length((): Self::Context) -> usize {
+        ED25519_PUBLIC_KEY_SIZE
+    }
+
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(self.as_bytes());
     }

--- a/blend/message/src/codec.rs
+++ b/blend/message/src/codec.rs
@@ -6,141 +6,169 @@ use lb_key_management_system_keys::keys::{
     ED25519_PUBLIC_KEY_SIZE, ED25519_SIGNATURE_SIZE, Ed25519PublicKey, Ed25519Signature,
 };
 
-/// Append a message component's fixed-size, prefix-free wire bytes to `out`.
-pub trait WireCodec: Sized {
-    type Context;
-
-    fn encoded_length(_context: Self::Context) -> usize {
-        size_of::<Self>()
-    }
-
-    fn encode_into(&self, out: &mut Vec<u8>);
-
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()>;
+/// A content error from decoding a wire component.
+///
+/// Length is deliberately NOT checked by any [`WireDecode`] implementation: the
+/// caller (the network-side size gate that rejects wrongly-sized peer messages
+/// up front) guarantees the input holds at least the bytes the component needs.
+/// These variants therefore only cover malformed *values*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum WireDecodeError {
+    #[error("Invalid boolean encoding")]
+    InvalidBool,
+    #[error("Invalid Ed25519 public key encoding")]
+    InvalidPublicKey,
+    #[error("Invalid proof of quota encoding")]
+    InvalidProofOfQuota,
+    #[error("Invalid proof of selection encoding")]
+    InvalidProofOfSelection,
+    #[error("Unsupported message version")]
+    UnsupportedVersion,
+    #[error("Invalid payload type discriminant")]
+    InvalidPayloadType,
 }
 
-impl WireCodec for u8 {
-    type Context = ();
+/// Append a message component's fixed-size, prefix-free wire bytes to `out`.
+///
+/// Every Blend message component has a size fully determined by the (fixed,
+/// network-wide) number of encapsulation layers, so nothing is length-prefixed.
+/// The output buffer is allocated by the caller; implementations only append.
+pub trait WireEncode {
+    fn encode_into(&self, out: &mut Vec<u8>);
+}
 
+/// Decode a message component from the front of `input`, returning the value and
+/// the unconsumed remainder (`(rest, value)`, as in `nom`).
+///
+/// Implementations do not check `input`'s length — the caller guarantees it is
+/// large enough (see [`WireDecodeError`]). `Context` carries anything the decoder
+/// needs that is not on the wire (e.g. the layer count); `()` for self-describing
+/// fixed-size components.
+pub trait WireDecode: Sized {
+    type Context;
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), WireDecodeError>;
+}
+
+impl WireEncode for u8 {
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.push(*self);
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.is_empty() {
-            return Err(());
-        }
-        let value = input[0];
-        let remaining = &input[1..];
-        Ok((remaining, value))
+impl WireDecode for u8 {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        Ok((&input[1..], input[0]))
     }
 }
 
-impl WireCodec for u16 {
-    type Context = ();
-
+impl WireEncode for u16 {
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.to_le_bytes());
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < size_of::<Self>() {
-            return Err(());
-        }
+impl WireDecode for u16 {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (bytes, remaining) = input.split_at(size_of::<Self>());
-        let value = Self::from_le_bytes(bytes.try_into().map_err(|_| ())?);
+        let value = Self::from_le_bytes(bytes.try_into().expect("split_at guarantees the length"));
         Ok((remaining, value))
     }
 }
 
-impl WireCodec for bool {
-    type Context = ();
-
+impl WireEncode for bool {
     fn encode_into(&self, out: &mut Vec<u8>) {
         u8::from(*self).encode_into(out);
     }
+}
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
-        let (remaining, value) = u8::decode(input, context)?;
-        Ok((remaining, Self::try_from(value).map_err(|_| ())?))
+impl WireDecode for bool {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        let (remaining, value) = u8::decode(input, ())?;
+        match value {
+            0 => Ok((remaining, false)),
+            1 => Ok((remaining, true)),
+            _ => Err(WireDecodeError::InvalidBool),
+        }
     }
 }
 
-impl WireCodec for Ed25519PublicKey {
-    type Context = ();
-
-    // Must be explicit: `size_of::<Ed25519PublicKey>()` is NOT the wire size — a
-    // `VerifyingKey` also caches the decompressed point, so it is far larger than
-    // the 32 bytes `encode_into` actually writes.
-    fn encoded_length((): Self::Context) -> usize {
-        ED25519_PUBLIC_KEY_SIZE
-    }
-
+impl WireEncode for Ed25519PublicKey {
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(self.as_bytes());
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < ED25519_PUBLIC_KEY_SIZE {
-            return Err(());
-        }
+impl WireDecode for Ed25519PublicKey {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (key_bytes, remaining) = input.split_at(ED25519_PUBLIC_KEY_SIZE);
-        let key_array: [u8; _] = key_bytes.try_into().map_err(|_| ())?;
-        let public_key = Self::from_bytes(&key_array).map_err(|_| ())?;
+        let key_array: [u8; ED25519_PUBLIC_KEY_SIZE] =
+            key_bytes.try_into().expect("split_at guarantees the length");
+        let public_key = Self::from_bytes(&key_array).map_err(|_| WireDecodeError::InvalidPublicKey)?;
         Ok((remaining, public_key))
     }
 }
 
-impl WireCodec for ProofOfQuota {
+impl WireEncode for ProofOfQuota {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&<[u8; PROOF_OF_QUOTA_SIZE]>::from(self));
+    }
+}
+
+impl WireDecode for ProofOfQuota {
     type Context = ();
 
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(&<[u8; _]>::from(self)[..]);
-    }
-
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < PROOF_OF_QUOTA_SIZE {
-            return Err(());
-        }
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (proof_bytes, remaining) = input.split_at(PROOF_OF_QUOTA_SIZE);
-        let proof_array: [u8; _] = proof_bytes.try_into().map_err(|_| ())?;
-        let proof = proof_array.try_into().map_err(|_| ())?;
+        let proof_array: [u8; PROOF_OF_QUOTA_SIZE] =
+            proof_bytes.try_into().expect("split_at guarantees the length");
+        let proof = Self::try_from(proof_array).map_err(|_| WireDecodeError::InvalidProofOfQuota)?;
         Ok((remaining, proof))
     }
 }
 
-impl WireCodec for ProofOfSelection {
+impl WireEncode for ProofOfSelection {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&<[u8; PROOF_OF_SELECTION_SIZE]>::from(self));
+    }
+}
+
+impl WireDecode for ProofOfSelection {
     type Context = ();
 
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(&<[u8; _]>::from(self)[..]);
-    }
-
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < PROOF_OF_SELECTION_SIZE {
-            return Err(());
-        }
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (proof_bytes, remaining) = input.split_at(PROOF_OF_SELECTION_SIZE);
-        let proof_array: [u8; _] = proof_bytes.try_into().map_err(|_| ())?;
-        let proof = proof_array.try_into().map_err(|_| ())?;
+        let proof_array: [u8; PROOF_OF_SELECTION_SIZE] =
+            proof_bytes.try_into().expect("split_at guarantees the length");
+        let proof =
+            Self::try_from(proof_array).map_err(|_| WireDecodeError::InvalidProofOfSelection)?;
         Ok((remaining, proof))
     }
 }
 
-impl WireCodec for Ed25519Signature {
+impl WireEncode for Ed25519Signature {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.to_bytes());
+    }
+}
+
+impl WireDecode for Ed25519Signature {
     type Context = ();
 
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(&self.to_bytes()[..]);
-    }
-
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < ED25519_SIGNATURE_SIZE {
-            return Err(());
-        }
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (sig_bytes, remaining) = input.split_at(ED25519_SIGNATURE_SIZE);
-        let sig_array: [u8; _] = sig_bytes.try_into().map_err(|_| ())?;
-        let signature = sig_array.into();
-        Ok((remaining, signature))
+        let sig_array: [u8; ED25519_SIGNATURE_SIZE] =
+            sig_bytes.try_into().expect("split_at guarantees the length");
+        // `Ed25519Signature::from_bytes` is infallible (any bytes are a valid
+        // signature value; verification happens elsewhere).
+        Ok((remaining, Self::from_bytes(&sig_array)))
     }
 }

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -1,11 +1,11 @@
-use std::{num::NonZeroU64, sync::LazyLock};
+use std::num::NonZeroU64;
 
 use derivative::Derivative;
 use itertools::Itertools as _;
 use lb_blend_crypto::{ZkHash, cipher::Cipher};
 use lb_blend_proofs::{
     quota::{self, PROOF_OF_QUOTA_SIZE, VerifiedProofOfQuota},
-    selection::{self, VerifiedProofOfSelection, inputs::VerifyInputs},
+    selection::{self, PROOF_OF_SELECTION_SIZE, VerifiedProofOfSelection, inputs::VerifyInputs},
 };
 use lb_core::codec::{DeserializeOp as _, SerializeOp as _};
 use lb_key_management_system_keys::keys::{
@@ -26,7 +26,8 @@ use crate::{
     },
     input::EncapsulationInput,
     message::{
-        BlendingHeader, Payload, PublicHeader, payload::PaddedPayloadBody,
+        BlendingHeader, Payload, PublicHeader,
+        payload::{MAX_PAYLOAD_BODY_SIZE, PaddedPayloadBody},
         public_header::VerifiedPublicHeader,
     },
 };
@@ -70,9 +71,10 @@ impl EncapsulatedMessage {
     /// all have a constant size, so the total is strictly linear in the number
     /// of layers and fully determined by `num_layers`.
     #[must_use]
-    pub fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
-        let SizeModel { base, per_layer } = *SIZE_MODEL;
-        base + num_layers.get() * per_layer
+    pub const fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
+        let private_header_size = SEQUENCE_LENGTH_PREFIX_SIZE
+            + num_layers.get() as usize * ENCAPSULATED_BLENDING_HEADER_SIZE;
+        (PUBLIC_HEADER_SIZE + private_header_size + ENCAPSULATED_PAYLOAD_SIZE) as u64
     }
 
     /// Deserialize a message received from an untrusted remote peer, enforcing
@@ -290,7 +292,7 @@ impl EncapsulatedPart {
         if self.private_header.layer_count() as u64 != num_layers.get() {
             return Err(Error::UnexpectedEncapsulationLayerCount);
         }
-        if !self.private_header.has_fixed_size_layers() || self.payload.byte_len() != *PAYLOAD_LEN {
+        if !self.private_header.has_fixed_size_layers() || self.payload.byte_len() != PAYLOAD_SIZE {
             return Err(Error::MalformedEncapsulatedMessage);
         }
         Ok(())
@@ -553,7 +555,7 @@ impl EncapsulatedPrivateHeader {
     fn has_fixed_size_layers(&self) -> bool {
         self.0
             .iter()
-            .all(|header| header.byte_len() == *BLENDING_HEADER_LEN)
+            .all(|header| header.byte_len() == BLENDING_HEADER_SIZE)
     }
 }
 
@@ -645,68 +647,46 @@ impl EncapsulatedPayload {
     }
 }
 
-/// The wire size of a message is `base + num_layers * per_layer` bytes. We
-/// recover these two coefficients once, by measuring two canonically-built
-/// messages, so that no assumption about the underlying codec's framing is
-/// hard-coded here.
-struct SizeModel {
-    base: u64,
-    per_layer: u64,
-}
+// Serialized sizes of the message components. The wire format is fixed-size
+// (see the Blend Payload Formatting spec): every field is either a primitive, a
+// fixed-size crypto object, or the payload padded to [`MAX_PAYLOAD_BODY_SIZE`],
+// so all of these are compile-time constants. The framing constants below follow
+// from the codec configuration (bincode, fixed-int, little-endian); the
+// `serialized_size_constants_match_wire_format` test pins them to the real
+// encoding.
 
-static SIZE_MODEL: LazyLock<SizeModel> = LazyLock::new(|| {
-    let size_of = |num_layers| {
-        canonical_message(num_layers)
-            .bytes_size()
-            .expect("A canonical message is always serializable.")
-    };
-    let one_layer = size_of(1);
-    let two_layers = size_of(2);
-    let per_layer = two_layers - one_layer;
-    SizeModel {
-        base: one_layer - per_layer,
-        per_layer,
-    }
-});
+/// bincode encodes a sequence's length as a `u64`.
+const SEQUENCE_LENGTH_PREFIX_SIZE: usize = size_of::<u64>();
 
-/// The fixed serialized size of a single encapsulated blending header (layer).
-static BLENDING_HEADER_LEN: LazyLock<usize> = LazyLock::new(|| {
-    EncapsulatedBlendingHeader::initialize(&BlendingHeader::pseudo_random(&[0])).byte_len()
-});
+/// bincode encodes an enum discriminant as a `u32`.
+const ENUM_DISCRIMINANT_SIZE: usize = size_of::<u32>();
 
-/// The fixed serialized size of an encapsulated payload.
-static PAYLOAD_LEN: LazyLock<usize> =
-    LazyLock::new(|| EncapsulatedPayload::initialize(&canonical_payload()).byte_len());
+/// Serialized size of a [`BlendingHeader`]: every field is fixed-size.
+const BLENDING_HEADER_SIZE: usize = ED25519_PUBLIC_KEY_SIZE
+    + PROOF_OF_QUOTA_SIZE
+    + ED25519_SIGNATURE_SIZE
+    + PROOF_OF_SELECTION_SIZE
+    + size_of::<bool>(); // `is_last`
 
-fn canonical_payload() -> Payload {
-    Payload::new(
-        PayloadType::Cover,
-        PaddedPayloadBody::try_from([0u8; 0].as_slice())
-            .expect("An empty payload body is always valid."),
-    )
-}
+/// Serialized size of one layer on the wire: an [`EncapsulatedBlendingHeader`]
+/// is a `Vec<u8>` wrapping the fixed-size blending header bytes.
+const ENCAPSULATED_BLENDING_HEADER_SIZE: usize =
+    SEQUENCE_LENGTH_PREFIX_SIZE + BLENDING_HEADER_SIZE;
 
-/// Builds a structurally-valid (but cryptographically meaningless) message with
-/// `num_layers` layers, used solely to measure the fixed wire size.
-fn canonical_message(num_layers: usize) -> EncapsulatedMessage {
-    let public_header = PublicHeader::new(
-        UnsecuredEd25519Key::from_bytes(&[0; ED25519_PUBLIC_KEY_SIZE]).public_key(),
-        &VerifiedProofOfQuota::from_bytes_unchecked([0; PROOF_OF_QUOTA_SIZE]).into_inner(),
-        Ed25519Signature::from_bytes(&[0; ED25519_SIGNATURE_SIZE]),
-    );
-    let private_header = EncapsulatedPrivateHeader(
-        (0..num_layers)
-            .map(|layer| {
-                EncapsulatedBlendingHeader::initialize(&BlendingHeader::pseudo_random(&[layer as u8]))
-            })
-            .collect::<Vec<_>>()
-            .into_boxed_slice(),
-    );
-    EncapsulatedMessage::from_components(
-        public_header,
-        EncapsulatedPart {
-            private_header,
-            payload: EncapsulatedPayload::initialize(&canonical_payload()),
-        },
-    )
-}
+/// Serialized size of a [`Payload`]: the body is always padded to
+/// [`MAX_PAYLOAD_BODY_SIZE`], so the whole payload has a constant size.
+///
+/// `PaddedPayloadBody::padded` is serialized via `serde_with::Bytes`, i.e. as a
+/// byte string, which bincode length-prefixes (unlike a bare fixed-size array).
+const PAYLOAD_SIZE: usize = ENUM_DISCRIMINANT_SIZE // `PayloadHeader::payload_type`
+    + size_of::<u16>() // `PayloadHeader::body_len`
+    + SEQUENCE_LENGTH_PREFIX_SIZE + MAX_PAYLOAD_BODY_SIZE // `PaddedPayloadBody::padded`
+    + size_of::<u16>(); // `PaddedPayloadBody::actual_len`
+
+/// Serialized size of the payload on the wire: an [`EncapsulatedPayload`] is a
+/// `Vec<u8>` wrapping the fixed-size serialized payload.
+const ENCAPSULATED_PAYLOAD_SIZE: usize = SEQUENCE_LENGTH_PREFIX_SIZE + PAYLOAD_SIZE;
+
+/// Serialized size of a [`PublicHeader`]: a version byte plus fixed-size fields.
+const PUBLIC_HEADER_SIZE: usize =
+    size_of::<u8>() + ED25519_PUBLIC_KEY_SIZE + PROOF_OF_QUOTA_SIZE + ED25519_SIGNATURE_SIZE;

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -11,6 +11,7 @@ use lb_key_management_system_keys::keys::{
     Ed25519PublicKey, Ed25519Signature, SharedKey, UnsecuredEd25519Key,
 };
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::{
     Error, PayloadType,
@@ -25,7 +26,9 @@ use crate::{
     },
     input::EncapsulationInput,
     message::{
-        BlendingHeader, Payload, PublicHeader, payload::PaddedPayloadBody,
+        BlendingHeader, Payload, PublicHeader,
+        blending_header::BLENDING_HEADER_ENCODED_SIZE,
+        payload::{PAYLOAD_ENCODED_SIZE, PaddedPayloadBody},
         public_header::VerifiedPublicHeader,
     },
 };
@@ -59,6 +62,46 @@ impl EncapsulatedMessage {
     #[must_use]
     pub fn into_components(self) -> (PublicHeader, EncapsulatedPart) {
         (self.public_header, self.encapsulated_part)
+    }
+
+    /// The exact serialized size, in bytes, of any well-formed message with
+    /// `num_layers` encapsulation layers. The wire format is fixed-size, so this
+    /// is fully determined by the layer count.
+    #[must_use]
+    pub fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
+        PublicHeader::encoded_length(())
+            .checked_add(EncapsulatedPart::encoded_length(num_layers))
+            .expect("message encoded length overflow") as u64
+    }
+
+    /// Serialize the message to its fixed-size, prefix-free wire representation
+    /// (`public_header || layer_0 || .. || layer_{N-1} || payload`, no length
+    /// framing).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        encode_message_components(&self.public_header, &self.encapsulated_part)
+    }
+
+    /// Decode a message received from an untrusted remote peer.
+    ///
+    /// Rejects in O(1) — before allocating a single layer — any input whose
+    /// length is not exactly that of a well-formed `num_layers`-layer message,
+    /// then decodes component by component so the layout is enforced by
+    /// construction.
+    pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
+        if bytes.len() as u64 != Self::expected_serialized_len(num_layers) {
+            return Err(Error::MessageDeserializationFailed);
+        }
+
+        let (remaining, public_header) =
+            PublicHeader::decode(bytes, ()).map_err(|()| Error::MessageDeserializationFailed)?;
+        let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)
+            .map_err(|()| Error::MessageDeserializationFailed)?;
+        debug_assert!(
+            remaining.is_empty(),
+            "The size gate guarantees the wire bytes are fully consumed"
+        );
+        Ok(Self::from_components(public_header, encapsulated_part))
     }
 
     /// Verify the message public header signature.
@@ -273,6 +316,12 @@ impl EncapsulatedPart {
     /// Signs the encapsulated part using the provided key.
     pub(super) fn sign(&self, key: &UnsecuredEd25519Key) -> Ed25519Signature {
         key.sign_payload(&signing_body(&self.private_header, &self.payload))
+    }
+
+    /// The number of encapsulation layers in this part (always at least one).
+    pub(super) fn encapsulation_layers(&self) -> NonZeroU64 {
+        NonZeroU64::new(self.private_header.0.len() as u64)
+            .expect("An encapsulated part always has at least one blending header.")
     }
 }
 
@@ -578,17 +627,27 @@ impl WireCodec for EncapsulatedPrivateHeader {
 }
 
 /// A blending header encapsulated zero or more times.
-// TODO: Consider having `SerializedBlendingHeader` (not encapsulated).
+///
+/// Always exactly [`BLENDING_HEADER_ENCODED_SIZE`] bytes (the cipher is
+/// length-preserving), so it is a fixed-size array — stored inline, so a whole
+/// [`EncapsulatedPrivateHeader`] is one contiguous allocation.
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-struct EncapsulatedBlendingHeader(Vec<u8>);
+struct EncapsulatedBlendingHeader(
+    #[serde_as(as = "serde_with::Bytes")] [u8; BLENDING_HEADER_ENCODED_SIZE],
+);
 
 impl EncapsulatedBlendingHeader {
     /// Build a [`EncapsulatedBlendingHeader`] by serializing a
     /// [`BlendingHeader`] without any encapsulation.
     fn initialize(header: &BlendingHeader) -> Self {
-        let mut bytes = Vec::with_capacity(BlendingHeader::encoded_length(()));
+        let mut bytes = Vec::with_capacity(BLENDING_HEADER_ENCODED_SIZE);
         header.encode_into(&mut bytes);
-        Self(bytes)
+        Self(
+            bytes
+                .try_into()
+                .expect("A BlendingHeader always encodes to BLENDING_HEADER_ENCODED_SIZE bytes."),
+        )
     }
 
     /// Try to deserialize into a [`BlendingHeader`].
@@ -605,12 +664,12 @@ impl EncapsulatedBlendingHeader {
 
     /// Add a layer of encapsulation.
     fn encapsulate(&mut self, cipher: &mut Cipher) {
-        cipher.encrypt(self.0.as_mut_slice());
+        cipher.encrypt(&mut self.0[..]);
     }
 
     /// Remove a layer of encapsulation.
     fn decapsulate(&mut self, cipher: &mut Cipher) {
-        cipher.decrypt(self.0.as_mut_slice());
+        cipher.decrypt(&mut self.0[..]);
     }
 
     fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
@@ -619,17 +678,25 @@ impl EncapsulatedBlendingHeader {
 }
 
 /// A payload encapsulated zero or more times.
-// TODO: Consider having `SerializedPayload` (not encapsulated).
+///
+/// Always exactly [`PAYLOAD_ENCODED_SIZE`] bytes; boxed because that is ~34 KiB
+/// and must not be stored inline in [`EncapsulatedPart`]/[`EncapsulatedMessage`].
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-struct EncapsulatedPayload(Vec<u8>);
+struct EncapsulatedPayload(#[serde_as(as = "serde_with::Bytes")] Box<[u8; PAYLOAD_ENCODED_SIZE]>);
 
 impl EncapsulatedPayload {
     /// Build a [`EncapsulatedPayload`] by serializing a [`Payload`]
     /// without any encapsulation.
     fn initialize(payload: &Payload) -> Self {
-        let mut bytes = Vec::with_capacity(Payload::encoded_length(()));
+        let mut bytes = Vec::with_capacity(PAYLOAD_ENCODED_SIZE);
         payload.encode_into(&mut bytes);
-        Self(bytes)
+        Self(
+            bytes
+                .into_boxed_slice()
+                .try_into()
+                .expect("A Payload always encodes to PAYLOAD_ENCODED_SIZE bytes."),
+        )
     }
 
     /// Try to deserialize into a [`Payload`].
@@ -637,7 +704,7 @@ impl EncapsulatedPayload {
     /// the deserialization will succeed.
     fn try_deserialize(&self) -> Result<Payload, Error> {
         let (remaining, payload) =
-            Payload::decode(&self.0, ()).map_err(|()| Error::PayloadDeserializationFailed)?;
+            Payload::decode(&self.0[..], ()).map_err(|()| Error::PayloadDeserializationFailed)?;
         if !remaining.is_empty() {
             return Err(Error::PayloadDeserializationFailed);
         }
@@ -646,13 +713,13 @@ impl EncapsulatedPayload {
 
     /// Add a layer of encapsulation.
     fn encapsulate(mut self, cipher: &mut Cipher) -> Self {
-        cipher.encrypt(self.0.as_mut_slice());
+        cipher.encrypt(&mut self.0[..]);
         self
     }
 
     /// Remove a layer of encapsulation.
     fn decapsulate(mut self, cipher: &mut Cipher) -> Self {
-        cipher.decrypt(self.0.as_mut_slice());
+        cipher.decrypt(&mut self.0[..]);
         self
     }
 
@@ -673,19 +740,12 @@ pub(super) fn encode_message_components(
     public_header: &PublicHeader,
     part: &EncapsulatedPart,
 ) -> Vec<u8> {
-    let mut bytes =
-        Vec::with_capacity(expected_serialized_message_len(part.encapsulation_layers()) as usize);
+    let mut bytes = Vec::with_capacity(
+        EncapsulatedMessage::expected_serialized_len(part.encapsulation_layers()) as usize,
+    );
     public_header.encode_into(&mut bytes);
     part.encode_into(&mut bytes);
     bytes
-}
-
-/// The exact serialized size, in bytes, of a well-formed message with
-/// `num_layers` encapsulation layers.
-fn expected_serialized_message_len(num_layers: NonZeroU64) -> u64 {
-    PublicHeader::encoded_length(())
-        .checked_add(EncapsulatedPart::encoded_length(num_layers))
-        .expect("message encoded length overflow") as u64
 }
 
 // The encapsulated leaves already hold their raw ciphered bytes, so encoding is
@@ -693,41 +753,40 @@ fn expected_serialized_message_len(num_layers: NonZeroU64) -> u64 {
 impl WireCodec for EncapsulatedBlendingHeader {
     type Context = ();
 
-    fn encoded_length(_context: Self::Context) -> usize {
-        BlendingHeader::encoded_length(())
+    fn encoded_length((): Self::Context) -> usize {
+        BLENDING_HEADER_ENCODED_SIZE
     }
 
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.0);
     }
 
-    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
-        let length = Self::encoded_length(());
-        if input.len() < length {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < BLENDING_HEADER_ENCODED_SIZE {
             return Err(());
         }
-        let (bytes, remaining) = input.split_at(length);
-        Ok((remaining, Self(bytes.to_vec())))
+        let (bytes, remaining) = input.split_at(BLENDING_HEADER_ENCODED_SIZE);
+        Ok((remaining, Self(bytes.try_into().map_err(|_| ())?)))
     }
 }
 
 impl WireCodec for EncapsulatedPayload {
     type Context = ();
 
-    fn encoded_length(_context: Self::Context) -> usize {
-        Payload::encoded_length(())
+    fn encoded_length((): Self::Context) -> usize {
+        PAYLOAD_ENCODED_SIZE
     }
 
     fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(&self.0);
+        out.extend_from_slice(&self.0[..]);
     }
 
-    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
-        let length = Self::encoded_length(());
-        if input.len() < length {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < PAYLOAD_ENCODED_SIZE {
             return Err(());
         }
-        let (bytes, remaining) = input.split_at(length);
-        Ok((remaining, Self(bytes.to_vec())))
+        let (bytes, remaining) = input.split_at(PAYLOAD_ENCODED_SIZE);
+        let boxed = bytes.to_vec().into_boxed_slice().try_into().map_err(|_| ())?;
+        Ok((remaining, Self(boxed)))
     }
 }

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -4,22 +4,23 @@ use derivative::Derivative;
 use itertools::Itertools as _;
 use lb_blend_crypto::{ZkHash, cipher::Cipher};
 use lb_blend_proofs::{
-    quota::{self, PROOF_OF_QUOTA_SIZE, VerifiedProofOfQuota},
-    selection::{self, PROOF_OF_SELECTION_SIZE, VerifiedProofOfSelection, inputs::VerifyInputs},
+    quota::{self, VerifiedProofOfQuota},
+    selection::{self, VerifiedProofOfSelection, inputs::VerifyInputs},
 };
-use lb_core::codec::{DeserializeOp as _, SerializeOp};
+use lb_core::codec::{DeserializeOp as _, SerializeOp as _};
 use lb_key_management_system_keys::keys::{
-    ED25519_PUBLIC_KEY_SIZE, ED25519_SIGNATURE_SIZE, Ed25519PublicKey, Ed25519Signature, SharedKey,
-    UnsecuredEd25519Key,
+    Ed25519PublicKey, Ed25519Signature, SharedKey, UnsecuredEd25519Key,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
     Error, PayloadType,
+    codec::WireEncode,
     crypto::{domains, key_ext::SharedKeyExt as _},
     encap::{
         ProofsVerifier,
         decapsulated::{PartDecapsulationOutput, PrivateHeaderDecapsulationOutput},
+        expected_serialized_message_len,
         validated::{
             EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
         },
@@ -27,8 +28,8 @@ use crate::{
     input::EncapsulationInput,
     message::{
         BlendingHeader, Payload, PublicHeader,
-        payload::{MAX_PAYLOAD_BODY_SIZE, PaddedPayloadBody},
-        public_header::VerifiedPublicHeader,
+        payload::PaddedPayloadBody,
+        public_header::{ENCODED_PUBLIC_HEADER_SIZE, VerifiedPublicHeader},
     },
 };
 
@@ -63,56 +64,37 @@ impl EncapsulatedMessage {
         (self.public_header, self.encapsulated_part)
     }
 
-    /// The exact serialized size, in bytes, of any well-formed message with
-    /// `num_layers` encapsulation layers.
-    ///
-    /// The wire format is a fixed-size, prefix-free concatenation (see the
-    /// Blend Payload Formatting spec and [`Self::encode`]): the public
-    /// header, every encapsulated blending header, and the payload all have
-    /// a constant size, so the total is strictly linear in the number of
-    /// layers and fully determined by `num_layers`.
-    #[must_use]
-    pub const fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
-        let blending_headers_size = (num_layers.get() as usize)
-            .checked_mul(BLENDING_HEADER_SIZE)
-            .unwrap();
-        PUBLIC_HEADER_SIZE
-            .checked_add(blending_headers_size)
-            .unwrap()
-            .checked_add(PAYLOAD_SIZE)
-            .unwrap() as u64
-    }
-
     /// Serialize the message to its fixed-size, prefix-free wire
     /// representation: `public_header || layer_0 || .. || layer_{N-1} ||
     /// payload`, with no length framing at the message level. The layer
     /// count is fixed by the network-wide configuration, so it is not
     /// encoded on the wire.
-    // TODO: Replace with `NomEncode` implementation.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
         encode_message_components(&self.public_header, &self.encapsulated_part)
     }
 
-    ///  a message.
+    /// Decode a message received from an untrusted remote peer.
     ///
     /// Because the format is fixed-size, we reject in O(1) — before allocating
     /// a single layer — any input whose length is not exactly that of a
     /// well-formed `num_layers`-layer message. A message encoding, say, 20
     /// layers when we expect 3 has a different length and is discarded up
-    /// front. The bytes are then sliced positionally into the public
-    /// header, exactly `num_layers` fixed-size layers, and the fixed-size
-    /// payload, so the layout is enforced by construction.
-    // TODO: Replace with `NomDecode` implementation.
+    /// front. The bytes are then decoded component by component (see
+    /// [`WireDecode`]); the size gate guarantees each fixed-size slice
+    /// lands on a component boundary and that the whole input is consumed,
+    /// so the layout is enforced by construction.
     pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
-        if bytes.len() as u64 != Self::expected_serialized_len(num_layers) {
+        if bytes.len() as u64 != expected_serialized_message_len(num_layers) {
             return Err(Error::MessageDeserializationFailed);
         }
 
-        let (public_header_bytes, part_bytes) = bytes.split_at(PUBLIC_HEADER_SIZE);
-        let public_header = PublicHeader::from_bytes(public_header_bytes)
-            .map_err(|_| Error::MessageDeserializationFailed)?;
-        let encapsulated_part = EncapsulatedPart::decode(part_bytes, num_layers);
+        let (remaining, public_header) = PublicHeader::decode(bytes, ())?;
+        let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)?;
+        debug_assert!(
+            remaining.is_empty(),
+            "The size gate guarantees the wire bytes are fully consumed"
+        );
         Ok(Self::from_components(public_header, encapsulated_part))
     }
 
@@ -301,29 +283,6 @@ impl EncapsulatedPart {
     /// Signs the encapsulated part using the provided key.
     pub(super) fn sign(&self, key: &UnsecuredEd25519Key) -> Ed25519Signature {
         key.sign_payload(&signing_body(&self.private_header, &self.payload))
-    }
-
-    /// Append the part's fixed-size, prefix-free wire bytes to `out`: every
-    /// layer's bytes in order, followed by the payload's bytes.
-    pub(super) fn encode_into(&self, out: &mut Vec<u8>) {
-        self.private_header.encode_into(out);
-        out.extend_from_slice(&self.payload.0);
-    }
-
-    /// Reconstruct a part from the bytes following the public header.
-    ///
-    /// `part_bytes` is expected to be exactly
-    /// `num_layers * BLENDING_HEADER_SIZE + PAYLOAD_SIZE` bytes long. The
-    /// caller ([`EncapsulatedMessage::deserialize_from_remote`]) guarantees
-    /// this via the O(1) size gate, so the split points always land on
-    /// layer/payload boundaries and the layout is enforced by construction.
-    pub(super) fn decode(part_bytes: &[u8], num_layers: NonZeroU64) -> Self {
-        let layers_len = num_layers.get() as usize * BLENDING_HEADER_SIZE;
-        let (layers_bytes, payload_bytes) = part_bytes.split_at(layers_len);
-        Self {
-            private_header: EncapsulatedPrivateHeader::decode(layers_bytes),
-            payload: EncapsulatedPayload(payload_bytes.to_vec()),
-        }
     }
 }
 
@@ -573,27 +532,6 @@ impl EncapsulatedPrivateHeader {
             .iter()
             .flat_map(EncapsulatedBlendingHeader::iter_bytes)
     }
-
-    /// Append every layer's fixed-size bytes to `out`, in order and without any
-    /// framing.
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        for header in &self.0 {
-            out.extend_from_slice(&header.0);
-        }
-    }
-
-    /// Split `layers_bytes` into fixed-size layers. The length is guaranteed by
-    /// the caller to be an exact multiple of [`BLENDING_HEADER_SIZE`], so
-    /// `chunks_exact` leaves no remainder.
-    fn decode(layers_bytes: &[u8]) -> Self {
-        Self(
-            layers_bytes
-                .chunks_exact(BLENDING_HEADER_SIZE)
-                .map(|chunk| EncapsulatedBlendingHeader(chunk.to_vec()))
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        )
-    }
 }
 
 /// A blending header encapsulated zero or more times.
@@ -676,72 +614,114 @@ impl EncapsulatedPayload {
     }
 }
 
-/// Encode a full message as `public_header || part` in the fixed-size,
-/// prefix-free wire format (see [`EncapsulatedMessage::encode`]).
+/// Encode a full message as `public_header || part`, the shared shape of all
+/// three message types.
 ///
-/// The public header is written as its own fixed-size bytes (bincode over
-/// fixed-width fields adds no length framing), followed by the part's raw layer
-/// and payload bytes. All three public-header variants
-/// ([`PublicHeader`], [`PublicHeaderWithVerifiedSignature`],
-/// [`VerifiedPublicHeader`]) serialize to the same fixed-size bytes, so this
-/// yields byte-identical output regardless of which one is passed — which is
-/// what lets a peer serialize a verified variant and the receiver decode an
-/// [`EncapsulatedMessage`].
-pub(super) fn encode_message_components<Header>(
-    public_header: &Header,
+/// Every public-header variant ([`PublicHeader`],
+/// [`PublicHeaderWithVerifiedSignature`], [`VerifiedPublicHeader`]) encodes to
+/// the same fixed-size bytes, so the output is byte-identical regardless of
+/// which is passed — which is what lets a peer serialize a verified variant and
+/// the receiver decode an (unverified) [`EncapsulatedMessage`].
+pub(super) fn encode_message_components<PublicHeader>(
+    public_header: &PublicHeader,
     part: &EncapsulatedPart,
 ) -> Vec<u8>
 where
-    Header: SerializeOp,
+    PublicHeader: WireEncode,
 {
-    let mut bytes = public_header
-        .to_bytes()
-        .expect("A public header is always serializable.")
-        .to_vec();
-    bytes.reserve(part.private_header.0.len() * BLENDING_HEADER_SIZE + PAYLOAD_SIZE);
+    let mut bytes =
+        Vec::with_capacity(expected_serialized_message_len(part.encapsulation_layers()));
+    public_header.encode_into(&mut bytes);
     part.encode_into(&mut bytes);
     bytes
 }
 
-// Fixed sizes of the message components. Every component is either a primitive,
-// a fixed-size crypto object, or the payload padded to
-// [`MAX_PAYLOAD_BODY_SIZE`], so all of these are compile-time constants.
-//
-// The message *framing* is now prefix-free (the layers and payload are
-// concatenated by [`encode_message`] with no length prefixes; the layer count
-// is fixed by the network configuration). The component bytes themselves are
-// still produced by the bincode codec, however, so `PAYLOAD_SIZE` and
-// `PUBLIC_HEADER_SIZE` account for that internal encoding — e.g. the enum
-// discriminant and the `serde_with::Bytes` length prefix inside a serialized
-// `Payload`. The `serialized_size_constants_match_wire_format` test pins these
-// constants to the real encoding.
+/// Split off the first `len` bytes of `input` as `(taken, rest)`, erroring if
+/// `input` is too short. This is unreachable once
+/// [`EncapsulatedMessage::decode`]'s size gate has run, but it keeps every
+/// component decode self-contained.
+const fn take(input: &[u8], len: usize) -> Result<(&[u8], &[u8]), Error> {
+    if input.len() < len {
+        return Err(Error::MessageDeserializationFailed);
+    }
+    Ok(input.split_at(len))
+}
 
-/// bincode encodes a `Vec`/byte-string length as a `u64`.
-const SEQUENCE_LENGTH_PREFIX_SIZE: usize = size_of::<u64>();
+// The encapsulated leaves already hold their raw ciphered bytes, so encoding is
+// the identity and decoding takes a fixed-size slice.
+impl WireEncode for EncapsulatedBlendingHeader {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.0);
+    }
+}
 
-/// bincode encodes an enum discriminant as a `u32`.
-const ENUM_DISCRIMINANT_SIZE: usize = size_of::<u32>();
+impl WireDecode for EncapsulatedBlendingHeader {
+    type Context = ();
 
-/// Serialized size of one layer: a [`BlendingHeader`] with all fixed-size
-/// fields. On the wire the layers are concatenated with no framing, so this is
-/// also the per-layer contribution to a message's size.
-const BLENDING_HEADER_SIZE: usize = ED25519_PUBLIC_KEY_SIZE
-    + PROOF_OF_QUOTA_SIZE
-    + ED25519_SIGNATURE_SIZE
-    + PROOF_OF_SELECTION_SIZE
-    + size_of::<bool>(); // `is_last`
+    fn decode(input: &[u8], (): ()) -> Result<(&[u8], Self), Error> {
+        let (bytes, rest) = take(input, BLENDING_HEADER_SIZE)?;
+        Ok((rest, Self(bytes.to_vec())))
+    }
+}
 
-/// Serialized size of a [`Payload`]: the body is always padded to
-/// [`MAX_PAYLOAD_BODY_SIZE`], so the whole payload has a constant size.
-///
-/// `PaddedPayloadBody::padded` is serialized via `serde_with::Bytes`, i.e. as a
-/// byte string, which bincode length-prefixes (unlike a bare fixed-size array).
-const PAYLOAD_SIZE: usize = ENUM_DISCRIMINANT_SIZE // `PayloadHeader::payload_type`
-    + size_of::<u16>() // `PayloadHeader::body_len`
-    + SEQUENCE_LENGTH_PREFIX_SIZE + MAX_PAYLOAD_BODY_SIZE // `PaddedPayloadBody::padded`
-    + size_of::<u16>(); // `PaddedPayloadBody::actual_len`
+impl WireEncode for EncapsulatedPayload {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.0);
+    }
+}
 
-/// Serialized size of a [`PublicHeader`]: a version byte plus fixed-size
-/// fields.
-const PUBLIC_HEADER_SIZE: usize =
-    size_of::<u8>() + ED25519_PUBLIC_KEY_SIZE + PROOF_OF_QUOTA_SIZE + ED25519_SIGNATURE_SIZE;
+impl WireDecode for EncapsulatedPayload {
+    type Context = ();
+
+    fn decode(input: &[u8], (): ()) -> Result<(&[u8], Self), Error> {
+        let (bytes, rest) = take(input, PAYLOAD_SIZE)?;
+        Ok((rest, Self(bytes.to_vec())))
+    }
+}
+
+// The private header is exactly `num_layers` blending headers, back to back.
+impl WireEncode for EncapsulatedPrivateHeader {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        for layer in &self.0 {
+            layer.encode_into(out);
+        }
+    }
+}
+
+impl WireDecode for EncapsulatedPrivateHeader {
+    type Context = NonZeroU64;
+
+    fn decode(mut input: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
+        let mut layers = Vec::with_capacity(num_layers.get() as usize);
+        for _ in 0..num_layers.get() {
+            let (rest, layer) = EncapsulatedBlendingHeader::decode(input, ())?;
+            layers.push(layer);
+            input = rest;
+        }
+        Ok((input, Self(layers.into_boxed_slice())))
+    }
+}
+
+// A part is its private header followed by its payload.
+impl WireEncode for EncapsulatedPart {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.private_header.encode_into(out);
+        self.payload.encode_into(out);
+    }
+}
+
+impl WireDecode for EncapsulatedPart {
+    type Context = NonZeroU64;
+
+    fn decode(input: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
+        let (input, private_header) = EncapsulatedPrivateHeader::decode(input, num_layers)?;
+        let (input, payload) = EncapsulatedPayload::decode(input, ())?;
+        Ok((
+            input,
+            Self {
+                private_header,
+                payload,
+            },
+        ))
+    }
+}

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use core::num::NonZeroU64;
 
 use derivative::Derivative;
 use itertools::Itertools as _;
@@ -66,38 +66,47 @@ impl EncapsulatedMessage {
     /// The exact serialized size, in bytes, of any well-formed message with
     /// `num_layers` encapsulation layers.
     ///
-    /// The wire format is a fixed-size, prefix-free concatenation (see the Blend
-    /// Payload Formatting spec and [`Self::encode`]): the public header, every
-    /// encapsulated blending header, and the payload all have a constant size,
-    /// so the total is strictly linear in the number of layers and fully
-    /// determined by `num_layers`.
+    /// The wire format is a fixed-size, prefix-free concatenation (see the
+    /// Blend Payload Formatting spec and [`Self::encode`]): the public
+    /// header, every encapsulated blending header, and the payload all have
+    /// a constant size, so the total is strictly linear in the number of
+    /// layers and fully determined by `num_layers`.
     #[must_use]
     pub const fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
-        (PUBLIC_HEADER_SIZE + num_layers.get() as usize * BLENDING_HEADER_SIZE + PAYLOAD_SIZE)
-            as u64
+        let blending_headers_size = (num_layers.get() as usize)
+            .checked_mul(BLENDING_HEADER_SIZE)
+            .unwrap();
+        PUBLIC_HEADER_SIZE
+            .checked_add(blending_headers_size)
+            .unwrap()
+            .checked_add(PAYLOAD_SIZE)
+            .unwrap() as u64
     }
 
-    /// Serialize the message to its fixed-size, prefix-free wire representation:
-    /// `public_header || layer_0 || .. || layer_{N-1} || payload`, with no
-    /// length framing at the message level. The layer count is fixed by the
-    /// network-wide configuration, so it is not encoded on the wire.
+    /// Serialize the message to its fixed-size, prefix-free wire
+    /// representation: `public_header || layer_0 || .. || layer_{N-1} ||
+    /// payload`, with no length framing at the message level. The layer
+    /// count is fixed by the network-wide configuration, so it is not
+    /// encoded on the wire.
+    // TODO: Replace with `NomEncode` implementation.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        encode_message(&self.public_header, &self.encapsulated_part)
+        encode_message_components(&self.public_header, &self.encapsulated_part)
     }
 
-    /// Deserialize a message received from an untrusted remote peer.
+    ///  a message.
     ///
-    /// Because the format is fixed-size, we reject in O(1) — before allocating a
-    /// single layer — any input whose length is not exactly that of a
-    /// well-formed `num_layers`-layer message. A message encoding, say, 20 layers
-    /// when we expect 3 has a different length and is discarded up front. The
-    /// bytes are then sliced positionally into the public header, exactly
-    /// `num_layers` fixed-size layers, and the fixed-size payload, so the layout
-    /// is enforced by construction.
-    pub fn deserialize_from_remote(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
+    /// Because the format is fixed-size, we reject in O(1) — before allocating
+    /// a single layer — any input whose length is not exactly that of a
+    /// well-formed `num_layers`-layer message. A message encoding, say, 20
+    /// layers when we expect 3 has a different length and is discarded up
+    /// front. The bytes are then sliced positionally into the public
+    /// header, exactly `num_layers` fixed-size layers, and the fixed-size
+    /// payload, so the layout is enforced by construction.
+    // TODO: Replace with `NomDecode` implementation.
+    pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
         if bytes.len() as u64 != Self::expected_serialized_len(num_layers) {
-            return Err(Error::UnexpectedMessageSize);
+            return Err(Error::MessageDeserializationFailed);
         }
 
         let (public_header_bytes, part_bytes) = bytes.split_at(PUBLIC_HEADER_SIZE);
@@ -304,10 +313,10 @@ impl EncapsulatedPart {
     /// Reconstruct a part from the bytes following the public header.
     ///
     /// `part_bytes` is expected to be exactly
-    /// `num_layers * BLENDING_HEADER_SIZE + PAYLOAD_SIZE` bytes long. The caller
-    /// ([`EncapsulatedMessage::deserialize_from_remote`]) guarantees this via the
-    /// O(1) size gate, so the split points always land on layer/payload
-    /// boundaries and the layout is enforced by construction.
+    /// `num_layers * BLENDING_HEADER_SIZE + PAYLOAD_SIZE` bytes long. The
+    /// caller ([`EncapsulatedMessage::deserialize_from_remote`]) guarantees
+    /// this via the O(1) size gate, so the split points always land on
+    /// layer/payload boundaries and the layout is enforced by construction.
     pub(super) fn decode(part_bytes: &[u8], num_layers: NonZeroU64) -> Self {
         let layers_len = num_layers.get() as usize * BLENDING_HEADER_SIZE;
         let (layers_bytes, payload_bytes) = part_bytes.split_at(layers_len);
@@ -678,10 +687,13 @@ impl EncapsulatedPayload {
 /// yields byte-identical output regardless of which one is passed — which is
 /// what lets a peer serialize a verified variant and the receiver decode an
 /// [`EncapsulatedMessage`].
-pub(super) fn encode_message<Header: SerializeOp>(
+pub(super) fn encode_message_components<Header>(
     public_header: &Header,
     part: &EncapsulatedPart,
-) -> Vec<u8> {
+) -> Vec<u8>
+where
+    Header: SerializeOp,
+{
     let mut bytes = public_header
         .to_bytes()
         .expect("A public header is always serializable.")
@@ -692,8 +704,8 @@ pub(super) fn encode_message<Header: SerializeOp>(
 }
 
 // Fixed sizes of the message components. Every component is either a primitive,
-// a fixed-size crypto object, or the payload padded to [`MAX_PAYLOAD_BODY_SIZE`],
-// so all of these are compile-time constants.
+// a fixed-size crypto object, or the payload padded to
+// [`MAX_PAYLOAD_BODY_SIZE`], so all of these are compile-time constants.
 //
 // The message *framing* is now prefix-free (the layers and payload are
 // concatenated by [`encode_message`] with no length prefixes; the layer count
@@ -729,6 +741,7 @@ const PAYLOAD_SIZE: usize = ENUM_DISCRIMINANT_SIZE // `PayloadHeader::payload_ty
     + SEQUENCE_LENGTH_PREFIX_SIZE + MAX_PAYLOAD_BODY_SIZE // `PaddedPayloadBody::padded`
     + size_of::<u16>(); // `PaddedPayloadBody::actual_len`
 
-/// Serialized size of a [`PublicHeader`]: a version byte plus fixed-size fields.
+/// Serialized size of a [`PublicHeader`]: a version byte plus fixed-size
+/// fields.
 const PUBLIC_HEADER_SIZE: usize =
     size_of::<u8>() + ED25519_PUBLIC_KEY_SIZE + PROOF_OF_QUOTA_SIZE + ED25519_SIGNATURE_SIZE;

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -64,38 +64,23 @@ impl EncapsulatedMessage {
         (self.public_header, self.encapsulated_part)
     }
 
-    /// The exact serialized size, in bytes, of any well-formed message with
-    /// `num_layers` encapsulation layers. The wire format is fixed-size, so this
-    /// is fully determined by the layer count. Used by the network crate to gate
-    /// received bytes and to size the encode buffer.
-    #[must_use]
-    pub fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
-        let layers_len = (num_layers.get() as usize)
-            .checked_mul(BLENDING_HEADER_ENCODED_SIZE)
-            .expect("message encoded length overflow");
-        PUBLIC_HEADER_ENCODED_SIZE
-            .checked_add(layers_len)
-            .and_then(|len| len.checked_add(PAYLOAD_ENCODED_SIZE))
-            .expect("message encoded length overflow") as u64
-    }
-
-    /// Append the message's fixed-size, prefix-free wire bytes to `out`
-    /// (`public_header || layer_0 || .. || layer_{N-1} || payload`, no length
-    /// framing). The caller owns the buffer allocation.
-    pub fn encode_into(&self, out: &mut Vec<u8>) {
-        self.public_header.encode_into(out);
-        self.encapsulated_part.encode_into(out);
-    }
-
-    /// Serialize the message to a freshly-allocated buffer — a convenience over
-    /// [`Self::encode_into`] for callers that don't own a buffer.
-    #[must_use]
+    #[cfg(test)]
     pub fn encode(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(
-            Self::expected_serialized_len(self.encapsulated_part.encapsulation_layers()) as usize,
+        let expected_encoded_len =
+            crate::encap::expected_serialized_len(self.encapsulation_layers());
+        let mut out = Vec::with_capacity(expected_encoded_len);
+        self.public_header.encode_into(&mut out);
+        self.encapsulated_part.encode_into(&mut out);
+        debug_assert!(
+            out.len() == expected_encoded_len,
+            "Message should encode to the expected length but it did not."
         );
-        self.encode_into(&mut out);
         out
+    }
+
+    #[cfg(test)]
+    fn encapsulation_layers(&self) -> NonZeroU64 {
+        self.encapsulated_part.encapsulation_layers()
     }
 
     /// Decode a message from the front of `bytes`, returning it and the
@@ -107,7 +92,10 @@ impl EncapsulatedMessage {
     pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
         let (remaining, public_header) = PublicHeader::decode(bytes, ())?;
         let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)?;
-        Ok((remaining, Self::from_components(public_header, encapsulated_part)))
+        Ok((
+            remaining,
+            Self::from_components(public_header, encapsulated_part),
+        ))
     }
 
     /// Verify the message public header signature.
@@ -297,10 +285,8 @@ impl EncapsulatedPart {
         key.sign_payload(&signing_body(&self.private_header, &self.payload))
     }
 
-    /// The number of encapsulation layers in this part (always at least one).
     pub(super) fn encapsulation_layers(&self) -> NonZeroU64 {
-        NonZeroU64::new(self.private_header.0.len() as u64)
-            .expect("An encapsulated part always has at least one blending header.")
+        self.private_header.encapsulation_layers()
     }
 }
 
@@ -573,6 +559,11 @@ impl EncapsulatedPrivateHeader {
             .iter()
             .flat_map(EncapsulatedBlendingHeader::iter_bytes)
     }
+
+    pub(super) fn encapsulation_layers(&self) -> NonZeroU64 {
+        NonZeroU64::new(self.0.len() as u64)
+            .expect("An encapsulated part always has at least one blending header.")
+    }
 }
 
 impl WireEncode for EncapsulatedPrivateHeader {
@@ -586,9 +577,9 @@ impl WireEncode for EncapsulatedPrivateHeader {
 impl WireDecode for EncapsulatedPrivateHeader {
     type Context = NonZeroU64;
 
-    fn decode(mut input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
-        let mut layers = Vec::with_capacity(num_layers.get() as usize);
-        for _ in 0..num_layers.get() {
+    fn decode(mut input: &[u8], context: Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        let mut layers = Vec::with_capacity(context.get() as usize);
+        for _ in 0..context.get() {
             let (remaining, layer) = EncapsulatedBlendingHeader::decode(input, ())?;
             layers.push(layer);
             input = remaining;
@@ -645,10 +636,33 @@ impl EncapsulatedBlendingHeader {
     }
 }
 
+// The encapsulated leaves already hold their raw ciphered bytes, so encoding is
+// the identity and decoding takes a fixed-size slice of the layer/payload size.
+// No length checks: the network-side size gate guarantees the input is large
+// enough (`split_at`/`try_into` therefore never fail).
+impl WireEncode for EncapsulatedBlendingHeader {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.0);
+    }
+}
+
+impl WireDecode for EncapsulatedBlendingHeader {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        let (bytes, remaining) = input.split_at(BLENDING_HEADER_ENCODED_SIZE);
+        Ok((
+            remaining,
+            Self(bytes.try_into().expect("split_at guarantees the length")),
+        ))
+    }
+}
+
 /// A payload encapsulated zero or more times.
 ///
 /// Always exactly [`PAYLOAD_ENCODED_SIZE`] bytes; boxed because that is ~34 KiB
-/// and must not be stored inline in [`EncapsulatedPart`]/[`EncapsulatedMessage`].
+/// and must not be stored inline in
+/// [`EncapsulatedPart`]/[`EncapsulatedMessage`].
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 struct EncapsulatedPayload(#[serde_as(as = "serde_with::Bytes")] Box<[u8; PAYLOAD_ENCODED_SIZE]>);
@@ -690,48 +704,6 @@ impl EncapsulatedPayload {
 
     fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
         self.0.iter().copied()
-    }
-}
-
-/// Encode a full message as `public_header || part`, the shared shape of all
-/// three message types.
-///
-/// Every public-header variant ([`PublicHeader`],
-/// [`PublicHeaderWithVerifiedSignature`], [`VerifiedPublicHeader`]) encodes to
-/// the same fixed-size bytes, so the output is byte-identical regardless of
-/// which is passed — which is what lets a peer serialize a verified variant and
-/// the receiver decode an (unverified) [`EncapsulatedMessage`].
-pub(super) fn encode_message_components<Header: WireEncode>(
-    public_header: &Header,
-    part: &EncapsulatedPart,
-) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(
-        EncapsulatedMessage::expected_serialized_len(part.encapsulation_layers()) as usize,
-    );
-    public_header.encode_into(&mut bytes);
-    part.encode_into(&mut bytes);
-    bytes
-}
-
-// The encapsulated leaves already hold their raw ciphered bytes, so encoding is
-// the identity and decoding takes a fixed-size slice of the layer/payload size.
-// No length checks: the network-side size gate guarantees the input is large
-// enough (`split_at`/`try_into` therefore never fail).
-impl WireEncode for EncapsulatedBlendingHeader {
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(&self.0);
-    }
-}
-
-impl WireDecode for EncapsulatedBlendingHeader {
-    type Context = ();
-
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
-        let (bytes, remaining) = input.split_at(BLENDING_HEADER_ENCODED_SIZE);
-        Ok((
-            remaining,
-            Self(bytes.try_into().expect("split_at guarantees the length")),
-        ))
     }
 }
 

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -7,7 +7,7 @@ use lb_blend_proofs::{
     quota::{self, PROOF_OF_QUOTA_SIZE, VerifiedProofOfQuota},
     selection::{self, PROOF_OF_SELECTION_SIZE, VerifiedProofOfSelection, inputs::VerifyInputs},
 };
-use lb_core::codec::{DeserializeOp as _, SerializeOp as _};
+use lb_core::codec::{DeserializeOp as _, SerializeOp};
 use lb_key_management_system_keys::keys::{
     ED25519_PUBLIC_KEY_SIZE, ED25519_SIGNATURE_SIZE, Ed25519PublicKey, Ed25519Signature, SharedKey,
     UnsecuredEd25519Key,
@@ -66,36 +66,45 @@ impl EncapsulatedMessage {
     /// The exact serialized size, in bytes, of any well-formed message with
     /// `num_layers` encapsulation layers.
     ///
-    /// The wire format is fixed-size (see the Blend Payload Formatting spec):
-    /// the public header, every encapsulated blending header, and the payload
-    /// all have a constant size, so the total is strictly linear in the number
-    /// of layers and fully determined by `num_layers`.
+    /// The wire format is a fixed-size, prefix-free concatenation (see the Blend
+    /// Payload Formatting spec and [`Self::encode`]): the public header, every
+    /// encapsulated blending header, and the payload all have a constant size,
+    /// so the total is strictly linear in the number of layers and fully
+    /// determined by `num_layers`.
     #[must_use]
     pub const fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
-        let private_header_size = SEQUENCE_LENGTH_PREFIX_SIZE
-            + num_layers.get() as usize * ENCAPSULATED_BLENDING_HEADER_SIZE;
-        (PUBLIC_HEADER_SIZE + private_header_size + ENCAPSULATED_PAYLOAD_SIZE) as u64
+        (PUBLIC_HEADER_SIZE + num_layers.get() as usize * BLENDING_HEADER_SIZE + PAYLOAD_SIZE)
+            as u64
     }
 
-    /// Deserialize a message received from an untrusted remote peer, enforcing
-    /// the fixed layout mandated by the Blend Payload Formatting spec.
+    /// Serialize the message to its fixed-size, prefix-free wire representation:
+    /// `public_header || layer_0 || .. || layer_{N-1} || payload`, with no
+    /// length framing at the message level. The layer count is fixed by the
+    /// network-wide configuration, so it is not encoded on the wire.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        encode_message(&self.public_header, &self.encapsulated_part)
+    }
+
+    /// Deserialize a message received from an untrusted remote peer.
     ///
-    /// Before allocating anything we reject any input whose length is not
-    /// exactly that of a well-formed `num_layers`-layer message. Because each
-    /// layer contributes a fixed number of bytes, this O(1) check bounds the
-    /// work an adversary can force on us: a message encoding, say, 20 layers
-    /// when we expect 3 has a different length and is discarded before a single
-    /// layer is parsed. Decoding is then re-checked against the expected layout,
-    /// since the total length alone does not pin down how the bytes are split
-    /// between layers and payload.
+    /// Because the format is fixed-size, we reject in O(1) — before allocating a
+    /// single layer — any input whose length is not exactly that of a
+    /// well-formed `num_layers`-layer message. A message encoding, say, 20 layers
+    /// when we expect 3 has a different length and is discarded up front. The
+    /// bytes are then sliced positionally into the public header, exactly
+    /// `num_layers` fixed-size layers, and the fixed-size payload, so the layout
+    /// is enforced by construction.
     pub fn deserialize_from_remote(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
         if bytes.len() as u64 != Self::expected_serialized_len(num_layers) {
             return Err(Error::UnexpectedMessageSize);
         }
 
-        let message = Self::from_bytes(bytes).map_err(|_| Error::MessageDeserializationFailed)?;
-        message.encapsulated_part.validate_layout(num_layers)?;
-        Ok(message)
+        let (public_header_bytes, part_bytes) = bytes.split_at(PUBLIC_HEADER_SIZE);
+        let public_header = PublicHeader::from_bytes(public_header_bytes)
+            .map_err(|_| Error::MessageDeserializationFailed)?;
+        let encapsulated_part = EncapsulatedPart::decode(part_bytes, num_layers);
+        Ok(Self::from_components(public_header, encapsulated_part))
     }
 
     /// Verify the message public header signature.
@@ -285,17 +294,27 @@ impl EncapsulatedPart {
         key.sign_payload(&signing_body(&self.private_header, &self.payload))
     }
 
-    /// Verifies that a decoded part matches the fixed layout of a well-formed
-    /// `num_layers`-layer message: exactly `num_layers` layers, each of the
-    /// fixed per-layer size, and a fixed-size payload.
-    fn validate_layout(&self, num_layers: NonZeroU64) -> Result<(), Error> {
-        if self.private_header.layer_count() as u64 != num_layers.get() {
-            return Err(Error::UnexpectedEncapsulationLayerCount);
+    /// Append the part's fixed-size, prefix-free wire bytes to `out`: every
+    /// layer's bytes in order, followed by the payload's bytes.
+    pub(super) fn encode_into(&self, out: &mut Vec<u8>) {
+        self.private_header.encode_into(out);
+        out.extend_from_slice(&self.payload.0);
+    }
+
+    /// Reconstruct a part from the bytes following the public header.
+    ///
+    /// `part_bytes` is expected to be exactly
+    /// `num_layers * BLENDING_HEADER_SIZE + PAYLOAD_SIZE` bytes long. The caller
+    /// ([`EncapsulatedMessage::deserialize_from_remote`]) guarantees this via the
+    /// O(1) size gate, so the split points always land on layer/payload
+    /// boundaries and the layout is enforced by construction.
+    pub(super) fn decode(part_bytes: &[u8], num_layers: NonZeroU64) -> Self {
+        let layers_len = num_layers.get() as usize * BLENDING_HEADER_SIZE;
+        let (layers_bytes, payload_bytes) = part_bytes.split_at(layers_len);
+        Self {
+            private_header: EncapsulatedPrivateHeader::decode(layers_bytes),
+            payload: EncapsulatedPayload(payload_bytes.to_vec()),
         }
-        if !self.private_header.has_fixed_size_layers() || self.payload.byte_len() != PAYLOAD_SIZE {
-            return Err(Error::MalformedEncapsulatedMessage);
-        }
-        Ok(())
     }
 }
 
@@ -546,16 +565,25 @@ impl EncapsulatedPrivateHeader {
             .flat_map(EncapsulatedBlendingHeader::iter_bytes)
     }
 
-    fn layer_count(&self) -> usize {
-        self.0.len()
+    /// Append every layer's fixed-size bytes to `out`, in order and without any
+    /// framing.
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        for header in &self.0 {
+            out.extend_from_slice(&header.0);
+        }
     }
 
-    /// Returns `true` iff every layer has the fixed serialized size mandated by
-    /// the Blend Payload Formatting spec.
-    fn has_fixed_size_layers(&self) -> bool {
-        self.0
-            .iter()
-            .all(|header| header.byte_len() == BLENDING_HEADER_SIZE)
+    /// Split `layers_bytes` into fixed-size layers. The length is guaranteed by
+    /// the caller to be an exact multiple of [`BLENDING_HEADER_SIZE`], so
+    /// `chunks_exact` leaves no remainder.
+    fn decode(layers_bytes: &[u8]) -> Self {
+        Self(
+            layers_bytes
+                .chunks_exact(BLENDING_HEADER_SIZE)
+                .map(|chunk| EncapsulatedBlendingHeader(chunk.to_vec()))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
     }
 }
 
@@ -595,10 +623,6 @@ impl EncapsulatedBlendingHeader {
 
     fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
         self.0.iter().copied()
-    }
-
-    const fn byte_len(&self) -> usize {
-        self.0.len()
     }
 }
 
@@ -641,37 +665,59 @@ impl EncapsulatedPayload {
     fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
         self.0.iter().copied()
     }
-
-    const fn byte_len(&self) -> usize {
-        self.0.len()
-    }
 }
 
-// Serialized sizes of the message components. The wire format is fixed-size
-// (see the Blend Payload Formatting spec): every field is either a primitive, a
-// fixed-size crypto object, or the payload padded to [`MAX_PAYLOAD_BODY_SIZE`],
-// so all of these are compile-time constants. The framing constants below follow
-// from the codec configuration (bincode, fixed-int, little-endian); the
-// `serialized_size_constants_match_wire_format` test pins them to the real
-// encoding.
+/// Encode a full message as `public_header || part` in the fixed-size,
+/// prefix-free wire format (see [`EncapsulatedMessage::encode`]).
+///
+/// The public header is written as its own fixed-size bytes (bincode over
+/// fixed-width fields adds no length framing), followed by the part's raw layer
+/// and payload bytes. All three public-header variants
+/// ([`PublicHeader`], [`PublicHeaderWithVerifiedSignature`],
+/// [`VerifiedPublicHeader`]) serialize to the same fixed-size bytes, so this
+/// yields byte-identical output regardless of which one is passed — which is
+/// what lets a peer serialize a verified variant and the receiver decode an
+/// [`EncapsulatedMessage`].
+pub(super) fn encode_message<Header: SerializeOp>(
+    public_header: &Header,
+    part: &EncapsulatedPart,
+) -> Vec<u8> {
+    let mut bytes = public_header
+        .to_bytes()
+        .expect("A public header is always serializable.")
+        .to_vec();
+    bytes.reserve(part.private_header.0.len() * BLENDING_HEADER_SIZE + PAYLOAD_SIZE);
+    part.encode_into(&mut bytes);
+    bytes
+}
 
-/// bincode encodes a sequence's length as a `u64`.
+// Fixed sizes of the message components. Every component is either a primitive,
+// a fixed-size crypto object, or the payload padded to [`MAX_PAYLOAD_BODY_SIZE`],
+// so all of these are compile-time constants.
+//
+// The message *framing* is now prefix-free (the layers and payload are
+// concatenated by [`encode_message`] with no length prefixes; the layer count
+// is fixed by the network configuration). The component bytes themselves are
+// still produced by the bincode codec, however, so `PAYLOAD_SIZE` and
+// `PUBLIC_HEADER_SIZE` account for that internal encoding — e.g. the enum
+// discriminant and the `serde_with::Bytes` length prefix inside a serialized
+// `Payload`. The `serialized_size_constants_match_wire_format` test pins these
+// constants to the real encoding.
+
+/// bincode encodes a `Vec`/byte-string length as a `u64`.
 const SEQUENCE_LENGTH_PREFIX_SIZE: usize = size_of::<u64>();
 
 /// bincode encodes an enum discriminant as a `u32`.
 const ENUM_DISCRIMINANT_SIZE: usize = size_of::<u32>();
 
-/// Serialized size of a [`BlendingHeader`]: every field is fixed-size.
+/// Serialized size of one layer: a [`BlendingHeader`] with all fixed-size
+/// fields. On the wire the layers are concatenated with no framing, so this is
+/// also the per-layer contribution to a message's size.
 const BLENDING_HEADER_SIZE: usize = ED25519_PUBLIC_KEY_SIZE
     + PROOF_OF_QUOTA_SIZE
     + ED25519_SIGNATURE_SIZE
     + PROOF_OF_SELECTION_SIZE
     + size_of::<bool>(); // `is_last`
-
-/// Serialized size of one layer on the wire: an [`EncapsulatedBlendingHeader`]
-/// is a `Vec<u8>` wrapping the fixed-size blending header bytes.
-const ENCAPSULATED_BLENDING_HEADER_SIZE: usize =
-    SEQUENCE_LENGTH_PREFIX_SIZE + BLENDING_HEADER_SIZE;
 
 /// Serialized size of a [`Payload`]: the body is always padded to
 /// [`MAX_PAYLOAD_BODY_SIZE`], so the whole payload has a constant size.
@@ -682,10 +728,6 @@ const PAYLOAD_SIZE: usize = ENUM_DISCRIMINANT_SIZE // `PayloadHeader::payload_ty
     + size_of::<u16>() // `PayloadHeader::body_len`
     + SEQUENCE_LENGTH_PREFIX_SIZE + MAX_PAYLOAD_BODY_SIZE // `PaddedPayloadBody::padded`
     + size_of::<u16>(); // `PaddedPayloadBody::actual_len`
-
-/// Serialized size of the payload on the wire: an [`EncapsulatedPayload`] is a
-/// `Vec<u8>` wrapping the fixed-size serialized payload.
-const ENCAPSULATED_PAYLOAD_SIZE: usize = SEQUENCE_LENGTH_PREFIX_SIZE + PAYLOAD_SIZE;
 
 /// Serialized size of a [`PublicHeader`]: a version byte plus fixed-size fields.
 const PUBLIC_HEADER_SIZE: usize =

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -29,7 +29,7 @@ use crate::{
         BlendingHeader, Payload, PublicHeader,
         blending_header::BLENDING_HEADER_ENCODED_SIZE,
         payload::{PAYLOAD_ENCODED_SIZE, PaddedPayloadBody},
-        public_header::{PUBLIC_HEADER_ENCODED_SIZE, VerifiedPublicHeader},
+        public_header::VerifiedPublicHeader,
     },
 };
 
@@ -65,6 +65,9 @@ impl EncapsulatedMessage {
     }
 
     #[cfg(test)]
+    // Encoding (and sending) of unverified messages should not be done outside of
+    // tests, so this function is only available in tests.
+    #[must_use]
     pub fn encode(&self) -> Vec<u8> {
         let expected_encoded_len =
             crate::encap::expected_serialized_len(self.encapsulation_layers());
@@ -87,8 +90,8 @@ impl EncapsulatedMessage {
     /// unconsumed remainder.
     ///
     /// This does not check `bytes`'s length nor that it is fully consumed — the
-    /// caller (the network-side size gate) guarantees `bytes` is exactly a
-    /// well-formed `num_layers`-layer message and checks the remainder.
+    /// caller `bytes` is exactly a well-formed `num_layers`-layer message and
+    /// checks the remainder.
     pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
         let (remaining, public_header) = PublicHeader::decode(bytes, ())?;
         let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)?;
@@ -300,8 +303,8 @@ impl WireEncode for EncapsulatedPart {
 impl WireDecode for EncapsulatedPart {
     type Context = NonZeroU64;
 
-    fn decode(input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
-        let (input, private_header) = EncapsulatedPrivateHeader::decode(input, num_layers)?;
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        let (input, private_header) = EncapsulatedPrivateHeader::decode(input, context)?;
         let (input, payload) = EncapsulatedPayload::decode(input, ())?;
         Ok((
             input,

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -1,13 +1,16 @@
+use std::{num::NonZeroU64, sync::LazyLock};
+
 use derivative::Derivative;
 use itertools::Itertools as _;
 use lb_blend_crypto::{ZkHash, cipher::Cipher};
 use lb_blend_proofs::{
-    quota::{self, VerifiedProofOfQuota},
+    quota::{self, PROOF_OF_QUOTA_SIZE, VerifiedProofOfQuota},
     selection::{self, VerifiedProofOfSelection, inputs::VerifyInputs},
 };
 use lb_core::codec::{DeserializeOp as _, SerializeOp as _};
 use lb_key_management_system_keys::keys::{
-    Ed25519PublicKey, Ed25519Signature, SharedKey, UnsecuredEd25519Key,
+    ED25519_PUBLIC_KEY_SIZE, ED25519_SIGNATURE_SIZE, Ed25519PublicKey, Ed25519Signature, SharedKey,
+    UnsecuredEd25519Key,
 };
 use serde::{Deserialize, Serialize};
 
@@ -57,6 +60,40 @@ impl EncapsulatedMessage {
     #[must_use]
     pub fn into_components(self) -> (PublicHeader, EncapsulatedPart) {
         (self.public_header, self.encapsulated_part)
+    }
+
+    /// The exact serialized size, in bytes, of any well-formed message with
+    /// `num_layers` encapsulation layers.
+    ///
+    /// The wire format is fixed-size (see the Blend Payload Formatting spec):
+    /// the public header, every encapsulated blending header, and the payload
+    /// all have a constant size, so the total is strictly linear in the number
+    /// of layers and fully determined by `num_layers`.
+    #[must_use]
+    pub fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
+        let SizeModel { base, per_layer } = *SIZE_MODEL;
+        base + num_layers.get() * per_layer
+    }
+
+    /// Deserialize a message received from an untrusted remote peer, enforcing
+    /// the fixed layout mandated by the Blend Payload Formatting spec.
+    ///
+    /// Before allocating anything we reject any input whose length is not
+    /// exactly that of a well-formed `num_layers`-layer message. Because each
+    /// layer contributes a fixed number of bytes, this O(1) check bounds the
+    /// work an adversary can force on us: a message encoding, say, 20 layers
+    /// when we expect 3 has a different length and is discarded before a single
+    /// layer is parsed. Decoding is then re-checked against the expected layout,
+    /// since the total length alone does not pin down how the bytes are split
+    /// between layers and payload.
+    pub fn deserialize_from_remote(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
+        if bytes.len() as u64 != Self::expected_serialized_len(num_layers) {
+            return Err(Error::UnexpectedMessageSize);
+        }
+
+        let message = Self::from_bytes(bytes).map_err(|_| Error::MessageDeserializationFailed)?;
+        message.encapsulated_part.validate_layout(num_layers)?;
+        Ok(message)
     }
 
     /// Verify the message public header signature.
@@ -245,6 +282,19 @@ impl EncapsulatedPart {
     pub(super) fn sign(&self, key: &UnsecuredEd25519Key) -> Ed25519Signature {
         key.sign_payload(&signing_body(&self.private_header, &self.payload))
     }
+
+    /// Verifies that a decoded part matches the fixed layout of a well-formed
+    /// `num_layers`-layer message: exactly `num_layers` layers, each of the
+    /// fixed per-layer size, and a fixed-size payload.
+    fn validate_layout(&self, num_layers: NonZeroU64) -> Result<(), Error> {
+        if self.private_header.layer_count() as u64 != num_layers.get() {
+            return Err(Error::UnexpectedEncapsulationLayerCount);
+        }
+        if !self.private_header.has_fixed_size_layers() || self.payload.byte_len() != *PAYLOAD_LEN {
+            return Err(Error::MalformedEncapsulatedMessage);
+        }
+        Ok(())
+    }
 }
 
 /// Verify the public header reconstructed when decapsulating all but the very
@@ -301,7 +351,7 @@ fn signing_body(
 // TODO: Consider having `InitializedPrivateHeader`
 // that just finished the initialization step and doesn't have `decapsulate` method.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub(super) struct EncapsulatedPrivateHeader(Vec<EncapsulatedBlendingHeader>);
+pub(super) struct EncapsulatedPrivateHeader(Box<[EncapsulatedBlendingHeader]>);
 
 impl EncapsulatedPrivateHeader {
     #[cfg(test)]
@@ -351,7 +401,8 @@ impl EncapsulatedPrivateHeader {
                         });
                     header
                 })
-                .collect(),
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
         )
     }
 
@@ -492,6 +543,18 @@ impl EncapsulatedPrivateHeader {
             .iter()
             .flat_map(EncapsulatedBlendingHeader::iter_bytes)
     }
+
+    fn layer_count(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` iff every layer has the fixed serialized size mandated by
+    /// the Blend Payload Formatting spec.
+    fn has_fixed_size_layers(&self) -> bool {
+        self.0
+            .iter()
+            .all(|header| header.byte_len() == *BLENDING_HEADER_LEN)
+    }
 }
 
 /// A blending header encapsulated zero or more times.
@@ -530,6 +593,10 @@ impl EncapsulatedBlendingHeader {
 
     fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
         self.0.iter().copied()
+    }
+
+    const fn byte_len(&self) -> usize {
+        self.0.len()
     }
 }
 
@@ -572,4 +639,74 @@ impl EncapsulatedPayload {
     fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
         self.0.iter().copied()
     }
+
+    const fn byte_len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// The wire size of a message is `base + num_layers * per_layer` bytes. We
+/// recover these two coefficients once, by measuring two canonically-built
+/// messages, so that no assumption about the underlying codec's framing is
+/// hard-coded here.
+struct SizeModel {
+    base: u64,
+    per_layer: u64,
+}
+
+static SIZE_MODEL: LazyLock<SizeModel> = LazyLock::new(|| {
+    let size_of = |num_layers| {
+        canonical_message(num_layers)
+            .bytes_size()
+            .expect("A canonical message is always serializable.")
+    };
+    let one_layer = size_of(1);
+    let two_layers = size_of(2);
+    let per_layer = two_layers - one_layer;
+    SizeModel {
+        base: one_layer - per_layer,
+        per_layer,
+    }
+});
+
+/// The fixed serialized size of a single encapsulated blending header (layer).
+static BLENDING_HEADER_LEN: LazyLock<usize> = LazyLock::new(|| {
+    EncapsulatedBlendingHeader::initialize(&BlendingHeader::pseudo_random(&[0])).byte_len()
+});
+
+/// The fixed serialized size of an encapsulated payload.
+static PAYLOAD_LEN: LazyLock<usize> =
+    LazyLock::new(|| EncapsulatedPayload::initialize(&canonical_payload()).byte_len());
+
+fn canonical_payload() -> Payload {
+    Payload::new(
+        PayloadType::Cover,
+        PaddedPayloadBody::try_from([0u8; 0].as_slice())
+            .expect("An empty payload body is always valid."),
+    )
+}
+
+/// Builds a structurally-valid (but cryptographically meaningless) message with
+/// `num_layers` layers, used solely to measure the fixed wire size.
+fn canonical_message(num_layers: usize) -> EncapsulatedMessage {
+    let public_header = PublicHeader::new(
+        UnsecuredEd25519Key::from_bytes(&[0; ED25519_PUBLIC_KEY_SIZE]).public_key(),
+        &VerifiedProofOfQuota::from_bytes_unchecked([0; PROOF_OF_QUOTA_SIZE]).into_inner(),
+        Ed25519Signature::from_bytes(&[0; ED25519_SIGNATURE_SIZE]),
+    );
+    let private_header = EncapsulatedPrivateHeader(
+        (0..num_layers)
+            .map(|layer| {
+                EncapsulatedBlendingHeader::initialize(&BlendingHeader::pseudo_random(&[layer as u8]))
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    EncapsulatedMessage::from_components(
+        public_header,
+        EncapsulatedPart {
+            private_header,
+            payload: EncapsulatedPayload::initialize(&canonical_payload()),
+        },
+    )
 }

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -15,7 +15,7 @@ use serde_with::serde_as;
 
 use crate::{
     Error, PayloadType,
-    codec::WireCodec,
+    codec::{WireDecode, WireDecodeError, WireEncode},
     crypto::{domains, key_ext::SharedKeyExt as _},
     encap::{
         ProofsVerifier,
@@ -29,7 +29,7 @@ use crate::{
         BlendingHeader, Payload, PublicHeader,
         blending_header::BLENDING_HEADER_ENCODED_SIZE,
         payload::{PAYLOAD_ENCODED_SIZE, PaddedPayloadBody},
-        public_header::VerifiedPublicHeader,
+        public_header::{PUBLIC_HEADER_ENCODED_SIZE, VerifiedPublicHeader},
     },
 };
 
@@ -66,42 +66,48 @@ impl EncapsulatedMessage {
 
     /// The exact serialized size, in bytes, of any well-formed message with
     /// `num_layers` encapsulation layers. The wire format is fixed-size, so this
-    /// is fully determined by the layer count.
+    /// is fully determined by the layer count. Used by the network crate to gate
+    /// received bytes and to size the encode buffer.
     #[must_use]
     pub fn expected_serialized_len(num_layers: NonZeroU64) -> u64 {
-        PublicHeader::encoded_length(())
-            .checked_add(EncapsulatedPart::encoded_length(num_layers))
+        let layers_len = (num_layers.get() as usize)
+            .checked_mul(BLENDING_HEADER_ENCODED_SIZE)
+            .expect("message encoded length overflow");
+        PUBLIC_HEADER_ENCODED_SIZE
+            .checked_add(layers_len)
+            .and_then(|len| len.checked_add(PAYLOAD_ENCODED_SIZE))
             .expect("message encoded length overflow") as u64
     }
 
-    /// Serialize the message to its fixed-size, prefix-free wire representation
+    /// Append the message's fixed-size, prefix-free wire bytes to `out`
     /// (`public_header || layer_0 || .. || layer_{N-1} || payload`, no length
-    /// framing).
-    #[must_use]
-    pub fn encode(&self) -> Vec<u8> {
-        encode_message_components(&self.public_header, &self.encapsulated_part)
+    /// framing). The caller owns the buffer allocation.
+    pub fn encode_into(&self, out: &mut Vec<u8>) {
+        self.public_header.encode_into(out);
+        self.encapsulated_part.encode_into(out);
     }
 
-    /// Decode a message received from an untrusted remote peer.
-    ///
-    /// Rejects in O(1) — before allocating a single layer — any input whose
-    /// length is not exactly that of a well-formed `num_layers`-layer message,
-    /// then decodes component by component so the layout is enforced by
-    /// construction.
-    pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
-        if bytes.len() as u64 != Self::expected_serialized_len(num_layers) {
-            return Err(Error::MessageDeserializationFailed);
-        }
-
-        let (remaining, public_header) =
-            PublicHeader::decode(bytes, ()).map_err(|()| Error::MessageDeserializationFailed)?;
-        let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)
-            .map_err(|()| Error::MessageDeserializationFailed)?;
-        debug_assert!(
-            remaining.is_empty(),
-            "The size gate guarantees the wire bytes are fully consumed"
+    /// Serialize the message to a freshly-allocated buffer — a convenience over
+    /// [`Self::encode_into`] for callers that don't own a buffer.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(
+            Self::expected_serialized_len(self.encapsulated_part.encapsulation_layers()) as usize,
         );
-        Ok(Self::from_components(public_header, encapsulated_part))
+        self.encode_into(&mut out);
+        out
+    }
+
+    /// Decode a message from the front of `bytes`, returning it and the
+    /// unconsumed remainder.
+    ///
+    /// This does not check `bytes`'s length nor that it is fully consumed — the
+    /// caller (the network-side size gate) guarantees `bytes` is exactly a
+    /// well-formed `num_layers`-layer message and checks the remainder.
+    pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
+        let (remaining, public_header) = PublicHeader::decode(bytes, ())?;
+        let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)?;
+        Ok((remaining, Self::from_components(public_header, encapsulated_part)))
     }
 
     /// Verify the message public header signature.
@@ -156,33 +162,6 @@ impl EncapsulatedMessage {
     #[must_use]
     pub const fn public_header_mut(&mut self) -> &mut PublicHeader {
         &mut self.public_header
-    }
-}
-
-impl WireCodec for EncapsulatedMessage {
-    type Context = NonZeroU64;
-
-    fn encoded_length(context: Self::Context) -> usize {
-        PublicHeader::encoded_length(())
-            .checked_add(EncapsulatedPart::encoded_length(context))
-            .unwrap()
-    }
-
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        self.public_header.encode_into(out);
-        self.encapsulated_part.encode_into(out);
-    }
-
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
-        let (input, public_header) = PublicHeader::decode(input, ())?;
-        let (input, encapsulated_part) = EncapsulatedPart::decode(input, context)?;
-        Ok((
-            input,
-            Self {
-                public_header,
-                encapsulated_part,
-            },
-        ))
     }
 }
 
@@ -325,21 +304,17 @@ impl EncapsulatedPart {
     }
 }
 
-impl WireCodec for EncapsulatedPart {
-    type Context = NonZeroU64;
-
-    fn encoded_length(num_layers: Self::Context) -> usize {
-        EncapsulatedPrivateHeader::encoded_length(num_layers)
-            .checked_add(EncapsulatedPayload::encoded_length(()))
-            .unwrap()
-    }
-
+impl WireEncode for EncapsulatedPart {
     fn encode_into(&self, out: &mut Vec<u8>) {
         self.private_header.encode_into(out);
         self.payload.encode_into(out);
     }
+}
 
-    fn decode(input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), ()> {
+impl WireDecode for EncapsulatedPart {
+    type Context = NonZeroU64;
+
+    fn decode(input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (input, private_header) = EncapsulatedPrivateHeader::decode(input, num_layers)?;
         let (input, payload) = EncapsulatedPayload::decode(input, ())?;
         Ok((
@@ -600,22 +575,18 @@ impl EncapsulatedPrivateHeader {
     }
 }
 
-impl WireCodec for EncapsulatedPrivateHeader {
-    type Context = NonZeroU64;
-
-    fn encoded_length(num_layers: Self::Context) -> usize {
-        (num_layers.get() as usize)
-            .checked_mul(EncapsulatedBlendingHeader::encoded_length(()))
-            .expect("private header encoded length overflow")
-    }
-
+impl WireEncode for EncapsulatedPrivateHeader {
     fn encode_into(&self, out: &mut Vec<u8>) {
         for layer in &self.0 {
             layer.encode_into(out);
         }
     }
+}
 
-    fn decode(mut input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), ()> {
+impl WireDecode for EncapsulatedPrivateHeader {
+    type Context = NonZeroU64;
+
+    fn decode(mut input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let mut layers = Vec::with_capacity(num_layers.get() as usize);
         for _ in 0..num_layers.get() {
             let (remaining, layer) = EncapsulatedBlendingHeader::decode(input, ())?;
@@ -654,11 +625,8 @@ impl EncapsulatedBlendingHeader {
     /// If there is no encapsulation left, and if the bytes are valid,
     /// the deserialization will succeed.
     fn try_deserialize(&self) -> Result<BlendingHeader, Error> {
-        let (remaining, header) = BlendingHeader::decode(&self.0, ())
-            .map_err(|()| Error::PrivateHeaderDeserializationFailed)?;
-        if !remaining.is_empty() {
-            return Err(Error::PrivateHeaderDeserializationFailed);
-        }
+        let (_remaining, header) = BlendingHeader::decode(&self.0, ())
+            .map_err(|_| Error::PrivateHeaderDeserializationFailed)?;
         Ok(header)
     }
 
@@ -703,11 +671,8 @@ impl EncapsulatedPayload {
     /// If there is no encapsulation left, and if the bytes are valid,
     /// the deserialization will succeed.
     fn try_deserialize(&self) -> Result<Payload, Error> {
-        let (remaining, payload) =
-            Payload::decode(&self.0[..], ()).map_err(|()| Error::PayloadDeserializationFailed)?;
-        if !remaining.is_empty() {
-            return Err(Error::PayloadDeserializationFailed);
-        }
+        let (_remaining, payload) =
+            Payload::decode(&self.0[..], ()).map_err(|_| Error::PayloadDeserializationFailed)?;
         Ok(payload)
     }
 
@@ -736,8 +701,8 @@ impl EncapsulatedPayload {
 /// the same fixed-size bytes, so the output is byte-identical regardless of
 /// which is passed — which is what lets a peer serialize a verified variant and
 /// the receiver decode an (unverified) [`EncapsulatedMessage`].
-pub(super) fn encode_message_components(
-    public_header: &PublicHeader,
+pub(super) fn encode_message_components<Header: WireEncode>(
+    public_header: &Header,
     part: &EncapsulatedPart,
 ) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(
@@ -750,43 +715,42 @@ pub(super) fn encode_message_components(
 
 // The encapsulated leaves already hold their raw ciphered bytes, so encoding is
 // the identity and decoding takes a fixed-size slice of the layer/payload size.
-impl WireCodec for EncapsulatedBlendingHeader {
-    type Context = ();
-
-    fn encoded_length((): Self::Context) -> usize {
-        BLENDING_HEADER_ENCODED_SIZE
-    }
-
+// No length checks: the network-side size gate guarantees the input is large
+// enough (`split_at`/`try_into` therefore never fail).
+impl WireEncode for EncapsulatedBlendingHeader {
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.0);
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < BLENDING_HEADER_ENCODED_SIZE {
-            return Err(());
-        }
+impl WireDecode for EncapsulatedBlendingHeader {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (bytes, remaining) = input.split_at(BLENDING_HEADER_ENCODED_SIZE);
-        Ok((remaining, Self(bytes.try_into().map_err(|_| ())?)))
+        Ok((
+            remaining,
+            Self(bytes.try_into().expect("split_at guarantees the length")),
+        ))
     }
 }
 
-impl WireCodec for EncapsulatedPayload {
-    type Context = ();
-
-    fn encoded_length((): Self::Context) -> usize {
-        PAYLOAD_ENCODED_SIZE
-    }
-
+impl WireEncode for EncapsulatedPayload {
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.0[..]);
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < PAYLOAD_ENCODED_SIZE {
-            return Err(());
-        }
+impl WireDecode for EncapsulatedPayload {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (bytes, remaining) = input.split_at(PAYLOAD_ENCODED_SIZE);
-        let boxed = bytes.to_vec().into_boxed_slice().try_into().map_err(|_| ())?;
+        let boxed = bytes
+            .to_vec()
+            .into_boxed_slice()
+            .try_into()
+            .expect("split_at guarantees the length");
         Ok((remaining, Self(boxed)))
     }
 }

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -7,7 +7,6 @@ use lb_blend_proofs::{
     quota::{self, VerifiedProofOfQuota},
     selection::{self, VerifiedProofOfSelection, inputs::VerifyInputs},
 };
-use lb_core::codec::{DeserializeOp as _, SerializeOp as _};
 use lb_key_management_system_keys::keys::{
     Ed25519PublicKey, Ed25519Signature, SharedKey, UnsecuredEd25519Key,
 };
@@ -15,21 +14,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Error, PayloadType,
-    codec::WireEncode,
+    codec::WireCodec,
     crypto::{domains, key_ext::SharedKeyExt as _},
     encap::{
         ProofsVerifier,
         decapsulated::{PartDecapsulationOutput, PrivateHeaderDecapsulationOutput},
-        expected_serialized_message_len,
         validated::{
             EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
         },
     },
     input::EncapsulationInput,
     message::{
-        BlendingHeader, Payload, PublicHeader,
-        payload::PaddedPayloadBody,
-        public_header::{ENCODED_PUBLIC_HEADER_SIZE, VerifiedPublicHeader},
+        BlendingHeader, Payload, PublicHeader, payload::PaddedPayloadBody,
+        public_header::VerifiedPublicHeader,
     },
 };
 
@@ -62,40 +59,6 @@ impl EncapsulatedMessage {
     #[must_use]
     pub fn into_components(self) -> (PublicHeader, EncapsulatedPart) {
         (self.public_header, self.encapsulated_part)
-    }
-
-    /// Serialize the message to its fixed-size, prefix-free wire
-    /// representation: `public_header || layer_0 || .. || layer_{N-1} ||
-    /// payload`, with no length framing at the message level. The layer
-    /// count is fixed by the network-wide configuration, so it is not
-    /// encoded on the wire.
-    #[must_use]
-    pub fn encode(&self) -> Vec<u8> {
-        encode_message_components(&self.public_header, &self.encapsulated_part)
-    }
-
-    /// Decode a message received from an untrusted remote peer.
-    ///
-    /// Because the format is fixed-size, we reject in O(1) — before allocating
-    /// a single layer — any input whose length is not exactly that of a
-    /// well-formed `num_layers`-layer message. A message encoding, say, 20
-    /// layers when we expect 3 has a different length and is discarded up
-    /// front. The bytes are then decoded component by component (see
-    /// [`WireDecode`]); the size gate guarantees each fixed-size slice
-    /// lands on a component boundary and that the whole input is consumed,
-    /// so the layout is enforced by construction.
-    pub fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, Error> {
-        if bytes.len() as u64 != expected_serialized_message_len(num_layers) {
-            return Err(Error::MessageDeserializationFailed);
-        }
-
-        let (remaining, public_header) = PublicHeader::decode(bytes, ())?;
-        let (remaining, encapsulated_part) = EncapsulatedPart::decode(remaining, num_layers)?;
-        debug_assert!(
-            remaining.is_empty(),
-            "The size gate guarantees the wire bytes are fully consumed"
-        );
-        Ok(Self::from_components(public_header, encapsulated_part))
     }
 
     /// Verify the message public header signature.
@@ -150,6 +113,33 @@ impl EncapsulatedMessage {
     #[must_use]
     pub const fn public_header_mut(&mut self) -> &mut PublicHeader {
         &mut self.public_header
+    }
+}
+
+impl WireCodec for EncapsulatedMessage {
+    type Context = NonZeroU64;
+
+    fn encoded_length(context: Self::Context) -> usize {
+        PublicHeader::encoded_length(())
+            .checked_add(EncapsulatedPart::encoded_length(context))
+            .unwrap()
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.public_header.encode_into(out);
+        self.encapsulated_part.encode_into(out);
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (input, public_header) = PublicHeader::decode(input, ())?;
+        let (input, encapsulated_part) = EncapsulatedPart::decode(input, context)?;
+        Ok((
+            input,
+            Self {
+                public_header,
+                encapsulated_part,
+            },
+        ))
     }
 }
 
@@ -283,6 +273,33 @@ impl EncapsulatedPart {
     /// Signs the encapsulated part using the provided key.
     pub(super) fn sign(&self, key: &UnsecuredEd25519Key) -> Ed25519Signature {
         key.sign_payload(&signing_body(&self.private_header, &self.payload))
+    }
+}
+
+impl WireCodec for EncapsulatedPart {
+    type Context = NonZeroU64;
+
+    fn encoded_length(num_layers: Self::Context) -> usize {
+        EncapsulatedPrivateHeader::encoded_length(num_layers)
+            .checked_add(EncapsulatedPayload::encoded_length(()))
+            .unwrap()
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.private_header.encode_into(out);
+        self.payload.encode_into(out);
+    }
+
+    fn decode(input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (input, private_header) = EncapsulatedPrivateHeader::decode(input, num_layers)?;
+        let (input, payload) = EncapsulatedPayload::decode(input, ())?;
+        Ok((
+            input,
+            Self {
+                private_header,
+                payload,
+            },
+        ))
     }
 }
 
@@ -534,6 +551,32 @@ impl EncapsulatedPrivateHeader {
     }
 }
 
+impl WireCodec for EncapsulatedPrivateHeader {
+    type Context = NonZeroU64;
+
+    fn encoded_length(num_layers: Self::Context) -> usize {
+        (num_layers.get() as usize)
+            .checked_mul(EncapsulatedBlendingHeader::encoded_length(()))
+            .expect("private header encoded length overflow")
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        for layer in &self.0 {
+            layer.encode_into(out);
+        }
+    }
+
+    fn decode(mut input: &[u8], num_layers: Self::Context) -> Result<(&[u8], Self), ()> {
+        let mut layers = Vec::with_capacity(num_layers.get() as usize);
+        for _ in 0..num_layers.get() {
+            let (remaining, layer) = EncapsulatedBlendingHeader::decode(input, ())?;
+            layers.push(layer);
+            input = remaining;
+        }
+        Ok((input, Self(layers.into_boxed_slice())))
+    }
+}
+
 /// A blending header encapsulated zero or more times.
 // TODO: Consider having `SerializedBlendingHeader` (not encapsulated).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -543,19 +586,21 @@ impl EncapsulatedBlendingHeader {
     /// Build a [`EncapsulatedBlendingHeader`] by serializing a
     /// [`BlendingHeader`] without any encapsulation.
     fn initialize(header: &BlendingHeader) -> Self {
-        Self(
-            header
-                .to_bytes()
-                .expect("BlendingHeader should be able to be serialized")
-                .to_vec(),
-        )
+        let mut bytes = Vec::with_capacity(BlendingHeader::encoded_length(()));
+        header.encode_into(&mut bytes);
+        Self(bytes)
     }
 
     /// Try to deserialize into a [`BlendingHeader`].
     /// If there is no encapsulation left, and if the bytes are valid,
     /// the deserialization will succeed.
     fn try_deserialize(&self) -> Result<BlendingHeader, Error> {
-        BlendingHeader::from_bytes(&self.0).map_err(|_| Error::PrivateHeaderDeserializationFailed)
+        let (remaining, header) = BlendingHeader::decode(&self.0, ())
+            .map_err(|()| Error::PrivateHeaderDeserializationFailed)?;
+        if !remaining.is_empty() {
+            return Err(Error::PrivateHeaderDeserializationFailed);
+        }
+        Ok(header)
     }
 
     /// Add a layer of encapsulation.
@@ -582,19 +627,21 @@ impl EncapsulatedPayload {
     /// Build a [`EncapsulatedPayload`] by serializing a [`Payload`]
     /// without any encapsulation.
     fn initialize(payload: &Payload) -> Self {
-        Self(
-            payload
-                .to_bytes()
-                .expect("Payload should be able to be serialized")
-                .to_vec(),
-        )
+        let mut bytes = Vec::with_capacity(Payload::encoded_length(()));
+        payload.encode_into(&mut bytes);
+        Self(bytes)
     }
 
     /// Try to deserialize into a [`Payload`].
     /// If there is no encapsulation left, and if the bytes are valid,
     /// the deserialization will succeed.
     fn try_deserialize(&self) -> Result<Payload, Error> {
-        Payload::from_bytes(&self.0).map_err(|_| Error::PayloadDeserializationFailed)
+        let (remaining, payload) =
+            Payload::decode(&self.0, ()).map_err(|()| Error::PayloadDeserializationFailed)?;
+        if !remaining.is_empty() {
+            return Err(Error::PayloadDeserializationFailed);
+        }
+        Ok(payload)
     }
 
     /// Add a layer of encapsulation.
@@ -622,106 +669,65 @@ impl EncapsulatedPayload {
 /// the same fixed-size bytes, so the output is byte-identical regardless of
 /// which is passed — which is what lets a peer serialize a verified variant and
 /// the receiver decode an (unverified) [`EncapsulatedMessage`].
-pub(super) fn encode_message_components<PublicHeader>(
+pub(super) fn encode_message_components(
     public_header: &PublicHeader,
     part: &EncapsulatedPart,
-) -> Vec<u8>
-where
-    PublicHeader: WireEncode,
-{
+) -> Vec<u8> {
     let mut bytes =
-        Vec::with_capacity(expected_serialized_message_len(part.encapsulation_layers()));
+        Vec::with_capacity(expected_serialized_message_len(part.encapsulation_layers()) as usize);
     public_header.encode_into(&mut bytes);
     part.encode_into(&mut bytes);
     bytes
 }
 
-/// Split off the first `len` bytes of `input` as `(taken, rest)`, erroring if
-/// `input` is too short. This is unreachable once
-/// [`EncapsulatedMessage::decode`]'s size gate has run, but it keeps every
-/// component decode self-contained.
-const fn take(input: &[u8], len: usize) -> Result<(&[u8], &[u8]), Error> {
-    if input.len() < len {
-        return Err(Error::MessageDeserializationFailed);
-    }
-    Ok(input.split_at(len))
+/// The exact serialized size, in bytes, of a well-formed message with
+/// `num_layers` encapsulation layers.
+fn expected_serialized_message_len(num_layers: NonZeroU64) -> u64 {
+    PublicHeader::encoded_length(())
+        .checked_add(EncapsulatedPart::encoded_length(num_layers))
+        .expect("message encoded length overflow") as u64
 }
 
 // The encapsulated leaves already hold their raw ciphered bytes, so encoding is
-// the identity and decoding takes a fixed-size slice.
-impl WireEncode for EncapsulatedBlendingHeader {
+// the identity and decoding takes a fixed-size slice of the layer/payload size.
+impl WireCodec for EncapsulatedBlendingHeader {
+    type Context = ();
+
+    fn encoded_length(_context: Self::Context) -> usize {
+        BlendingHeader::encoded_length(())
+    }
+
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.0);
     }
-}
 
-impl WireDecode for EncapsulatedBlendingHeader {
-    type Context = ();
-
-    fn decode(input: &[u8], (): ()) -> Result<(&[u8], Self), Error> {
-        let (bytes, rest) = take(input, BLENDING_HEADER_SIZE)?;
-        Ok((rest, Self(bytes.to_vec())))
+    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let length = Self::encoded_length(());
+        if input.len() < length {
+            return Err(());
+        }
+        let (bytes, remaining) = input.split_at(length);
+        Ok((remaining, Self(bytes.to_vec())))
     }
 }
 
-impl WireEncode for EncapsulatedPayload {
+impl WireCodec for EncapsulatedPayload {
+    type Context = ();
+
+    fn encoded_length(_context: Self::Context) -> usize {
+        Payload::encoded_length(())
+    }
+
     fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.0);
     }
-}
 
-impl WireDecode for EncapsulatedPayload {
-    type Context = ();
-
-    fn decode(input: &[u8], (): ()) -> Result<(&[u8], Self), Error> {
-        let (bytes, rest) = take(input, PAYLOAD_SIZE)?;
-        Ok((rest, Self(bytes.to_vec())))
-    }
-}
-
-// The private header is exactly `num_layers` blending headers, back to back.
-impl WireEncode for EncapsulatedPrivateHeader {
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        for layer in &self.0 {
-            layer.encode_into(out);
+    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let length = Self::encoded_length(());
+        if input.len() < length {
+            return Err(());
         }
-    }
-}
-
-impl WireDecode for EncapsulatedPrivateHeader {
-    type Context = NonZeroU64;
-
-    fn decode(mut input: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
-        let mut layers = Vec::with_capacity(num_layers.get() as usize);
-        for _ in 0..num_layers.get() {
-            let (rest, layer) = EncapsulatedBlendingHeader::decode(input, ())?;
-            layers.push(layer);
-            input = rest;
-        }
-        Ok((input, Self(layers.into_boxed_slice())))
-    }
-}
-
-// A part is its private header followed by its payload.
-impl WireEncode for EncapsulatedPart {
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        self.private_header.encode_into(out);
-        self.payload.encode_into(out);
-    }
-}
-
-impl WireDecode for EncapsulatedPart {
-    type Context = NonZeroU64;
-
-    fn decode(input: &[u8], num_layers: NonZeroU64) -> Result<(&[u8], Self), Error> {
-        let (input, private_header) = EncapsulatedPrivateHeader::decode(input, num_layers)?;
-        let (input, payload) = EncapsulatedPayload::decode(input, ())?;
-        Ok((
-            input,
-            Self {
-                private_header,
-                payload,
-            },
-        ))
+        let (bytes, remaining) = input.split_at(length);
+        Ok((remaining, Self(bytes.to_vec())))
     }
 }

--- a/blend/message/src/encap/mod.rs
+++ b/blend/message/src/encap/mod.rs
@@ -1,10 +1,18 @@
+use core::num::NonZeroU64;
+
 use lb_blend_proofs::{
     quota::{ProofOfQuota, VerifiedProofOfQuota},
     selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
 };
 use lb_key_management_system_keys::keys::Ed25519PublicKey;
 
-use crate::crypto::proofs::PoQVerificationInputsMinusSigningKey;
+use crate::{
+    crypto::proofs::PoQVerificationInputsMinusSigningKey,
+    message::{
+        blending_header::BLENDING_HEADER_ENCODED_SIZE, payload::PAYLOAD_ENCODED_SIZE,
+        public_header::PUBLIC_HEADER_ENCODED_SIZE,
+    },
+};
 
 pub mod decapsulated;
 pub mod encapsulated;
@@ -34,4 +42,21 @@ pub trait ProofsVerifier {
         proof: ProofOfSelection,
         inputs: &VerifyInputs,
     ) -> Result<VerifiedProofOfSelection, Self::Error>;
+}
+
+/// The exact serialized size, in bytes, of any well-formed message with
+/// `num_layers` encapsulation layers.
+///
+/// The wire format is fixed-size, so this is fully determined by the layer
+/// count. Used by the network crate to gate received bytes and to size the
+/// encode buffer.
+#[must_use]
+pub fn expected_serialized_len(num_layers: NonZeroU64) -> usize {
+    let layers_len = (num_layers.get() as usize)
+        .checked_mul(BLENDING_HEADER_ENCODED_SIZE)
+        .expect("message encoded length overflow");
+    PUBLIC_HEADER_ENCODED_SIZE
+        .checked_add(layers_len)
+        .and_then(|len| len.checked_add(PAYLOAD_ENCODED_SIZE))
+        .expect("message encoded length overflow")
 }

--- a/blend/message/src/encap/mod.rs
+++ b/blend/message/src/encap/mod.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU64;
+
 use lb_blend_proofs::{
     quota::{ProofOfQuota, VerifiedProofOfQuota},
     selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
@@ -34,4 +36,10 @@ pub trait ProofsVerifier {
         proof: ProofOfSelection,
         inputs: &VerifyInputs,
     ) -> Result<VerifiedProofOfSelection, Self::Error>;
+}
+
+pub(crate) trait WireCodec: Sized {
+    fn expected_serialized_len(num_layers: NonZeroU64) -> u64;
+    fn encode_into(&self, out: &mut Vec<u8>);
+    fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, ()>;
 }

--- a/blend/message/src/encap/mod.rs
+++ b/blend/message/src/encap/mod.rs
@@ -1,5 +1,3 @@
-use core::num::NonZeroU64;
-
 use lb_blend_proofs::{
     quota::{ProofOfQuota, VerifiedProofOfQuota},
     selection::{ProofOfSelection, VerifiedProofOfSelection, inputs::VerifyInputs},
@@ -36,10 +34,4 @@ pub trait ProofsVerifier {
         proof: ProofOfSelection,
         inputs: &VerifyInputs,
     ) -> Result<VerifiedProofOfSelection, Self::Error>;
-}
-
-pub(crate) trait WireCodec: Sized {
-    fn expected_serialized_len(num_layers: NonZeroU64) -> u64;
-    fn encode_into(&self, out: &mut Vec<u8>);
-    fn decode(bytes: &[u8], num_layers: NonZeroU64) -> Result<Self, ()>;
 }

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -427,9 +427,10 @@ fn encode_decode_round_trip() {
         let message = EncapsulatedMessage::from(sample_message(num_layers as usize));
 
         let encoded = message.encode();
-        let decoded =
+        let (remaining, decoded) =
             EncapsulatedMessage::decode(&encoded, num_layers.try_into().unwrap()).unwrap();
 
+        assert!(remaining.is_empty(), "leftover bytes for {num_layers} layer(s)");
         assert_eq!(
             decoded, message,
             "round-trip mismatch for {num_layers} layer(s)"
@@ -451,18 +452,10 @@ fn wire_bytes_identical_across_message_types() {
     assert_eq!(unverified.encode(), bytes);
 }
 
-#[test]
-fn decode_rejects_wrong_layer_count() {
-    // A well-formed 3-layer message must be rejected in O(1) when a different
-    // layer count is expected, because its length no longer matches.
-    let encoded = EncapsulatedMessage::from(sample_message(3)).encode();
-    for expected_layers in [1u64, 2, 4] {
-        assert!(matches!(
-            EncapsulatedMessage::decode(&encoded, expected_layers.try_into().unwrap(),),
-            Err(Error::MessageDeserializationFailed)
-        ));
-    }
-}
+// Rejecting a message whose layer count differs from the expected one is now
+// the responsibility of the network-side size gate (it compares the received
+// length against `EncapsulatedMessage::expected_serialized_len`), covered by the
+// `blend-network` tests. `decode` itself assumes a correctly-sized input.
 
 fn generate_inputs(cnt: usize) -> (Vec<EncapsulationInput>, Vec<X25519PrivateKey>) {
     let recipient_signing_keys =

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -459,7 +459,7 @@ fn decode_rejects_wrong_layer_count() {
     for expected_layers in [1u64, 2, 4] {
         assert!(matches!(
             EncapsulatedMessage::decode(&encoded, expected_layers.try_into().unwrap(),),
-            Err(Error::UnexpectedMessageSize)
+            Err(Error::MessageDeserializationFailed)
         ));
     }
 }

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -427,13 +427,13 @@ fn encode_decode_round_trip() {
         let message = EncapsulatedMessage::from(sample_message(num_layers as usize));
 
         let encoded = message.encode();
-        let decoded = EncapsulatedMessage::deserialize_from_remote(
-            &encoded,
-            num_layers.try_into().unwrap(),
-        )
-        .unwrap();
+        let decoded =
+            EncapsulatedMessage::decode(&encoded, num_layers.try_into().unwrap()).unwrap();
 
-        assert_eq!(decoded, message, "round-trip mismatch for {num_layers} layer(s)");
+        assert_eq!(
+            decoded, message,
+            "round-trip mismatch for {num_layers} layer(s)"
+        );
     }
 }
 
@@ -458,10 +458,7 @@ fn decode_rejects_wrong_layer_count() {
     let encoded = EncapsulatedMessage::from(sample_message(3)).encode();
     for expected_layers in [1u64, 2, 4] {
         assert!(matches!(
-            EncapsulatedMessage::deserialize_from_remote(
-                &encoded,
-                expected_layers.try_into().unwrap(),
-            ),
+            EncapsulatedMessage::decode(&encoded, expected_layers.try_into().unwrap(),),
             Err(Error::UnexpectedMessageSize)
         ));
     }

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -387,6 +387,35 @@ fn decapsulate_empty_private_headers_returns_error() {
     assert!(matches!(result, Err(Error::EmptyEncapsulationInputs)));
 }
 
+#[test]
+fn serialized_size_constants_match_wire_format() {
+    // The O(1) size gate in `deserialize_from_remote` relies on
+    // `expected_serialized_len` being exact. Build real, genuinely-encapsulated
+    // messages of varying layer counts and confirm the constant-derived length
+    // matches the actual serialized length — this pins every codec framing
+    // assumption baked into the size constants to the real wire encoding.
+    for num_layers in 1..=4u64 {
+        let (inputs, _) = generate_inputs(num_layers as usize);
+        let message = EncapsulatedMessage::from(
+            EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+                &inputs,
+                PayloadType::Data,
+                b"payload".as_slice().try_into().unwrap(),
+            )
+            .unwrap(),
+        );
+
+        let actual_len = message.to_bytes().unwrap().len() as u64;
+        let expected_len =
+            EncapsulatedMessage::expected_serialized_len(num_layers.try_into().unwrap());
+
+        assert_eq!(
+            expected_len, actual_len,
+            "expected_serialized_len mismatch for {num_layers} layer(s)"
+        );
+    }
+}
+
 fn generate_inputs(cnt: usize) -> (Vec<EncapsulationInput>, Vec<X25519PrivateKey>) {
     let recipient_signing_keys =
         core::iter::repeat_with(UnsecuredEd25519Key::generate_with_blake_rng)

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -17,7 +17,8 @@ use crate::{
         decapsulated::DecapsulationOutput,
         encapsulated::{EncapsulatedMessage, EncapsulatedPart},
         validated::{
-            EncapsulatedMessageWithVerifiedPublicHeader, RequiredProofOfSelectionVerificationInputs,
+            EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
+            RequiredProofOfSelectionVerificationInputs,
         },
     },
     input::EncapsulationInput,
@@ -387,25 +388,27 @@ fn decapsulate_empty_private_headers_returns_error() {
     assert!(matches!(result, Err(Error::EmptyEncapsulationInputs)));
 }
 
+fn sample_message(num_layers: usize) -> EncapsulatedMessageWithVerifiedPublicHeader {
+    let (inputs, _) = generate_inputs(num_layers);
+    EncapsulatedMessageWithVerifiedPublicHeader::try_new(
+        &inputs,
+        PayloadType::Data,
+        b"payload".as_slice().try_into().unwrap(),
+    )
+    .unwrap()
+}
+
 #[test]
 fn serialized_size_constants_match_wire_format() {
     // The O(1) size gate in `deserialize_from_remote` relies on
     // `expected_serialized_len` being exact. Build real, genuinely-encapsulated
     // messages of varying layer counts and confirm the constant-derived length
-    // matches the actual serialized length — this pins every codec framing
-    // assumption baked into the size constants to the real wire encoding.
+    // matches the actual encoded length — this pins every size constant to the
+    // real wire encoding.
     for num_layers in 1..=4u64 {
-        let (inputs, _) = generate_inputs(num_layers as usize);
-        let message = EncapsulatedMessage::from(
-            EncapsulatedMessageWithVerifiedPublicHeader::try_new(
-                &inputs,
-                PayloadType::Data,
-                b"payload".as_slice().try_into().unwrap(),
-            )
-            .unwrap(),
-        );
+        let message = EncapsulatedMessage::from(sample_message(num_layers as usize));
 
-        let actual_len = message.to_bytes().unwrap().len() as u64;
+        let actual_len = message.encode().len() as u64;
         let expected_len =
             EncapsulatedMessage::expected_serialized_len(num_layers.try_into().unwrap());
 
@@ -413,6 +416,54 @@ fn serialized_size_constants_match_wire_format() {
             expected_len, actual_len,
             "expected_serialized_len mismatch for {num_layers} layer(s)"
         );
+    }
+}
+
+#[test]
+fn encode_decode_round_trip() {
+    // A message encoded to the wire format and decoded back with the expected
+    // layer count reconstructs the original.
+    for num_layers in 1..=4u64 {
+        let message = EncapsulatedMessage::from(sample_message(num_layers as usize));
+
+        let encoded = message.encode();
+        let decoded = EncapsulatedMessage::deserialize_from_remote(
+            &encoded,
+            num_layers.try_into().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(decoded, message, "round-trip mismatch for {num_layers} layer(s)");
+    }
+}
+
+#[test]
+fn wire_bytes_identical_across_message_types() {
+    // The send path serializes a verified variant; the receiver decodes an
+    // `EncapsulatedMessage`. All three must produce byte-identical wire output.
+    let with_public_header = sample_message(3);
+    let with_signature: EncapsulatedMessageWithVerifiedSignature =
+        with_public_header.clone().into();
+    let unverified = EncapsulatedMessage::from(with_public_header.clone());
+
+    let bytes = with_public_header.encode();
+    assert_eq!(with_signature.encode(), bytes);
+    assert_eq!(unverified.encode(), bytes);
+}
+
+#[test]
+fn decode_rejects_wrong_layer_count() {
+    // A well-formed 3-layer message must be rejected in O(1) when a different
+    // layer count is expected, because its length no longer matches.
+    let encoded = EncapsulatedMessage::from(sample_message(3)).encode();
+    for expected_layers in [1u64, 2, 4] {
+        assert!(matches!(
+            EncapsulatedMessage::deserialize_from_remote(
+                &encoded,
+                expected_layers.try_into().unwrap(),
+            ),
+            Err(Error::UnexpectedMessageSize)
+        ));
     }
 }
 

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -16,6 +16,7 @@ use crate::{
         ProofsVerifier,
         decapsulated::DecapsulationOutput,
         encapsulated::{EncapsulatedMessage, EncapsulatedPart},
+        expected_serialized_len,
         validated::{
             EncapsulatedMessageWithVerifiedPublicHeader, EncapsulatedMessageWithVerifiedSignature,
             RequiredProofOfSelectionVerificationInputs,
@@ -409,8 +410,7 @@ fn serialized_size_constants_match_wire_format() {
         let message = EncapsulatedMessage::from(sample_message(num_layers as usize));
 
         let actual_len = message.encode().len() as u64;
-        let expected_len =
-            EncapsulatedMessage::expected_serialized_len(num_layers.try_into().unwrap());
+        let expected_len = expected_serialized_len(num_layers.try_into().unwrap()) as u64;
 
         assert_eq!(
             expected_len, actual_len,
@@ -430,7 +430,10 @@ fn encode_decode_round_trip() {
         let (remaining, decoded) =
             EncapsulatedMessage::decode(&encoded, num_layers.try_into().unwrap()).unwrap();
 
-        assert!(remaining.is_empty(), "leftover bytes for {num_layers} layer(s)");
+        assert!(
+            remaining.is_empty(),
+            "leftover bytes for {num_layers} layer(s)"
+        );
         assert_eq!(
             decoded, message,
             "round-trip mismatch for {num_layers} layer(s)"
@@ -454,8 +457,8 @@ fn wire_bytes_identical_across_message_types() {
 
 // Rejecting a message whose layer count differs from the expected one is now
 // the responsibility of the network-side size gate (it compares the received
-// length against `EncapsulatedMessage::expected_serialized_len`), covered by the
-// `blend-network` tests. `decode` itself assumes a correctly-sized input.
+// length against `EncapsulatedMessage::expected_serialized_len`), covered by
+// the `blend-network` tests. `decode` itself assumes a correctly-sized input.
 
 fn generate_inputs(cnt: usize) -> (Vec<EncapsulationInput>, Vec<X25519PrivateKey>) {
     let recipient_signing_keys =

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -83,6 +83,19 @@ impl EncapsulatedMessageWithVerifiedSignature {
         self.public_header_with_verified_signature.id()
     }
 
+    /// Serialize to the fixed-size, prefix-free wire format. Produces
+    /// byte-identical output to the equivalent [`EncapsulatedMessage`], so the
+    /// receiver can decode it as one.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        // All public-header variants encode to identical bytes; convert to the
+        // unverified form (a cheap copy) so encoding stays single-typed.
+        encode_message_components(
+            &PublicHeader::from(self.public_header_with_verified_signature.clone()),
+            &self.encapsulated_part,
+        )
+    }
+
     #[cfg(any(feature = "unsafe-test-functions", test))]
     pub const fn public_header_mut(&mut self) -> &mut PublicHeaderWithVerifiedSignature {
         &mut self.public_header_with_verified_signature

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -16,9 +16,7 @@ use crate::{
         encapsulated::{EncapsulatedMessage, EncapsulatedPart, encode_message_components},
     },
     input::EncapsulationInput,
-    message::public_header::{
-        PublicHeader, PublicHeaderWithVerifiedSignature, VerifiedPublicHeader,
-    },
+    message::public_header::{PublicHeaderWithVerifiedSignature, VerifiedPublicHeader},
     reward::BlendingToken,
 };
 
@@ -88,10 +86,8 @@ impl EncapsulatedMessageWithVerifiedSignature {
     /// receiver can decode it as one.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        // All public-header variants encode to identical bytes; convert to the
-        // unverified form (a cheap copy) so encoding stays single-typed.
         encode_message_components(
-            &PublicHeader::from(self.public_header_with_verified_signature.clone()),
+            &self.public_header_with_verified_signature,
             &self.encapsulated_part,
         )
     }
@@ -208,12 +204,7 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
     /// receiver can decode it as one.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        // All public-header variants encode to identical bytes; convert to the
-        // unverified form (a cheap copy) so encoding stays single-typed.
-        encode_message_components(
-            &PublicHeader::from(self.validated_public_header.clone()),
-            &self.encapsulated_part,
-        )
+        encode_message_components(&self.validated_public_header, &self.encapsulated_part)
     }
 
     /// Decapsulates the message using the provided key.

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -13,7 +13,7 @@ use crate::{
     encap::{
         ProofsVerifier,
         decapsulated::{DecapsulatedMessage, DecapsulationOutput, PartDecapsulationOutput},
-        encapsulated::{EncapsulatedMessage, EncapsulatedPart},
+        encapsulated::{EncapsulatedMessage, EncapsulatedPart, encode_message},
     },
     input::EncapsulationInput,
     message::public_header::{PublicHeaderWithVerifiedSignature, VerifiedPublicHeader},
@@ -79,6 +79,17 @@ impl EncapsulatedMessageWithVerifiedSignature {
     #[must_use]
     pub const fn id(&self) -> MessageIdentifier {
         self.public_header_with_verified_signature.id()
+    }
+
+    /// Serialize to the fixed-size, prefix-free wire format. Produces
+    /// byte-identical output to the equivalent [`EncapsulatedMessage`], so the
+    /// receiver can decode it as one.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        encode_message(
+            &self.public_header_with_verified_signature,
+            &self.encapsulated_part,
+        )
     }
 
     #[cfg(any(feature = "unsafe-test-functions", test))]
@@ -186,6 +197,14 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
     #[must_use]
     pub const fn id(&self) -> MessageIdentifier {
         self.validated_public_header.id()
+    }
+
+    /// Serialize to the fixed-size, prefix-free wire format. Produces
+    /// byte-identical output to the equivalent [`EncapsulatedMessage`], so the
+    /// receiver can decode it as one.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        encode_message(&self.validated_public_header, &self.encapsulated_part)
     }
 
     /// Decapsulates the message using the provided key.

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU64;
+
 use derivative::Derivative;
 use lb_blend_crypto::random_sized_bytes;
 use lb_blend_proofs::{
@@ -9,11 +11,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Error, MessageIdentifier, PaddedPayloadBody, PayloadType,
+    codec::WireEncode as _,
     crypto::key_ext::Ed25519SecretKeyExt as _,
     encap::{
         ProofsVerifier,
         decapsulated::{DecapsulatedMessage, DecapsulationOutput, PartDecapsulationOutput},
-        encapsulated::{EncapsulatedMessage, EncapsulatedPart, encode_message_components},
+        encapsulated::{EncapsulatedMessage, EncapsulatedPart},
+        expected_serialized_len,
     },
     input::EncapsulationInput,
     message::public_header::{PublicHeaderWithVerifiedSignature, VerifiedPublicHeader},
@@ -81,15 +85,23 @@ impl EncapsulatedMessageWithVerifiedSignature {
         self.public_header_with_verified_signature.id()
     }
 
-    /// Serialize to the fixed-size, prefix-free wire format. Produces
-    /// byte-identical output to the equivalent [`EncapsulatedMessage`], so the
-    /// receiver can decode it as one.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        encode_message_components(
-            &self.public_header_with_verified_signature,
-            &self.encapsulated_part,
-        )
+        let expected_encoded_len = expected_serialized_len(self.encapsulation_layers());
+        let mut out = Vec::with_capacity(expected_encoded_len);
+        self.public_header_with_verified_signature
+            .encode_into(&mut out);
+        self.encapsulated_part.encode_into(&mut out);
+        debug_assert!(
+            out.len() == expected_encoded_len,
+            "Message should encode to the expected length but it did not."
+        );
+        out
+    }
+
+    #[must_use]
+    fn encapsulation_layers(&self) -> NonZeroU64 {
+        self.encapsulated_part.encapsulation_layers()
     }
 
     #[cfg(any(feature = "unsafe-test-functions", test))]
@@ -199,14 +211,6 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
         self.validated_public_header.id()
     }
 
-    /// Serialize to the fixed-size, prefix-free wire format. Produces
-    /// byte-identical output to the equivalent [`EncapsulatedMessage`], so the
-    /// receiver can decode it as one.
-    #[must_use]
-    pub fn encode(&self) -> Vec<u8> {
-        encode_message_components(&self.validated_public_header, &self.encapsulated_part)
-    }
-
     /// Decapsulates the message using the provided key.
     ///
     /// If the provided key is eligible, returns the following:
@@ -295,6 +299,24 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
     #[cfg(any(feature = "unsafe-test-functions", test))]
     pub const fn public_header_mut(&mut self) -> &mut VerifiedPublicHeader {
         &mut self.validated_public_header
+    }
+
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let expected_encoded_len = expected_serialized_len(self.encapsulation_layers());
+        let mut out = Vec::with_capacity(expected_encoded_len);
+        self.validated_public_header.encode_into(&mut out);
+        self.encapsulated_part.encode_into(&mut out);
+        debug_assert!(
+            out.len() == expected_encoded_len,
+            "Message should encode to the expected length but it did not."
+        );
+        out
+    }
+
+    #[must_use]
+    fn encapsulation_layers(&self) -> NonZeroU64 {
+        self.encapsulated_part.encapsulation_layers()
     }
 }
 

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -13,7 +13,7 @@ use crate::{
     encap::{
         ProofsVerifier,
         decapsulated::{DecapsulatedMessage, DecapsulationOutput, PartDecapsulationOutput},
-        encapsulated::{EncapsulatedMessage, EncapsulatedPart, encode_message},
+        encapsulated::{EncapsulatedMessage, EncapsulatedPart, encode_message_components},
     },
     input::EncapsulationInput,
     message::public_header::{PublicHeaderWithVerifiedSignature, VerifiedPublicHeader},
@@ -86,7 +86,7 @@ impl EncapsulatedMessageWithVerifiedSignature {
     /// receiver can decode it as one.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        encode_message(
+        encode_message_components(
             &self.public_header_with_verified_signature,
             &self.encapsulated_part,
         )
@@ -204,7 +204,7 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
     /// receiver can decode it as one.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        encode_message(&self.validated_public_header, &self.encapsulated_part)
+        encode_message_components(&self.validated_public_header, &self.encapsulated_part)
     }
 
     /// Decapsulates the message using the provided key.

--- a/blend/message/src/encap/validated.rs
+++ b/blend/message/src/encap/validated.rs
@@ -16,7 +16,9 @@ use crate::{
         encapsulated::{EncapsulatedMessage, EncapsulatedPart, encode_message_components},
     },
     input::EncapsulationInput,
-    message::public_header::{PublicHeaderWithVerifiedSignature, VerifiedPublicHeader},
+    message::public_header::{
+        PublicHeader, PublicHeaderWithVerifiedSignature, VerifiedPublicHeader,
+    },
     reward::BlendingToken,
 };
 
@@ -79,17 +81,6 @@ impl EncapsulatedMessageWithVerifiedSignature {
     #[must_use]
     pub const fn id(&self) -> MessageIdentifier {
         self.public_header_with_verified_signature.id()
-    }
-
-    /// Serialize to the fixed-size, prefix-free wire format. Produces
-    /// byte-identical output to the equivalent [`EncapsulatedMessage`], so the
-    /// receiver can decode it as one.
-    #[must_use]
-    pub fn encode(&self) -> Vec<u8> {
-        encode_message_components(
-            &self.public_header_with_verified_signature,
-            &self.encapsulated_part,
-        )
     }
 
     #[cfg(any(feature = "unsafe-test-functions", test))]
@@ -204,7 +195,12 @@ impl EncapsulatedMessageWithVerifiedPublicHeader {
     /// receiver can decode it as one.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
-        encode_message_components(&self.validated_public_header, &self.encapsulated_part)
+        // All public-header variants encode to identical bytes; convert to the
+        // unverified form (a cheap copy) so encoding stays single-typed.
+        encode_message_components(
+            &PublicHeader::from(self.validated_public_header.clone()),
+            &self.encapsulated_part,
+        )
     }
 
     /// Decapsulates the message using the provided key.

--- a/blend/message/src/error.rs
+++ b/blend/message/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     ProofOfQuotaVerificationFailed(quota::Error),
     #[error("Encapsulated message deserialization failed")]
     MessageDeserializationFailed,
+    #[error(transparent)]
+    WireDecode(#[from] crate::codec::WireDecodeError),
     #[error("Payload deserialization failed")]
     PayloadDeserializationFailed,
     #[error("Private header deserialization failed")]

--- a/blend/message/src/error.rs
+++ b/blend/message/src/error.rs
@@ -14,8 +14,6 @@ pub enum Error {
     ProofOfQuotaVerificationFailed(quota::Error),
     #[error("Encapsulated message deserialization failed")]
     MessageDeserializationFailed,
-    #[error("Encapsulated message has an unexpected serialized size")]
-    UnexpectedMessageSize,
     #[error("Payload deserialization failed")]
     PayloadDeserializationFailed,
     #[error("Private header deserialization failed")]

--- a/blend/message/src/error.rs
+++ b/blend/message/src/error.rs
@@ -14,6 +14,12 @@ pub enum Error {
     ProofOfQuotaVerificationFailed(quota::Error),
     #[error("Encapsulated message deserialization failed")]
     MessageDeserializationFailed,
+    #[error("Encapsulated message has an unexpected serialized size")]
+    UnexpectedMessageSize,
+    #[error("Encapsulated message has an unexpected number of encapsulation layers")]
+    UnexpectedEncapsulationLayerCount,
+    #[error("Encapsulated message layout does not match the fixed wire format")]
+    MalformedEncapsulatedMessage,
     #[error("Payload deserialization failed")]
     PayloadDeserializationFailed,
     #[error("Private header deserialization failed")]

--- a/blend/message/src/error.rs
+++ b/blend/message/src/error.rs
@@ -16,10 +16,6 @@ pub enum Error {
     MessageDeserializationFailed,
     #[error("Encapsulated message has an unexpected serialized size")]
     UnexpectedMessageSize,
-    #[error("Encapsulated message has an unexpected number of encapsulation layers")]
-    UnexpectedEncapsulationLayerCount,
-    #[error("Encapsulated message layout does not match the fixed wire format")]
-    MalformedEncapsulatedMessage,
     #[error("Payload deserialization failed")]
     PayloadDeserializationFailed,
     #[error("Private header deserialization failed")]

--- a/blend/message/src/lib.rs
+++ b/blend/message/src/lib.rs
@@ -1,3 +1,4 @@
+mod codec;
 pub mod crypto;
 pub mod encap;
 mod error;

--- a/blend/message/src/message/blending_header.rs
+++ b/blend/message/src/message/blending_header.rs
@@ -9,7 +9,7 @@ use lb_key_management_system_keys::keys::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::crypto::domains;
+use crate::{codec::WireCodec, crypto::domains};
 
 /// A blending header that is fully decapsulated.
 /// This must be encapsulated when being sent to the blend network.
@@ -60,4 +60,44 @@ impl BlendingHeader {
 
 fn concat(a: &[u8], b: &[u8]) -> Vec<u8> {
     a.iter().chain(b.iter()).copied().collect::<Vec<_>>()
+}
+
+impl WireCodec for BlendingHeader {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        Ed25519PublicKey::encoded_length(())
+            .checked_add(ProofOfQuota::encoded_length(()))
+            .and_then(|len| len.checked_add(Ed25519Signature::encoded_length(())))
+            .and_then(|len| len.checked_add(ProofOfSelection::encoded_length(())))
+            .and_then(|len| len.checked_add(bool::encoded_length(())))
+            .expect("BlendingHeader encoded length overflow")
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.signing_pubkey.encode_into(out);
+        self.proof_of_quota.encode_into(out);
+        self.signature.encode_into(out);
+        self.proof_of_selection.encode_into(out);
+        self.is_last.encode_into(out);
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (input, signing_pubkey) = Ed25519PublicKey::decode(input, ())?;
+        let (input, proof_of_quota) = ProofOfQuota::decode(input, ())?;
+        let (input, signature) = Ed25519Signature::decode(input, ())?;
+        let (input, proof_of_selection) = ProofOfSelection::decode(input, ())?;
+        let (input, is_last) = bool::decode(input, ())?;
+
+        Ok((
+            input,
+            Self {
+                signing_pubkey,
+                proof_of_quota,
+                signature,
+                proof_of_selection,
+                is_last,
+            },
+        ))
+    }
 }

--- a/blend/message/src/message/blending_header.rs
+++ b/blend/message/src/message/blending_header.rs
@@ -9,7 +9,10 @@ use lb_key_management_system_keys::keys::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{codec::WireCodec, crypto::domains};
+use crate::{
+    codec::{WireDecode, WireDecodeError, WireEncode},
+    crypto::domains,
+};
 
 /// A blending header that is fully decapsulated.
 /// This must be encapsulated when being sent to the blend network.
@@ -74,13 +77,8 @@ pub const BLENDING_HEADER_ENCODED_SIZE: usize = ED25519_PUBLIC_KEY_SIZE
     .unwrap()
     .checked_add(size_of::<bool>())
     .unwrap();
-impl WireCodec for BlendingHeader {
-    type Context = ();
 
-    fn encoded_length((): Self::Context) -> usize {
-        BLENDING_HEADER_ENCODED_SIZE
-    }
-
+impl WireEncode for BlendingHeader {
     fn encode_into(&self, out: &mut Vec<u8>) {
         self.signing_pubkey.encode_into(out);
         self.proof_of_quota.encode_into(out);
@@ -88,8 +86,12 @@ impl WireCodec for BlendingHeader {
         self.proof_of_selection.encode_into(out);
         self.is_last.encode_into(out);
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
+impl WireDecode for BlendingHeader {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (input, signing_pubkey) = Ed25519PublicKey::decode(input, ())?;
         let (input, proof_of_quota) = ProofOfQuota::decode(input, ())?;
         let (input, signature) = Ed25519Signature::decode(input, ())?;

--- a/blend/message/src/message/blending_header.rs
+++ b/blend/message/src/message/blending_header.rs
@@ -62,16 +62,23 @@ fn concat(a: &[u8], b: &[u8]) -> Vec<u8> {
     a.iter().chain(b.iter()).copied().collect::<Vec<_>>()
 }
 
+/// The exact number of bytes a [`BlendingHeader`] encodes to. Every field is
+/// fixed-size, so this is a compile-time constant — which lets the encapsulated
+/// (ciphered) form be stored as a `[u8; BLENDING_HEADER_ENCODED_SIZE]`.
+pub const BLENDING_HEADER_ENCODED_SIZE: usize = ED25519_PUBLIC_KEY_SIZE
+    .checked_add(PROOF_OF_QUOTA_SIZE)
+    .unwrap()
+    .checked_add(ED25519_SIGNATURE_SIZE)
+    .unwrap()
+    .checked_add(PROOF_OF_SELECTION_SIZE)
+    .unwrap()
+    .checked_add(size_of::<bool>())
+    .unwrap();
 impl WireCodec for BlendingHeader {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        Ed25519PublicKey::encoded_length(())
-            .checked_add(ProofOfQuota::encoded_length(()))
-            .and_then(|len| len.checked_add(Ed25519Signature::encoded_length(())))
-            .and_then(|len| len.checked_add(ProofOfSelection::encoded_length(())))
-            .and_then(|len| len.checked_add(bool::encoded_length(())))
-            .expect("BlendingHeader encoded length overflow")
+    fn encoded_length((): Self::Context) -> usize {
+        BLENDING_HEADER_ENCODED_SIZE
     }
 
     fn encode_into(&self, out: &mut Vec<u8>) {
@@ -82,7 +89,7 @@ impl WireCodec for BlendingHeader {
         self.is_last.encode_into(out);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         let (input, signing_pubkey) = Ed25519PublicKey::decode(input, ())?;
         let (input, proof_of_quota) = ProofOfQuota::decode(input, ())?;
         let (input, signature) = Ed25519Signature::decode(input, ())?;

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -123,3 +123,61 @@ impl Payload {
         Ok((self.payload_type(), self.body()?.to_vec()))
     }
 }
+
+impl WireCodec for PayloadType {
+    type Context = ();
+
+    fn encoded_length(_context: Self::Context) -> usize {
+        u8::encoded_length(())
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        (*self as u8).encode_into(out);
+    }
+
+    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (remaining, discriminant) = u8::decode(input, ())?;
+        let payload_type = match discriminant {
+            0x00 => Self::Cover,
+            0x01 => Self::Data,
+            _ => return Err(()),
+        };
+        Ok((remaining, payload_type))
+    }
+}
+
+impl WireCodec for Payload {
+    type Context = ();
+
+    fn encoded_length(_context: Self::Context) -> usize {
+        PayloadType::encoded_length(())
+            .checked_add(u16::encoded_length(())) // `body_len`
+            .and_then(|len| len.checked_add(PaddedPayloadBody::encoded_length(())))
+            .expect("Payload encoded length overflow")
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.header.payload_type.encode_into(out);
+        self.header.body_len.encode_into(out);
+        self.body.encode_into(out);
+    }
+
+    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (input, payload_type) = PayloadType::decode(input, ())?;
+        let (input, body_len) = u16::decode(input, ())?;
+        let (input, mut body) = PaddedPayloadBody::decode(input, ())?;
+        // `PaddedPayloadBody` does not encode its own length; the authoritative
+        // value travels once as the header's `body_len`, so restore it here.
+        body.actual_len = body_len;
+        Ok((
+            input,
+            Self {
+                header: PayloadHeader {
+                    payload_type,
+                    body_len,
+                },
+                body,
+            },
+        ))
+    }
+}

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::Error;
+use crate::{Error, codec::WireCodec};
 
 pub const MAX_PAYLOAD_BODY_SIZE: usize = 34 * 1024;
 
@@ -60,6 +60,27 @@ impl TryFrom<&[u8]> for PaddedPayloadBody {
             actual_len: body_len,
             padded,
         })
+    }
+}
+
+impl WireCodec for PaddedPayloadBody {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        MAX_PAYLOAD_BODY_SIZE
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.padded[..]);
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        if input.len() < MAX_PAYLOAD_BODY_SIZE {
+            return Err(());
+        }
+        let (body_bytes, remaining) = input.split_at(MAX_PAYLOAD_BODY_SIZE);
+        let body = Self::try_from(body_bytes).map_err(|_| ())?;
+        Ok((remaining, body))
     }
 }
 

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -1,17 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::{Error, codec::WireCodec};
+use crate::{
+    Error,
+    codec::{WireDecode, WireDecodeError, WireEncode},
+};
 
 pub const MAX_PAYLOAD_BODY_SIZE: usize = 34 * 1024;
-
-/// A payload header that is fully decapsulated.
-/// This must be encapsulated when being sent to the blend network.
-#[derive(Clone, Serialize, Deserialize)]
-struct PayloadHeader {
-    payload_type: PayloadType,
-    body_len: u16,
-}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PayloadType {
@@ -19,14 +14,19 @@ pub enum PayloadType {
     Data = 0x01,
 }
 
+/// The decapsulated payload body, padded to a fixed size.
+///
+/// `actual_len` is the length of the real (unpadded) content and is the single
+/// source of truth for it — the payload no longer stores it a second time.
 #[serde_as]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PaddedPayloadBody {
-    /// A body is padded to [`MAX_PAYLOAD_BODY_SIZE`],
-    /// Box is used to not allocate a big array on the stack.
+    /// The real content length; `padded[..actual_len]` is the body.
+    actual_len: u16,
+    /// A body padded to [`MAX_PAYLOAD_BODY_SIZE`]. `Box` avoids a large stack
+    /// allocation.
     #[serde_as(as = "serde_with::Bytes")]
     padded: Box<[u8; MAX_PAYLOAD_BODY_SIZE]>,
-    actual_len: u16,
 }
 
 impl TryFrom<Vec<u8>> for PaddedPayloadBody {
@@ -45,7 +45,7 @@ impl TryFrom<&[u8]> for PaddedPayloadBody {
             return Err(Error::PayloadTooLarge);
         }
 
-        let body_len: u16 = value
+        let actual_len: u16 = value
             .len()
             .try_into()
             .map_err(|_| Error::InvalidPayloadLength)?;
@@ -56,10 +56,7 @@ impl TryFrom<&[u8]> for PaddedPayloadBody {
             .expect("body must be created with the correct size");
         padded[..value.len()].copy_from_slice(value);
 
-        Ok(Self {
-            actual_len: body_len,
-            padded,
-        })
+        Ok(Self { actual_len, padded })
     }
 }
 
@@ -70,56 +67,49 @@ impl TryFrom<&[u8]> for PaddedPayloadBody {
 pub const PAYLOAD_ENCODED_SIZE: usize =
     size_of::<u8>() + size_of::<u16>() + MAX_PAYLOAD_BODY_SIZE;
 
-impl WireCodec for PaddedPayloadBody {
-    type Context = ();
-
-    fn encoded_length((): Self::Context) -> usize {
-        MAX_PAYLOAD_BODY_SIZE
-    }
-
+impl WireEncode for PaddedPayloadBody {
     fn encode_into(&self, out: &mut Vec<u8>) {
+        self.actual_len.encode_into(out);
         out.extend_from_slice(&self.padded[..]);
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
-        if input.len() < MAX_PAYLOAD_BODY_SIZE {
-            return Err(());
-        }
+impl WireDecode for PaddedPayloadBody {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        let (input, actual_len) = u16::decode(input, ())?;
         let (body_bytes, remaining) = input.split_at(MAX_PAYLOAD_BODY_SIZE);
-        let body = Self::try_from(body_bytes).map_err(|_| ())?;
-        Ok((remaining, body))
+        let padded: Box<[u8; MAX_PAYLOAD_BODY_SIZE]> = body_bytes
+            .to_vec()
+            .into_boxed_slice()
+            .try_into()
+            .expect("split_at guarantees the length");
+        Ok((remaining, Self { actual_len, padded }))
     }
 }
 
 /// A payload that is fully decapsulated.
 /// This must be encapsulated when being sent to the blend network.
-#[serde_as]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Payload {
-    header: PayloadHeader,
+    payload_type: PayloadType,
     body: PaddedPayloadBody,
 }
 
 impl Payload {
-    pub const fn new(payload_type: PayloadType, payload_body: PaddedPayloadBody) -> Self {
-        Self {
-            header: PayloadHeader {
-                payload_type,
-                body_len: payload_body.actual_len,
-            },
-            body: payload_body,
-        }
+    pub const fn new(payload_type: PayloadType, body: PaddedPayloadBody) -> Self {
+        Self { payload_type, body }
     }
 
     pub const fn payload_type(&self) -> PayloadType {
-        self.header.payload_type
+        self.payload_type
     }
 
     /// Returns the payload body unpadded.
-    /// Returns an error if the payload cannot be read up to the length
-    /// specified in the header
+    /// Returns an error if the recorded length exceeds the padded buffer.
     pub fn body(&self) -> Result<&[u8], Error> {
-        let len = self.header.body_len as usize;
+        let len = self.body.actual_len as usize;
         if self.body.padded.len() < len {
             return Err(Error::InvalidPayloadLength);
         }
@@ -131,57 +121,39 @@ impl Payload {
     }
 }
 
-impl WireCodec for PayloadType {
-    type Context = ();
-
-    fn encoded_length(_context: Self::Context) -> usize {
-        u8::encoded_length(())
-    }
-
+impl WireEncode for PayloadType {
     fn encode_into(&self, out: &mut Vec<u8>) {
         (*self as u8).encode_into(out);
     }
+}
 
-    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
+impl WireDecode for PayloadType {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (remaining, discriminant) = u8::decode(input, ())?;
         let payload_type = match discriminant {
             0x00 => Self::Cover,
             0x01 => Self::Data,
-            _ => return Err(()),
+            _ => return Err(WireDecodeError::InvalidPayloadType),
         };
         Ok((remaining, payload_type))
     }
 }
 
-impl WireCodec for Payload {
-    type Context = ();
-
-    fn encoded_length((): Self::Context) -> usize {
-        PAYLOAD_ENCODED_SIZE
-    }
-
+impl WireEncode for Payload {
     fn encode_into(&self, out: &mut Vec<u8>) {
-        self.header.payload_type.encode_into(out);
-        self.header.body_len.encode_into(out);
+        self.payload_type.encode_into(out);
         self.body.encode_into(out);
     }
+}
 
-    fn decode(input: &[u8], _context: Self::Context) -> Result<(&[u8], Self), ()> {
+impl WireDecode for Payload {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (input, payload_type) = PayloadType::decode(input, ())?;
-        let (input, body_len) = u16::decode(input, ())?;
-        let (input, mut body) = PaddedPayloadBody::decode(input, ())?;
-        // `PaddedPayloadBody` does not encode its own length; the authoritative
-        // value travels once as the header's `body_len`, so restore it here.
-        body.actual_len = body_len;
-        Ok((
-            input,
-            Self {
-                header: PayloadHeader {
-                    payload_type,
-                    body_len,
-                },
-                body,
-            },
-        ))
+        let (input, body) = PaddedPayloadBody::decode(input, ())?;
+        Ok((input, Self { payload_type, body }))
     }
 }

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -9,9 +9,22 @@ use crate::{
 pub const MAX_PAYLOAD_BODY_SIZE: usize = 34 * 1024;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[repr(u8)]
 pub enum PayloadType {
     Cover = 0x00,
     Data = 0x01,
+}
+
+impl TryFrom<u8> for PayloadType {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::Cover),
+            0x01 => Ok(Self::Data),
+            _ => Err(()),
+        }
+    }
 }
 
 impl WireEncode for PayloadType {
@@ -25,11 +38,8 @@ impl WireDecode for PayloadType {
 
     fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (remaining, discriminant) = u8::decode(input, ())?;
-        let payload_type = match discriminant {
-            0x00 => Self::Cover,
-            0x01 => Self::Data,
-            _ => return Err(WireDecodeError::InvalidPayloadType),
-        };
+        let payload_type =
+            Self::try_from(discriminant).map_err(|()| WireDecodeError::InvalidPayloadType)?;
         Ok((remaining, payload_type))
     }
 }
@@ -106,7 +116,8 @@ impl WireDecode for PaddedPayloadBody {
 /// discriminant, the `u16` body length, and the body padded to
 /// [`MAX_PAYLOAD_BODY_SIZE`]. Compile-time constant, so the encapsulated
 /// (ciphered) form can be stored as a `Box<[u8; PAYLOAD_ENCODED_SIZE]>`.
-pub const PAYLOAD_ENCODED_SIZE: usize = size_of::<u8>() + size_of::<u16>() + MAX_PAYLOAD_BODY_SIZE;
+pub const PAYLOAD_ENCODED_SIZE: usize =
+    size_of::<PayloadType>() + size_of::<u16>() + MAX_PAYLOAD_BODY_SIZE;
 
 /// A payload that is fully decapsulated.
 /// This must be encapsulated when being sent to the blend network.

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -14,6 +14,26 @@ pub enum PayloadType {
     Data = 0x01,
 }
 
+impl WireEncode for PayloadType {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        (*self as u8).encode_into(out);
+    }
+}
+
+impl WireDecode for PayloadType {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
+        let (remaining, discriminant) = u8::decode(input, ())?;
+        let payload_type = match discriminant {
+            0x00 => Self::Cover,
+            0x01 => Self::Data,
+            _ => return Err(WireDecodeError::InvalidPayloadType),
+        };
+        Ok((remaining, payload_type))
+    }
+}
+
 /// The decapsulated payload body, padded to a fixed size.
 ///
 /// `actual_len` is the length of the real (unpadded) content and is the single
@@ -60,13 +80,6 @@ impl TryFrom<&[u8]> for PaddedPayloadBody {
     }
 }
 
-/// The exact number of bytes a [`Payload`] encodes to: a fixed enum
-/// discriminant, the `u16` body length, and the body padded to
-/// [`MAX_PAYLOAD_BODY_SIZE`]. Compile-time constant, so the encapsulated
-/// (ciphered) form can be stored as a `Box<[u8; PAYLOAD_ENCODED_SIZE]>`.
-pub const PAYLOAD_ENCODED_SIZE: usize =
-    size_of::<u8>() + size_of::<u16>() + MAX_PAYLOAD_BODY_SIZE;
-
 impl WireEncode for PaddedPayloadBody {
     fn encode_into(&self, out: &mut Vec<u8>) {
         self.actual_len.encode_into(out);
@@ -88,6 +101,12 @@ impl WireDecode for PaddedPayloadBody {
         Ok((remaining, Self { actual_len, padded }))
     }
 }
+
+/// The exact number of bytes a [`Payload`] encodes to: a fixed enum
+/// discriminant, the `u16` body length, and the body padded to
+/// [`MAX_PAYLOAD_BODY_SIZE`]. Compile-time constant, so the encapsulated
+/// (ciphered) form can be stored as a `Box<[u8; PAYLOAD_ENCODED_SIZE]>`.
+pub const PAYLOAD_ENCODED_SIZE: usize = size_of::<u8>() + size_of::<u16>() + MAX_PAYLOAD_BODY_SIZE;
 
 /// A payload that is fully decapsulated.
 /// This must be encapsulated when being sent to the blend network.
@@ -118,26 +137,6 @@ impl Payload {
 
     pub fn try_into_components(self) -> Result<(PayloadType, Vec<u8>), Error> {
         Ok((self.payload_type(), self.body()?.to_vec()))
-    }
-}
-
-impl WireEncode for PayloadType {
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        (*self as u8).encode_into(out);
-    }
-}
-
-impl WireDecode for PayloadType {
-    type Context = ();
-
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
-        let (remaining, discriminant) = u8::decode(input, ())?;
-        let payload_type = match discriminant {
-            0x00 => Self::Cover,
-            0x01 => Self::Data,
-            _ => return Err(WireDecodeError::InvalidPayloadType),
-        };
-        Ok((remaining, payload_type))
     }
 }
 

--- a/blend/message/src/message/payload.rs
+++ b/blend/message/src/message/payload.rs
@@ -63,10 +63,17 @@ impl TryFrom<&[u8]> for PaddedPayloadBody {
     }
 }
 
+/// The exact number of bytes a [`Payload`] encodes to: a fixed enum
+/// discriminant, the `u16` body length, and the body padded to
+/// [`MAX_PAYLOAD_BODY_SIZE`]. Compile-time constant, so the encapsulated
+/// (ciphered) form can be stored as a `Box<[u8; PAYLOAD_ENCODED_SIZE]>`.
+pub const PAYLOAD_ENCODED_SIZE: usize =
+    size_of::<u8>() + size_of::<u16>() + MAX_PAYLOAD_BODY_SIZE;
+
 impl WireCodec for PaddedPayloadBody {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
+    fn encoded_length((): Self::Context) -> usize {
         MAX_PAYLOAD_BODY_SIZE
     }
 
@@ -74,7 +81,7 @@ impl WireCodec for PaddedPayloadBody {
         out.extend_from_slice(&self.padded[..]);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         if input.len() < MAX_PAYLOAD_BODY_SIZE {
             return Err(());
         }
@@ -149,11 +156,8 @@ impl WireCodec for PayloadType {
 impl WireCodec for Payload {
     type Context = ();
 
-    fn encoded_length(_context: Self::Context) -> usize {
-        PayloadType::encoded_length(())
-            .checked_add(u16::encoded_length(())) // `body_len`
-            .and_then(|len| len.checked_add(PaddedPayloadBody::encoded_length(())))
-            .expect("Payload encoded length overflow")
+    fn encoded_length((): Self::Context) -> usize {
+        PAYLOAD_ENCODED_SIZE
     }
 
     fn encode_into(&self, out: &mut Vec<u8>) {

--- a/blend/message/src/message/public_header.rs
+++ b/blend/message/src/message/public_header.rs
@@ -145,29 +145,6 @@ impl WireDecode for PublicHeader {
     }
 }
 
-// The verified public-header variants are never decoded from the wire (a peer's
-// bytes always decode into an unverified `PublicHeader`); they only need to
-// encode, and all three variants produce identical bytes. Implementing only
-// `WireEncode` for them means a verified message can be serialized directly,
-// with no conversion/copy through `PublicHeader`.
-impl WireEncode for PublicHeaderWithVerifiedSignature {
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        self.version.encode_into(out);
-        self.signing_pubkey.encode_into(out);
-        self.proof_of_quota.encode_into(out);
-        self.signature.encode_into(out);
-    }
-}
-
-impl WireEncode for VerifiedPublicHeader {
-    fn encode_into(&self, out: &mut Vec<u8>) {
-        self.version.encode_into(out);
-        self.signing_pubkey.encode_into(out);
-        self.proof_of_quota.as_ref().encode_into(out);
-        self.signature.encode_into(out);
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PublicHeaderWithVerifiedSignature {
     version: u8,
@@ -238,6 +215,20 @@ impl PublicHeaderWithVerifiedSignature {
     #[cfg(any(feature = "unsafe-test-functions", test))]
     pub const fn signature_mut(&mut self) -> &mut Ed25519Signature {
         &mut self.signature
+    }
+}
+
+// The verified public-header variants are never decoded from the wire (a peer's
+// bytes always decode into an unverified `PublicHeader`); they only need to
+// encode, and all three variants produce identical bytes. Implementing only
+// `WireEncode` for them means a verified message can be serialized directly,
+// with no conversion/copy through `PublicHeader`.
+impl WireEncode for PublicHeaderWithVerifiedSignature {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.version.encode_into(out);
+        self.signing_pubkey.encode_into(out);
+        self.proof_of_quota.encode_into(out);
+        self.signature.encode_into(out);
     }
 }
 
@@ -336,6 +327,15 @@ impl VerifiedPublicHeader {
             self.proof_of_quota,
             self.signature,
         )
+    }
+}
+
+impl WireEncode for VerifiedPublicHeader {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.version.encode_into(out);
+        self.signing_pubkey.encode_into(out);
+        self.proof_of_quota.as_ref().encode_into(out);
+        self.signature.encode_into(out);
     }
 }
 

--- a/blend/message/src/message/public_header.rs
+++ b/blend/message/src/message/public_header.rs
@@ -2,10 +2,7 @@ use lb_blend_proofs::quota::{self, ProofOfQuota, VerifiedProofOfQuota};
 use lb_key_management_system_keys::keys::{Ed25519PublicKey, Ed25519Signature};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
-use crate::{
-    Error, MessageIdentifier,
-    encap::{ProofsVerifier, WireCodec},
-};
+use crate::{Error, MessageIdentifier, codec::WireCodec, encap::ProofsVerifier};
 
 const LATEST_BLEND_MESSAGE_VERSION: u8 = 1;
 
@@ -102,6 +99,44 @@ impl PublicHeader {
     #[cfg(test)]
     pub const fn proof_of_quota_mut(&mut self) -> &mut ProofOfQuota {
         &mut self.proof_of_quota
+    }
+}
+
+impl WireCodec for PublicHeader {
+    type Context = ();
+
+    fn encoded_length(context: Self::Context) -> usize {
+        u8::encoded_length(())
+            .checked_add(Ed25519PublicKey::encoded_length(()))
+            .and_then(|len| len.checked_add(ProofOfQuota::encoded_length(())))
+            .and_then(|len| len.checked_add(Ed25519Signature::encoded_length(())))
+            .unwrap()
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.version.encode_into(out);
+        self.signing_pubkey.encode_into(out);
+        self.proof_of_quota.encode_into(out);
+        self.signature.encode_into(out);
+    }
+
+    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+        let (input, version) = u8::decode(input, ())?;
+        if version != LATEST_BLEND_MESSAGE_VERSION {
+            return Err(());
+        }
+        let (input, signing_pubkey) = Ed25519PublicKey::decode(input, ())?;
+        let (input, proof_of_quota) = ProofOfQuota::decode(input, ())?;
+        let (input, signature) = Ed25519Signature::decode(input, ())?;
+        Ok((
+            input,
+            Self {
+                version,
+                signing_pubkey,
+                proof_of_quota,
+                signature,
+            },
+        ))
     }
 }
 

--- a/blend/message/src/message/public_header.rs
+++ b/blend/message/src/message/public_header.rs
@@ -1,10 +1,17 @@
-use lb_blend_proofs::quota::{self, ProofOfQuota, VerifiedProofOfQuota};
-use lb_key_management_system_keys::keys::{Ed25519PublicKey, Ed25519Signature};
+use lb_blend_proofs::quota::{self, PROOF_OF_QUOTA_SIZE, ProofOfQuota, VerifiedProofOfQuota};
+use lb_key_management_system_keys::keys::{
+    ED25519_PUBLIC_KEY_SIZE, ED25519_SIGNATURE_SIZE, Ed25519PublicKey, Ed25519Signature,
+};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::{Error, MessageIdentifier, codec::WireCodec, encap::ProofsVerifier};
 
 const LATEST_BLEND_MESSAGE_VERSION: u8 = 1;
+
+/// The exact number of bytes a [`PublicHeader`] encodes to (a version byte plus
+/// fixed-size fields). Compile-time constant.
+pub const PUBLIC_HEADER_ENCODED_SIZE: usize =
+    size_of::<u8>() + ED25519_PUBLIC_KEY_SIZE + PROOF_OF_QUOTA_SIZE + ED25519_SIGNATURE_SIZE;
 
 // A public header that is revealed to all nodes.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -105,12 +112,8 @@ impl PublicHeader {
 impl WireCodec for PublicHeader {
     type Context = ();
 
-    fn encoded_length(context: Self::Context) -> usize {
-        u8::encoded_length(())
-            .checked_add(Ed25519PublicKey::encoded_length(()))
-            .and_then(|len| len.checked_add(ProofOfQuota::encoded_length(())))
-            .and_then(|len| len.checked_add(Ed25519Signature::encoded_length(())))
-            .unwrap()
+    fn encoded_length((): Self::Context) -> usize {
+        PUBLIC_HEADER_ENCODED_SIZE
     }
 
     fn encode_into(&self, out: &mut Vec<u8>) {
@@ -120,7 +123,7 @@ impl WireCodec for PublicHeader {
         self.signature.encode_into(out);
     }
 
-    fn decode(input: &[u8], context: Self::Context) -> Result<(&[u8], Self), ()> {
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
         let (input, version) = u8::decode(input, ())?;
         if version != LATEST_BLEND_MESSAGE_VERSION {
             return Err(());

--- a/blend/message/src/message/public_header.rs
+++ b/blend/message/src/message/public_header.rs
@@ -4,7 +4,11 @@ use lb_key_management_system_keys::keys::{
 };
 use serde::{Deserialize, Deserializer, Serialize, de};
 
-use crate::{Error, MessageIdentifier, codec::WireCodec, encap::ProofsVerifier};
+use crate::{
+    Error, MessageIdentifier,
+    codec::{WireDecode, WireDecodeError, WireEncode},
+    encap::ProofsVerifier,
+};
 
 const LATEST_BLEND_MESSAGE_VERSION: u8 = 1;
 
@@ -109,24 +113,22 @@ impl PublicHeader {
     }
 }
 
-impl WireCodec for PublicHeader {
-    type Context = ();
-
-    fn encoded_length((): Self::Context) -> usize {
-        PUBLIC_HEADER_ENCODED_SIZE
-    }
-
+impl WireEncode for PublicHeader {
     fn encode_into(&self, out: &mut Vec<u8>) {
         self.version.encode_into(out);
         self.signing_pubkey.encode_into(out);
         self.proof_of_quota.encode_into(out);
         self.signature.encode_into(out);
     }
+}
 
-    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), ()> {
+impl WireDecode for PublicHeader {
+    type Context = ();
+
+    fn decode(input: &[u8], (): Self::Context) -> Result<(&[u8], Self), WireDecodeError> {
         let (input, version) = u8::decode(input, ())?;
         if version != LATEST_BLEND_MESSAGE_VERSION {
-            return Err(());
+            return Err(WireDecodeError::UnsupportedVersion);
         }
         let (input, signing_pubkey) = Ed25519PublicKey::decode(input, ())?;
         let (input, proof_of_quota) = ProofOfQuota::decode(input, ())?;
@@ -140,6 +142,29 @@ impl WireCodec for PublicHeader {
                 signature,
             },
         ))
+    }
+}
+
+// The verified public-header variants are never decoded from the wire (a peer's
+// bytes always decode into an unverified `PublicHeader`); they only need to
+// encode, and all three variants produce identical bytes. Implementing only
+// `WireEncode` for them means a verified message can be serialized directly,
+// with no conversion/copy through `PublicHeader`.
+impl WireEncode for PublicHeaderWithVerifiedSignature {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.version.encode_into(out);
+        self.signing_pubkey.encode_into(out);
+        self.proof_of_quota.encode_into(out);
+        self.signature.encode_into(out);
+    }
+}
+
+impl WireEncode for VerifiedPublicHeader {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        self.version.encode_into(out);
+        self.signing_pubkey.encode_into(out);
+        self.proof_of_quota.as_ref().encode_into(out);
+        self.signature.encode_into(out);
     }
 }
 

--- a/blend/message/src/message/public_header.rs
+++ b/blend/message/src/message/public_header.rs
@@ -2,7 +2,10 @@ use lb_blend_proofs::quota::{self, ProofOfQuota, VerifiedProofOfQuota};
 use lb_key_management_system_keys::keys::{Ed25519PublicKey, Ed25519Signature};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
-use crate::{Error, MessageIdentifier, encap::ProofsVerifier};
+use crate::{
+    Error, MessageIdentifier,
+    encap::{ProofsVerifier, WireCodec},
+};
 
 const LATEST_BLEND_MESSAGE_VERSION: u8 = 1;
 

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -1,6 +1,6 @@
 use core::{
     mem::{self},
-    num::NonZeroUsize,
+    num::{NonZeroU64, NonZeroUsize},
 };
 use std::{
     collections::{HashMap, VecDeque, hash_map::Entry},
@@ -59,6 +59,10 @@ pub struct Config {
     pub peering_degree: RangeInclusive<usize>,
     /// The minimum Blend network size for messages to be relayed between peers.
     pub minimum_network_size: NonZeroUsize,
+    /// `ß_c`: the fixed number of encapsulation layers every well-formed Blend
+    /// message carries. Used to validate the layout of messages received from
+    /// remote peers before processing them.
+    pub num_blend_layers: NonZeroU64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -121,6 +125,9 @@ pub struct Behaviour<ObservationWindowClockProvider> {
     protocol_name: StreamProtocol,
     /// The minimum Blend network size for messages to be relayed between peers.
     minimum_network_size: NonZeroUsize,
+    /// `ß_c`: the fixed number of encapsulation layers every well-formed Blend
+    /// message carries.
+    num_blend_layers: NonZeroU64,
     /// States for processing messages from the old epoch
     /// before the transition period has passed.
     old_epoch: Option<OldEpoch>,
@@ -239,6 +246,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             local_peer_id,
             protocol_name,
             minimum_network_size: config.minimum_network_size,
+            num_blend_layers: config.num_blend_layers,
             old_epoch: None,
         }
     }
@@ -266,6 +274,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
                 .collect(),
             mem::take(&mut self.message_cache),
             current_epoch_number,
+            self.num_blend_layers,
         ));
 
         tracing::debug!(target: LOG_TARGET, "Started a new epoch by passing negotiated peers and exchanged message IDs to the old epoch. Now, no negotiated peers in the current epoch.");
@@ -933,6 +942,7 @@ impl<ObservationWindowClockProvider> Behaviour<ObservationWindowClockProvider> {
             &mut self.events,
             &mut self.waker,
             self.current_epoch_info.1,
+            self.num_blend_layers,
         ) {
             tracing::debug!(target: LOG_TARGET, "Failed to handle message from the current epoch: {receive_error:?}");
             let spam_reason = match receive_error {

--- a/blend/network/src/core/with_core/behaviour/old_epoch.rs
+++ b/blend/network/src/core/with_core/behaviour/old_epoch.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, VecDeque, hash_map::Entry},
     convert::Infallible,
+    num::NonZeroU64,
     task::{Context, Poll, Waker},
 };
 
@@ -38,6 +39,7 @@ pub struct OldEpoch {
     waker: Option<Waker>,
     message_cache: MessageCache,
     epoch: Epoch,
+    num_blend_layers: NonZeroU64,
 }
 
 impl OldEpoch {
@@ -46,6 +48,7 @@ impl OldEpoch {
         negotiated_peers: HashMap<PeerId, ConnectionId>,
         message_cache: MessageCache,
         epoch: Epoch,
+        num_blend_layers: NonZeroU64,
     ) -> Self {
         Self {
             negotiated_peers,
@@ -53,6 +56,7 @@ impl OldEpoch {
             events: VecDeque::new(),
             waker: None,
             epoch,
+            num_blend_layers,
         }
     }
 
@@ -154,6 +158,7 @@ impl OldEpoch {
             &mut self.events,
             &mut self.waker,
             self.epoch,
+            self.num_blend_layers,
         ).inspect_err(|receive_error| {
             tracing::debug!(target: LOG_TARGET, "Failed to handle message from the old epoch: {receive_error:?}. Closing connection with spammy peer.");
             self.events.push_back(ToSwarm::NotifyHandler {

--- a/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/message_handling.rs
@@ -2,6 +2,7 @@ use core::time::Duration;
 use std::collections::HashSet;
 
 use futures::StreamExt as _;
+use lb_blend_scheduling::serialize_encapsulated_message_with_verified_public_header;
 use lb_libp2p::SwarmEvent;
 use libp2p_swarm_test::SwarmExt as _;
 use test_log::test;
@@ -115,6 +116,63 @@ async fn undeserializable_message_received() {
         .behaviour_mut()
         .force_send_serialized_message_to_current_epoch_peer(
             b"msg".to_vec(),
+            *listening_swarm.local_peer_id(),
+        )
+        .unwrap();
+
+    let mut events_to_match = 2u8;
+    loop {
+        select! {
+            _ = dialing_swarm.select_next_some() => {}
+            listening_swarm_event = listening_swarm.select_next_some() => {
+                match listening_swarm_event {
+                    SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, peer_state)) => {
+                        assert_eq!(peer_id, *dialing_swarm.local_peer_id());
+                        assert_eq!(peer_state, NegotiatedPeerState::Spammy(SpamReason::UndeserializableMessage));
+                        events_to_match -= 1;
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
+                        assert_eq!(peer_id, *dialing_swarm.local_peer_id());
+                        assert!(endpoint.is_listener());
+                        events_to_match -= 1;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if events_to_match == 0 {
+            break;
+        }
+    }
+}
+
+#[test(tokio::test)]
+async fn message_with_unexpected_layer_count_disconnects_peer() {
+    // The listening node expects a single encapsulation layer, but the sender
+    // delivers a well-formed 3-layer message. The size gate in
+    // `EncapsulatedMessage::deserialize_from_remote` rejects it up front, and
+    // the sender is treated exactly like one delivering undeserializable bytes.
+    let (mut identities, nodes) = new_nodes_with_empty_address(2);
+    let mut dialing_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id).with_membership(&nodes).build()
+    });
+    let mut listening_swarm = TestSwarm::new(&identities.next().unwrap(), |id| {
+        BehaviourBuilder::new(id)
+            .with_membership(&nodes)
+            .with_num_blend_layers(1)
+            .build()
+    });
+
+    listening_swarm.listen().with_memory_addr_external().await;
+    dialing_swarm
+        .connect_and_wait_for_upgrade(&mut listening_swarm)
+        .await;
+
+    let message = TestEncapsulatedMessage::new(b"unexpected_layer_count");
+    dialing_swarm
+        .behaviour_mut()
+        .force_send_serialized_message_to_current_epoch_peer(
+            serialize_encapsulated_message_with_verified_public_header(message.as_ref()),
             *listening_swarm.local_peer_id(),
         )
         .unwrap();

--- a/blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -155,8 +155,6 @@ impl BehaviourBuilder {
             minimum_network_size: self
                 .minimum_network_size
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),
-            // Matches the number of layers produced by the shared test message
-            // helper (`generate_valid_inputs` uses 3 inputs).
             num_blend_layers: self
                 .num_blend_layers
                 .unwrap_or_else(|| 3.try_into().unwrap()),

--- a/blend/network/src/core/with_core/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/utils.rs
@@ -1,4 +1,8 @@
-use core::{num::NonZeroUsize, ops::RangeInclusive, time::Duration};
+use core::{
+    num::{NonZeroU64, NonZeroUsize},
+    ops::RangeInclusive,
+    time::Duration,
+};
 use std::{
     collections::{HashMap, VecDeque},
     iter::repeat_with,
@@ -87,6 +91,7 @@ pub struct BehaviourBuilder {
     provider: Option<IntervalProvider>,
     peering_degree: Option<RangeInclusive<usize>>,
     minimum_network_size: Option<NonZeroUsize>,
+    num_blend_layers: Option<NonZeroU64>,
 }
 
 impl BehaviourBuilder {
@@ -97,6 +102,7 @@ impl BehaviourBuilder {
             provider: None,
             peering_degree: None,
             minimum_network_size: None,
+            num_blend_layers: None,
         }
     }
 
@@ -124,6 +130,11 @@ impl BehaviourBuilder {
         self
     }
 
+    pub fn with_num_blend_layers(mut self, num_blend_layers: u64) -> Self {
+        self.num_blend_layers = Some(num_blend_layers.try_into().unwrap());
+        self
+    }
+
     pub fn build(self) -> Behaviour<IntervalProvider> {
         Behaviour {
             negotiated_peers: HashMap::new(),
@@ -144,6 +155,11 @@ impl BehaviourBuilder {
             minimum_network_size: self
                 .minimum_network_size
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),
+            // Matches the number of layers produced by the shared test message
+            // helper (`generate_valid_inputs` uses 3 inputs).
+            num_blend_layers: self
+                .num_blend_layers
+                .unwrap_or_else(|| 3.try_into().unwrap()),
             old_epoch: None,
             message_cache: MessageCache::new(),
         }

--- a/blend/network/src/core/with_core/behaviour/utils.rs
+++ b/blend/network/src/core/with_core/behaviour/utils.rs
@@ -1,4 +1,4 @@
-use core::{convert::Infallible, task::Waker};
+use core::{convert::Infallible, num::NonZeroU64, task::Waker};
 use std::collections::VecDeque;
 
 use either::Either;
@@ -76,10 +76,12 @@ pub fn handle_received_serialized_encapsulated_message_and_update_cache(
     events_queue: &mut VecDeque<ToSwarm<Event, Either<FromBehaviour, Infallible>>>,
     waker: &mut Option<Waker>,
     epoch: Epoch,
+    num_blend_layers: NonZeroU64,
 ) -> Result<(), ReceiveError> {
     // Deserialize the message.
-    let deserialized_encapsulated_message = deserialize_encapsulated_message(serialized_message)
-        .map_err(|_| ReceiveError::UndeserializableMessage)?;
+    let deserialized_encapsulated_message =
+        deserialize_encapsulated_message(serialized_message, num_blend_layers)
+            .map_err(|_| ReceiveError::UndeserializableMessage)?;
 
     // Add the message to the set of exchanged message identifiers with the sender,
     // returning `Err` if the message was already sent by this peer previously.

--- a/blend/network/src/core/with_edge/behaviour/mod.rs
+++ b/blend/network/src/core/with_edge/behaviour/mod.rs
@@ -1,4 +1,4 @@
-use core::num::NonZeroUsize;
+use core::num::{NonZeroU64, NonZeroUsize};
 use std::{
     collections::{HashSet, VecDeque},
     convert::Infallible,
@@ -51,6 +51,10 @@ pub struct Config {
     pub connection_timeout: Duration,
     pub max_incoming_connections: usize,
     pub minimum_network_size: NonZeroUsize,
+    /// `ß_c`: the fixed number of encapsulation layers every well-formed Blend
+    /// message carries. Used to validate the layout of messages received from
+    /// remote peers before processing them.
+    pub num_blend_layers: NonZeroU64,
 }
 
 /// A [`NetworkBehaviour`]:
@@ -67,6 +71,7 @@ pub struct Behaviour {
     max_incoming_connections: usize,
     protocol_name: StreamProtocol,
     minimum_network_size: NonZeroUsize,
+    num_blend_layers: NonZeroU64,
 }
 
 impl Behaviour {
@@ -85,6 +90,7 @@ impl Behaviour {
             max_incoming_connections: config.max_incoming_connections,
             protocol_name,
             minimum_network_size: config.minimum_network_size,
+            num_blend_layers: config.num_blend_layers,
         }
     }
 
@@ -153,7 +159,7 @@ impl Behaviour {
 
     fn handle_received_serialized_encapsulated_message(&mut self, serialized_message: &[u8]) {
         let Ok(deserialized_encapsulated_message) =
-            deserialize_encapsulated_message(serialized_message)
+            deserialize_encapsulated_message(serialized_message, self.num_blend_layers)
         else {
             tracing::trace!(target: LOG_TARGET, "Failed to deserialize received message. Ignoring...");
             return;

--- a/blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/message_handling.rs
@@ -51,6 +51,50 @@ async fn receive_valid_message() {
 }
 
 #[test(tokio::test)]
+async fn reject_message_with_unexpected_layer_count() {
+    // The behaviour is configured to expect a single encapsulation layer, but
+    // the shared test helper builds a 3-layer message. The size gate in
+    // `EncapsulatedMessage::deserialize_from_remote` must reject it up front,
+    // before the (larger) message is fully parsed or its header processed.
+    let mut core_swarm = TestSwarm::new_ephemeral(|_| {
+        BehaviourBuilder::new(PeerId::random())
+            .with_num_blend_layers(1)
+            .build()
+    });
+    let mut edge_swarm = TestSwarm::new_ephemeral(|_| StreamBehaviour::new());
+
+    core_swarm.listen().with_memory_addr_external().await;
+    let stream = edge_swarm
+        .connect_and_upgrade_to_blend(&mut core_swarm)
+        .await;
+    let message = TestEncapsulatedMessage::new(b"unexpected_layer_count");
+    send_msg(
+        stream,
+        serialize_encapsulated_message_with_verified_public_header(message.as_ref()),
+    )
+    .await
+    .unwrap();
+
+    loop {
+        select! {
+            _ = edge_swarm.select_next_some() => {}
+            core_swarm_event = core_swarm.select_next_some() => {
+                match core_swarm_event {
+                    SwarmEvent::Behaviour(Event::Message(_)) => {
+                        panic!("No `Message` event should be generated for a message with an unexpected number of layers.");
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                        assert_eq!(peer_id, *edge_swarm.local_peer_id());
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+#[test(tokio::test)]
 async fn message_timeout() {
     let mut core_swarm = TestSwarm::new_ephemeral(|_| {
         BehaviourBuilder::new(PeerId::random())

--- a/blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -1,4 +1,7 @@
-use core::{num::NonZeroUsize, time::Duration};
+use core::{
+    num::{NonZeroU64, NonZeroUsize},
+    time::Duration,
+};
 use std::collections::{HashSet, VecDeque};
 
 use async_trait::async_trait;
@@ -20,6 +23,7 @@ pub struct BehaviourBuilder {
     max_incoming_connections: Option<usize>,
     timeout: Option<Duration>,
     minimum_network_size: Option<NonZeroUsize>,
+    num_blend_layers: Option<NonZeroU64>,
 }
 
 impl BehaviourBuilder {
@@ -29,7 +33,13 @@ impl BehaviourBuilder {
             max_incoming_connections: None,
             timeout: None,
             minimum_network_size: None,
+            num_blend_layers: None,
         }
+    }
+
+    pub fn with_num_blend_layers(mut self, num_blend_layers: u64) -> Self {
+        self.num_blend_layers = Some(num_blend_layers.try_into().unwrap());
+        self
     }
 
     pub fn with_max_incoming_connections(mut self, max_incoming_connections: usize) -> Self {
@@ -71,6 +81,11 @@ impl BehaviourBuilder {
             minimum_network_size: self
                 .minimum_network_size
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),
+            // Matches the number of layers produced by the shared test message
+            // helper (`generate_valid_inputs` uses 3 inputs).
+            num_blend_layers: self
+                .num_blend_layers
+                .unwrap_or_else(|| 3.try_into().unwrap()),
         }
     }
 }

--- a/blend/network/src/core/with_edge/behaviour/tests/utils.rs
+++ b/blend/network/src/core/with_edge/behaviour/tests/utils.rs
@@ -81,8 +81,6 @@ impl BehaviourBuilder {
             minimum_network_size: self
                 .minimum_network_size
                 .unwrap_or_else(|| 1usize.try_into().unwrap()),
-            // Matches the number of layers produced by the shared test message
-            // helper (`generate_valid_inputs` uses 3 inputs).
             num_blend_layers: self
                 .num_blend_layers
                 .unwrap_or_else(|| 3.try_into().unwrap()),

--- a/blend/scheduling/src/message_blend/crypto/mod.rs
+++ b/blend/scheduling/src/message_blend/crypto/mod.rs
@@ -52,9 +52,9 @@ pub fn deserialize_encapsulated_message(
     message: &[u8],
     num_blend_layers: NonZeroU64,
 ) -> Result<EncapsulatedMessage, Error> {
-    let (remaining, message) = EncapsulatedMessage::decode(message, num_blend_layers)?;
+    let (remaining, deserialized_message) = EncapsulatedMessage::decode(message, num_blend_layers)?;
     if !remaining.is_empty() {
         return Err(Error::MessageDeserializationFailed);
     }
-    Ok(message)
+    Ok(deserialized_message)
 }

--- a/blend/scheduling/src/message_blend/crypto/mod.rs
+++ b/blend/scheduling/src/message_blend/crypto/mod.rs
@@ -10,7 +10,7 @@ use lb_blend_message::{
         },
     },
 };
-use lb_core::codec::{DeserializeOp as _, SerializeOp};
+use lb_core::codec::SerializeOp;
 use lb_key_management_system_keys::keys::X25519PrivateKey;
 
 pub mod core_and_leader;
@@ -59,6 +59,9 @@ where
         .to_vec()
 }
 
-pub fn deserialize_encapsulated_message(message: &[u8]) -> Result<EncapsulatedMessage, Error> {
-    EncapsulatedMessage::from_bytes(message).map_err(|_| Error::MessageDeserializationFailed)
+pub fn deserialize_encapsulated_message(
+    message: &[u8],
+    num_blend_layers: NonZeroU64,
+) -> Result<EncapsulatedMessage, Error> {
+    EncapsulatedMessage::deserialize_from_remote(message, num_blend_layers)
 }

--- a/blend/scheduling/src/message_blend/crypto/mod.rs
+++ b/blend/scheduling/src/message_blend/crypto/mod.rs
@@ -10,7 +10,6 @@ use lb_blend_message::{
         },
     },
 };
-use lb_core::codec::SerializeOp;
 use lb_key_management_system_keys::keys::X25519PrivateKey;
 
 pub mod core_and_leader;
@@ -39,24 +38,14 @@ pub struct EpochCryptographicProcessorSettings {
 pub fn serialize_encapsulated_message_with_verified_public_header(
     message: &EncapsulatedMessageWithVerifiedPublicHeader,
 ) -> Vec<u8> {
-    serialize_message(message)
+    message.encode()
 }
 
 #[must_use]
 pub fn serialize_encapsulated_message_with_verified_signature(
     message: &EncapsulatedMessageWithVerifiedSignature,
 ) -> Vec<u8> {
-    serialize_message(message)
-}
-
-fn serialize_message<Message>(message: &Message) -> Vec<u8>
-where
-    Message: SerializeOp,
-{
-    message
-        .to_bytes()
-        .expect("Message should be serializable")
-        .to_vec()
+    message.encode()
 }
 
 pub fn deserialize_encapsulated_message(

--- a/blend/scheduling/src/message_blend/crypto/mod.rs
+++ b/blend/scheduling/src/message_blend/crypto/mod.rs
@@ -52,5 +52,5 @@ pub fn deserialize_encapsulated_message(
     message: &[u8],
     num_blend_layers: NonZeroU64,
 ) -> Result<EncapsulatedMessage, Error> {
-    EncapsulatedMessage::deserialize_from_remote(message, num_blend_layers)
+    EncapsulatedMessage::decode(message, num_blend_layers)
 }

--- a/blend/scheduling/src/message_blend/crypto/mod.rs
+++ b/blend/scheduling/src/message_blend/crypto/mod.rs
@@ -52,5 +52,15 @@ pub fn deserialize_encapsulated_message(
     message: &[u8],
     num_blend_layers: NonZeroU64,
 ) -> Result<EncapsulatedMessage, Error> {
-    EncapsulatedMessage::decode(message, num_blend_layers)
+    // The message-crate decoder assumes a correctly-sized input, so the O(1) size
+    // gate that rejects malformed / wrongly-sized peer bytes up front — and the
+    // check that nothing is left over — live here, at the network boundary.
+    if message.len() as u64 != EncapsulatedMessage::expected_serialized_len(num_blend_layers) {
+        return Err(Error::MessageDeserializationFailed);
+    }
+    let (remaining, decoded) = EncapsulatedMessage::decode(message, num_blend_layers)?;
+    if !remaining.is_empty() {
+        return Err(Error::MessageDeserializationFailed);
+    }
+    Ok(decoded)
 }

--- a/blend/scheduling/src/message_blend/crypto/mod.rs
+++ b/blend/scheduling/src/message_blend/crypto/mod.rs
@@ -52,15 +52,9 @@ pub fn deserialize_encapsulated_message(
     message: &[u8],
     num_blend_layers: NonZeroU64,
 ) -> Result<EncapsulatedMessage, Error> {
-    // The message-crate decoder assumes a correctly-sized input, so the O(1) size
-    // gate that rejects malformed / wrongly-sized peer bytes up front — and the
-    // check that nothing is left over — live here, at the network boundary.
-    if message.len() as u64 != EncapsulatedMessage::expected_serialized_len(num_blend_layers) {
-        return Err(Error::MessageDeserializationFailed);
-    }
-    let (remaining, decoded) = EncapsulatedMessage::decode(message, num_blend_layers)?;
+    let (remaining, message) = EncapsulatedMessage::decode(message, num_blend_layers)?;
     if !remaining.is_empty() {
         return Err(Error::MessageDeserializationFailed);
     }
-    Ok(decoded)
+    Ok(message)
 }

--- a/services/blend/src/core/backends/libp2p/behaviour.rs
+++ b/services/blend/src/core/backends/libp2p/behaviour.rs
@@ -39,11 +39,13 @@ where
                         peering_degree: minimum_core_healthy_peering_degree
                             ..=maximum_core_peering_degree,
                         minimum_network_size: config.minimum_network_size.try_into().unwrap(),
+                        num_blend_layers: config.num_blend_layers,
                     },
                     with_edge: lb_blend::network::core::with_edge::behaviour::Config {
                         connection_timeout: config.backend.edge_node_connection_timeout,
                         max_incoming_connections: maximum_edge_incoming_connections,
                         minimum_network_size: config.minimum_network_size.try_into().unwrap(),
+                        num_blend_layers: config.num_blend_layers,
                     },
                 },
                 observation_window_interval_provider,

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -198,8 +198,6 @@ impl BlendBehaviourBuilder {
                     with_core: CoreToCoreConfig {
                         peering_degree,
                         minimum_network_size: 1.try_into().unwrap(),
-                        // Matches the number of layers produced by the shared
-                        // test message helper (`generate_valid_inputs` uses 3).
                         num_blend_layers: 3.try_into().unwrap(),
                     },
                     with_edge: CoreToEdgeConfig {

--- a/services/blend/src/core/backends/libp2p/tests/utils.rs
+++ b/services/blend/src/core/backends/libp2p/tests/utils.rs
@@ -198,11 +198,15 @@ impl BlendBehaviourBuilder {
                     with_core: CoreToCoreConfig {
                         peering_degree,
                         minimum_network_size: 1.try_into().unwrap(),
+                        // Matches the number of layers produced by the shared
+                        // test message helper (`generate_valid_inputs` uses 3).
+                        num_blend_layers: 3.try_into().unwrap(),
                     },
                     with_edge: CoreToEdgeConfig {
                         connection_timeout: Duration::from_secs(1),
                         max_incoming_connections: 300,
                         minimum_network_size: 1.try_into().unwrap(),
+                        num_blend_layers: 3.try_into().unwrap(),
                     },
                 },
                 TestObservationWindowProvider {


### PR DESCRIPTION
## 1. What does this PR implement?

By design, all Blend messages are supposed to look the same. That means that, given the number of encapsulations, all messages have the same length. We can enforce that when decoding messages from the wire. Also, we can use arrays and boxed slices in Rust because we are never growing those layers once a message is created, and that is also by definition.

To make things easier to follow, I introduced `WireEncode` and `WireDecode` traits, similar to what we do for nom encoding, but with an additional context when decoding, which types can request to make judgment about the expected size of the input being decoded. In practice, most types use `()` as the context, with some types requesting the number of encapsulation layers. This allows for a modular, bottom-up approach to implementing encoding/decoding logic which also stays separate from the rest of the types implementations.

At the top level, the `EncapsulatedMessage` type, which is only ever received by a node, exposes a `decode` function only, with a test-only `encode` one for tests. On the other hand, the verified counterparts `EncapsulatedMessageWithVerifiedPublicHeader` and `EncapsulatedMessageWithVerifiedSignature`, which are both supposed to only be sent over the wire and never received, expose only an `encode` function.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No. But we might want to use this implementation to generate a test vector to include in the spec.