### PR TITLE
refactor(cryptarchia-engine): block-tree invariants by construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ dependencies = [
  "logos-blockchain-utils",
  "rpds",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.18",
  "time",

--- a/consensus/cryptarchia-engine/Cargo.toml
+++ b/consensus/cryptarchia-engine/Cargo.toml
@@ -27,5 +27,8 @@ time       = { workspace = true }
 tokio      = { features = ["time"], optional = true, workspace = true }
 tracing    = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [features]
 tokio = ["dep:tokio"]

--- a/consensus/cryptarchia-engine/src/block.rs
+++ b/consensus/cryptarchia-engine/src/block.rs
@@ -1,0 +1,215 @@
+use core::hash::Hash;
+use std::num::NonZero;
+
+use rpds::HashTrieMapSync;
+
+use crate::time::Slot;
+
+/// Holds the immutable facts about a block: its identity, parentage, slot
+/// and chain length.
+///
+/// Values of this type are plain data, safe to copy and hold across engine
+/// mutations. A block's *role* in the tree (LIB, fork point, tip) changes as
+/// the tree evolves, so it is deliberately not part of this type: role
+/// questions are only answerable by the live block tree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Branch<Id> {
+    id: Id,
+    parent: Id,
+    slot: Slot,
+    length: u64,
+}
+
+impl<Id: Copy> Branch<Id> {
+    pub(crate) const fn new(id: Id, parent: Id, slot: Slot, length: u64) -> Self {
+        Self {
+            id,
+            parent,
+            slot,
+            length,
+        }
+    }
+
+    /// The block id.
+    pub const fn id(&self) -> Id {
+        self.id
+    }
+
+    /// The parent block id.
+    ///
+    /// Tree-root convention: the block the tree was created from is its own
+    /// parent. Code that walks parent links must therefore either stop when
+    /// `parent() == id()` or treat a failed lookup of the parent as the end
+    /// of the in-memory lineage (the parent of an advanced LIB is real but
+    /// pruned from memory).
+    ///
+    /// Instead of manually walking parent links, use the `LineageIterator`
+    /// which walks back the chain starting from a provided initial block
+    /// and naturally stops at the LIB block.
+    pub const fn parent(&self) -> Id {
+        self.parent
+    }
+
+    /// The slot the block belongs to.
+    pub const fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    /// The chain length up to and including this block.
+    pub const fn length(&self) -> u64 {
+        self.length
+    }
+}
+
+/// A block's current role in the block tree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Role {
+    /// The root of the in-memory tree: the latest immutable block.
+    /// Its ancestors have been pruned from memory.
+    Lib,
+    /// An interior block with at least one child.
+    ///
+    /// The count lets fork pruning turn a block back into a `Role::Tip`
+    /// when its last remaining child is removed.
+    Internal { children_count: NonZero<usize> },
+    /// A leaf: a chain tip with no children.
+    Tip,
+}
+
+/// A block-tree map entry: the immutable block data plus its current role.
+///
+/// `Block` values must not escape the tree, the role is only true for as
+/// long as the tree is not mutated. Public APIs hand out `Branch` copies
+/// instead, which cannot go stale.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Block<Id> {
+    pub(crate) branch: Branch<Id>,
+    pub(crate) role: Role,
+}
+
+impl<Id: Copy> Block<Id> {
+    pub(crate) const fn is_lib(&self) -> bool {
+        matches!(self.role, Role::Lib)
+    }
+
+    pub(crate) const fn is_tip(&self) -> bool {
+        matches!(self.role, Role::Tip)
+    }
+
+    pub(crate) const fn has_single_child(&self) -> bool {
+        matches!(self.role, Role::Internal{children_count} if children_count.get() == 1)
+    }
+
+    pub(crate) fn with_child_added(self) -> Self {
+        let role = match self.role {
+            Role::Lib => Role::Lib,
+            Role::Tip => Role::Internal {
+                children_count: NonZero::<usize>::MIN,
+            },
+            Role::Internal { children_count: n } => Role::Internal {
+                // SOUNDNESS: n >= 1, so n + 1 >= 2.
+                children_count: (n.get() + 1).try_into().unwrap(),
+            },
+        };
+        Self { role, ..self }
+    }
+
+    pub(crate) fn with_child_removed(self) -> Self {
+        let role = match self.role {
+            Role::Lib => Role::Lib,
+            Role::Tip => unreachable!("a childless block cannot lose a child"),
+            Role::Internal { children_count } => match children_count.get() {
+                1 => Role::Tip,
+                n => Role::Internal {
+                    // SOUNDNESS: this arm only matches n >= 2, so n - 1 >= 1.
+                    children_count: (n - 1).try_into().unwrap(),
+                },
+            },
+        };
+        Self { role, ..self }
+    }
+}
+
+/// Iterates a lineage from the given block (inclusive) up to the LIB
+/// (inclusive), following parent links.
+///
+/// Every element is fetched from the map by id, so the yielded blocks
+/// always reflect the tree the iterator was created over.
+pub struct LineageIterator<'a, Id> {
+    cursor: Option<Id>,
+    blocks: &'a HashTrieMapSync<Id, Block<Id>>,
+}
+
+impl<'a, Id> LineageIterator<'a, Id> {
+    pub(crate) const fn new(cursor: Id, blocks: &'a HashTrieMapSync<Id, Block<Id>>) -> Self {
+        Self {
+            cursor: Some(cursor),
+            blocks,
+        }
+    }
+}
+
+impl<'a, Id: Copy + Eq + Hash> Iterator for LineageIterator<'a, Id> {
+    type Item = &'a Block<Id>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let id = self.cursor?;
+        // SOUNDNESS: a lineage walk only follows parent links of in-tree
+        // blocks, pruning removes children before their parents, and the
+        // walk stops at the LIB before reaching its (pruned) parent.
+        let block = self.blocks.get(&id).unwrap();
+        self.cursor = if block.is_lib() {
+            None
+        } else {
+            Some(block.branch.parent())
+        };
+        Some(block)
+    }
+}
+
+/// Pairs each element with whether it is the last one, via one-element
+/// lookahead.
+///
+/// The lookahead runs the upstream iterator one step ahead of the consumer,
+/// so this is only appropriate over side-effect-free upstreams.
+pub struct WithIsLast<I: Iterator> {
+    inner: std::iter::Peekable<I>,
+}
+
+impl<I: Iterator> Iterator for WithIsLast<I> {
+    type Item = (I::Item, bool);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.inner.next()?;
+        Some((item, self.inner.peek().is_none()))
+    }
+}
+
+/// Extension trait adding [`WithIsLast`] to any iterator.
+pub trait WithIsLastExt: Iterator + Sized {
+    /// Pairs each element with whether it is the last one.
+    fn with_is_last(self) -> WithIsLast<Self> {
+        WithIsLast {
+            inner: self.peekable(),
+        }
+    }
+}
+
+impl<I: Iterator> WithIsLastExt for I {}
+
+#[cfg(test)]
+mod tests {
+    use super::WithIsLastExt as _;
+
+    #[test]
+    fn with_is_last_flags_only_the_final_element() {
+        let empty: Vec<(u8, bool)> = std::iter::empty().with_is_last().collect();
+        assert_eq!(empty, vec![]);
+
+        let single: Vec<_> = std::iter::once(7).with_is_last().collect();
+        assert_eq!(single, vec![(7, true)]);
+
+        let multi: Vec<_> = [1, 2, 3].into_iter().with_is_last().collect();
+        assert_eq!(multi, vec![(1, false), (2, false), (3, true)]);
+    }
+}

--- a/consensus/cryptarchia-engine/src/lib.rs
+++ b/consensus/cryptarchia-engine/src/lib.rs
@@ -1,5 +1,15 @@
+//! The Cryptarchia consensus engine: an in-memory block tree with
+//! Ouroboros-style fork choice, Genesis while bootstrapping, Praos when
+//! online, and pruning driven by advances of the LIB, the latest
+//! immutable block.
+
+mod block;
+/// Consensus configuration: the security parameter, slot activation
+/// coefficient and lottery constants.
 pub mod config;
+/// Slots, epochs and slot timing.
 pub mod time;
+mod typestate;
 
 use core::{fmt::Debug, hash::Hash};
 use std::{
@@ -7,62 +17,39 @@ use std::{
     num::NonZero,
 };
 
+use crate::block::{Block, LineageIterator, Role, WithIsLastExt as _};
+pub use block::Branch;
 pub use config::*;
+
 use rpds::{HashTrieMapSync, HashTrieSetSync};
 use thiserror::Error;
 pub use time::{Epoch, EpochConfig, Slot};
 
 pub(crate) const LOG_TARGET: &str = "cryptarchia::engine";
 
+/// The engine's operating mode, which selects the fork choice rule and the
+/// LIB update policy.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum State {
+    /// Catching up with the network: Ouroboros Genesis fork choice, LIB
+    /// frozen at the block the engine was created from.
     Bootstrapping,
+    /// Caught up: Ouroboros Praos fork choice, LIB trailing the local chain
+    /// tip by the security parameter.
     Online,
 }
 
 impl State {
+    /// Whether the engine is bootstrapping.
     #[must_use]
     pub const fn is_bootstrapping(&self) -> bool {
         matches!(self, Self::Bootstrapping)
     }
 
+    /// Whether the engine is online.
     #[must_use]
     pub const fn is_online(&self) -> bool {
         matches!(self, Self::Online)
-    }
-
-    /// Runs the fork choice rule and returns the selected new local chain tip.
-    fn fork_choice<Id>(cryptarchia: &Cryptarchia<Id>) -> Branch<Id>
-    where
-        Id: Eq + Hash + Copy,
-    {
-        match cryptarchia.state {
-            Self::Bootstrapping => {
-                let k = cryptarchia.config.security_param().get().into();
-                let s_gen = cryptarchia.config.s_gen();
-                maxvalid_bg(cryptarchia.local_chain, &cryptarchia.branches, k, s_gen)
-            }
-            Self::Online => {
-                let k = cryptarchia.config.security_param().get().into();
-                maxvalid_mc(cryptarchia.local_chain, &cryptarchia.branches, k)
-            }
-        }
-    }
-
-    fn lib<Id>(cryptarchia: &Cryptarchia<Id>) -> Id
-    where
-        Id: Eq + Hash + Copy,
-    {
-        match cryptarchia.state {
-            Self::Bootstrapping => cryptarchia.branches.lib,
-            Self::Online => cryptarchia
-                .branches
-                .nth_ancestor(
-                    &cryptarchia.local_chain,
-                    cryptarchia.config.security_param().get().into(),
-                )
-                .id(),
-        }
     }
 }
 
@@ -84,18 +71,44 @@ where
     let forks = branches.branches();
     for chain in forks {
         let lowest_common_ancestor = branches.lca(&cmax, &chain);
-        let m = cmax.length - lowest_common_ancestor.length;
+
+        // SOUNDNESS: LCA is found on `cmax`'s own lineage, where lengths
+        // strictly decrease walking parent-ward, so its length is at most
+        // `cmax.length()` so the subtraction cannot underflow.
+        let m = cmax.length() - lowest_common_ancestor.length();
+
         if m <= k {
             // Classic longest chain rule with parameter k
-            if cmax.length < chain.length {
+            if cmax.length() < chain.length() {
                 cmax = chain;
             }
         } else {
             // The chain is forking too much, we need to pay a bit more attention
             // In particular, select the chain that is the densest after the fork
-            let density_slot = Slot::from(u64::from(lowest_common_ancestor.slot) + s_gen.get());
-            let cmax_density = branches.walk_back_before(&cmax, density_slot).length;
-            let candidate_density = branches.walk_back_before(&chain, density_slot).length;
+            let density_slot = lowest_common_ancestor.slot().strict_add(s_gen.get().into());
+
+            // SOUNDNESS:
+            //            a0 - a1 - a2 - a3 - a4 - a5 - a6 - cmax - a6 - a7 - a8 - ...
+            //           /     ^ density_slot maybe here       ^ or here      ^ or here
+            // ... b0 - lca
+            //           \
+            //           c0 - c1 - c2 - c3 - chain - c5 - ...
+            //
+            //  Given density_slot is past LCA, at LCA+s_gen, then
+            //  - if cmax lies after the density_slot then density_slot is returned
+            //  - if cmax lies before or at the density_slot then cmax is returned
+            //  So since in all cases the walk finds an entry, it's safe to unwrap.
+            let cmax_density = branches
+                .walk_back_before(&cmax, density_slot)
+                .unwrap()
+                .length();
+
+            // SOUNDNESS: same argument as for cmax.
+            let candidate_density = branches
+                .walk_back_before(&chain, density_slot)
+                .unwrap()
+                .length();
+
             if cmax_density < candidate_density {
                 cmax = chain;
             }
@@ -115,8 +128,11 @@ where
     let forks = branches.branches();
     for chain in forks {
         let lowest_common_ancestor = branches.lca(&cmax, &chain);
-        let m = cmax.length - lowest_common_ancestor.length;
-        if m <= k && cmax.length < chain.length {
+
+        // SOUNDNESS: same argument as in `maxvalid_bg`.
+        let m = cmax.length() - lowest_common_ancestor.length();
+
+        if m <= k && cmax.length() < chain.length() {
             // Classic longest chain rule with parameter k
             cmax = chain;
         }
@@ -124,6 +140,8 @@ where
     cmax
 }
 
+/// The consensus engine: a block tree plus the configuration and operating
+/// mode that drive fork choice and LIB updates.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Cryptarchia<Id>
 where
@@ -135,12 +153,14 @@ where
     state: State,
 }
 
+/// The in-memory block tree, rooted at the LIB: every known block, the set
+/// of chain tips, and the LIB pointer.
 #[derive(Clone, Debug)]
 pub struct Branches<Id>
 where
     Id: Eq + Hash,
 {
-    branches: HashTrieMapSync<Id, Branch<Id>>,
+    blocks: HashTrieMapSync<Id, Block<Id>>,
     tips: HashTrieSetSync<Id>,
     lib: Id,
 }
@@ -150,31 +170,7 @@ where
     Id: Eq + Hash,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.branches == other.branches && self.tips == other.tips && self.lib == other.lib
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct Branch<Id> {
-    id: Id,
-    parent: Id,
-    slot: Slot,
-    // chain length
-    length: u64,
-}
-
-impl<Id: Copy> Branch<Id> {
-    pub const fn id(&self) -> Id {
-        self.id
-    }
-    pub const fn parent(&self) -> Id {
-        self.parent
-    }
-    pub const fn slot(&self) -> Slot {
-        self.slot
-    }
-    pub const fn length(&self) -> u64 {
-        self.length
+        self.blocks == other.blocks && self.tips == other.tips && self.lib == other.lib
     }
 }
 
@@ -182,171 +178,190 @@ impl<Id> Branches<Id>
 where
     Id: Eq + Hash + Copy,
 {
+    /// Creates a block tree with `lib` as its only block and root.
     pub fn from_lib(lib: Id, slot: Slot, length: u64) -> Self {
-        let mut branches = HashTrieMapSync::new_sync();
-        branches.insert_mut(
+        let mut blocks = HashTrieMapSync::new_sync();
+        blocks.insert_mut(
             lib,
-            Branch {
-                id: lib,
-                parent: lib,
-                slot,
-                length,
+            Block {
+                // tree-root convention: set the root to be its own parent.
+                branch: Branch::new(lib, lib, slot, length),
+                role: Role::Lib,
             },
         );
         let mut tips = HashTrieSetSync::new_sync();
         tips.insert_mut(lib);
-        Self {
-            branches,
-            tips,
-            lib,
-        }
+        Self { blocks, tips, lib }
     }
 
-    /// Apply a new header to the branches.
+    /// Apply a new header.
+    ///
+    /// Re-applying a header that is already in the tree is a no-op: it is
+    /// logged and `Ok` is returned without modifying `self`.
     ///
     /// On error, `self` is not modified.
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    fn apply_header(&mut self, header: Id, parent: Id, slot: Slot) -> Result<(), Error<Id>> {
-        let parent_branch = self
-            .branches
-            .get(&parent)
-            .ok_or(Error::ParentMissing(parent))?;
+    fn apply_header(&mut self, id: Id, parent_id: Id, slot: Slot) -> Result<(), Error<Id>>
+    where
+        Id: Debug,
+    {
+        let parent = *self
+            .blocks
+            .get(&parent_id)
+            .ok_or(Error::ParentMissing(parent_id))?;
 
-        if parent_branch.slot > slot {
-            return Err(Error::InvalidSlot(parent));
+        if parent.branch.slot() > slot {
+            return Err(Error::InvalidSlot(parent_id));
         }
 
-        let length = parent_branch
-            .length
+        // Re-inserting an existing block must be refused:
+        // - inflates its parent's children_count causing leaks in `prune_stale_forks`
+        // - erases existing block's children_count. Pruning may then remove this block leaving
+        // its children no way to walk back to it which results in a panic
+        // - the tips set regains a block that may have children, feeding
+        //   fork choice and fork pruning a candidate that is not a leaf.
+        if let Some(branch) = self.get(&id) {
+            tracing::debug!(
+                target: LOG_TARGET,
+                "Header {branch:?} already in the tree. Re-insertion attempted with parent_id: {parent_id:?} and slot: {slot:?}"
+            );
+            return Ok(());
+        }
+
+        let length = parent
+            .branch
+            .length()
             .checked_add(1)
             .expect("New branch height overflows.");
 
-        self.tips.remove_mut(&parent);
-        self.tips.insert_mut(header);
+        self.insert_mut(parent.with_child_added());
 
-        self.branches.insert_mut(
-            header,
-            Branch {
-                id: header,
-                parent,
-                length,
-                slot,
-            },
-        );
+        self.tips.remove_mut(&parent_id);
+        self.tips.insert_mut(id);
+
+        self.insert_mut(Block {
+            branch: Branch::new(id, parent_id, slot, length),
+            role: Role::Tip,
+        });
 
         Ok(())
     }
 
+    /// Iterates over the blocks at the current chain tips.
     pub fn branches(&self) -> impl Iterator<Item = Branch<Id>> + '_ {
-        self.tips.iter().map(|id| self.branches[id])
+        // SOUNDNESS: the tips set only contains ids of blocks in the map
+        // both are updated together on insert and prune.
+        self.tips.iter().map(|id| self.blocks[id].branch)
     }
 
-    /// find the lowest common ancestor of two branches
-    pub fn lca<'a>(&'a self, mut b1: &'a Branch<Id>, mut b2: &'a Branch<Id>) -> Branch<Id> {
-        // first reduce branches to the same length
-        while b1.length > b2.length {
-            b1 = &self.branches[&b1.parent];
-        }
+    /// Find the lowest common ancestor of two branches.
+    pub fn lca(&self, b1: &Branch<Id>, b2: &Branch<Id>) -> Branch<Id> {
+        assert!(
+            self.blocks.contains_key(&b1.id()) && self.blocks.contains_key(&b2.id()),
+            "lca() requires branches that are currently in the tree"
+        );
 
-        while b2.length > b1.length {
-            b2 = &self.branches[&b2.parent];
+        let mut it1 = LineageIterator::new(b1.id(), &self.blocks);
+        let mut it2 = LineageIterator::new(b2.id(), &self.blocks);
+
+        // first reduce branches to the same length
+        // SOUNDNESS: each `+ 1` is guarded by its arm's strict inequality, so
+        // the result is at most the longer branch's length and cannot overflow.
+        if b1.length() > b2.length() {
+            let _ = it1.find(|block| block.branch.length() == b2.length() + 1);
+        } else if b2.length() > b1.length() {
+            let _ = it2.find(|block| block.branch.length() == b1.length() + 1);
         }
 
         // then walk up the chain until we find the common ancestor
-        while b1.id != b2.id {
-            b1 = &self.branches[&b1.parent];
-            b2 = &self.branches[&b2.parent];
-        }
-
-        *b1
+        // SOUNDNESS: b1 and b2 have LIB in common if nothing else.
+        it1.zip(it2)
+            .find(|(n1, n2)| n1.branch.id() == n2.branch.id())
+            .unwrap()
+            .0
+            .branch
     }
 
+    /// Returns the block with the given id, if it is in the tree.
     pub fn get(&self, id: &Id) -> Option<&Branch<Id>> {
-        self.branches.get(id)
+        self.blocks.get(id).map(|block| &block.branch)
     }
 
+    /// Returns the chain length of the given block, if it is in the tree.
     pub fn get_length_for_header(&self, header_id: &Id) -> Option<u64> {
-        self.get(header_id).map(|branch| branch.length)
+        self.get(header_id).map(Branch::length)
     }
 
-    /// Walk back the chain until the target slot
-    fn walk_back_before(&self, branch: &Branch<Id>, slot: Slot) -> Branch<Id> {
-        let mut current = branch;
-        while current.slot > slot {
-            current = &self.branches[&current.parent];
-        }
-        *current
+    /// Walk back the chain until the target slot.
+    fn walk_back_before(&self, branch: &Branch<Id>, slot: Slot) -> Option<Branch<Id>> {
+        LineageIterator::new(branch.id(), &self.blocks)
+            .find(|block| block.branch.slot() <= slot)
+            .map(|block| block.branch)
     }
 
     /// Walk back the chain and return all blocks in the range
-    /// `[branch.id, target_exclusive)`.
-    fn walk_back_to_block<'s>(
-        &'s self,
-        branch: &'s Branch<Id>,
-        target_exclusive: Id,
-    ) -> impl Iterator<Item = Id> + 's {
-        let mut current = branch.id;
-        std::iter::from_fn(move || {
-            if current == target_exclusive {
-                None
-            } else {
-                let branch = &self.branches[&current];
-                current = branch.parent;
-                Some(branch.id)
-            }
-        })
+    /// `[branch, target_exclusive)`.
+    fn walk_back_to_block(&self, branch: Id, target_exclusive: Id) -> impl Iterator<Item = Id> {
+        LineageIterator::new(branch, &self.blocks)
+            .map(|block| block.branch.id())
+            .take_while(move |id| id != &target_exclusive)
     }
 
     /// Returns the min(n, A)-th ancestor of the provided block, where A is the
     /// number of ancestors of this block.
-    fn nth_ancestor(&self, branch: &Branch<Id>, mut n: u64) -> Branch<Id> {
-        let mut current = branch;
-        while n > 0 {
-            n -= 1;
-            if let Some(parent) = self.branches.get(&current.parent) {
-                current = parent;
-            } else {
-                return *current;
-            }
-        }
-        *current
+    ///
+    /// # Example
+    ///
+    /// Each block is labelled with the `n` that reaches it from `a4`:
+    ///
+    /// ```text
+    ///       LIB --- a1 --- a2 --- a3 --- a4
+    /// n:    >=4     3      2      1      0
+    /// ```
+    ///
+    /// `nth_ancestor(a4, 0)` returns `a4` itself,
+    /// `nth_ancestor(a4, 2)` returns `a2`,
+    /// `nth_ancestor(a4, 99)` returns `LIB`.
+    fn nth_ancestor(&self, id: Id, n: usize) -> Branch<Id> {
+        let m = n.checked_add(1).expect("security_param < usize::MAX");
+        LineageIterator::new(id, &self.blocks)
+            .take(m)
+            .last()
+            // SOUNDNESS: a lineage yields at least its start block
+            // `take` requests n + 1 >= 1 elements, so `last()` always finds one.
+            .unwrap()
+            .branch
+    }
+
+    fn insert_mut(&mut self, block: Block<Id>) {
+        self.blocks.insert_mut(block.branch.id(), block);
     }
 }
 
+/// Errors returned when applying a block to the tree.
 #[derive(Debug, Clone, Error)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum Error<Id> {
+    /// The block's parent is not in the tree.
     #[error("Parent block: {0:?} is not know to this node")]
     ParentMissing(Id),
+    /// An orphan proof was not found in the ledger.
     #[error("Orphan proof has was not found in the ledger: {0:?}, can't import it")]
     OrphanMissing(Id),
+    /// The block's slot precedes its parent's slot.
     #[error("Invalid slot for block {0:?}, parent slot is greater than child slot")]
     InvalidSlot(Id),
-}
-
-/// Information about a fork's divergence from the canonical branch.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ForkDivergenceInfo<Id> {
-    /// The tip of the diverging fork.
-    pub tip: Branch<Id>,
-    /// The LCA (lowest common ancestor) of the fork and the local canonical
-    /// chain.
-    pub lca: Branch<Id>,
 }
 
 impl<Id> Cryptarchia<Id>
 where
     Id: Eq + Hash + Copy + Debug,
 {
+    /// Creates an engine whose block tree contains only the given LIB block,
+    /// which starts as the local chain tip.
     pub fn from_lib(id: Id, config: Config, state: State, slot: Slot, length: u64) -> Self {
         Self {
             branches: Branches::from_lib(id, slot, length),
-            local_chain: Branch {
-                id,
-                length,
-                parent: id,
-                slot,
-            },
+            local_chain: Branch::new(id, id, slot, length),
             config,
             state,
         }
@@ -355,6 +370,7 @@ where
     /// Apply the given block.
     ///
     /// On success, returns the pruned/reorged blocks resulting from the update.
+    /// Re-receiving a block that is already in the tree is a no-op.
     /// On error, `self` is not modified.
     #[must_use = "Returns a new instance with the updated state, without modifying the original."]
     pub fn receive_block(
@@ -371,7 +387,7 @@ where
 
         // Before `update_lib` which may prune blocks,
         // collect the reorged blocks in the old local chain.
-        let reorged_blocks = if self.local_chain.id == old_local_chain.id {
+        let reorged_blocks = if self.local_chain.id() == old_local_chain.id() {
             ReorgedBlocks::new()
         } else {
             // It's safer to compute LCA here, not in `fork_choice`,
@@ -380,7 +396,7 @@ where
             let lca = self.branches.lca(&old_local_chain, &new_local_chain);
             ReorgedBlocks(
                 self.branches
-                    .walk_back_to_block(&old_local_chain, lca.id())
+                    .walk_back_to_block(old_local_chain.id(), lca.id())
                     .collect(),
             )
         };
@@ -394,136 +410,216 @@ where
     /// Whether the LIB is actually updated or not depends on the
     /// current state.
     ///
-    /// If the LIB is updated, forks that diverged before the new LIB
-    /// are pruned, and the blocks of the pruned forks are returned.
-    /// as [`PrunedBlocks`].
+    /// If the LIB is updated, forks that diverged before the new LIB are
+    /// pruned, and so are the new LIB's ancestors, which have become
+    /// immutable; both prunes are returned as [`PrunedBlocks`].
     /// Otherwise, an empty [`PrunedBlocks`] is returned.
     fn update_lib(&mut self) -> PrunedBlocks<Id> {
-        let new_lib = State::lib(&*self);
+        let new_lib = self.new_lib();
         // Trigger pruning only if the LIB has changed.
-        if self.branches.lib == new_lib {
-            PrunedBlocks::new()
-        } else {
-            self.branches.lib = new_lib;
-            PrunedBlocks {
-                // TODO: Eliminate the need of `lib_depth` by refactoring `prune_stale_forks`,
-                //       similar as `prune_immutable_blocks`.
-                stale_blocks: self.prune_stale_forks(self.lib_depth()).collect(),
-                immutable_blocks: self.prune_immutable_blocks().collect(),
-            }
+        if self.branches.lib == new_lib.id() {
+            return PrunedBlocks::new();
+        }
+
+        // - `prune_stale_forks` must happen before `prune_immutable_blocks`
+        // otherwise blocks would be left dangling
+        // - `prune_immutable_blocks` must happen before committing to the new LIB
+        // since the old LIB marks where to stop removal.
+        //
+        // Any other order of operations corrupts the state.
+        typestate::LibUpdate::new(new_lib)
+            .prune_stale_forks(self)
+            .prune_immutable_blocks(self)
+            .commit(self)
+    }
+
+    /// The block the LIB should point at under the current operating mode.
+    fn new_lib(&self) -> Branch<Id> {
+        let k = self
+            .config
+            .security_param()
+            .get()
+            .try_into()
+            .expect("usize must be at least as wide as the security parameter");
+
+        match self.state {
+            State::Bootstrapping => self.get_unwrap(self.branches.lib).branch,
+            State::Online => self.branches.nth_ancestor(self.local_chain.id(), k),
         }
     }
 
     /// Runs the fork choice rule and returns the selected new local chain tip.
     pub fn fork_choice(&self) -> Branch<Id> {
-        State::fork_choice(self)
+        match self.state {
+            State::Bootstrapping => {
+                let k = self.config.security_param().get().into();
+                let s_gen = self.config.s_gen();
+                maxvalid_bg(self.local_chain, &self.branches, k, s_gen)
+            }
+            State::Online => {
+                let k = self.config.security_param().get().into();
+                maxvalid_mc(self.local_chain, &self.branches, k)
+            }
+        }
     }
 
+    /// The id of the local canonical chain's tip.
     pub const fn tip(&self) -> Id {
-        self.local_chain.id
+        self.local_chain.id()
     }
 
+    /// The block at the local canonical chain's tip.
     pub const fn tip_branch(&self) -> &Branch<Id> {
         &self.local_chain
     }
 
-    /// Prune all blocks that are included in forks that diverged before
-    /// the `max_div_depth`-th block from the current local chain tip.
-    /// It returns the block IDs that were part of the pruned forks.
+    /// Removes the blocks of all forks that diverged before the new LIB and
+    /// returns their ids. A fork is prunable if its LCA with the local chain
+    /// is below the new LIB; forks diverging at or after the new LIB may
+    /// still become canonical and are kept.
     ///
-    /// For example,
-    /// Given a block tree:
-    ///               b6
-    ///             /
-    /// G - b1 - b2 - b3 - b4 - b5 == local chain tip
-    ///                  \
-    ///                    b7
-    /// Calling `prune_forks(2)` will remove `b6` because it is diverged from
-    /// `b2`, which is deeper than the 2nd block `b3` from the local chain tip.
-    /// The `b7` is not removed since it is diverged from `b3`.
-    fn prune_stale_forks(&mut self, max_div_depth: u64) -> impl Iterator<Item = Id> + '_ {
-        #[expect(
-            clippy::needless_collect,
-            reason = "We need to collect since we cannot borrow both immutably (in `self.prunable_forks`) and mutably (in `self.prune_fork`) at the same time."
-        )]
-        // Collect prunable forks first to avoid borrowing issues
-        let forks: Vec<_> = self.prunable_forks(max_div_depth).collect();
-        forks
-            .into_iter()
-            .flat_map(move |prunable_fork_info| self.prune_fork(&prunable_fork_info))
-    }
-
-    /// Get an iterator over the prunable forks that diverged before
-    /// the `max_div_depth`-th block from the current local chain tip.
-    fn prunable_forks(
-        &self,
-        max_div_depth: u64,
-    ) -> impl Iterator<Item = ForkDivergenceInfo<Id>> + '_ {
-        let local_chain = self.local_chain;
-        let Some(deepest_div_block) = local_chain.length.checked_sub(max_div_depth) else {
-            tracing::debug!(
-                target: LOG_TARGET,
-                "No prunable fork, the canonical chain is not longer than the provided depth. Canonical chain length: {}, provided max_div_depth: {}", local_chain.length, max_div_depth
-            );
-            return Box::new(core::iter::empty())
-                as Box<dyn Iterator<Item = ForkDivergenceInfo<Id>>>;
-        };
-        Box::new(self.non_canonical_forks().filter_map(move |fork| {
-            // We calculate LCA once and store it in `ForkInfo` so it can be consumed
-            // elsewhere without the need to re-calculate it.
-            let lca = self.branches.lca(&local_chain, &fork);
-            // If the fork is diverged deeper than `deepest_div_block`, it's prunable.
-            (lca.length < deepest_div_block).then_some(ForkDivergenceInfo { tip: fork, lca })
-        }))
-    }
-
-    /// Returns all the forks that are not part of the local canonical chain.
+    /// # Example
     ///
-    /// The result contains both prunable and non prunable forks.
-    pub fn non_canonical_forks(&self) -> impl Iterator<Item = Branch<Id>> + '_ {
-        self.branches
-            .branches()
-            .filter(|fork_tip| fork_tip.id != self.tip())
+    /// With `new_lib_length = 3` (the new LIB is `a3`).
+    ///
+    /// ```text
+    ///      b1                  <- prunable: diverged below the new LIB
+    ///     /
+    /// G - a1 - a2 - a3 - a4    <- local chain, a3 = new LIB
+    ///               \
+    ///                c2        <- kept: diverged at the new LIB
+    /// ```
+    ///
+    /// `b1` is pruned because its LCA `a1` lies below `a3`,
+    /// while `c2` survives because its LCA is `a3` itself.
+    ///
+    /// ```text
+    /// G - a1 - a2 - a3 - a4    <- local chain, a3 = new LIB
+    ///               \
+    ///                c2        <- kept: diverged at the new LIB
+    /// ```
+    fn prune_stale_forks(&mut self, new_lib_length: u64) -> HashSet<Id> {
+        self.clone()
+            .prunable_forks(new_lib_length)
+            .flat_map(|tip| self.prune_fork(tip.id()))
+            .collect()
     }
 
-    /// Remove all blocks of a fork from `tip` to `lca`, excluding `lca`.
-    fn prune_fork(&mut self, &ForkDivergenceInfo { lca, tip }: &ForkDivergenceInfo<Id>) -> Vec<Id> {
-        let tip_removed = self.branches.tips.remove_mut(&tip.id);
-        if !tip_removed {
-            tracing::error!(target: LOG_TARGET, "Fork tip {tip:#?} not found in the set of tips.");
-        }
-
-        let mut current_tip = tip.id;
-        let mut removed_blocks = vec![];
-        while current_tip != lca.id {
-            let Some(branch) = self.branches.branches.get(&current_tip).copied() else {
-                // If tip is not in branch set, it means this tip was sharing part of its
-                // history with another fork that has already been removed.
-                break;
-            };
-            self.branches.branches.remove_mut(&current_tip);
-            removed_blocks.push(branch.id);
-            current_tip = branch.parent;
-        }
-        tracing::debug!(
-            target: LOG_TARGET,
-            "Pruned {} blocks from {tip:#?} to {current_tip:#?}.", removed_blocks.len()
-        );
-        removed_blocks
-    }
-
-    /// Prunes all immutable blocks (excluding LIB) that are deeper than LIB,
-    /// and returns the slots and IDs of the pruned blocks.
-    fn prune_immutable_blocks(&mut self) -> impl Iterator<Item = (Slot, Id)> + '_ {
-        let mut block = self.lib_branch().parent;
-        std::iter::from_fn(move || {
-            let branch = self.branches.branches.get(&block).copied()?;
-            self.branches.branches.remove_mut(&block);
-            block = branch.parent;
-            Some((branch.slot, branch.id))
+    /// Iterates over the fork tips whose divergence from the local chain
+    /// lies strictly below the given LIB length.
+    fn prunable_forks(&self, lib_length: u64) -> impl Iterator<Item = Branch<Id>> + '_ {
+        self.non_canonical_forks().filter(move |non_canonical_tip| {
+            let lca = self.branches.lca(&self.local_chain, non_canonical_tip);
+            // non-canonical forks at or past LIB may still become canonical so none should be pruned.
+            lca.length() < lib_length
         })
     }
 
+    /// Iterates over the tips of all forks other than the local canonical
+    /// chain, prunable or not.
+    pub fn non_canonical_forks(&self) -> impl Iterator<Item = Branch<Id>> + '_ {
+        let canonical_id = self.local_chain.id();
+        self.branches
+            .branches()
+            .filter(move |tip| tip.id() != canonical_id)
+    }
+
+    /// Removes the blocks of the stale fork ending in `tip_id` and returns
+    /// their ids. A block is removable if it is a tip or has only one child.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    ///              c1 - c2    <- stale tip C
+    ///             /
+    ///       b1 - b2 - b3      <- stale tip B
+    ///      /
+    /// G - a1 - a2 - a3 - a4   <- local chain
+    /// ```
+    ///
+    /// First pass, `prune_fork(b3)`: only `b3` is removable, since `b2` has
+    /// two children; `b2` is updated to have one child.
+    ///
+    /// ```text
+    ///              c1 - c2    <- stale tip C
+    ///             /
+    ///       b1 - b2
+    ///      /
+    /// G - a1 - a2 - a3 - a4   <- local chain
+    /// ```
+    ///
+    /// Second pass, `prune_fork(c2)`: every block from `c2` down to `b1`
+    /// is removable, since `a1` has two children; `a1` is updated to have one
+    /// child.
+    ///
+    /// ```text
+    /// G - a1 - a2 - a3 - a4   <- local chain
+    /// ```
+    fn prune_fork(&mut self, tip: Id) -> HashSet<Id> {
+        self.branches.tips.remove_mut(&tip);
+
+        let is_removable = |block: &&Block<Id>| block.is_tip() || block.has_single_child();
+
+        let snapshot = self.branches.blocks.clone();
+
+        LineageIterator::new(tip, &snapshot)
+            .take_while(is_removable)
+            .with_is_last()
+            .map(|(block, is_last)| {
+                self.remove_mut(block.branch.id());
+                if is_last {
+                    let lca = self.get_unwrap(block.branch.parent());
+                    self.insert_mut(lca.with_child_removed());
+                }
+                block.branch.id()
+            })
+            .collect()
+    }
+
+    fn get_unwrap(&self, id: Id) -> &Block<Id> {
+        // SOUNDNESS: callers only pass ids obtained from the tree itself
+        // (tips, parent links, the LIB pointer), which never dangle. A miss
+        // means the tree is corrupt, and panicking is deliberate.
+        self.branches.blocks.get(&id).unwrap()
+    }
+
+    fn remove_mut(&mut self, id: Id) {
+        self.branches.blocks.remove_mut(&id);
+    }
+
+    fn insert_mut(&mut self, block: Block<Id>) {
+        self.branches.insert_mut(block);
+    }
+
+    /// Removes every ancestor of the new LIB.
+    ///
+    /// # Example
+    ///
+    /// The LIB advances from `G` to `a3`:
+    ///
+    /// ```text
+    /// G - a1 - a2 - a3 - a4 - a5   <- local chain
+    /// ^ old LIB     ^ new LIB
+    /// ```
+    ///
+    /// `prune_immutable_blocks()` removes `a2`, `a1` and `G`:
+    ///
+    /// ```text
+    /// a3 - a4 - a5   <- local chain
+    /// ^ LIB
+    /// ```
+    fn prune_immutable_blocks(&mut self, new_lib: Id) -> BTreeMap<Slot, Id> {
+        let snapshot = self.branches.blocks.clone();
+        LineageIterator::new(new_lib, &snapshot)
+            .skip(1) // don't remove the new LIB
+            .map(|block| {
+                self.remove_mut(block.branch.id());
+                (block.branch.slot(), block.branch.id())
+            })
+            .collect()
+    }
+
+    /// The underlying block tree.
     pub const fn branches(&self) -> &Branches<Id> {
         &self.branches
     }
@@ -534,29 +630,27 @@ where
         self.branches.lib
     }
 
+    /// The latest immutable block.
     pub fn lib_branch(&self) -> &Branch<Id> {
-        &self.branches.branches[&self.lib()]
+        &self.get_unwrap(self.lib()).branch
     }
 
+    /// The engine's current operating mode.
     pub const fn state(&self) -> &State {
         &self.state
     }
 
-    /// Calculate the depth of LIB from the local chain tip.
-    fn lib_depth(&self) -> u64 {
-        self.tip_branch()
-            .length()
-            .checked_sub(self.lib_branch().length())
-            .expect("Local chain tip height must be >= LIB height.")
-    }
-
+    /// Switches the engine to `State::Online`, updating the LIB and
+    /// pruning accordingly.
     pub fn online(mut self) -> (Self, PrunedBlocks<Id>) {
         self.state = State::Online;
-        // Update the LIB to the current local chain's tip
+        // With the state now Online, the LIB jumps from wherever bootstrapping
+        // left it to the security-param-th ancestor of the local chain tip.
         let pruned_blocks = self.update_lib();
         (self, pruned_blocks)
     }
 
+    /// The consensus configuration.
     pub const fn config(&self) -> &Config {
         &self.config
     }
@@ -588,13 +682,18 @@ impl<Id> PrunedBlocks<Id> {
         }
     }
 
+    /// Whether no blocks were pruned.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.stale_blocks.is_empty() && self.immutable_blocks.is_empty()
     }
 
+    /// The total number of pruned blocks, stale and immutable.
     #[must_use]
     pub fn len(&self) -> usize {
+        // SOUNDNESS: no process can allocate more than usize::MAX bytes
+        // thus existence of these collections at runtime is proof
+        // that, even combined, they don't exceed usize::MAX elements.
         self.stale_blocks.len() + self.immutable_blocks.len()
     }
 
@@ -628,6 +727,9 @@ where
     }
 }
 
+/// The blocks abandoned by a reorg: the segment of the old local chain from
+/// its tip down to — excluding — the common ancestor with the new chain,
+/// in tip-first order.
 pub struct ReorgedBlocks<Id>(Vec<Id>);
 
 impl<Id> ReorgedBlocks<Id> {
@@ -636,16 +738,19 @@ impl<Id> ReorgedBlocks<Id> {
         Self(vec![])
     }
 
+    /// The number of reorged blocks.
     #[must_use]
     pub const fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Whether no blocks were reorged.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Iterates over the reorged block ids, old tip first.
     pub fn iter(&self) -> std::slice::Iter<'_, Id> {
         <&Self as IntoIterator>::into_iter(self)
     }
@@ -669,8 +774,10 @@ pub mod tests {
 
     use lb_utils::math::NonNegativeRatio;
 
-    use super::{Cryptarchia, Error, Slot, maxvalid_bg};
-    use crate::{Config, ReorgedBlocks, State};
+    use std::collections::HashMap;
+
+    use super::{Branch, Cryptarchia, Error, Slot, maxvalid_bg, maxvalid_mc};
+    use crate::{Config, ReorgedBlocks, State, block::Role};
 
     #[must_use]
     pub fn config() -> Config {
@@ -722,6 +829,392 @@ pub mod tests {
             parent = new_block;
         }
         engine
+    }
+
+    /// Asserts the structural invariants of the block tree that the engine
+    /// maintains by hand:
+    /// - every non-LIB node has a parent that is in the tree, and is never
+    ///   its own parent (only the tree root is self-parented);
+    /// - only the LIB has the `Lib` role, and it is in the tree;
+    /// - the LIB is either self-parented (tree root since creation) or its
+    ///   parent has been pruned;
+    /// - each node's role matches its actual child count: `Tip` nodes have
+    ///   none, `Internal` nodes have exactly `children_count`;
+    /// - the `tips` set contains exactly the childless nodes;
+    /// - the local chain tip is one of the tips.
+    fn assert_tree_consistent(cryptarchia: &Cryptarchia<[u8; 32]>) {
+        let nodes = &cryptarchia.branches.blocks;
+        let lib = cryptarchia.branches.lib;
+        assert!(nodes.contains_key(&lib), "the LIB must be in the tree");
+
+        // Count each node's children from the parent links.
+        let mut children_counts: HashMap<[u8; 32], usize> = HashMap::new();
+        for (id, node) in nodes.iter() {
+            if node.is_lib() {
+                assert_eq!(*id, lib, "only the LIB may have the Lib role");
+                let parent_id = node.branch.parent();
+                assert!(
+                    parent_id == *id || !nodes.contains_key(&parent_id),
+                    "the LIB's ancestors must have been pruned"
+                );
+                continue;
+            }
+            let parent_id = node.branch.parent();
+            assert_ne!(parent_id, *id, "only the tree root may be its own parent");
+            assert!(
+                nodes.contains_key(&parent_id),
+                "a non-LIB node's parent must be in the tree"
+            );
+            *children_counts.entry(parent_id).or_default() += 1;
+        }
+
+        for (id, node) in nodes.iter() {
+            let actual = children_counts.get(id).copied().unwrap_or_default();
+            match node.role {
+                // The LIB does not track its children.
+                Role::Lib => {}
+                Role::Internal { children_count } => assert_eq!(
+                    children_count.get(),
+                    actual,
+                    "children_count must match the actual number of children"
+                ),
+                Role::Tip => assert_eq!(actual, 0, "a tip must have no children"),
+            }
+            assert_eq!(
+                cryptarchia.branches.tips.contains(id),
+                actual == 0,
+                "the tips set must contain exactly the childless nodes"
+            );
+        }
+
+        assert!(
+            cryptarchia
+                .branches
+                .tips
+                .contains(&cryptarchia.local_chain.id()),
+            "the local chain tip must be one of the tips"
+        );
+        assert_eq!(
+            cryptarchia.local_chain,
+            cryptarchia.branches.blocks[&cryptarchia.local_chain.id()].branch,
+            "the stored local chain tip must match its map entry"
+        );
+    }
+
+    #[test]
+    fn tree_invariants_through_forks_reorg_and_lib_advance() {
+        // G - b1 - b2 - b3 (bootstrapping, k = 2)
+        let mut engine = create_canonical_chain(4.try_into().unwrap(), Some(config_with(2)));
+        assert_tree_consistent(&engine);
+
+        // Hang two forks off b1 and extend the first, making b1 a fork
+        // point with three children:
+        //          f1a - f1b
+        //         /
+        // G - b1 - b2 - b3
+        //         \
+        //          f2a
+        let b1 = hash(&1u64);
+        let (f1a, f1b, f1c, f2a) = (hash(&"f1a"), hash(&"f1b"), hash(&"f1c"), hash(&"f2a"));
+        engine.receive_block(f1a, b1, 2.into()).unwrap();
+        assert_tree_consistent(&engine);
+        engine.receive_block(f1b, f1a, 3.into()).unwrap();
+        assert_tree_consistent(&engine);
+        engine.receive_block(f2a, b1, 2.into()).unwrap();
+        assert_tree_consistent(&engine);
+
+        // Extend the f1 fork past the canonical chain to force a reorg.
+        let (_, reorged) = engine.receive_block(f1c, f1b, 4.into()).unwrap();
+        assert!(!reorged.is_empty(), "switching to the f1 fork must reorg");
+        assert_eq!(engine.tip(), f1c);
+        assert_tree_consistent(&engine);
+
+        // Going online advances the LIB to k blocks behind the tip, pruning
+        // the stale forks (b2-b3 and f2a) and the immutable blocks (G, b1).
+        // Pruning f2a exercises the fork-point decrement; pruning b3
+        // exercises the removal of a single-child interior block (b2).
+        let (mut engine, pruned) = engine.online();
+        assert!(!pruned.is_empty());
+        assert_eq!(engine.lib(), f1a);
+        assert_tree_consistent(&engine);
+
+        // A fork branching at the LIB must survive pruning...
+        let at_lib = hash(&"at_lib");
+        engine.receive_block(at_lib, f1a, 3.into()).unwrap();
+        assert_tree_consistent(&engine);
+
+        // ...until the LIB advances past its divergence point.
+        let m1 = hash(&"m1");
+        engine.receive_block(m1, f1c, 5.into()).unwrap();
+        assert_eq!(engine.lib(), f1b);
+        assert!(
+            engine.branches().get(&at_lib).is_none(),
+            "a fork diverged before the new LIB must be pruned"
+        );
+        assert_tree_consistent(&engine);
+    }
+
+    #[test]
+    fn lca_alignment() {
+        //  g1
+        // /
+        // G - b1 - b2 - b3 - b4
+        //       \
+        //        f1
+        let mut engine = create_canonical_chain(5.try_into().unwrap(), None);
+        let (genesis, b1, b2, b4) = (hash(&0u64), hash(&1u64), hash(&2u64), hash(&4u64));
+        let (f1, g1) = (hash(&"f1"), hash(&"g1"));
+        engine.receive_block(f1, b1, 2.into()).unwrap();
+        engine.receive_block(g1, genesis, 1.into()).unwrap();
+
+        let branches = engine.branches();
+        let get = |id| *branches.get(&id).unwrap();
+        let (genesis, b1, b2, b4, f1, g1) =
+            (get(genesis), get(b1), get(b2), get(b4), get(f1), get(g1));
+
+        // One branch is an ancestor of the other.
+        assert_eq!(branches.lca(&b4, &b1), b1);
+        assert_eq!(branches.lca(&b1, &b4), b1);
+
+        // Tips of different lengths diverging at b1.
+        assert_eq!(branches.lca(&b4, &f1), b1);
+        assert_eq!(branches.lca(&f1, &b4), b1);
+
+        // Equal-length branches diverging at b1.
+        assert_eq!(branches.lca(&f1, &b2), b1);
+
+        // A branch is its own LCA.
+        assert_eq!(branches.lca(&b2, &b2), b2);
+
+        // Worst case: only the LIB (genesis) is in common.
+        assert_eq!(branches.lca(&g1, &b4), genesis);
+    }
+
+    #[test]
+    fn duplicate_block_is_ignored_without_mutation() {
+        // G - b1 - b2 - b3
+        let mut engine = create_canonical_chain(4.try_into().unwrap(), None);
+        let snapshot = engine.clone();
+
+        // Re-sending a block with its original parent and slot is a no-op...
+        let (pruned, reorged) = engine
+            .receive_block(hash(&2u64), hash(&1u64), 2.into())
+            .expect("duplicate blocks are ignored");
+        assert!(pruned.is_empty());
+        assert!(reorged.is_empty());
+
+        // ...but a duplicate goes through the same validations as a new
+        // block first, so re-sending it with garbage metadata still errors.
+        let result = engine.receive_block(hash(&2u64), hash(&99u64), 9.into());
+        assert!(matches!(result, Err(Error::ParentMissing(_))));
+
+        // The slot validation also runs before the duplicate check.
+        let result = engine.receive_block(hash(&2u64), hash(&1u64), 0.into());
+        assert!(matches!(result, Err(Error::InvalidSlot(_))));
+
+        assert_eq!(engine, snapshot, "an ignored block must not mutate state");
+    }
+
+    #[test]
+    fn online_with_only_the_genesis_block_keeps_the_lib() {
+        let genesis = hash(&0u64);
+        let engine =
+            <Cryptarchia<_>>::from_lib(genesis, config(), State::Bootstrapping, 0.into(), 0);
+
+        // The LIB clamps at the tree root when there are no ancestors.
+        let (engine, pruned) = engine.online();
+        assert_eq!(engine.lib(), genesis);
+        assert_eq!(engine.tip(), genesis);
+        assert!(pruned.is_empty());
+        assert_tree_consistent(&engine);
+    }
+
+    #[test]
+    fn same_slot_immutable_blocks_are_all_pruned() {
+        // The engine accepts a block in the same slot as its parent; all
+        // same-slot blocks must be removed when they become immutable, even
+        // though the pruning report keys blocks by slot.
+        // G - b1 - b2 - b3 - b4   (b1 and b2 share slot 1)
+        let genesis = hash(&0u64);
+        let mut engine =
+            Cryptarchia::from_lib(genesis, config_with(1), State::Bootstrapping, 0.into(), 0);
+        let (b1, b2, b3, b4) = (hash(&"b1"), hash(&"b2"), hash(&"b3"), hash(&"b4"));
+        engine.receive_block(b1, genesis, 1.into()).unwrap();
+        engine.receive_block(b2, b1, 1.into()).unwrap();
+        engine.receive_block(b3, b2, 2.into()).unwrap();
+        engine.receive_block(b4, b3, 3.into()).unwrap();
+
+        // Going online advances the LIB to b3 (k = 1), pruning b2, b1 and G.
+        let (engine, pruned) = engine.online();
+        assert_eq!(engine.lib(), b3);
+
+        // Both same-slot blocks are gone from the tree...
+        assert!(engine.branches().get(&b1).is_none());
+        assert!(engine.branches().get(&b2).is_none());
+        assert!(engine.branches().get(&genesis).is_none());
+        // ...while the report collapses them into a single slot-1 entry.
+        assert_eq!(pruned.immutable_blocks.len(), 2);
+        let reported = pruned.immutable_blocks.get(&1.into()).copied();
+        assert!(reported == Some(b1) || reported == Some(b2));
+        assert_tree_consistent(&engine);
+    }
+
+    #[test]
+    fn reorg_and_lib_advance_in_a_single_receive_block() {
+        //           f3 - f4    <- fork, wins on the last block
+        //          /
+        // G - b1 - b2 - b3     <- local chain, LIB = b2 once online
+        let mut engine = create_canonical_chain(4.try_into().unwrap(), Some(config_with(1)));
+        let (b1, b2, b3) = (hash(&1u64), hash(&2u64), hash(&3u64));
+        let (f3, f4) = (hash(&"f3"), hash(&"f4"));
+        engine.receive_block(f3, b2, 3.into()).unwrap();
+        let (mut engine, pruned) = engine.online();
+        assert_eq!(engine.lib(), b2);
+        // The equal-length fork survives: it diverged at the LIB.
+        assert!(pruned.stale_blocks.is_empty());
+        assert!(engine.branches().get(&b1).is_none());
+
+        // One block both reorgs the local chain to the fork and advances
+        // the LIB; the reorged blocks are collected against the pre-prune
+        // tree, so b3 is reported as reorged *and* as pruned.
+        let (pruned, reorged) = engine.receive_block(f4, f3, 4.into()).unwrap();
+        assert_eq!(engine.tip(), f4);
+        assert_eq!(engine.lib(), f3);
+        assert_eq!(reorged.len(), 1);
+        assert_eq!(reorged.iter().next(), Some(&b3));
+        assert_eq!(pruned.stale_blocks, [b3].into());
+        assert_eq!(pruned.immutable_blocks, [(2.into(), b2)].into());
+        assert_tree_consistent(&engine);
+    }
+
+    #[test]
+    fn lib_parent_follows_the_tree_root_conventions() {
+        // G - b1 - b2 - b3
+        let engine = create_canonical_chain(4.try_into().unwrap(), Some(config_with(1)));
+
+        // The tree root is its own parent while it is the LIB...
+        let genesis = *engine.branches().get(&hash(&0u64)).unwrap();
+        assert_eq!(genesis.parent(), genesis.id());
+
+        // ...while an advanced LIB keeps the id of its real, pruned parent.
+        let (engine, _) = engine.online();
+        assert_eq!(engine.lib(), hash(&2u64));
+        assert_eq!(engine.lib_branch().parent(), hash(&1u64));
+        assert!(
+            engine.branches().get(&hash(&1u64)).is_none(),
+            "the LIB's parent must be pruned from memory"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "lca() requires branches that are currently in the tree")]
+    fn lca_rejects_branches_not_in_the_tree() {
+        let engine = create_canonical_chain(3.try_into().unwrap(), None);
+        let foreign =
+            Cryptarchia::from_lib(hash(&99u64), config(), State::Bootstrapping, 0.into(), 0);
+        let foreign_branch = *foreign.branches().get(&hash(&99u64)).unwrap();
+        let local = *engine.branches().get(&hash(&1u64)).unwrap();
+
+        let _ = engine.branches().lca(&local, &foreign_branch);
+    }
+
+    #[test]
+    fn online_fork_choice_rejects_reorgs_deeper_than_k() {
+        //          f2 - f3 - f4 - f5 - f6    <- longer fork, diverged at b1
+        //         /
+        // G - b1 - b2 - b3 - b4 - b5         <- local chain
+        //
+        // The engine's pruning keeps every surviving fork within k of the
+        // tip while Online, so the rejection arm of `maxvalid_mc` is tested
+        // directly on a bootstrapped tree (as `test_fork_choice` does for
+        // `maxvalid_bg`).
+        let mut engine = create_canonical_chain(6.try_into().unwrap(), Some(config_with(2)));
+        let mut parent = hash(&1u64);
+        for i in 2..=6u64 {
+            let block = hash(&format!("f{i}"));
+            engine.receive_block(block, parent, i.into()).unwrap();
+            parent = block;
+        }
+
+        let branches = engine.branches();
+        let canonical_tip = *branches.get(&hash(&5u64)).unwrap();
+        let fork_tip = *branches.get(&hash(&format!("f{}", 6u64))).unwrap();
+        assert_eq!(fork_tip.length(), canonical_tip.length() + 1);
+
+        // The fork diverged 4 blocks behind the canonical tip: with k = 2
+        // the longer fork must not win...
+        assert_eq!(maxvalid_mc(canonical_tip, branches, 2), canonical_tip);
+        // ...while with k = 4 the divergence is within bounds and it must.
+        assert_eq!(maxvalid_mc(canonical_tip, branches, 4), fork_tip);
+    }
+
+    #[test]
+    fn reorged_blocks_are_reported_from_old_tip_to_lca() {
+        //      f2 - f3 - f4    <- new local chain after the reorg
+        //     /
+        // G - b1 - b2 - b3     <- old local chain
+        //
+        // k is large so the longest-chain rule (not the density rule)
+        // decides the fork choice.
+        let mut engine = create_canonical_chain(4.try_into().unwrap(), Some(config_with(10)));
+        let (f2, f3, f4) = (hash(&"f2"), hash(&"f3"), hash(&"f4"));
+        engine.receive_block(f2, hash(&1u64), 2.into()).unwrap();
+        engine.receive_block(f3, f2, 3.into()).unwrap();
+
+        let (_, reorged) = engine.receive_block(f4, f3, 4.into()).unwrap();
+        assert_eq!(engine.tip(), f4);
+        assert_eq!(
+            reorged.iter().copied().collect::<Vec<_>>(),
+            vec![hash(&3u64), hash(&2u64)],
+            "reorged blocks are the old chain from its tip down to the LCA \
+             (exclusive), in child-to-parent order"
+        );
+    }
+
+    #[test]
+    fn equal_length_fork_does_not_displace_the_tip() {
+        //      f2 - f3        <- competing fork of equal length
+        //     /
+        // G - b1 - b2 - b3    <- local chain (seen first, must stay)
+        let mut engine = create_canonical_chain(4.try_into().unwrap(), Some(config_with(10)));
+        let (f2, f3) = (hash(&"f2"), hash(&"f3"));
+        engine.receive_block(f2, hash(&1u64), 2.into()).unwrap();
+        let (_, reorged) = engine.receive_block(f3, f2, 3.into()).unwrap();
+
+        assert!(reorged.is_empty());
+        assert_eq!(
+            engine.tip(),
+            hash(&3u64),
+            "the first-seen chain wins length ties"
+        );
+    }
+
+    #[test]
+    fn branch_serde_format() {
+        // G - b1
+        let engine = create_canonical_chain(2.try_into().unwrap(), None);
+        let branches = engine.branches();
+        let genesis = *branches.get(&hash(&0u64)).unwrap();
+        let b1 = *branches.get(&hash(&1u64)).unwrap();
+
+        // The tree root is encoded as its own parent (see `Branch::parent`)...
+        let genesis_json = serde_json::to_value(genesis).unwrap();
+        assert_eq!(
+            genesis_json["parent"],
+            serde_json::to_value(genesis.id()).unwrap()
+        );
+        // ...while other blocks serialize their parent id.
+        let b1_json = serde_json::to_value(b1).unwrap();
+        assert_eq!(
+            b1_json["parent"],
+            serde_json::to_value(genesis.id()).unwrap()
+        );
+
+        // Both round-trip to equal values.
+        for (json, branch) in [(genesis_json, genesis), (b1_json, b1)] {
+            let roundtripped: Branch<[u8; 32]> = serde_json::from_value(json).unwrap();
+            assert_eq!(roundtripped, branch);
+        }
     }
 
     #[test]
@@ -821,19 +1314,19 @@ pub mod tests {
 
         {
             let bs = engine.branches();
-            let long_branch = bs.branches().find(|b| b.id == long_p).unwrap();
-            let short_branch = bs.branches().find(|b| b.id == short_p).unwrap();
+            let long_branch = bs.branches().find(|b| b.id() == long_p).unwrap();
+            let short_branch = bs.branches().find(|b| b.id() == short_p).unwrap();
 
             // however, if we set k to the fork length, it will be accepted
-            let k = long_branch.length;
+            let k = long_branch.length();
             assert_eq!(
-                maxvalid_bg(short_branch, engine.branches(), k, engine.config.s_gen()).id,
+                maxvalid_bg(short_branch, engine.branches(), k, engine.config.s_gen()).id(),
                 long_p
             );
 
             // a new denser chain will be selected as the main tip
             let mut parent = orig_engine.tip();
-            let tip_height = engine.tip_branch().length;
+            let tip_height = engine.tip_branch().length();
             for slot in initial_height..=tip_height {
                 let new_block = hash(&format!("dense-{slot}"));
                 let (_, reorged_blocks) = engine
@@ -943,7 +1436,7 @@ pub mod tests {
         // greater than local chain length.
         assert!(pruned_blocks.all().next().is_none());
         assert!(cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
 
         // Add two new blocks to the local honest chain,
         // and check if the LIB is updated and blocks are pruned.
@@ -959,14 +1452,14 @@ pub mod tests {
         // The stale fork b100 was pruned.
         assert_eq!(pruned_blocks.stale_blocks, [hash(&100u64)].into());
         assert!(!cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
         // The immutable block b0 was pruned.
         assert_eq!(
             pruned_blocks.immutable_blocks,
             [(0.into(), hash(&0u64))].into()
         );
         assert!(!cryptarchia.branches.tips.contains(&hash(&0u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&0u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&0u64)));
     }
 
     #[test]
@@ -992,7 +1485,7 @@ pub mod tests {
         // But, b100 was not pruned.
         assert!(pruned_blocks.stale_blocks.is_empty());
         assert!(cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
 
         // Immutable blocks (excluding LIB) were pruned.
         assert_eq!(
@@ -1049,13 +1542,13 @@ pub mod tests {
         // A fork from b38 was pruned.
         assert_eq!(pruned_blocks.stale_blocks, [hash(&100u64)].into());
         assert!(!cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
 
         // Other forks were not pruned
         assert!(cryptarchia.branches.tips.contains(&hash(&101u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&101u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&101u64)));
         assert!(cryptarchia.branches.tips.contains(&hash(&102u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&102u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&102u64)));
 
         // Immutable blocks (excluding LIB) were pruned.
         assert_eq!(
@@ -1100,13 +1593,13 @@ pub mod tests {
             [hash(&100u64), hash(&200u64)].into()
         );
         assert!(!cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
         assert!(!cryptarchia.branches.tips.contains(&hash(&200u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&200u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&200u64)));
 
         // Fork at b39 was not pruned.
         assert!(cryptarchia.branches.tips.contains(&hash(&101u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&101u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&101u64)));
 
         // Immutable blocks (excluding LIB) were pruned.
         assert_eq!(
@@ -1151,10 +1644,10 @@ pub mod tests {
             [hash(&100u64), hash(&101u64), hash(&200u64)].into()
         );
         assert!(!cryptarchia.branches.tips.contains(&hash(&101u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&100u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&101u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&101u64)));
         assert!(!cryptarchia.branches.tips.contains(&hash(&200u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&200u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&200u64)));
 
         // Immutable blocks (excluding LIB) were pruned.
         assert_eq!(
@@ -1186,14 +1679,14 @@ pub mod tests {
             .receive_block(
                 hash(&100u64),
                 cryptarchia.lib(),
-                cryptarchia.lib_branch().slot.strict_add(1.into()),
+                cryptarchia.lib_branch().slot().strict_add(1.into()),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&7u64));
         // No block is pruned since LIB was not updated.
         assert!(pruned_blocks.all().next().is_none());
         assert!(cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
 
         // Add a fork after than LIB
         // b7(LIB) - b8 - b9
@@ -1202,17 +1695,17 @@ pub mod tests {
         let (pruned_blocks, _) = cryptarchia
             .receive_block(
                 hash(&101u64),
-                cryptarchia.tip_branch().parent,
-                cryptarchia.tip_branch().slot,
+                cryptarchia.tip_branch().parent(),
+                cryptarchia.tip_branch().slot(),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&7u64));
         // No block was pruned since LIB was not updated.
         assert!(pruned_blocks.all().next().is_none());
         assert!(cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
         assert!(cryptarchia.branches.tips.contains(&hash(&101u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&101u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&101u64)));
 
         // Add a block to the tip to update the LIB.
         // b7 - b8(LIB) - b9 - b102
@@ -1222,19 +1715,19 @@ pub mod tests {
             .receive_block(
                 hash(&102u64),
                 cryptarchia.tip(),
-                cryptarchia.tip_branch().slot.strict_add(1.into()),
+                cryptarchia.tip_branch().slot().strict_add(1.into()),
             )
             .expect("test block to be applied successfully.");
         assert_eq!(cryptarchia.lib(), hash(&8u64));
         // One fork (b100) was pruned since LIB was updated.
         assert_eq!(pruned_blocks.stale_blocks, [hash(&100u64)].into());
         assert!(!cryptarchia.branches.tips.contains(&hash(&100u64)));
-        assert!(!cryptarchia.branches.branches.contains_key(&hash(&100u64)));
+        assert!(!cryptarchia.branches.blocks.contains_key(&hash(&100u64)));
         // b101 and b102 were not pruned.
         assert!(cryptarchia.branches.tips.contains(&hash(&101u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&101u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&101u64)));
         assert!(cryptarchia.branches.tips.contains(&hash(&102u64)));
-        assert!(cryptarchia.branches.branches.contains_key(&hash(&102u64)));
+        assert!(cryptarchia.branches.blocks.contains_key(&hash(&102u64)));
         // Immutable blocks (excluding LIB) were pruned.
         assert_eq!(
             pruned_blocks.immutable_blocks,

--- a/consensus/cryptarchia-engine/src/typestate.rs
+++ b/consensus/cryptarchia-engine/src/typestate.rs
@@ -1,0 +1,78 @@
+//! Type-state tokens enforcing the LIB-update protocol at compile time.
+//!
+//! Updating the LIB is a three-phase mutation:
+//!
+//! 1. stale forks are pruned first
+//! 2. immutable blocks are pruned next
+//! 3. the new LIB block is written last.
+//!
+//! Each phase consumes the previous token by value, so the phases cannot be
+//! reordered, repeated or skipped without a compile error.
+//!
+//! Once started, ignoring any step of the protocol, i.e. by not using a
+//! returned value, is linted against by `must_use`.
+
+use core::{fmt::Debug, hash::Hash};
+use std::collections::{BTreeMap, HashSet};
+
+use crate::{
+    Branch, Cryptarchia, PrunedBlocks, Slot,
+    block::{Block, Role},
+};
+
+#[must_use = "a started LIB update must be committed"]
+pub struct LibUpdate<Id> {
+    new_lib: Branch<Id>,
+}
+
+#[must_use = "a started LIB update must be committed"]
+pub struct StalePruned<Id> {
+    new_lib: Branch<Id>,
+    stale_blocks: HashSet<Id>,
+}
+
+#[must_use = "a started LIB update must be committed"]
+pub struct ImmutablePruned<Id> {
+    new_lib: Branch<Id>,
+    stale_blocks: HashSet<Id>,
+    immutable_blocks: BTreeMap<Slot, Id>,
+}
+
+impl<Id: Eq + Hash + Copy + Debug> LibUpdate<Id> {
+    pub const fn new(new_lib: Branch<Id>) -> Self {
+        Self { new_lib }
+    }
+
+    pub fn prune_stale_forks(self, tree: &mut Cryptarchia<Id>) -> StalePruned<Id> {
+        let stale_blocks = tree.prune_stale_forks(self.new_lib.length());
+        StalePruned {
+            new_lib: self.new_lib,
+            stale_blocks,
+        }
+    }
+}
+
+impl<Id: Eq + Hash + Copy + Debug> StalePruned<Id> {
+    pub fn prune_immutable_blocks(self, tree: &mut Cryptarchia<Id>) -> ImmutablePruned<Id> {
+        let immutable_blocks = tree.prune_immutable_blocks(self.new_lib.id());
+        ImmutablePruned {
+            new_lib: self.new_lib,
+            stale_blocks: self.stale_blocks,
+            immutable_blocks,
+        }
+    }
+}
+
+impl<Id: Eq + Hash + Copy + Debug> ImmutablePruned<Id> {
+    pub fn commit(self, tree: &mut Cryptarchia<Id>) -> PrunedBlocks<Id> {
+        tree.branches.lib = self.new_lib.id();
+        tree.branches.insert_mut(Block {
+            branch: self.new_lib,
+            role: Role::Lib,
+        });
+        PrunedBlocks {
+            stale_blocks: self.stale_blocks,
+            immutable_blocks: self.immutable_blocks,
+        }
+    }
+}


### PR DESCRIPTION
## 1. What does this PR implement?

No new protocol behavior. This PR restructures the cryptarchia-engine's internal block tree so that the invariants the engine used to maintain by convention are now maintained by construction, while keeping the public API and wire format compatible with master. The observable behavior of the engine is unchanged except for the deltas listed below: all pre-existing tests pass unmodified, and the dependent chain-service compiles and passes its test suite without a single change.

## Motivation

This started as a fix for a small TODO on master https://github.com/logos-blockchain/logos-blockchain/blob/81a6a37694b9889c98caca8a30c1ce10b5133461/consensus/cryptarchia-engine/src/lib.rs#L409-L410

Eliminating `lib_depth` meant expressing "which forks are prunable" directly against the LIB rather than through a depth recomputed from the tip. Pulling that thread exposed how much of the block tree's correctness rested on conventions — hand-maintained parent walks, a tips set kept in sync by habit, pruning phases whose order was load-bearing but unenforced — and the fix grew into this refactor: making those conventions structural. The original TODO is resolved: the tip-relative `lib_depth` (and its round-trip — `tip.length - lib.length`, converted straight back to `lib.length` inside the pruning filter) is gone; stale-fork pruning is now driven by the LIB's own length, symmetric with `prune_immutable_blocks`.

### Design

**`Branch` / `Block` / `Role` split** (`block.rs`, renamed from `branch.rs`): a block's immutable facts and its mutable position in the tree are now different types.

- `Branch<Id>` (public, unchanged shape): plain data — id, parent, slot, length. Safe to copy and hold across engine mutations; nothing in it can go stale. Serialization format is identical to master, including the genesis-is-its-own-parent convention (pinned by a test).
- `Role` (crate-internal): `Lib` (the in-memory tree root), `Internal { children_count }`, or `Tip`. Roles change as the tree evolves, so they live only in the tree.
- `Block<Id>` (crate-internal): the map entry — `branch` plus `role`. Block values never escape the tree; public APIs hand out `Branch` copies.

The `children_count` on interior blocks lets fork pruning cascade: removing a fork demotes its fork point back to a `Tip` exactly when its last child is removed, so shared stale segments are cleaned up across multiple pruning passes without recomputing LCAs.

**Lineage walks** are centralized in `LineageIterator` (start block inclusive down to the LIB inclusive), used by LCA computation, density lookups, reorg collection, `nth_ancestor` and both pruning passes. `prune_fork` is a single iterator pipeline using a small `WithIsLast` adapter to apply the boundary decrement on the final removed block.

**LIB update is a typestate** (`typestate.rs`). Updating the LIB is a three-phase mutation in a precise order (stale forks must be pruned while the immutable segment still exists; the immutable walk terminates at the old LIB's role marker; the new LIB is re-tagged last). Each phase consumes a token only the previous phase produces, so reordering the phases is a compile error rather than a runtime corruption:

```rust
typestate::LibUpdate::new(new_lib)
    .prune_stale_forks(self)
    .prune_immutable_blocks(self)
    .commit(self)
```

### Public API compatibility

`config.rs` and `time.rs` are untouched. All public types, methods, bounds, const-ness, serde formats and error strings are identical to master, with these exceptions:

1. **Removed: `ForkDivergenceInfo`.** It was dead code (no consumers in this repository); external consumers would get a loud compile error.
2. **Duplicate block re-application no longer perturbs the tree.** On master, re-applying a known block overwrote its entry and re-inserted its id into the tips set (adding a non-leaf to the fork-choice candidate set). Now a duplicate passes the same validations as a new block (`ParentMissing` / `InvalidSlot` behave exactly as on master) and a fully valid duplicate is a logged no-op. `Ok`/`Err` results are unchanged.
3. **`Branches::lca` asserts its precondition.** Passing branches that are not in the tree now panics with a message; on master such inputs produced an index panic or a non-terminating walk. Valid inputs are unaffected. The signature's lifetimes were also relaxed (callers compile unchanged).

### Robustness

- Every panic-capable expression (unwraps, indexing, arithmetic) either carries a `SOUNDNESS:` comment stating the invariant that makes it unreachable, or fails with a message naming the violated assumption. Arithmetic on protocol values uses `checked_*`/`strict_*` operations; the fork-choice expressions are kept byte-identical to master.
- `assert_tree_consistent` (test-only) recomputes the tree's ground truth from parent links — child counts vs roles, tips ⇔ leaves, single LIB root, lineage integrity — and is exercised throughout the scenario tests.

### Testing

25 unit tests (up from 12), all of master's tests preserved. New coverage:

- tree invariants through forks, a reorg and two LIB advances;
- LCA in all orientations (ancestor/descendant, unequal/equal lengths, self-LCA) plus the not-in-tree panic contract;
- fork-choice: equal-length ties, the `maxvalid_mc` rejection arm from both sides of `k`;
- duplicates: valid no-op against a full engine snapshot (including a block with children), and both validation errors ordered before the no-op;
- pruning: same-slot immutable blocks (report collapses by slot, the tree removes all), reorg + LIB advance in a single `receive_block` (reorged blocks are collected against the pre-prune tree);
- LIB parent conventions (genesis self-parent; an advanced LIB keeps its pruned parent's id) — the contract chain-service's storage fallback depends on;
- serde wire-format pinning and round-trip;
- the `WithIsLast` adapter and the genesis-only LIB clamp.

### Future work

- Property-based testing: random insert/reorg/advance sequences with `assert_tree_consistent` as the oracle (proptest is already a workspace dependency).
- `Branch::parent` is kept for compatibility; migrating consumers to an `Option`-returning accessor and removing the self-parent convention is a separate breaking change (TODO in `block.rs`).

## 2. Does the code have enough context to be clearly understood?

Specification (executable): https://github.com/logos-blockchain/logos-blockchain-specs/blob/master/cryptarchia/cryptarchia.py — `fork_choice` and the Genesis/Praos rules (`maxvalid_bg`, around lines 416 and 678), and the LIB computation ("the k-th block in the chain", around line 396). Behavioral reference tests: https://github.com/logos-blockchain/logos-blockchain-specs/blob/master/cryptarchia/test_fork_choice.py

The consensus rules themselves (`maxvalid_bg`, `maxvalid_mc`, the LIB trailing the tip by the security parameter) are unchanged and kept expression-identical to master where practical.

Implementation details that are idiosyncratic (not derived from the specification) are documented in code where they live:

- the `Role` taxonomy and `children_count` bookkeeping (`block.rs`), with a worked multi-pass pruning example on `prune_fork`;
- the typestate tokens (`typestate.rs` module docs state the three ordering facts they enforce and why each is load-bearing);
- the tree-root ("genesis is its own parent") convention and the advanced LIB keeping its pruned parent's id — documented on `Branch::parent` and pinned by tests; chain-service's storage fallback depends on it;
- duplicate re-application as a validated no-op — rationale documented at the guard in `apply_header` (the insertion path is not idempotent under count bookkeeping).

## 3. Who are the specification authors and who is accountable for this PR?

- Accountable for this PR: @diogofriggo
- Specification author(s) (main authors of `cryptarchia.py` in the specs repository): @davidrusu, @zeegomo, @youngjoon-lee
- Suggested code reviewers (main historical authors of this crate): @ntn-x2, @youngjoon-lee, @zeegomo

## 4. Is the specification accurate and complete?

The refactor surfaced three behaviors that appear implementation-defined rather than specified. This PR preserves the existing semantics for all three; confirming them with the specification authors is advisable:

1. **Duplicate block re-application**: previous behavior mutated internal state (see API delta 2); this PR makes it a validated no-op. Neither behavior appears specified.
2. **Equal-length fork ties**: the first-seen chain wins (now pinned by a test). Tie-breaking does not appear in the specification.
3. **Forks diverging exactly at the LIB are retained** (only strictly deeper divergences are pruned). The boundary condition does not appear specified.

## 5. Does the implementation introduce changes in the specification?

No. Protocol-level behavior is unchanged; the deltas listed in section 1 are Rust API surface only. If the section-4 clarifications result in specification updates, they would document existing behavior rather than change it.

## Checklist

* [x] 1. PR title follows Conventional Commits (`refactor(cryptarchia-engine): …`).
* [x] 2. Description added.
* [x] 3. Context and links to specification document(s) added (section 2).
* [x] 4. Main contacts (developers and specification authors) added (section 3).
* [x] 5. Implementation and specification are in sync: no protocol behavior changed; three implementation-defined behaviors are flagged in section 4 for clarification (all preserved as-is).
* [ ] 6. PR linked to a milestone
* [x] 7. New and changed logs reviewed against the logging guidelines: the two touched logs (`prune_fork`'s pruning summary, `apply_header`'s duplicate no-op) are `debug` on the existing `cryptarchia::engine` target; both explain "why a block was treated a certain way", matching the guideline's `debug` definition. No new `error`/`warn`/`info` logs.
