### PR TITLE
fix: remove features check step

### DIFF
--- a/.github/workflows/rust-latest-version-check.yml
+++ b/.github/workflows/rust-latest-version-check.yml
@@ -54,14 +54,3 @@ jobs:
           filename: ./.github/rust_update_issue_template.md
           update_existing: false
           search_existing: all
-  check-features:
-    name: Check features
-    needs: notify-new-version
-    runs-on: ubuntu-latest
-    steps:
-        - name: Checkout repository
-          uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2  # Version 4.2.2
-        - name: Install cargo-features-manager
-          run: cargo install cargo-features-manager@0.10.0
-        - name: Run cargo-features-manager
-          run: cargo features prune --dry-run


### PR DESCRIPTION
Nightly workflow keeps failing. Also, we need to look into an alternative way of checking enabled features as that solution had a lot of false positives. Let's remove it for now.