### PR TITLE
feat(api): add `/mantle/sdp/snapshot`

### DIFF
--- a/nodes/api-common/src/paths.rs
+++ b/nodes/api-common/src/paths.rs
@@ -1,6 +1,7 @@
 pub const MANTLE_METRICS: &str = "/mantle/metrics";
 pub const MANTLE_STATUS: &str = "/mantle/status";
 pub const MANTLE_SDP_DECLARATIONS: &str = "/mantle/sdp/declarations";
+pub const MANTLE_SDP_SNAPSHOT: &str = "/mantle/sdp/snapshot";
 pub const MANTLE_GAS_PRICES: &str = "/mantle/gas-prices";
 pub const CRYPTARCHIA_INFO: &str = "/cryptarchia/info";
 pub const CRYPTARCHIA_HEADERS: &str = "/cryptarchia/headers";

--- a/nodes/node/binary/src/api/backend.rs
+++ b/nodes/node/binary/src/api/backend.rs
@@ -46,8 +46,8 @@ use utoipa_swagger_ui::SwaggerUi;
 use super::handlers::{
     add_tx, blend_info, block, block_events, blocks_range_stream, blocks_stream,
     cryptarchia_headers, cryptarchia_info, cryptarchia_lib_stream, dial_peer, get_gas_prices,
-    get_sdp_declarations, immutable_blocks, libp2p_info, mantle_metrics, mantle_status,
-    mempool_view, time_info, transaction, wallet,
+    get_sdp_declarations, get_sdp_snapshot, immutable_blocks, libp2p_info, mantle_metrics,
+    mantle_status, mempool_view, time_info, transaction, wallet,
 };
 use crate::{
     BlendBroadcastSettings, BlendService, TracingService, WalletService,
@@ -310,6 +310,10 @@ where
             .route(
                 paths::MANTLE_SDP_DECLARATIONS,
                 routing::get(get_sdp_declarations::<RuntimeServiceId>),
+            )
+            .route(
+                paths::MANTLE_SDP_SNAPSHOT,
+                routing::get(get_sdp_snapshot::<RuntimeServiceId>),
             )
             .route(
                 paths::LEADER_CLAIM,

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -1234,6 +1234,24 @@ where
 }
 
 #[utoipa::path(
+    get,
+    path = paths::MANTLE_SDP_SNAPSHOT,
+    responses(
+        (status = 200, description = "Get the SDP snapshot for the current epoch keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
+        (status = 500, description = "Internal server error", body = String),
+    )
+)]
+pub async fn get_sdp_snapshot<RuntimeServiceId>(
+    State(handle): State<OverwatchHandle<RuntimeServiceId>>,
+) -> Response
+where
+    RuntimeServiceId:
+        Debug + Send + Sync + Display + 'static + AsServiceId<Cryptarchia<RuntimeServiceId>>,
+{
+    make_request_and_return_response!(mantle::get_sdp_snapshot::<RuntimeServiceId>(&handle))
+}
+
+#[utoipa::path(
     post,
     path = paths::LEADER_CLAIM,
     responses(

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -21,6 +21,7 @@ use utoipa::OpenApi;
         crate::api::handlers::post_activity,
         crate::api::handlers::post_withdrawal,
         crate::api::handlers::get_sdp_declarations,
+        crate::api::handlers::get_sdp_snapshot,
         crate::api::handlers::leader_claim,
         crate::api::handlers::immutable_blocks,
         crate::api::handlers::block,

--- a/services/api/src/http/mantle.rs
+++ b/services/api/src/http/mantle.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::{fmt::Display, num::NonZeroUsize, ops::RangeInclusive};
+use std::{collections::HashMap, fmt::Display, num::NonZeroUsize, ops::RangeInclusive};
 
 use bytes::Bytes;
 use futures::{Stream, StreamExt as _, future::join_all};
@@ -13,7 +13,7 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{SignedMantleTx, Transaction, TxHash, channel::ChannelState, ops::channel::ChannelId},
-    sdp::Declaration,
+    sdp::{Declaration, DeclarationId},
 };
 use lb_log_targets::api;
 use lb_storage_service::{
@@ -928,4 +928,29 @@ where
         .collect();
 
     Ok(declarations)
+}
+
+pub async fn get_sdp_snapshot<RuntimeServiceId>(
+    handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
+) -> Result<HashMap<DeclarationId, Declaration>, super::DynError>
+where
+    RuntimeServiceId: Debug
+        + Send
+        + Sync
+        + Display
+        + 'static
+        + AsServiceId<Cryptarchia<RuntimeServiceId>>
+        + 'static,
+{
+    let relay = handle.relay::<Cryptarchia<RuntimeServiceId>>().await?;
+    let (sender, receiver) = oneshot::channel();
+
+    relay
+        .send(ConsensusMsg::GetSdpSnapshot {
+            reply_channel: sender,
+        })
+        .await
+        .map_err(|(e, _)| e)?;
+
+    Ok(receiver.await?)
 }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use core::fmt::Debug;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Display,
     path::PathBuf,
     pin::Pin,
@@ -143,8 +143,13 @@ pub enum ConsensusMsg<Tx> {
         block_id: HeaderId,
         reply_channel: oneshot::Sender<Option<LedgerState>>,
     },
+    /// Returns all declarations in the current SDP registry, not snapshot
     GetSdpDeclarations {
         reply_channel: oneshot::Sender<Vec<(DeclarationId, Declaration)>>,
+    },
+    /// Returns the frozen SDP snapshot for the current epoch
+    GetSdpSnapshot {
+        reply_channel: oneshot::Sender<HashMap<DeclarationId, Declaration>>,
     },
     GetEpochState {
         slot: Slot,
@@ -937,6 +942,28 @@ where
                     .collect();
                 reply_channel.send(declarations).unwrap_or_else(|_| {
                     error!("Could not send SDP declarations through channel");
+                });
+            }
+            ConsensusMsg::GetSdpSnapshot { reply_channel } => {
+                let tip = cryptarchia.tip();
+                let declarations = cryptarchia
+                    .ledger
+                    .state(&tip)
+                    .map(|ledger_state| {
+                        ledger_state
+                            .epoch_state()
+                            .active_declarations
+                            .iter()
+                            .flat_map(|(_, declarations)| {
+                                declarations
+                                    .iter()
+                                    .map(|(id, declaration)| (*id, declaration.clone()))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                reply_channel.send(declarations).unwrap_or_else(|_| {
+                    error!("Could not send SDP snapshot through channel");
                 });
             }
             ConsensusMsg::GetEpochState {


### PR DESCRIPTION
## 1. What does this PR implement?

We already have `GET /mantle/sdp/declarations` but it shows the declarations in the current SDP registry, not snapshot. 
The SDP snapshot is taken at the end of `current_epoch - 2`. This PR adds a new API to show that snapshot.

The response is a map keyed by declaration ID.
```json
{
  "aefdd1bfa545a47ed8126889f21b617a3ab92e0d04963bfdadb013dd9701088e": {
    "service_type": "BN",
    "provider_id": "015e73fefc8b54813f28636293edd83cd9b3384830e7dd483e58502ab399c00e",
    ...
  }
}
```

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?
yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
