### PR TITLE
refactor(api): return SDP declarations as a HashMap keyed by id

### DIFF
--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -1219,7 +1219,7 @@ where
     get,
     path = paths::MANTLE_SDP_DECLARATIONS,
     responses(
-        (status = 200, description = "Get current SDP declarations", body = Vec<lb_core::sdp::Declaration>),
+        (status = 200, description = "Get current SDP declarations keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
         (status = 500, description = "Internal server error", body = String),
     )
 )]

--- a/services/api/src/http/mantle.rs
+++ b/services/api/src/http/mantle.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::{fmt::Display, num::NonZeroUsize, ops::RangeInclusive};
+use std::{collections::HashMap, fmt::Display, num::NonZeroUsize, ops::RangeInclusive};
 
 use bytes::Bytes;
 use futures::{Stream, StreamExt as _, future::join_all};
@@ -13,7 +13,7 @@ use lb_core::{
     events::Events,
     header::HeaderId,
     mantle::{SignedMantleTx, Transaction, TxHash, channel::ChannelState, ops::channel::ChannelId},
-    sdp::Declaration,
+    sdp::{Declaration, DeclarationId},
 };
 use lb_log_targets::api;
 use lb_storage_service::{
@@ -901,7 +901,7 @@ where
 
 pub async fn get_sdp_declarations<RuntimeServiceId>(
     handle: &overwatch::overwatch::handle::OverwatchHandle<RuntimeServiceId>,
-) -> Result<Vec<Declaration>, super::DynError>
+) -> Result<HashMap<DeclarationId, Declaration>, super::DynError>
 where
     RuntimeServiceId: Debug
         + Send
@@ -921,11 +921,5 @@ where
         .await
         .map_err(|(e, _)| e)?;
 
-    let declarations = receiver
-        .await?
-        .into_iter()
-        .map(|(_, declaration)| declaration)
-        .collect();
-
-    Ok(declarations)
+    Ok(receiver.await?)
 }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use core::fmt::Debug;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Display,
     path::PathBuf,
     pin::Pin,
@@ -144,7 +144,7 @@ pub enum ConsensusMsg<Tx> {
         reply_channel: oneshot::Sender<Option<LedgerState>>,
     },
     GetSdpDeclarations {
-        reply_channel: oneshot::Sender<Vec<(DeclarationId, Declaration)>>,
+        reply_channel: oneshot::Sender<HashMap<DeclarationId, Declaration>>,
     },
     GetEpochState {
         slot: Slot,

--- a/tests/src/cucumber/steps/manual_nodes/steps.rs
+++ b/tests/src/cucumber/steps/manual_nodes/steps.rs
@@ -1353,7 +1353,7 @@ async fn step_verify_blend_sdp_declaration_included(
             }
         };
 
-        if declarations.iter().any(|declaration| {
+        if declarations.values().any(|declaration| {
             declaration.locked_note_id == locked_note_id && declaration.zk_id == blend_zk_pk
         }) {
             info!(

--- a/tests/src/tests/mantle/sdp/activity.rs
+++ b/tests/src/tests/mantle/sdp/activity.rs
@@ -199,7 +199,7 @@ async fn wait_for_declarations(
         loop {
             if let Ok(declarations) = node.get_sdp_declarations().await {
                 return declarations
-                    .into_iter()
+                    .into_values()
                     .map(|declaration| (declaration.provider_id, declaration))
                     .collect();
             }

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -13,7 +13,10 @@ use lb_chain_service::Epoch;
 use lb_common_http_client::Error;
 use lb_core::{
     mantle::{NoteId, OpProof, Transaction as _, Utxo, ops::Op},
-    sdp::{Declaration, DeclarationMessage, Locator, ProviderId, ServiceType, WithdrawMessage},
+    sdp::{
+        Declaration, DeclarationId, DeclarationMessage, Locator, ProviderId, ServiceType,
+        WithdrawMessage,
+    },
 };
 use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature, ZkKey};
 use lb_node::config::{
@@ -76,7 +79,7 @@ async fn sdp_ops_e2e() {
     let existing = wait_for_sdp_declarations(&node0, Duration::from_secs(30))
         .await
         .expect("fetching SDP declarations should succeed");
-    let locked: HashSet<_> = existing.iter().map(|decl| decl.locked_note_id).collect();
+    let locked: HashSet<_> = existing.values().map(|decl| decl.locked_note_id).collect();
     let locked_note_id = spare_note_id;
     assert!(
         !locked.contains(&locked_note_id),
@@ -202,7 +205,7 @@ async fn sdp_ops_e2e() {
             .get_sdp_declarations()
             .await
             .unwrap()
-            .iter()
+            .values()
             .any(|declaration| declaration.provider_id == provider_id)
     );
 }
@@ -229,7 +232,7 @@ async fn sdp_declaration_restoration_e2e() {
         "validators should have declarations from genesis"
     );
 
-    let initial_declaration = declarations.first().unwrap().clone();
+    let initial_declaration = declarations.values().next().unwrap().clone();
     let target_locked_note = initial_declaration.locked_note_id;
 
     cluster_harness
@@ -253,7 +256,7 @@ async fn sdp_declaration_restoration_e2e() {
     );
 
     let restored_declaration = post_restart_declarations
-        .iter()
+        .values()
         .find(|d| d.locked_note_id == target_locked_note)
         .expect("original declaration should still exist after restart");
 
@@ -280,14 +283,14 @@ async fn get_declaration(
     Ok(node
         .get_sdp_declarations()
         .await?
-        .into_iter()
+        .into_values()
         .find(|declaration| &declaration.provider_id == provider_id))
 }
 
 async fn wait_for_sdp_declarations(
     node: &NodeHttpClient,
     duration: Duration,
-) -> Option<Vec<Declaration>> {
+) -> Option<HashMap<DeclarationId, Declaration>> {
     timeout(duration, async {
         loop {
             if let Ok(declarations) = node.get_sdp_declarations().await {

--- a/tests/testing_framework/src/node/http_client.rs
+++ b/tests/testing_framework/src/node/http_client.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, pin::Pin, time::Duration};
+use std::{collections::HashMap, net::SocketAddr, pin::Pin, time::Duration};
 
 use common_http_client::{
     ApiBlock, BasicAuthCredentials, CommonHttpClient, Error, ProcessedBlockEvent,
@@ -194,7 +194,7 @@ impl NodeHttpClient {
         .await
     }
 
-    pub async fn get_sdp_declarations(&self) -> Result<Vec<Declaration>, Error> {
+    pub async fn get_sdp_declarations(&self) -> Result<HashMap<DeclarationId, Declaration>, Error> {
         self.get_sdp_declarations_at(self.base_url.clone()).await
     }
 
@@ -234,13 +234,16 @@ impl NodeHttpClient {
     }
 
     /// Fetches testing-only SDP declarations from one explicit base URL.
-    async fn get_sdp_declarations_at(&self, base_url: Url) -> Result<Vec<Declaration>, Error> {
+    async fn get_sdp_declarations_at(
+        &self,
+        base_url: Url,
+    ) -> Result<HashMap<DeclarationId, Declaration>, Error> {
         let request_url = Self::join_path(&base_url, MANTLE_SDP_DECLARATIONS)?;
 
         self.with_timeout(
             "SDP declarations request",
             self.http_client
-                .get::<(), Vec<Declaration>>(request_url, None),
+                .get::<(), HashMap<DeclarationId, Declaration>>(request_url, None),
         )
         .await
     }


### PR DESCRIPTION
## 1. What does this PR implement?

`GET /mantle/sdp/declarations` was returning a list of declarations:
```json
[
  {
    "service_type": "BN",
    "provider_id": "015e73fefc8b54813f28636293edd83cd9b3384830e7dd483e58502ab399c00e",
    ...
  }
]
```
But we were not able to know the declaration ID of each declaration, which is especially useful to withdraw declarations. 

This PR changes the response format as below — a map keyed by declaration ID.
```json
{
  "aefdd1bfa545a47ed8126889f21b617a3ab92e0d04963bfdadb013dd9701088e": {
    "service_type": "BN",
    "provider_id": "015e73fefc8b54813f28636293edd83cd9b3384830e7dd483e58502ab399c00e",
    ...
  }
}
```

I updated e2e tests for this breaking changes. Please let me know if there is anything I forgot to update.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?
yes

## 5. Does the implementation introduce changes in the specification?
no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
