### PR TITLE
feat(zone-sdk): surface L1 op identity and finalized slot on channel messages

### DIFF
--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -329,3 +329,127 @@ fn op_to_zone_message(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use lb_core::mantle::{
+        NoteId,
+        ledger::Inputs,
+        ops::channel::{
+            deposit::{DepositOp, Metadata},
+            withdraw::ChannelWithdrawOp,
+        },
+    };
+    use lb_groth16::Fr;
+
+    use super::*;
+    use crate::test_support::unverified_tx_with_ops;
+
+    fn deposit_op(channel_id: ChannelId, input_seed: u32, metadata: Metadata) -> DepositOp {
+        DepositOp {
+            channel_id,
+            inputs: Inputs::new([NoteId::from(Fr::from(input_seed))]),
+            metadata,
+        }
+    }
+
+    /// A withdraw op is identified by `hash(channel_id || inputs)` — it
+    /// carries no nonce — so distinct `input_seed`s are what give two
+    /// withdraws distinct `op_id`s. That mirrors the chain, where the notes
+    /// being released are spent-once.
+    fn withdraw_op(channel_id: ChannelId, input_seed: u32) -> ChannelWithdrawOp {
+        ChannelWithdrawOp {
+            channel_id,
+            inputs: Inputs::new([NoteId::from(Fr::from(input_seed))]),
+        }
+    }
+
+    /// Each indexer-facing message must carry the identity of the op it was
+    /// built from — not a neighbouring op's, and not a neighbouring tx's.
+    /// Zone consumers correlate an L2 mint to a finalized L1 deposit by
+    /// `(tx_hash, op_id)`, so a crossed identity is silent corruption of the
+    /// exactly-once key rather than a visible failure.
+    #[test]
+    fn block_to_messages_stamps_each_op_with_its_own_identity() {
+        let channel_id = ChannelId::from([0; 32]);
+        let other_channel = ChannelId::from([9; 32]);
+
+        // tx_a mixes three ops so a walker that reused the wrong op's id
+        // (or the wrong channel's) would surface here.
+        let our_deposit = deposit_op(channel_id, 1, b"to Alice".into());
+        let foreign_deposit = deposit_op(other_channel, 2, b"to Bob".into());
+        let our_withdraw = withdraw_op(channel_id, 42);
+        let tx_a = unverified_tx_with_ops(vec![
+            Op::ChannelDeposit(our_deposit.clone()),
+            Op::ChannelDeposit(foreign_deposit.clone()),
+            Op::ChannelWithdraw(our_withdraw.clone()),
+        ]);
+        let tx_a_hash = tx_a.hash();
+
+        // A second tx proves `tx_hash` is stamped per-tx, not per-block.
+        let later_withdraw = withdraw_op(channel_id, 7);
+        let tx_b = unverified_tx_with_ops(vec![Op::ChannelWithdraw(later_withdraw.clone())]);
+        let tx_b_hash = tx_b.hash();
+
+        // Both deposits get an event, so channel filtering is proven to be
+        // the reason the foreign one is dropped — not a missing amount.
+        let deposit_amounts = HashMap::from([
+            ((tx_a_hash, our_deposit.op_id()), 1234),
+            ((tx_a_hash, foreign_deposit.op_id()), 999),
+        ]);
+
+        let messages = block_to_messages(vec![tx_a, tx_b], channel_id, &deposit_amounts);
+
+        assert_eq!(
+            messages.len(),
+            3,
+            "two ops on our channel in tx_a, one in tx_b"
+        );
+        match &messages[0] {
+            ZoneMessage::Deposit(deposit) => {
+                assert_eq!(deposit.tx_hash, tx_a_hash);
+                assert_eq!(deposit.op_id, our_deposit.op_id());
+                assert_eq!(deposit.amount, 1234);
+                assert_eq!(deposit.inputs, our_deposit.inputs);
+                assert_ne!(
+                    deposit.op_id,
+                    our_withdraw.op_id(),
+                    "deposit must not inherit its tx-mate's identity"
+                );
+            }
+            other => panic!("expected Deposit, got {other:?}"),
+        }
+        match &messages[1] {
+            ZoneMessage::Withdraw(withdraw) => {
+                assert_eq!(withdraw.tx_hash, tx_a_hash);
+                assert_eq!(withdraw.op_id, our_withdraw.op_id());
+                assert_eq!(withdraw.inputs, our_withdraw.inputs);
+            }
+            other => panic!("expected Withdraw, got {other:?}"),
+        }
+        match &messages[2] {
+            ZoneMessage::Withdraw(withdraw) => {
+                assert_eq!(withdraw.tx_hash, tx_b_hash);
+                assert_eq!(withdraw.op_id, later_withdraw.op_id());
+            }
+            other => panic!("expected Withdraw, got {other:?}"),
+        }
+    }
+
+    /// A deposit whose amount is absent from the block's events is dropped
+    /// entirely, taking its identity with it — consumers never see a deposit
+    /// they cannot value.
+    #[test]
+    fn block_to_messages_skips_deposit_without_matching_event() {
+        let channel_id = ChannelId::from([0; 32]);
+        let tx = unverified_tx_with_ops(vec![Op::ChannelDeposit(deposit_op(
+            channel_id,
+            1,
+            b"to Alice".into(),
+        ))]);
+
+        let messages = block_to_messages(vec![tx], channel_id, &HashMap::new());
+
+        assert!(messages.is_empty(), "deposit without an event is skipped");
+    }
+}

--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -321,6 +321,8 @@ fn op_to_zone_message(
         }
         Op::ChannelWithdraw(withdraw) if withdraw.channel_id == channel_id => {
             Some(ZoneMessage::Withdraw(Withdraw {
+                tx_hash,
+                op_id: withdraw.op_id(),
                 inputs: withdraw.inputs.clone(),
             }))
         }

--- a/zone-sdk/src/adapter.rs
+++ b/zone-sdk/src/adapter.rs
@@ -303,6 +303,8 @@ fn op_to_zone_message(
             let op_id = deposit.op_id();
             if let Some(&amount) = deposit_amounts.get(&(tx_hash, op_id)) {
                 Some(ZoneMessage::Deposit(Deposit {
+                    tx_hash,
+                    op_id,
                     inputs: deposit.inputs.clone(),
                     amount,
                     metadata: deposit.metadata.clone(),

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -124,7 +124,7 @@ mod tests {
     use lb_core::mantle::{
         NoteId, TxHash,
         ledger::Inputs,
-        ops::channel::{MsgId, deposit::Metadata, inscribe::Inscription},
+        ops::channel::{MsgId, inscribe::Inscription},
     };
     use lb_groth16::Fr;
 
@@ -144,10 +144,7 @@ mod tests {
     async fn next_messages_no_skip() {
         let messages = vec![
             (block_msg(1, &[1]), Slot::new(0)),
-            (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(10u32))]), 0, [10].into()),
-                Slot::new(0),
-            ),
+            (deposit_msg(10), Slot::new(0)),
             (block_msg(2, &[2]), Slot::new(1)),
         ];
         let indexer = indexer(Slot::new(1), messages.clone());
@@ -164,10 +161,7 @@ mod tests {
     async fn next_messages_until_lib() {
         let messages = vec![
             (block_msg(1, &[1]), Slot::new(0)),
-            (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(10u32))]), 0, [10].into()),
-                Slot::new(1),
-            ),
+            (deposit_msg(10), Slot::new(1)),
             (block_msg(2, &[2]), Slot::new(2)), // after LIB
         ];
         let indexer = indexer(Slot::new(1), messages.clone());
@@ -183,15 +177,9 @@ mod tests {
     async fn next_messages_resume_from_cursor() {
         let messages = vec![
             (block_msg(1, &[1]), Slot::new(0)),
-            (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(10u32))]), 0, [10].into()),
-                Slot::new(0),
-            ),
+            (deposit_msg(10), Slot::new(0)),
             (block_msg(2, &[2]), Slot::new(1)),
-            (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(11u32))]), 0, [11].into()),
-                Slot::new(2),
-            ),
+            (deposit_msg(11), Slot::new(2)),
             (block_msg(3, &[3]), Slot::new(2)),
         ];
         let indexer = indexer(Slot::new(2), messages.clone());
@@ -208,10 +196,7 @@ mod tests {
     async fn next_messages_cursor_at_lib_emits_nothing() {
         let messages = vec![
             (block_msg(1, &[1]), Slot::new(0)),
-            (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(10u32))]), 0, [10].into()),
-                Slot::new(0),
-            ),
+            (deposit_msg(10), Slot::new(0)),
             (block_msg(2, &[2]), Slot::new(1)),
         ];
         let indexer = indexer(Slot::new(1), messages);
@@ -243,10 +228,7 @@ mod tests {
     async fn next_messages_across_batches() {
         let messages = vec![
             (block_msg(1, &[1]), Slot::new(0)),
-            (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(10u32))]), 0, [10].into()),
-                BATCH_SIZE,
-            ),
+            (deposit_msg(10), BATCH_SIZE),
             (
                 block_msg(2, &[2]),
                 BATCH_SIZE.into_inner().checked_mul(2).unwrap().into(),
@@ -256,7 +238,7 @@ mod tests {
                 BATCH_SIZE.into_inner().checked_mul(2).unwrap().into(),
             ),
             (
-                deposit_msg(Inputs::new([NoteId::from(Fr::from(11u32))]), 0, [11].into()),
+                deposit_msg(11),
                 BATCH_SIZE.into_inner().checked_mul(3).unwrap().into(),
             ),
             (
@@ -299,13 +281,22 @@ mod tests {
         })
     }
 
-    fn deposit_msg(inputs: Inputs, amount: u64, metadata: Metadata) -> ZoneMessage {
+    /// Deposit fixture whose every field derives from `seed`, so two
+    /// fixtures never share an identity. `tx_hash` and `op_id` differ from
+    /// each other as well, so a swap between the two is visible.
+    fn deposit_msg(seed: u8) -> ZoneMessage {
+        let mut tx_hash = [0u8; 32];
+        tx_hash[0] = seed;
+        let mut op_id = [0u8; 32];
+        op_id[0] = seed;
+        op_id[31] = 1;
+
         ZoneMessage::Deposit(Deposit {
-            tx_hash: TxHash::default(),
-            op_id: [0u8; 32],
-            inputs,
-            amount,
-            metadata,
+            tx_hash: TxHash::from(tx_hash),
+            op_id,
+            inputs: Inputs::new([NoteId::from(Fr::from(u32::from(seed)))]),
+            amount: 0,
+            metadata: [seed].into(),
         })
     }
 

--- a/zone-sdk/src/indexer.rs
+++ b/zone-sdk/src/indexer.rs
@@ -122,7 +122,7 @@ where
 mod tests {
 
     use lb_core::mantle::{
-        NoteId,
+        NoteId, TxHash,
         ledger::Inputs,
         ops::channel::{MsgId, deposit::Metadata, inscribe::Inscription},
     };
@@ -301,6 +301,8 @@ mod tests {
 
     fn deposit_msg(inputs: Inputs, amount: u64, metadata: Metadata) -> ZoneMessage {
         ZoneMessage::Deposit(Deposit {
+            tx_hash: TxHash::default(),
+            op_id: [0u8; 32],
             inputs,
             amount,
             metadata,

--- a/zone-sdk/src/lib.rs
+++ b/zone-sdk/src/lib.rs
@@ -115,6 +115,10 @@ pub struct Deposit {
 /// An withdrawal from a zone channel, included/finalized in Bedrock
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Withdraw {
+    /// The transaction hash containing this withdraw op.
+    pub tx_hash: TxHash,
+    /// The `op_id` of the withdraw op: its stable identity within the tx.
+    pub op_id: Hash,
     /// The channel notes released by the withdrawal
     pub inputs: Inputs,
 }

--- a/zone-sdk/src/lib.rs
+++ b/zone-sdk/src/lib.rs
@@ -67,10 +67,13 @@ mod test_support;
 
 pub use lb_common_http_client::{CommonHttpClient, Slot};
 pub use lb_core::mantle::ops::channel::Ed25519PublicKey;
-use lb_core::mantle::{
-    Value,
-    ledger::Inputs,
-    ops::channel::{MsgId, deposit::Metadata, inscribe::Inscription},
+use lb_core::{
+    crypto::Hash,
+    mantle::{
+        TxHash, Value,
+        ledger::Inputs,
+        ops::channel::{MsgId, deposit::Metadata, inscribe::Inscription},
+    },
 };
 
 /// A message from a zone channel, included/finalized in Bedrock
@@ -96,8 +99,12 @@ pub struct ZoneBlock {
 /// A deposit from a zone channel, included/finalized in Bedrock
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Deposit {
-    /// Notes consumed by the deposit. Acts as the natural unique key (notes
-    /// are spent-once at the UTXO layer).
+    /// The transaction hash containing this deposit op.
+    pub tx_hash: TxHash,
+    /// The `op_id` of the deposit op: its stable identity within the tx,
+    /// matching `DepositInfo::op_id` on the sequencer side.
+    pub op_id: Hash,
+    /// Notes consumed by the deposit (spent-once at the UTXO layer).
     pub inputs: Inputs,
     /// Total value deposited, sourced from the block's events.
     pub amount: Value,

--- a/zone-sdk/src/sequencer/block_fetch.rs
+++ b/zone-sdk/src/sequencer/block_fetch.rs
@@ -339,8 +339,12 @@ where
         let deposit_amounts =
             fetch_block_deposit_amounts(node, block.header.id, &block.transactions, channel_id)
                 .await?;
-        let block_items =
-            extract_finalized_items(&block.transactions, channel_id, &deposit_amounts);
+        let block_items = extract_finalized_items(
+            &block.transactions,
+            channel_id,
+            block.header.slot,
+            &deposit_amounts,
+        );
 
         result.our_tx_hashes.extend(our_txs.iter().copied());
         result.items.extend(block_items);
@@ -453,6 +457,7 @@ where
 fn extract_finalized_items(
     transactions: &[SignedMantleTx],
     channel_id: ChannelId,
+    l1_slot: Slot,
     deposit_amounts: &HashMap<(TxHash, Hash), Value>,
 ) -> Vec<FinalizedTx> {
     let mut items: Vec<FinalizedTx> = Vec::new();
@@ -521,7 +526,11 @@ fn extract_finalized_items(
             }
         }
         if !ops.is_empty() {
-            items.push(FinalizedTx { tx_hash, ops });
+            items.push(FinalizedTx {
+                tx_hash,
+                l1_slot,
+                ops,
+            });
         }
     }
 
@@ -785,7 +794,7 @@ mod tests {
         channel_id: ChannelId,
         amounts: &HashMap<(TxHash, Hash), u64>,
     ) -> Vec<DepositInfo> {
-        extract_finalized_items(transactions, channel_id, amounts)
+        extract_finalized_items(transactions, channel_id, Slot::from(0), amounts)
             .into_iter()
             .flat_map(|t| t.ops.into_iter())
             .filter_map(|op| match op {
@@ -843,6 +852,7 @@ mod tests {
         drop(extract_finalized_items(
             std::slice::from_ref(&tx),
             channel_id,
+            Slot::from(0),
             &HashMap::new(),
         ));
     }
@@ -902,10 +912,16 @@ mod tests {
         let mut amounts = HashMap::new();
         amounts.insert((tx_hash, dep_op_id), 500u64);
 
-        let items = extract_finalized_items(std::slice::from_ref(&tx), channel_id, &amounts);
+        let items = extract_finalized_items(
+            std::slice::from_ref(&tx),
+            channel_id,
+            Slot::from(42),
+            &amounts,
+        );
 
         assert_eq!(items.len(), 1, "one FinalizedTx for the single Mantle tx");
         assert_eq!(items[0].tx_hash, tx_hash);
+        assert_eq!(items[0].l1_slot, Slot::from(42));
         assert_eq!(items[0].ops.len(), 2);
         assert!(matches!(items[0].ops[0], FinalizedOp::Deposit(_)));
         assert!(matches!(items[0].ops[1], FinalizedOp::Inscription(_)));
@@ -1086,10 +1102,16 @@ mod tests {
         ]);
         let tx_hash = tx.mantle_tx.hash();
 
-        let items = extract_finalized_items(std::slice::from_ref(&tx), channel_id, &HashMap::new());
+        let items = extract_finalized_items(
+            std::slice::from_ref(&tx),
+            channel_id,
+            Slot::from(7),
+            &HashMap::new(),
+        );
 
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].tx_hash, tx_hash);
+        assert_eq!(items[0].l1_slot, Slot::from(7));
         assert_eq!(items[0].ops.len(), 1, "only our channel's withdraw");
         match &items[0].ops[0] {
             FinalizedOp::Withdraw(w) => {

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -481,6 +481,9 @@ impl PendingTx {
 pub struct FinalizedTx {
     /// Transaction hash of the Mantle tx.
     pub tx_hash: TxHash,
+    /// L1 slot of the block this tx finalized in. Every op in one Mantle tx
+    /// shares the block, hence the slot, so it is stamped per-tx.
+    pub l1_slot: Slot,
     /// Channel-relevant ops in on-chain execution order. A tx with a
     /// deposit and an inscription emits both, deposit-first.
     pub ops: Vec<FinalizedOp>,


### PR DESCRIPTION
## 1. What does this PR implement?

Enriches the zone-sdk's consumer-facing channel messages with L1 context the SDK already computes but was discarding. We have three commits with no behavioural change to existing flows:

1. **`Deposit`** (indexer-facing `ZoneMessage::Deposit`) gains `tx_hash` and `op_id`, mirroring the sequencer-facing `DepositInfo`. Closes #3138
2. **`FinalizedTx`** (sequencer-facing `Event::BlocksProcessed { finalized }`) gains `l1_slot`, stamped from the block header at the per-block extraction site. Closes #3139 
3. **`Withdraw`** (indexer-facing `ZoneMessage::Withdraw`) gains `tx_hash` and `op_id`, for symmetry with `Deposit`.

Confined to `zone-sdk` (`lib.rs`, `adapter.rs`, `indexer.rs`, `sequencer/types.rs`, `sequencer/block_fetch.rs`); no `core` change, no new dependency, no wire-format/serde impact.

## 2. Does the code have enough context to be clearly understood?

These are additive fields; the rationale for each:

**Why `Deposit` needs `op_id` (+ `tx_hash`).** The SDK exposes deposits through two APIs asymmetrically: the sequencer-facing `DepositInfo` carries `{ tx_hash, op_id, .. }`, but the indexer-facing `ZoneMessage::Deposit` carried only `{ inputs, amount, metadata }`. A zone's L2 mint transaction embeds the L1 deposit's `op_id` as its exactly-once key. For a zone *indexer* to verify that a mint tx inside an inscribed block corresponds to a genuine finalized L1 deposit — rather than trusting the sequencer's asserted id — it must correlate the streamed deposit to the mint by that stable op identity. `inputs` (the spent-once UTXO note key) is not a substitute: it lives in a different namespace from the `op_id` that both the ledger and the sequencer API already speak. This becomes load-bearing under **decentralised sequencing**: when several sequencers share one channel, each observes every deposit, so a robust exactly-once mint path needs the identity present on both the sequencer and indexer sides. `tx_hash` accompanies `op_id` (the block-events amount lookup is keyed on the `(tx_hash, op_id)` tuple, and it locates the originating L1 tx). Both values are already computed at the sole constructor (`adapter.rs::op_to_zone_message`) and were being thrown away.

**Why a finalized block needs `l1_slot`.** The indexer stream (`ZoneIndexer::next_messages`) already yields `(ZoneMessage, Slot)`, so an indexer always knows which L1 slot delivered a message. The sequencer-facing finalized stream (`Event::BlocksProcessed { finalized }`) dropped it entirely. When a *finalized* zone block fails to apply to a zone's chain state, the zone records a durable stall (in https://github.com/logos-blockchain/logos-execution-zone/pull/603) whose `l1_slot` field says **where on the L1** the offending block finalized — the indexer populates it from `next_messages`. The slot is already in scope at the per-block extraction site (`block.header.slot`) and was simply discarded on the way into `FinalizedTx`. Per-tx granularity is correct because `extract_finalized_items` is called once per block, so every `FinalizedTx` it yields belongs to that one block's slot; both emit paths (live + backfill) carry the slot for free since it rides inside `FinalizedTx`.

**Why `Withdraw` mirrors `Deposit`.** Same asymmetry (`WithdrawInfo` carried identity, the indexer-facing `Withdraw` did not); added `tx_hash`/`op_id` so both indexer-facing messages expose a stable op identity. If we think this is unnecessary, we can remove it; however it is a really lightweight addition and the indexer currently ignores these messages so I figured it may need them, akin to Deposit messages.

## 3. Who are the specification authors and who is accountable for this PR?

There is no spec on this, it's a pure fix. @erhant is the accountable author of the PR.

## 4. Is the specification accurate and complete?

Additive SDK-surface change; no gap identified in the underlying channel/deposit spec. The new fields are re-exposed identities/slots the SDK already derives.

## 5. Does the implementation introduce changes in the specification?

No: the on-chain protocol, wire format, and channel semantics are unchanged. This only widens what the SDK hands to its Rust consumers.

## Checklist

* [x] 1. PR title follows Conventional Commits.
* [x] 2. Description added.
* [ ] 3. ~Context and links to Specification document(s) added~
* [x] 4. Main contact(s) added.
* [x] 5. Implementation and Specification in sync (no spec change).
* [ ] 6. ~Link PR to a milestone.~
* [x] 7. Logs reviewed — no log lines added or changed (the pre-existing deposit skip-warning is untouched).

Test with:

```sh
cargo test -p logos-blockchain-zone-sdk
```