### PR TITLE
fix(wallet): keep deposited notes and track ChannelTransfer/Withdraw ops

### DIFF
--- a/tests/src/common/wallet/transaction/builder_funding.rs
+++ b/tests/src/common/wallet/transaction/builder_funding.rs
@@ -56,6 +56,7 @@ pub fn wallet_state_from_utxos(utxos: Vec<Utxo>) -> WalletState {
         utxos: utxo_map,
         pk_index,
         locked_notes: HashTrieSetSync::new_sync(),
+        channel_notes: HashTrieSetSync::new_sync(),
         epoch: 0.into(),
         vouchers: MerkleMountainRange::new(),
         voucher_paths: HashTrieMapSync::new_sync(),

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -18,7 +18,7 @@ use lb_core::{
         AuthenticatedMantleTx, GasConstants, NoteId, TxHash, Utxo, Value,
         ops::{
             Op, OpId as _,
-            channel::channel_transfer::ChannelTransferOp,
+            channel::{channel_transfer::ChannelTransferOp, withdraw::ChannelWithdrawOp},
             leader_claim::{VoucherCm, VoucherNullifier},
             transfer::TransferOp,
         },
@@ -98,6 +98,8 @@ pub enum WalletOp {
     /// Drop the input channel notes from the wallet and insert the output
     /// channel notes owned by known keys.
     ChannelTransfer(ChannelTransferOp),
+    /// Unmark the input channel notes, so they become spendable.
+    ChannelWithdraw(ChannelWithdrawOp),
 }
 
 impl WalletBlock {
@@ -129,7 +131,7 @@ impl WalletBlock {
                 WalletOp::ChannelDeposit(inputs) => inputs.clone(),
                 WalletOp::ChannelTransfer(op) => op.inputs.iter().copied().collect::<Vec<_>>(),
                 WalletOp::Lock(note_id) => vec![*note_id],
-                WalletOp::LeaderClaim(_) => Vec::new(),
+                WalletOp::ChannelWithdraw(_) | WalletOp::LeaderClaim(_) => Vec::new(),
             })
             .collect()
     }
@@ -391,6 +393,13 @@ impl WalletState {
                             }
                         }
                     }
+                    WalletOp::ChannelWithdraw(op) => {
+                        // Drop the channel-note marker so they're spendable again.
+                        // They still stay in `utxos`.
+                        for input_id in op.inputs.iter() {
+                            channel_notes.remove_mut(input_id);
+                        }
+                    }
                     WalletOp::Lock(note_id) => {
                         if utxos.contains_key(note_id) {
                             locked_notes.insert_mut(*note_id);
@@ -566,6 +575,7 @@ fn transform_op(op: &Op, event: Option<TxEventPayload>) -> Option<WalletOp> {
             deposit.inputs.iter().copied().collect(),
         )),
         Op::ChannelTransfer(op) => Some(WalletOp::ChannelTransfer(op.clone())),
+        Op::ChannelWithdraw(op) => Some(WalletOp::ChannelWithdraw(op.clone())),
         Op::SDPDeclare(declaration) => Some(WalletOp::Lock(declaration.locked_note_id)),
         Op::LeaderClaim(_) => match event.expect("event for LeaderClaim op must exist") {
             TxEventPayload::LeaderRewardClaimed { utxo, .. } => Some(WalletOp::LeaderClaim(utxo)),
@@ -576,12 +586,9 @@ fn transform_op(op: &Op, event: Option<TxEventPayload>) -> Option<WalletOp> {
         // `Op::SDPWithdraw` is ignored here — the note will be unlocked
         // after the delay and the corresponding event will be handled by
         // [`HeaderOp::from`].
-        // TODO: `Op::ChannelWithdraw` should release channel notes back to spendable.
-        Op::ChannelInscribe(_)
-        | Op::ChannelConfig(_)
-        | Op::ChannelWithdraw(_)
-        | Op::SDPWithdraw(_)
-        | Op::SDPActive(_) => None,
+        Op::ChannelInscribe(_) | Op::ChannelConfig(_) | Op::SDPWithdraw(_) | Op::SDPActive(_) => {
+            None
+        }
     }
 }
 
@@ -2010,5 +2017,91 @@ mod tests {
         // Stranger's new note is not tracked.
         assert!(!state.utxos.contains_key(&stranger_output_id));
         assert!(!state.channel_notes.contains(&stranger_output_id));
+    }
+
+    /// A `ChannelWithdraw` unmarks channel notes so the wallet can spend
+    /// them again.
+    #[test]
+    fn test_channel_withdraw_releases_note() {
+        let alice = pk(1);
+        let channel_id = ChannelId::from([1; 32]);
+        let genesis = HeaderId::from([0; 32]);
+
+        // Seed Alice with a 100 NMO note and deposit it into a channel.
+        let alice_utxo = Utxo::new(tx_hash(0), 0, Note::new(100, alice));
+        let genesis_ledger = LedgerState::from_utxos([alice_utxo], &ledger_config());
+        let (v_cm_1, _) = voucher(1, 0);
+        let (v_cm_2, _) = voucher(1, 1);
+        let mut wallet = Wallet::<_, TestVoucherId>::from_lib_ledger_state(
+            [(alice, 1)],
+            Vouchers::default(),
+            genesis,
+            &genesis_ledger,
+        );
+        let deposit_block = WalletBlock {
+            id: HeaderId::from([1; 32]),
+            parent: genesis,
+            epoch: 1.into(),
+            voucher_cm: v_cm_1,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelDeposit(vec![alice_utxo.id()])],
+            }],
+        };
+        wallet.apply_block(&deposit_block).unwrap();
+
+        // Sanity: after deposit the note is channel-marked, so balance is 0.
+        let state = wallet.wallet_state_at(deposit_block.id).unwrap();
+        assert!(state.channel_notes.contains(&alice_utxo.id()));
+        assert_eq!(state.balance(alice).unwrap().balance, 0);
+
+        // Withdraw releases the channel note back to spendable.
+        let withdraw_op = ChannelWithdrawOp {
+            channel_id,
+            inputs: Inputs::new([alice_utxo.id()]),
+        };
+        let withdraw_block = WalletBlock {
+            id: HeaderId::from([2; 32]),
+            parent: deposit_block.id,
+            epoch: 1.into(),
+            voucher_cm: v_cm_2,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelWithdraw(withdraw_op)],
+            }],
+        };
+        wallet.apply_block(&withdraw_block).unwrap();
+
+        let state = wallet.wallet_state_at(withdraw_block.id).unwrap();
+        assert!(state.utxos.contains_key(&alice_utxo.id()));
+        assert!(!state.channel_notes.contains(&alice_utxo.id()));
+        assert!(
+            state
+                .pk_index
+                .get(&alice)
+                .is_some_and(|set| set.contains(&alice_utxo.id()))
+        );
+        assert_eq!(state.balance(alice).unwrap().balance, 100);
+
+        // `fund_tx` can now use the released note.
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        };
+        let err = state
+            .fund_tx::<Gas>(
+                &MantleTxBuilder::new(),
+                alice,
+                [alice],
+                &context,
+                &HashSet::new(),
+                0,
+            )
+            .unwrap_err();
+        // The error detail says that the withdrawn note is now spendable.
+        assert_eq!(err, WalletError::InsufficientFunds { available: 100 });
     }
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -18,6 +18,7 @@ use lb_core::{
         AuthenticatedMantleTx, GasConstants, NoteId, TxHash, Utxo, Value,
         ops::{
             Op, OpId as _,
+            channel::channel_transfer::ChannelTransferOp,
             leader_claim::{VoucherCm, VoucherNullifier},
             transfer::TransferOp,
         },
@@ -94,6 +95,9 @@ pub enum WalletOp {
     /// and remain eligible for `PoL`, but are gated out of wallet-driven
     /// spending.
     ChannelDeposit(Vec<NoteId>),
+    /// Drop the input channel notes from the wallet and insert the output
+    /// channel notes owned by known keys.
+    ChannelTransfer(ChannelTransferOp),
 }
 
 impl WalletBlock {
@@ -123,6 +127,7 @@ impl WalletBlock {
             .flat_map(|op| match op {
                 WalletOp::Transfer(transfer) => transfer.inputs.iter().copied().collect::<Vec<_>>(),
                 WalletOp::ChannelDeposit(inputs) => inputs.clone(),
+                WalletOp::ChannelTransfer(op) => op.inputs.iter().copied().collect::<Vec<_>>(),
                 WalletOp::Lock(note_id) => vec![*note_id],
                 WalletOp::LeaderClaim(_) => Vec::new(),
             })
@@ -375,6 +380,17 @@ impl WalletState {
                             }
                         }
                     }
+                    WalletOp::ChannelTransfer(op) => {
+                        for input_id in op.inputs.iter() {
+                            remove_spent_utxo(input_id, &mut utxos, &mut pk_index);
+                            channel_notes.remove_mut(input_id);
+                        }
+                        for utxo in op.outputs.utxos(op) {
+                            if insert_utxo_if_owned(utxo, known_keys, &mut utxos, &mut pk_index) {
+                                channel_notes.insert_mut(utxo.id());
+                            }
+                        }
+                    }
                     WalletOp::Lock(note_id) => {
                         if utxos.contains_key(note_id) {
                             locked_notes.insert_mut(*note_id);
@@ -455,14 +471,16 @@ impl WalletState {
     }
 }
 
+/// Insert `utxo` into `utxos`/`pk_index` if the wallet owns its key.
+/// Returns whether the insertion happened.
 fn insert_utxo_if_owned<KeyId>(
     utxo: Utxo,
     known_keys: &HashMap<ZkPublicKey, KeyId>,
     utxos: &mut rpds::HashTrieMapSync<NoteId, Utxo>,
     pk_index: &mut rpds::HashTrieMapSync<ZkPublicKey, rpds::HashTrieSetSync<NoteId>>,
-) {
+) -> bool {
     if !known_keys.contains_key(&utxo.note.pk) {
-        return;
+        return false;
     }
 
     let note_id = utxo.id();
@@ -474,6 +492,7 @@ fn insert_utxo_if_owned<KeyId>(
         .unwrap_or_else(rpds::HashTrieSetSync::new_sync)
         .insert(note_id);
     pk_index.insert_mut(utxo.note.pk, note_set);
+    true
 }
 
 fn transform_txs<'t, Tx>(
@@ -546,6 +565,7 @@ fn transform_op(op: &Op, event: Option<TxEventPayload>) -> Option<WalletOp> {
         Op::ChannelDeposit(deposit) => Some(WalletOp::ChannelDeposit(
             deposit.inputs.iter().copied().collect(),
         )),
+        Op::ChannelTransfer(op) => Some(WalletOp::ChannelTransfer(op.clone())),
         Op::SDPDeclare(declaration) => Some(WalletOp::Lock(declaration.locked_note_id)),
         Op::LeaderClaim(_) => match event.expect("event for LeaderClaim op must exist") {
             TxEventPayload::LeaderRewardClaimed { utxo, .. } => Some(WalletOp::LeaderClaim(utxo)),
@@ -553,15 +573,13 @@ fn transform_op(op: &Op, event: Option<TxEventPayload>) -> Option<WalletOp> {
                 panic!("event for LeaderClaim op must be LeaderRewardClaimed")
             }
         },
-        // `Op::ChannelWithdraw` and `Op::ChannelTransfer` only move notes in and
-        // out of a channel's ownership. The wallet doesn't track channel notes
-        // `Op::SDPWithdraw` is ignored in this function. The note will be unlocked
+        // `Op::SDPWithdraw` is ignored here — the note will be unlocked
         // after the delay and the corresponding event will be handled by
         // [`HeaderOp::from`].
+        // TODO: `Op::ChannelWithdraw` should release channel notes back to spendable.
         Op::ChannelInscribe(_)
         | Op::ChannelConfig(_)
         | Op::ChannelWithdraw(_)
-        | Op::ChannelTransfer(_)
         | Op::SDPWithdraw(_)
         | Op::SDPActive(_) => None,
     }
@@ -1846,5 +1864,151 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(err, WalletError::InsufficientFunds { available: 0 });
+    }
+
+    /// A `ChannelTransfer` must drop the consumed channel note from the
+    /// previous delegate and hand the newly created channel note to the
+    /// new delegate (if their key is known to the wallet), so `PoS`
+    /// participation follows the delegation.
+    #[test]
+    fn test_channel_transfer_moves_notes() {
+        let pk1 = pk(1);
+        let pk2 = pk(2);
+        let channel_id = ChannelId::from([1; 32]);
+        let genesis = HeaderId::from([0; 32]);
+
+        // Seed the wallet with 100 NMO note with `pk1` and mark it as a
+        // channel note via a prior `ChannelDeposit`.
+        let pk1_utxo = Utxo::new(tx_hash(0), 0, Note::new(100, pk1));
+        let genesis_ledger = LedgerState::from_utxos([pk1_utxo], &ledger_config());
+        let (v_cm_1, _) = voucher(1, 0);
+        let (v_cm_2, _) = voucher(1, 1);
+        let mut wallet = Wallet::<_, TestVoucherId>::from_lib_ledger_state(
+            [(pk1, 1), (pk2, 2)],
+            Vouchers::default(),
+            genesis,
+            &genesis_ledger,
+        );
+        let deposit_block = WalletBlock {
+            id: HeaderId::from([1; 32]),
+            parent: genesis,
+            epoch: 1.into(),
+            voucher_cm: v_cm_1,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelDeposit(vec![pk1_utxo.id()])],
+            }],
+        };
+        wallet.apply_block(&deposit_block).unwrap();
+
+        // Transfer the channel note to `pk2`.
+        let transfer_op = ChannelTransferOp {
+            channel_id,
+            inputs: Inputs::new([pk1_utxo.id()]),
+            outputs: Outputs::new([Note::new(100, pk2)]),
+        };
+        let pk2_output_id = transfer_op
+            .outputs
+            .utxo_by_index(0, &transfer_op)
+            .unwrap()
+            .id();
+        let transfer_block = WalletBlock {
+            id: HeaderId::from([2; 32]),
+            parent: deposit_block.id,
+            epoch: 1.into(),
+            voucher_cm: v_cm_2,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelTransfer(transfer_op)],
+            }],
+        };
+        wallet.apply_block(&transfer_block).unwrap();
+
+        let state = wallet.wallet_state_at(transfer_block.id).unwrap();
+        // The original note has been gone from the wallet.
+        assert!(!state.utxos.contains_key(&pk1_utxo.id()));
+        assert!(!state.channel_notes.contains(&pk1_utxo.id()));
+        assert!(
+            state
+                .pk_index
+                .get(&pk1)
+                .is_none_or(|set| !set.contains(&pk1_utxo.id()))
+        );
+        // The `pk2` note has been added to the wallet, as a channel note.
+        assert!(state.utxos.contains_key(&pk2_output_id));
+        assert!(state.channel_notes.contains(&pk2_output_id));
+        assert!(
+            state
+                .pk_index
+                .get(&pk2)
+                .is_some_and(|set| set.contains(&pk2_output_id))
+        );
+        // Balances stay at zero for both: the note is still channel-owned.
+        assert_eq!(state.balance(pk1).map_or(0, |b| b.balance), 0);
+        assert_eq!(state.balance(pk2).unwrap().balance, 0);
+    }
+
+    /// A `ChannelTransfer` output whose new `ZkPublicKey` is unknown to
+    /// the wallet must not be inserted — the wallet stops tracking the
+    /// note entirely.
+    #[test]
+    fn test_channel_transfer_ignores_unknown_outputs() {
+        let alice = pk(1);
+        let stranger = pk(99);
+        let channel_id = ChannelId::from([1; 32]);
+        let genesis = HeaderId::from([0; 32]);
+
+        let alice_utxo = Utxo::new(tx_hash(0), 0, Note::new(100, alice));
+        let genesis_ledger = LedgerState::from_utxos([alice_utxo], &ledger_config());
+        let (v_cm_1, _) = voucher(1, 0);
+        let (v_cm_2, _) = voucher(1, 1);
+        let mut wallet = Wallet::<_, TestVoucherId>::from_lib_ledger_state(
+            [(alice, 1)],
+            Vouchers::default(),
+            genesis,
+            &genesis_ledger,
+        );
+        let deposit_block = WalletBlock {
+            id: HeaderId::from([1; 32]),
+            parent: genesis,
+            epoch: 1.into(),
+            voucher_cm: v_cm_1,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelDeposit(vec![alice_utxo.id()])],
+            }],
+        };
+        wallet.apply_block(&deposit_block).unwrap();
+
+        // Transfer Alice -> an unknown-to-wallet pk.
+        let transfer_op = ChannelTransferOp {
+            channel_id,
+            inputs: Inputs::new([alice_utxo.id()]),
+            outputs: Outputs::new([Note::new(100, stranger)]),
+        };
+        let stranger_output_id = transfer_op
+            .outputs
+            .utxo_by_index(0, &transfer_op)
+            .unwrap()
+            .id();
+        let transfer_block = WalletBlock {
+            id: HeaderId::from([2; 32]),
+            parent: deposit_block.id,
+            epoch: 1.into(),
+            voucher_cm: v_cm_2,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelTransfer(transfer_op)],
+            }],
+        };
+        wallet.apply_block(&transfer_block).unwrap();
+
+        let state = wallet.wallet_state_at(transfer_block.id).unwrap();
+        // Alice's note is gone.
+        assert!(!state.utxos.contains_key(&alice_utxo.id()));
+        assert!(!state.channel_notes.contains(&alice_utxo.id()));
+        // Stranger's new note is not tracked.
+        assert!(!state.utxos.contains_key(&stranger_output_id));
+        assert!(!state.channel_notes.contains(&stranger_output_id));
     }
 }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -90,9 +90,9 @@ pub enum WalletOp {
     Lock(NoteId),
     /// Create the reward note.
     LeaderClaim(Utxo),
-    /// The deposited notes are now owned by the channel and can no longer be
-    /// spent by the wallet.
-    /// TODO: support channel note tracking and channel note `PoS` participation
+    /// Mark the deposited notes as channel notes: they stay in the wallet
+    /// and remain eligible for `PoL`, but are gated out of wallet-driven
+    /// spending.
     ChannelDeposit(Vec<NoteId>),
 }
 
@@ -135,6 +135,11 @@ pub struct WalletState {
     pub utxos: rpds::HashTrieMapSync<NoteId, Utxo>,
     pub pk_index: rpds::HashTrieMapSync<ZkPublicKey, rpds::HashTrieSetSync<NoteId>>,
     pub locked_notes: rpds::HashTrieSetSync<NoteId>,
+    /// Notes known by the wallet but currently owned by a channel. They stay
+    /// in `utxos` and are still eligible for `PoL`, but must be gated out of
+    /// wallet-driven spending.
+    #[serde(default)]
+    pub channel_notes: rpds::HashTrieSetSync<NoteId>,
     pub epoch: Epoch,
     /// MMR of all voucher commitments included in the chain
     pub vouchers: MerkleMountainRange<VoucherCm, ZkHasher>,
@@ -155,19 +160,13 @@ impl WalletState {
         let mut utxos = rpds::HashTrieMapSync::new_sync();
         let mut pk_index = rpds::HashTrieMapSync::new_sync();
         let mut locked_notes = rpds::HashTrieSetSync::new_sync();
+        let mut channel_notes = rpds::HashTrieSetSync::new_sync();
 
         let all_locked_notes = ledger.mantle_ledger().sdp_ledger().locked_notes();
         let channels = ledger.mantle_ledger().channels();
         for (_, (utxo, _)) in ledger.latest_utxos().utxos().iter() {
             if known_keys.contains_key(&utxo.note.pk) {
                 let note_id = utxo.id();
-
-                // A channel note keeps the depositor's key but is owned by the
-                // channel, so the wallet must skip it.
-                // TODO: track channel notes from channel of interest
-                if channels.is_channel_note(&note_id) {
-                    continue;
-                }
 
                 utxos = utxos.insert(note_id, *utxo);
 
@@ -181,6 +180,13 @@ impl WalletState {
                 if all_locked_notes.contains(&note_id) {
                     locked_notes = locked_notes.insert(note_id);
                 }
+
+                // A channel note keeps the depositor's key but is owned by the channel:
+                // keep it in `utxos` so it stays eligible for PoL,
+                // and mark it so wallet-driven spending gates it out.
+                if channels.is_channel_note(&note_id) {
+                    channel_notes = channel_notes.insert(note_id);
+                }
             }
         }
 
@@ -188,6 +194,7 @@ impl WalletState {
             utxos,
             pk_index,
             locked_notes,
+            channel_notes,
             epoch: ledger.epoch_state().epoch,
             vouchers: ledger.mantle_ledger().vouchers().clone(),
             voucher_paths: rpds::HashTrieMapSync::new_sync(),
@@ -221,16 +228,18 @@ impl WalletState {
         // Get all UTXOs owned by the provided PKs, excluding the following notes:
         // - Notes that are being consumed/locked by the tx
         // - Notes that are already locked in Ledger
+        // - Notes currently owned by a channel (deposited)
         // - Notes excluded by the caller (e.g. reserved for in-flight txs)
-        let consumed_or_locked = tx_builder
+        let excluded_notes = tx_builder
             .consumed_or_locked_notes()
             .chain(self.locked_notes.iter().copied())
+            .chain(self.channel_notes.iter().copied())
             .chain(excluded_notes.iter().copied())
             .collect::<HashSet<_>>();
         let mut utxos = self
             .utxos_owned_by_pks(pks)
             .into_iter()
-            .filter(|utxo| !consumed_or_locked.contains(&utxo.id()))
+            .filter(|utxo| !excluded_notes.contains(&utxo.id()))
             .collect::<Vec<_>>();
 
         // Consume large valued notes first to ensure we converge.
@@ -304,6 +313,10 @@ impl WalletState {
         };
 
         self.pk_index.get(&pk)?.iter().for_each(|id| {
+            // Channel notes should be counted in the wallet's total balance
+            if self.channel_notes.contains(id) {
+                return;
+            }
             let value = self.utxos[id].note.value;
             balance.balance += value;
             balance.notes.insert(*id, value);
@@ -322,6 +335,7 @@ impl WalletState {
         let mut utxos = self.utxos.clone();
         let mut pk_index = self.pk_index.clone();
         let mut locked_notes = self.locked_notes.clone();
+        let mut channel_notes = self.channel_notes.clone();
 
         // Header-level effects come first, matching the ledger's
         // header -> contents processing order.
@@ -353,10 +367,12 @@ impl WalletState {
                         }
                     }
                     WalletOp::ChannelDeposit(inputs) => {
-                        // When removing spent notes, we don't check if the notes are owned
-                        // by the wallet because they will be ignored automatically.
+                        // Mark the input notes as channel notes since they shouldn't be spent by
+                        // wallet. They keep staying in `utxos`, so they're still eligible for PoL.
                         for input_id in inputs {
-                            remove_spent_utxo(input_id, &mut utxos, &mut pk_index);
+                            if utxos.contains_key(input_id) {
+                                channel_notes.insert_mut(*input_id);
+                            }
                         }
                     }
                     WalletOp::Lock(note_id) => {
@@ -378,6 +394,7 @@ impl WalletState {
             utxos,
             pk_index,
             locked_notes,
+            channel_notes,
             epoch: block.epoch,
             vouchers,
             voucher_paths,
@@ -1009,7 +1026,8 @@ mod tests {
         );
 
         // Block 3 (still, epoch 2)
-        // - alice spends the 80 NMO note through a non-transfer operation.
+        // - alice deposits the 80 NMO note into a channel. The note stays in the wallet
+        //   (still eligible for PoL) but is marked as a channel note.
         // - voucher v3 is not ours -> should not be tracked
         let alice_80_nmo_utxo = transfer2.outputs.utxo_by_index(1, &transfer2).unwrap();
 
@@ -1028,6 +1046,7 @@ mod tests {
         };
         wallet.apply_block(&block_3).unwrap();
 
+        // The deposited note shouldn't be counted in the wallet's total balance
         assert_eq!(
             wallet.balance(block_3.id, alice).unwrap().unwrap().balance,
             42
@@ -1036,6 +1055,11 @@ mod tests {
             wallet.balance(block_3.id, bob).unwrap().unwrap().balance,
             20
         );
+        // The deposit marks the 80 NMO note as a channel note; the note
+        // itself stays in the wallet so it remains eligible for PoL.
+        let state = wallet.wallet_state_at(block_3.id).unwrap();
+        assert!(state.utxos.contains_key(&alice_80_nmo_utxo.id()));
+        assert!(state.channel_notes.contains(&alice_80_nmo_utxo.id()));
 
         // v1 is still claimable
         assert_snapshotted_voucher(&wallet, block_3.id, &v1_cm);
@@ -1754,5 +1778,73 @@ mod tests {
     ) {
         assert!(wallet.voucher_path(tip, cm).unwrap().is_none());
         assert!(wallet.voucher_path_snapshot(tip, cm).unwrap().is_none());
+    }
+
+    /// A `ChannelDeposit` must keep the deposited note in the wallet so the
+    /// depositor retains `PoL` eligibility on their bridged funds, while
+    /// marking it as a channel note so `fund_tx` gates it
+    /// out.
+    #[test]
+    fn test_channel_deposit_keeps_note() {
+        let alice = pk(1);
+        let genesis = HeaderId::from([0; 32]);
+
+        // Seed the wallet with a 100 NMO note owned by alice.
+        let alice_utxo = Utxo::new(tx_hash(0), 0, Note::new(100, alice));
+        let genesis_ledger = LedgerState::from_utxos([alice_utxo], &ledger_config());
+        let (v_cm, _) = voucher(1, 0);
+        let mut wallet = Wallet::<_, TestVoucherId>::from_lib_ledger_state(
+            [(alice, 1)],
+            Vouchers::default(),
+            genesis,
+            &genesis_ledger,
+        );
+
+        // The note starts spendable.
+        let state = wallet.wallet_state_at(genesis).unwrap();
+        assert!(state.utxos.contains_key(&alice_utxo.id()));
+        assert!(!state.channel_notes.contains(&alice_utxo.id()));
+        assert_eq!(state.balance(alice).unwrap().balance, 100);
+
+        // Deposit the note into a channel.
+        let block = WalletBlock {
+            id: HeaderId::from([1; 32]),
+            parent: genesis,
+            epoch: 1.into(),
+            voucher_cm: v_cm,
+            header_ops: vec![],
+            txs: vec![WalletTx {
+                ops: vec![WalletOp::ChannelDeposit(vec![alice_utxo.id()])],
+            }],
+        };
+        wallet.apply_block(&block).unwrap();
+
+        // The note is still in the wallet (still eligible for PoL) but
+        // marked as a channel note, so it drops out of the balance.
+        let state = wallet.wallet_state_at(block.id).unwrap();
+        assert!(state.utxos.contains_key(&alice_utxo.id()));
+        assert!(state.channel_notes.contains(&alice_utxo.id()));
+        assert_eq!(state.balance(alice).unwrap().balance, 0);
+
+        // `fund_tx` must also exclude the channel note: with no other
+        // UTXOs available, funding a fee-paying tx must fail.
+        let context = MantleTxContext {
+            gas_context: MantleTxGasContext::from_channels(
+                &Channels::default(),
+                GasPrices::new(1, 1),
+            ),
+            leader_reward_amount: 0,
+        };
+        let err = state
+            .fund_tx::<Gas>(
+                &MantleTxBuilder::new(),
+                alice,
+                [alice],
+                &context,
+                &HashSet::new(),
+                0,
+            )
+            .unwrap_err();
+        assert_eq!(err, WalletError::InsufficientFunds { available: 0 });
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

Following PR #3145, this PR fixes wallet to achieve the goal of https://github.com/logos-co/logos-lips/pull/364 completely. 

So far, the wallet have stopped tracking a note once it is deposited to a channel. But, after https://github.com/logos-co/logos-lips/pull/364, we want the wallet to keep participating in PoL using that note.

So, in this PR, wallet keeps the note, so the note is still eligible for PoL. But, it also marks the note as a channel note, so that it is not used for funding txs.

More PRs are coming soon, to track ChannelTransfer and ChannelWithdraw. This PR focuses on only ChannelDeposit.

EDIT: Two subsequent PRs have been merged into this PR: https://github.com/logos-blockchain/logos-blockchain/pull/3151 and https://github.com/logos-blockchain/logos-blockchain/pull/3152.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @thomaslavaur 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
