### PR TITLE
chore: convert vec of op proof into bounded vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,6 +5307,7 @@ dependencies = [
  "logos-blockchain-mmr",
  "logos-blockchain-services-utils",
  "logos-blockchain-storage-service",
+ "logos-blockchain-utils",
  "logos-blockchain-wallet",
  "overwatch",
  "serde",

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -1339,7 +1339,7 @@ pub(crate) fn channel_deposit_sync(
             })?;
         let signed_tx = SignedMantleTx::new(
             tx,
-            vec![OpProof::ZkSig(user_sig.clone()), OpProof::ZkSig(user_sig)],
+            [OpProof::ZkSig(user_sig.clone()), OpProof::ZkSig(user_sig)].into(),
         )
         .map_err(|error| {
             OperationStatus::error(

--- a/core/benches/mantle_tx_components.rs
+++ b/core/benches/mantle_tx_components.rs
@@ -67,7 +67,7 @@ fn make_signed_tx(payload_size: usize) -> SignedMantleTx {
     let tx = make_inscription_tx(payload_size);
     let txhash = tx.hash();
     let op_sig = signing_key.sign_payload(&txhash.as_signing_bytes());
-    SignedMantleTx::new(tx, vec![OpProof::Ed25519Sig(op_sig)]).unwrap()
+    SignedMantleTx::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).unwrap()
 }
 
 // `Blake2b` wrapper function usign the defined `Hasher`.
@@ -151,7 +151,7 @@ fn bench_sign_c_mantle_tx_new_verify_ops_proofs_single_proof(bencher: Bencher, s
             (tx, op_sig)
         })
         .bench_values(|(tx, op_sig): (MantleTx, Ed25519Signature)| {
-            black_box(SignedMantleTx::new(tx, vec![OpProof::Ed25519Sig(op_sig)]).unwrap())
+            black_box(SignedMantleTx::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).unwrap())
         });
 }
 
@@ -170,7 +170,7 @@ fn bench_sign_d_fully_empty(bencher: Bencher, size: usize) {
         })
         .bench_values(|(tx, txhash): (MantleTx, TxHash)| {
             let op_sig = signing_key.sign_payload(&txhash.as_signing_bytes());
-            black_box(SignedMantleTx::new(tx, vec![OpProof::Ed25519Sig(op_sig)]).unwrap())
+            black_box(SignedMantleTx::new(tx, [OpProof::Ed25519Sig(op_sig)].into()).unwrap())
         });
 }
 

--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -66,11 +66,11 @@ where
     I: IntoIterator<Item = N>,
     N: Into<Note>,
 {
-    let notes: Vec<Note> = notes.into_iter().map(Into::into).collect();
-    if notes.is_empty() {
+    let mut notes_iter = notes.into_iter().map(Into::into).peekable();
+    if notes_iter.peek().is_none() {
         return Err(Error::EmptyNotes);
     }
-    BoundedOutputs::try_from(notes).map_err(|error| map_notes_bounded_error(&error))
+    BoundedOutputs::try_from_iter(notes_iter).map_err(|error| map_notes_bounded_error(&error))
 }
 
 fn push_note(mut notes: BoundedOutputs, note: Note) -> Result<BoundedOutputs> {
@@ -80,21 +80,17 @@ fn push_note(mut notes: BoundedOutputs, note: Note) -> Result<BoundedOutputs> {
     Ok(notes)
 }
 
-fn extend_non_empty_notes<I, N>(mut existing: BoundedOutputs, notes: I) -> Result<BoundedOutputs>
+fn extend_non_empty_notes<I, N>(existing: BoundedOutputs, notes: I) -> Result<BoundedOutputs>
 where
     I: IntoIterator<Item = N>,
     N: Into<Note>,
 {
-    let mut iter = notes.into_iter().peekable();
-    if iter.peek().is_none() {
+    let mut notes_iter = notes.into_iter().map(Into::into).peekable();
+    if notes_iter.peek().is_none() {
         return Err(Error::EmptyNotes);
     }
-    for note in iter.map(Into::into) {
-        existing
-            .try_push(note)
-            .map_err(|error| map_notes_bounded_error(&error))?;
-    }
-    Ok(existing)
+    BoundedOutputs::try_from_iter(existing.into_iter().chain(notes_iter))
+        .map_err(|error| map_notes_bounded_error(&error))
 }
 
 /// A [`Block`] whose transactions are all [`GenesisTx`] values.
@@ -1315,24 +1311,18 @@ mod tests {
         ];
         ops.extend(extra_ops);
 
-        let mut ops_proofs = OpsProofs::empty();
-        for op in &ops {
-            let proof = match op {
-                Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
-                Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
-                    CompressedGroth16Proof::from_bytes(&[0u8; 128]),
-                )),
-                Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
-                    zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
-                    ed25519_sig: Ed25519Signature::zero(),
-                },
-                other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
-            };
-
-            ops_proofs
-                .try_push(proof)
-                .expect("genesis transaction proofs are bounded");
-        }
+        let ops_proofs = OpsProofs::try_from_iter(ops.iter().map(|op| match op {
+            Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
+            Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
+                CompressedGroth16Proof::from_bytes(&[0u8; 128]),
+            )),
+            Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
+                zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+                ed25519_sig: Ed25519Signature::zero(),
+            },
+            other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
+        }))
+        .expect("genesis transaction proofs are bounded");
 
         SignedMantleTx::new_unverified(MantleTx(Ops::new_unchecked(ops)), ops_proofs)
     }

--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -13,7 +13,7 @@ use crate::{
         MantleTx, Note, Op, OpProof, SignedMantleTx,
         ledger::{BoundedOutputs, Inputs, Outputs},
         ops::{channel::inscribe::InscriptionOp, sdp::SDPDeclareOp, transfer::TransferOp},
-        transactions::{GenesisTx, Ops, VerificationError, genesis_tx},
+        transactions::{GenesisTx, Ops, VerificationError, genesis_tx, tx::OpsProofs},
     },
 };
 
@@ -1198,24 +1198,21 @@ impl GenesisBlockBuilder<WithAll> {
                 count: n,
             }));
         };
-        let signed_tx = SignedMantleTx::new_unverified(
-            MantleTx(capped_ops),
-            vec![
-                OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
-                    &[0u8; 128],
-                ))),
-                OpProof::Ed25519Sig(Ed25519Signature::zero()),
-            ]
-            .into_iter()
-            .chain(vec![
-                OpProof::ZkAndEd25519Sigs {
+        let mut ops_proofs = OpsProofs::from([
+            OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
+                &[0u8; 128],
+            ))),
+            OpProof::Ed25519Sig(Ed25519Signature::zero()),
+        ]);
+        for _ in 0..n - 2 {
+            ops_proofs
+                .try_push(OpProof::ZkAndEd25519Sigs {
                     zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
                     ed25519_sig: Ed25519Signature::zero(),
-                };
-                n - 2
-            ])
-            .collect(),
-        );
+                })
+                .expect("genesis transaction proofs are bounded");
+        }
+        let signed_tx = SignedMantleTx::new_unverified(MantleTx(capped_ops), ops_proofs);
         Ok(GenesisBlock::genesis(GenesisTx::from_tx(signed_tx)?))
     }
 }
@@ -1317,20 +1314,22 @@ mod tests {
             Op::ChannelInscribe(valid_inscription()),
         ];
         ops.extend(extra_ops);
-        let ops_proofs = ops
-            .iter()
-            .map(|op| match op {
-                Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
-                Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
-                    CompressedGroth16Proof::from_bytes(&[0u8; 128]),
-                )),
-                Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
-                    zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
-                    ed25519_sig: Ed25519Signature::zero(),
-                },
-                other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
-            })
-            .collect();
+        let ops_proofs = OpsProofs::try_from(
+            ops.iter()
+                .map(|op| match op {
+                    Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
+                    Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
+                        CompressedGroth16Proof::from_bytes(&[0u8; 128]),
+                    )),
+                    Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
+                        zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+                        ed25519_sig: Ed25519Signature::zero(),
+                    },
+                    other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .expect("genesis transaction proofs are bounded");
         SignedMantleTx::new_unverified(MantleTx(Ops::new_unchecked(ops)), ops_proofs)
     }
 

--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -1314,22 +1314,26 @@ mod tests {
             Op::ChannelInscribe(valid_inscription()),
         ];
         ops.extend(extra_ops);
-        let ops_proofs = OpsProofs::try_from(
-            ops.iter()
-                .map(|op| match op {
-                    Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
-                    Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
-                        CompressedGroth16Proof::from_bytes(&[0u8; 128]),
-                    )),
-                    Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
-                        zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
-                        ed25519_sig: Ed25519Signature::zero(),
-                    },
-                    other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
-                })
-                .collect::<Vec<_>>(),
-        )
-        .expect("genesis transaction proofs are bounded");
+
+        let mut ops_proofs = OpsProofs::empty();
+        for op in &ops {
+            let proof = match op {
+                Op::ChannelInscribe(_) => OpProof::Ed25519Sig(Ed25519Signature::zero()),
+                Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
+                    CompressedGroth16Proof::from_bytes(&[0u8; 128]),
+                )),
+                Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
+                    zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+                    ed25519_sig: Ed25519Signature::zero(),
+                },
+                other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
+            };
+
+            ops_proofs
+                .try_push(proof)
+                .expect("genesis transaction proofs are bounded");
+        }
+
         SignedMantleTx::new_unverified(MantleTx(Ops::new_unchecked(ops)), ops_proofs)
     }
 

--- a/core/src/mantle/ops/codec.rs
+++ b/core/src/mantle/ops/codec.rs
@@ -1,17 +1,22 @@
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
-use nom::{IResult, Parser as _, combinator::map};
+use nom::{
+    IResult, Parser as _,
+    combinator::map,
+    error::{Error, ErrorKind},
+};
 
 use crate::{
     mantle::{
         Op, OpProof,
         nom::{NomDecode as _, NomEncode as _},
+        transactions::tx::OpsProofs,
     },
     proofs::{
         channel_multi_sig_proof::ChannelMultiSigProof, leader_claim_proof::Groth16LeaderClaimProof,
     },
 };
 
-pub fn decode_ops_proofs<'a>(input: &'a [u8], ops: &[Op]) -> IResult<&'a [u8], Vec<OpProof>> {
+pub fn decode_ops_proofs<'a>(input: &'a [u8], ops: &[Op]) -> IResult<&'a [u8], OpsProofs> {
     let mut remaining = input;
     let mut proofs = Vec::with_capacity(ops.len());
 
@@ -20,8 +25,10 @@ pub fn decode_ops_proofs<'a>(input: &'a [u8], ops: &[Op]) -> IResult<&'a [u8], V
         proofs.push(proof);
         remaining = new_remaining;
     }
+    let ops_proofs = OpsProofs::try_from(proofs)
+        .map_err(|_| nom::Err::Error(Error::new(remaining, ErrorKind::LengthValue)))?;
 
-    Ok((remaining, proofs))
+    Ok((remaining, ops_proofs))
 }
 
 fn decode_op_proof<'a>(input: &'a [u8], op: &Op) -> IResult<&'a [u8], OpProof> {

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -116,7 +116,7 @@ mod tests {
                 sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
                 transfer::TransferOp,
             },
-            transactions::{GasPrices, Ops},
+            transactions::{GasPrices, Ops, tx::OpsProofs},
         },
         proofs::{
             channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
@@ -160,7 +160,7 @@ mod tests {
 
         let signed_tx = SignedMantleTx {
             mantle_tx,
-            ops_proofs: vec![],
+            ops_proofs: OpsProofs::empty(),
         };
 
         #[expect(
@@ -199,7 +199,7 @@ mod tests {
         let txhash = mantle_tx.hash();
         let inscribe_sig =
             OpProof::Ed25519Sig(signing_key.sign_payload(&txhash.as_signing_bytes()));
-        let signed_tx = SignedMantleTx::new(mantle_tx, vec![inscribe_sig]).unwrap();
+        let signed_tx = SignedMantleTx::new(mantle_tx, [inscribe_sig].into()).unwrap();
 
         #[expect(
             clippy::string_add,
@@ -260,10 +260,11 @@ mod tests {
         // are deterministic)
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![
+            [
                 OpProof::Ed25519Sig(sig),
                 OpProof::ChannelMultiSigProof(config_proof),
-            ],
+            ]
+            .into(),
         )
         .unwrap();
 
@@ -302,7 +303,7 @@ mod tests {
                 let txhash = mantle_tx.hash();
                 let op_sig = signing_key.sign_payload(&txhash.as_signing_bytes());
                 let signed_tx =
-                    SignedMantleTx::new(mantle_tx, vec![OpProof::Ed25519Sig(op_sig)]).unwrap();
+                    SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(op_sig)].into()).unwrap();
 
                 let encoded = encode_signed_mantle_tx(&signed_tx);
 
@@ -379,7 +380,7 @@ mod tests {
     fn test_encode_decode_roundtrip_signed_tx() {
         // Create a simple SignedMantleTx
         let mantle_tx = MantleTx(Ops::new_unchecked(vec![]));
-        let original_tx = SignedMantleTx::new(mantle_tx, vec![]).unwrap();
+        let original_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty()).unwrap();
 
         // Encode
         let encoded = encode_signed_mantle_tx(&original_tx);
@@ -403,7 +404,7 @@ mod tests {
         let predicted_size = predict_signed_mantle_tx_size(&mantle_tx, &gas_context);
 
         // Create a signed tx and encode it to get actual size
-        let signed_tx = SignedMantleTx::new(mantle_tx, vec![]).unwrap();
+        let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::empty()).unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -430,7 +431,8 @@ mod tests {
         // Create a signed tx and encode it to get actual size
         let txhash = mantle_tx.hash();
         let op_sig = signing_key.sign_payload(&txhash.as_signing_bytes());
-        let signed_tx = SignedMantleTx::new(mantle_tx, vec![OpProof::Ed25519Sig(op_sig)]).unwrap();
+        let signed_tx =
+            SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(op_sig)].into()).unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -467,9 +469,11 @@ mod tests {
         // Create a signed tx and encode it to get the actual size.
         // New channel → empty proof (no signatures required for just-in-time create).
         let config_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
-        let signed_tx =
-            SignedMantleTx::new(mantle_tx, vec![OpProof::ChannelMultiSigProof(config_proof)])
-                .unwrap();
+        let signed_tx = SignedMantleTx::new(
+            mantle_tx,
+            [OpProof::ChannelMultiSigProof(config_proof)].into(),
+        )
+        .unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -516,10 +520,11 @@ mod tests {
         let txhash = mantle_tx.hash();
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![OpProof::ZkAndEd25519Sigs {
+            [OpProof::ZkAndEd25519Sigs {
                 zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &txhash.to_fr()).unwrap(),
                 ed25519_sig: Ed25519Signature::from_bytes(&[0u8; 64]),
-            }],
+            }]
+            .into(),
         )
         .unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
@@ -550,9 +555,10 @@ mod tests {
         // Create a signed tx and encode it to get actual size
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![OpProof::ZkSig(
+            [OpProof::ZkSig(
                 ZkKey::multi_sign(&[ZkKey::zero()], &txhash.to_fr()).unwrap(),
-            )],
+            )]
+            .into(),
         )
         .unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
@@ -588,9 +594,10 @@ mod tests {
         let txhash = mantle_tx.hash();
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![OpProof::ZkSig(
+            [OpProof::ZkSig(
                 ZkKey::multi_sign(&[ZkKey::zero()], &txhash.to_fr()).unwrap(),
-            )],
+            )]
+            .into(),
         )
         .unwrap();
 
@@ -651,11 +658,12 @@ mod tests {
         let config_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![
+            [
                 OpProof::Ed25519Sig(op_sig),
                 OpProof::ChannelMultiSigProof(config_proof),
                 OpProof::ZkSig(ZkKey::zero().sign_payload(&txhash.to_fr()).unwrap()),
-            ],
+            ]
+            .into(),
         )
         .unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
@@ -691,7 +699,7 @@ mod tests {
         // Create a signed tx and encode it to get actual size
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![OpProof::ZkSig(ZkKey::multi_sign(&[], &Fr::ZERO).unwrap())],
+            [OpProof::ZkSig(ZkKey::multi_sign(&[], &Fr::ZERO).unwrap())].into(),
         )
         .unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
@@ -760,7 +768,7 @@ mod tests {
         let config_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![
+            [
                 OpProof::Ed25519Sig(op_ed25519_sig),
                 OpProof::ChannelMultiSigProof(config_proof),
                 OpProof::ZkAndEd25519Sigs {
@@ -768,7 +776,8 @@ mod tests {
                     ed25519_sig: op_ed25519_sig,
                 },
                 OpProof::ZkSig(ZkKey::multi_sign(&[], &Fr::ZERO).unwrap()),
-            ],
+            ]
+            .into(),
         )
         .unwrap();
         let encoded = encode_signed_mantle_tx(&signed_tx);
@@ -797,7 +806,7 @@ mod tests {
         // Construct directly to skip proof verification (dummy proof won't verify)
         let signed_tx = SignedMantleTx {
             mantle_tx,
-            ops_proofs: vec![OpProof::PoC(poc_proof)],
+            ops_proofs: [OpProof::PoC(poc_proof)].into(),
         };
 
         let encoded = encode_signed_mantle_tx(&signed_tx);
@@ -841,7 +850,7 @@ mod tests {
         )
         .unwrap();
         let signed_tx =
-            SignedMantleTx::new(mantle_tx, vec![OpProof::ChannelMultiSigProof(proof)]).unwrap();
+            SignedMantleTx::new(mantle_tx, [OpProof::ChannelMultiSigProof(proof)].into()).unwrap();
 
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let (remaining, decoded_tx) = decode_signed_mantle_tx(&encoded).unwrap();

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -24,6 +24,7 @@ use crate::{
             sdp::SDPDeclareOp,
             transfer::TransferOp,
         },
+        transactions::tx::OpsProofs,
     },
 };
 
@@ -258,7 +259,7 @@ impl<'de> Deserialize<'de> for GenesisTx {
         #[derive(Deserialize)]
         struct Helper {
             mantle_tx: MantleTx,
-            ops_proofs: Vec<OpProof>,
+            ops_proofs: OpsProofs,
         }
 
         let helper = Helper::deserialize(deserializer)?;
@@ -482,15 +483,18 @@ mod tests {
 
     // Helper function to create a basic signed transaction
     // Genesis transactions don't need verified proofs for Blob/Inscription ops
-    fn create_tx(mut ops: Vec<Op>, mut ops_proofs: Vec<OpProof>) -> SignedMantleTx {
+    fn create_tx(mut ops: Vec<Op>, ops_proofs: Vec<OpProof>) -> SignedMantleTx {
         let transfer_op = TransferOp::new(Inputs::empty(), Outputs::new([create_test_note(1000)]));
         let mut new_ops = vec![Op::Transfer(transfer_op)];
         new_ops.append(&mut ops);
         let mantle_tx = MantleTx(Ops::new_unchecked(new_ops));
-        let mut new_op_proofs = vec![OpProof::ZkSig(
+        let ops_proofs = OpsProofs::try_from(ops_proofs).unwrap();
+        let mut new_op_proofs = OpsProofs::from(OpProof::ZkSig(
             ZkKey::multi_sign(&[], &mantle_tx.hash().to_fr()).unwrap(),
-        )];
-        new_op_proofs.append(&mut ops_proofs);
+        ));
+        for proof in ops_proofs {
+            new_op_proofs.try_push(proof).unwrap();
+        }
         SignedMantleTx {
             mantle_tx,
             ops_proofs: new_op_proofs,

--- a/core/src/mantle/transactions/tx.rs
+++ b/core/src/mantle/transactions/tx.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use lb_core_macros::NomCodec;
 use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::Ed25519PublicKey;
+use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -23,7 +24,7 @@ use crate::{
             transfer::TransferOp,
         },
         transactions::{
-            Ops,
+            MAX_OPS_PER_TX, Ops,
             codec::{
                 decode_signed_mantle_tx, encode_signed_mantle_tx, predict_signed_mantle_tx_size,
             },
@@ -333,6 +334,8 @@ impl From<SignedMantleTx> for MantleTx {
     }
 }
 
+pub type OpsProofs = UpperBoundedVec<OpProof, MAX_OPS_PER_TX>;
+
 // Deserializing here is dangerous, as it bypasses the verification without
 // confirmation.
 // TODO: Split entity into a system that allows for verification in different
@@ -341,7 +344,7 @@ impl From<SignedMantleTx> for MantleTx {
 pub struct SignedMantleTx {
     pub mantle_tx: MantleTx,
     // TODO: make this more efficient
-    pub ops_proofs: Vec<OpProof>,
+    pub ops_proofs: OpsProofs,
 }
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -413,7 +416,7 @@ impl SignedMantleTx {
     /// This enforces at construction time that:
     /// - `ChannelInscribe` operations have a valid Ed25519 signature from the
     ///   declared signer
-    pub fn new(mantle_tx: MantleTx, ops_proofs: Vec<OpProof>) -> Result<Self, VerificationError> {
+    pub fn new(mantle_tx: MantleTx, ops_proofs: OpsProofs) -> Result<Self, VerificationError> {
         let tx = Self {
             mantle_tx,
             ops_proofs,
@@ -426,7 +429,7 @@ impl SignedMantleTx {
     /// This should only be used for `GenesisTx` or in tests.
     #[doc(hidden)]
     #[must_use]
-    pub const fn new_unverified(mantle_tx: MantleTx, ops_proofs: Vec<OpProof>) -> Self {
+    pub const fn new_unverified(mantle_tx: MantleTx, ops_proofs: OpsProofs) -> Self {
         Self {
             mantle_tx,
             ops_proofs,
@@ -739,7 +742,7 @@ impl<'de> Deserialize<'de> for SignedMantleTx {
             #[derive(Deserialize)]
             struct SignedMantleTxHelper {
                 mantle_tx: MantleTx,
-                ops_proofs: Vec<OpProof>,
+                ops_proofs: OpsProofs,
             }
 
             let helper = SignedMantleTxHelper::deserialize(deserializer)?;
@@ -856,7 +859,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let proof = create_channel_multi_sig_proof(&tx_hash, signing_keys);
 
-        SignedMantleTx::new(mantle_tx, vec![OpProof::ChannelMultiSigProof(proof)]).unwrap()
+        SignedMantleTx::new(mantle_tx, [OpProof::ChannelMultiSigProof(proof)].into()).unwrap()
     }
 
     fn create_config_op(channel: ChannelId, signing_key: &Ed25519Key) -> ChannelConfigOp {
@@ -950,11 +953,12 @@ mod tests {
 
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
-            vec![
+            [
                 OpProof::ChannelMultiSigProof(config_proof),
                 OpProof::ZkSig(deposit_proof),
                 OpProof::ChannelMultiSigProof(withdraw_proof),
-            ],
+            ]
+            .into(),
         )
         .unwrap();
 
@@ -983,7 +987,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
-        let result = SignedMantleTx::new(mantle_tx, vec![OpProof::Ed25519Sig(signature)]);
+        let result = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into());
 
         assert!(result.is_ok());
     }
@@ -993,7 +997,7 @@ mod tests {
         let signing_key = Ed25519Key::from_bytes(&[1; 32]);
         let inscribe_op = create_test_inscribe_op(&signing_key);
         let mantle_tx = create_test_mantle_tx(vec![Op::ChannelInscribe(inscribe_op)]);
-        let result = SignedMantleTx::new(mantle_tx, vec![]);
+        let result = SignedMantleTx::new(mantle_tx, OpsProofs::empty());
 
         assert!(matches!(
             result,
@@ -1015,7 +1019,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let signature = wrong_signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
-        let result = SignedMantleTx::new(mantle_tx, vec![OpProof::Ed25519Sig(signature)]);
+        let result = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into());
 
         assert!(matches!(
             result,
@@ -1032,7 +1036,7 @@ mod tests {
         // Use wrong proof type
         let tx_hash = mantle_tx.hash();
         let zk_sig = OpProof::ZkSig(ZkKey::multi_sign(&[], &tx_hash.to_fr()).unwrap());
-        let result = SignedMantleTx::new(mantle_tx, vec![zk_sig]);
+        let result = SignedMantleTx::new(mantle_tx, [zk_sig].into());
 
         assert!(matches!(
             result,
@@ -1062,7 +1066,7 @@ mod tests {
 
         let result = SignedMantleTx::new(
             mantle_tx,
-            vec![OpProof::Ed25519Sig(sig1), OpProof::Ed25519Sig(sig2)],
+            [OpProof::Ed25519Sig(sig1), OpProof::Ed25519Sig(sig2)].into(),
         );
 
         assert!(result.is_ok());
@@ -1088,7 +1092,7 @@ mod tests {
 
         let result = SignedMantleTx::new(
             mantle_tx,
-            vec![OpProof::Ed25519Sig(sig1), OpProof::Ed25519Sig(sig2)],
+            [OpProof::Ed25519Sig(sig1), OpProof::Ed25519Sig(sig2)].into(),
         );
 
         assert!(matches!(
@@ -1107,7 +1111,7 @@ mod tests {
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
         let signed_tx =
-            SignedMantleTx::new(mantle_tx, vec![OpProof::Ed25519Sig(signature)]).unwrap();
+            SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(signature)].into()).unwrap();
 
         // Serialize and deserialize
         let serialized = serde_json::to_string(&signed_tx).unwrap();
@@ -1125,7 +1129,7 @@ mod tests {
 
         let helper = SignedMantleTx {
             mantle_tx,
-            ops_proofs: vec![],
+            ops_proofs: OpsProofs::empty(),
         };
 
         let serialized = serde_json::to_string(&helper).unwrap();
@@ -1151,7 +1155,7 @@ mod tests {
 
         let helper = SignedMantleTx {
             mantle_tx,
-            ops_proofs: vec![OpProof::Ed25519Sig(wrong_signature)],
+            ops_proofs: [OpProof::Ed25519Sig(wrong_signature)].into(),
         };
 
         let serialized = serde_json::to_string(&helper).unwrap();
@@ -1171,7 +1175,7 @@ mod tests {
         let signature = signing_key.sign_payload(&tx_hash.as_signing_bytes());
 
         // Test too few proofs
-        let result = SignedMantleTx::new(mantle_tx.clone(), vec![]);
+        let result = SignedMantleTx::new(mantle_tx.clone(), OpsProofs::empty());
         assert!(matches!(
             result,
             Err(VerificationError::ProofCountMismatch {
@@ -1183,10 +1187,11 @@ mod tests {
         // Test too many proofs
         let result = SignedMantleTx::new(
             mantle_tx,
-            vec![
+            [
                 OpProof::Ed25519Sig(signature),
                 OpProof::Ed25519Sig(signature),
-            ],
+            ]
+            .into(),
         );
         assert!(matches!(
             result,

--- a/deployment/l2-sequencer-archival-demo/sequencer/src/sequencer.rs
+++ b/deployment/l2-sequencer-archival-demo/sequencer/src/sequencer.rs
@@ -179,7 +179,7 @@ impl Sequencer {
             lb_key_management_system_service::keys::Ed25519Signature::from_bytes(&signature_bytes);
 
         SignedMantleTx {
-            ops_proofs: vec![OpProof::Ed25519Sig(signature)],
+            ops_proofs: [OpProof::Ed25519Sig(signature)].into(),
             mantle_tx: inscribe_tx,
         }
     }

--- a/deployment/tui-zone/src/run_commands/run_config.rs
+++ b/deployment/tui-zone/src/run_commands/run_config.rs
@@ -237,7 +237,7 @@ pub(crate) fn run_config_combine(args: ConfigCombineArgs) -> RunResult<()> {
         )
         .into());
     }
-    let signed_tx = SignedMantleTx::new(tx, vec![OpProof::ChannelMultiSigProof(proof)])?;
+    let signed_tx = SignedMantleTx::new(tx, [OpProof::ChannelMultiSigProof(proof)].into())?;
     let signed = SignedConfigFile {
         version: ZONE_FILE_TRANSFER_VERSION,
         kind: ZONE_SIGNED_CONFIG.to_owned(),

--- a/deployment/tui-zone/src/run_commands/run_deposit.rs
+++ b/deployment/tui-zone/src/run_commands/run_deposit.rs
@@ -44,11 +44,12 @@ pub(crate) async fn run_deposit(args: DepositArgs) -> RunResult<()> {
     let user_sig = ZkKey::multi_sign(&[wallet_key], &tx.hash().to_fr())?;
     let signed_tx = SignedMantleTx::new(
         tx,
-        vec![
+        [
             OpProof::ZkSig(user_sig.clone()),
             OpProof::ZkSig(user_sig),
             OpProof::Ed25519Sig(sequencer_sig),
-        ],
+        ]
+        .into(),
     )?;
     let tx_hash = signed_tx.hash();
 

--- a/deployment/tui-zone/src/run_commands/run_withdraw.rs
+++ b/deployment/tui-zone/src/run_commands/run_withdraw.rs
@@ -203,7 +203,8 @@ pub(crate) fn run_withdraw_combine(args: WithdrawCombineArgs) -> RunResult<()> {
             Op::ChannelInscribe(_) => Ok(OpProof::Ed25519Sig(inscription_signature)),
             other => Err(format!("unexpected op in withdraw intent: {other:?}").into()),
         })
-        .collect::<RunResult<Vec<_>>>()?;
+        .collect::<RunResult<Vec<_>>>()?
+        .try_into()?;
     let signed_tx = SignedMantleTx::new(tx, op_proofs)?;
     let signed = SignedWithdrawFile {
         version: ZONE_FILE_TRANSFER_VERSION,

--- a/deployment/tui-zone/src/run_commands/unit_tests.rs
+++ b/deployment/tui-zone/src/run_commands/unit_tests.rs
@@ -15,7 +15,7 @@ mod tests {
             inscribe::{Inscription, InscriptionOp},
             withdraw::ChannelWithdrawOp,
         },
-        transactions::{Ops, codec::encode_signed_mantle_tx},
+        transactions::{Ops, codec::encode_signed_mantle_tx, tx::OpsProofs},
     };
     use lb_groth16::{Fr, fr_to_bytes};
     use lb_key_management_system_service::keys::{ED25519_SECRET_KEY_SIZE, Ed25519Key, ZkKey};
@@ -121,7 +121,7 @@ mod tests {
         ensure_tx_hash(&hex::encode(tx.hash().as_ref()), tx.hash()).unwrap();
         assert!(ensure_tx_hash(&hex::encode([1u8; 32]), tx.hash()).is_err());
 
-        let signed_tx = SignedMantleTx::new(tx, Vec::new()).unwrap();
+        let signed_tx = SignedMantleTx::new(tx, OpsProofs::empty()).unwrap();
         let signed_encoded = hex::encode(encode_signed_mantle_tx(&signed_tx));
         assert_eq!(
             decode_signed_mantle_tx_hex(&signed_encoded).unwrap(),

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -1597,7 +1597,7 @@ pub mod tests {
         let transfer_sig = ZkKey::multi_sign(&sks, &mantle_tx.hash().to_fr()).unwrap();
         (
             SignedMantleTx {
-                ops_proofs: vec![ZkSig(transfer_sig.clone())],
+                ops_proofs: [ZkSig(transfer_sig.clone())].into(),
                 mantle_tx,
             },
             transfer_op,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -782,7 +782,7 @@ mod tests {
                 sdp::SDPActiveOp,
                 transfer::TransferOp,
             },
-            transactions::Ops,
+            transactions::{Ops, tx::OpsProofs},
         },
         proofs::{
             channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
@@ -817,9 +817,10 @@ mod tests {
         );
         let mantle_tx = MantleTx([Op::Transfer(transfer_op)].into());
         SignedMantleTx {
-            ops_proofs: vec![OpProof::ZkSig(
+            ops_proofs: [OpProof::ZkSig(
                 ZkKey::multi_sign(sks, &mantle_tx.hash().to_fr()).unwrap(),
-            )],
+            )]
+            .into(),
             mantle_tx,
         }
     }
@@ -904,7 +905,8 @@ mod tests {
                 Key::EmptyZk => OpProof::ZkSig(ZkKey::multi_sign(&[], &tx_hash.to_fr()).unwrap()),
                 Key::MultiSequencer(proof) => OpProof::ChannelMultiSigProof(proof.clone()),
             })
-            .collect();
+            .collect::<Vec<_>>();
+        let ops_proofs = OpsProofs::try_from(ops_proofs).expect("operation proofs are bounded");
 
         SignedMantleTx::new(mantle_tx, ops_proofs)
             .expect("Test transaction should have valid signatures")

--- a/nodes/node/binary/src/api/serializers/transactions.rs
+++ b/nodes/node/binary/src/api/serializers/transactions.rs
@@ -1,4 +1,7 @@
-use lb_core::mantle::{MantleTx, OpProof, SignedMantleTx, TxHash, transactions::Ops};
+use lb_core::mantle::{
+    MantleTx, SignedMantleTx, TxHash,
+    transactions::{Ops, tx::OpsProofs},
+};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -15,7 +18,7 @@ pub struct ApiTransactionSerializer {
 pub struct ApiSignedTransactionSerializer {
     #[serde(with = "ApiTransactionSerializer")]
     mantle_tx: MantleTx,
-    ops_proofs: Vec<OpProof>,
+    ops_proofs: OpsProofs,
 }
 
 #[derive(Serialize)]

--- a/services/wallet/Cargo.toml
+++ b/services/wallet/Cargo.toml
@@ -29,6 +29,7 @@ lb-log-targets                   = { workspace = true }
 lb-mmr                           = { workspace = true }
 lb-services-utils                = { workspace = true }
 lb-storage-service               = { workspace = true }
+lb-utils                         = { workspace = true }
 lb-wallet                        = { workspace = true }
 overwatch                        = { workspace = true }
 

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -17,7 +17,7 @@ use lb_core::{
     header::HeaderId,
     mantle::{
         AuthenticatedMantleTx, NoteId, Op, OpProof, SignedMantleTx, Transaction as _, TxHash, Utxo,
-        Value,
+        Value, VerificationError,
         gas::{GasCost, GasOverflow, MainnetGasConstants},
         ledger::Inputs,
         ops::{
@@ -27,7 +27,7 @@ use lb_core::{
             },
             sdp::{SDPActiveOp, SDPDeclareOp, SDPWithdrawOp},
         },
-        transactions::{MantleTxBuilder, MantleTxContext, TxBuilderError},
+        transactions::{MantleTxBuilder, MantleTxContext, TxBuilderError, tx::OpsProofs},
     },
     proofs::leader_claim_proof::{Groth16LeaderClaimProof, LeaderClaimPrivate, LeaderClaimPublic},
 };
@@ -48,6 +48,7 @@ use lb_services_utils::{
     wait_until_services_are_ready,
 };
 use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use lb_utils::bounded::BoundedError;
 use lb_wallet::{WalletBalance, WalletBlock, WalletError};
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
@@ -128,6 +129,12 @@ pub enum WalletServiceError {
 
     #[error("Failed to fetch Channel Withdraw proof for op index {0} from the TxBuilder")]
     ChannelMultiSigProofNotFound(usize),
+
+    #[error(transparent)]
+    BoundedError(#[from] BoundedError),
+
+    #[error(transparent)]
+    VerificationError(#[from] VerificationError),
 }
 
 #[derive(Debug)]
@@ -893,7 +900,7 @@ where
         let mantle_tx = tx_builder.clone().build()?;
         let tx_hash = mantle_tx.hash();
 
-        let mut ops_proofs = Vec::new();
+        let mut ops_proofs = OpsProofs::empty();
         for (i, op) in mantle_tx.ops().iter().enumerate() {
             let proof = match op {
                 Op::ChannelInscribe(inscribe_op) => {
@@ -929,11 +936,10 @@ where
                         .await?
                 }
             };
-            ops_proofs.push(proof);
+            ops_proofs.try_push(proof)?;
         }
 
-        let signed_mantle_tx = SignedMantleTx::new(mantle_tx, ops_proofs)
-            .expect("Failed to create signed transaction");
+        let signed_mantle_tx = SignedMantleTx::new(mantle_tx, ops_proofs)?;
 
         Ok(signed_mantle_tx)
     }

--- a/tests/src/common/wallet/chain/state.rs
+++ b/tests/src/common/wallet/chain/state.rs
@@ -269,6 +269,7 @@ mod tests {
         MantleTx, Note,
         ledger::Inputs,
         ops::channel::{ChannelId, deposit::DepositOp},
+        transactions::tx::OpsProofs,
     };
 
     use super::*;
@@ -328,7 +329,7 @@ mod tests {
                 })]
                 .into(),
             ),
-            Vec::new(),
+            OpsProofs::empty(),
         );
 
         let update = chain_state.apply_transaction(&tx);

--- a/tests/src/common/wallet/funding_from_chain.rs
+++ b/tests/src/common/wallet/funding_from_chain.rs
@@ -5,7 +5,9 @@ use lb_core::mantle::{
     Op, OpProof, SignedMantleTx, Transaction as _, TxHash, Utxo,
     gas::MainnetGasConstants,
     ops::channel::{ChannelId, ChannelKeyIndex},
-    transactions::{GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext},
+    transactions::{
+        GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext, tx::OpsProofs,
+    },
 };
 use lb_testing_framework::{NodeHttpClient, configs::wallet::WalletAccount};
 use thiserror::Error;
@@ -90,8 +92,8 @@ pub async fn funded_signed_tx(
             .expect("transfer proofs should build"),
     );
 
-    let signed_tx =
-        SignedMantleTx::new(mantle_tx, proofs).expect("funded transaction should be valid");
+    let signed_tx = SignedMantleTx::new(mantle_tx, OpsProofs::try_from(proofs).unwrap())
+        .expect("funded transaction should be valid");
 
     (signed_tx, fee)
 }

--- a/tests/src/common/wallet/scanner/accounting.rs
+++ b/tests/src/common/wallet/scanner/accounting.rs
@@ -215,6 +215,7 @@ mod tests {
                 channel::{ChannelId, deposit::DepositOp},
                 transfer::TransferOp,
             },
+            transactions::tx::OpsProofs,
         },
         proofs::leader_proof::Groth16LeaderProof,
         sdp::{DeclarationMessage, Locator, ProviderId, ServiceType, WithdrawMessage},
@@ -262,7 +263,7 @@ mod tests {
                 ))]
                 .into(),
             ),
-            Vec::new(),
+            OpsProofs::empty(),
         )
     }
 
@@ -340,7 +341,7 @@ mod tests {
                 })]
                 .into(),
             ),
-            Vec::new(),
+            OpsProofs::empty(),
         );
         let mut accounting =
             ScannerAccounting::new(vec![TrackedWalletKeys::new("alice", [pk(1)])], &[owned])
@@ -367,7 +368,7 @@ mod tests {
         let declaration = sdp_declaration(locked.id());
         let declare_tx = SignedMantleTx::new_unverified(
             MantleTx([Op::SDPDeclare(declaration.clone())].into()),
-            Vec::new(),
+            OpsProofs::empty(),
         );
         let withdraw_tx = SignedMantleTx::new_unverified(
             MantleTx(
@@ -378,7 +379,7 @@ mod tests {
                 })]
                 .into(),
             ),
-            Vec::new(),
+            OpsProofs::empty(),
         );
         let mut accounting =
             ScannerAccounting::new(vec![TrackedWalletKeys::new("alice", [pk(1)])], &[locked])

--- a/tests/src/common/wallet/transaction/prepared.rs
+++ b/tests/src/common/wallet/transaction/prepared.rs
@@ -1,8 +1,8 @@
 //! Funded wallet transaction before final signing.
 
 use lb_core::mantle::{
-    OpProof, TxHash,
-    transactions::{MantleTxBuilder, MantleTxContext},
+    TxHash,
+    transactions::{MantleTxBuilder, MantleTxContext, tx::OpsProofs},
 };
 
 use super::{
@@ -15,7 +15,7 @@ pub struct PreparedWalletTransaction {
     funded_builder: MantleTxBuilder,
     context: MantleTxContext,
     tx_hash: TxHash,
-    transfer_proofs: Vec<OpProof>,
+    transfer_proofs: OpsProofs,
     reserved_inputs: WalletReservedInputs,
 }
 
@@ -25,7 +25,7 @@ impl PreparedWalletTransaction {
         funded_builder: MantleTxBuilder,
         context: MantleTxContext,
         tx_hash: TxHash,
-        transfer_proofs: Vec<OpProof>,
+        transfer_proofs: OpsProofs,
         reserved_inputs: WalletReservedInputs,
     ) -> Self {
         Self {
@@ -44,7 +44,7 @@ impl PreparedWalletTransaction {
 
     pub fn sign_with_leading_proofs(
         self,
-        leading_op_proofs: Vec<OpProof>,
+        leading_op_proofs: OpsProofs,
     ) -> Result<SignedWalletTransaction, WalletTransactionError> {
         let Self {
             funded_builder,

--- a/tests/src/common/wallet/transaction/signing.rs
+++ b/tests/src/common/wallet/transaction/signing.rs
@@ -6,7 +6,7 @@ use lb_core::mantle::{
     AuthenticatedMantleTx as _, MantleTx, NoteId, Op, OpProof, SignedMantleTx, Transaction as _,
     TxHash,
     gas::MainnetGasConstants,
-    transactions::{MantleTxBuilder, MantleTxContext},
+    transactions::{MantleTxBuilder, MantleTxContext, tx::OpsProofs},
 };
 use lb_key_management_system_service::keys::ZkKey;
 
@@ -20,14 +20,15 @@ pub(super) fn sign_prepared_wallet_transaction(
     funded_builder: MantleTxBuilder,
     context: &MantleTxContext,
     tx_hash: TxHash,
-    transfer_proofs: Vec<OpProof>,
+    transfer_proofs: OpsProofs,
     reserved_inputs: WalletReservedInputs,
-    leading_op_proofs: Vec<OpProof>,
+    leading_op_proofs: OpsProofs,
 ) -> Result<SignedWalletTransaction, WalletTransactionError> {
     let gas_prices = context.gas_context.get_gas_prices();
     let mantle_tx = funded_builder.build()?;
-    let mut op_proofs = leading_op_proofs;
+    let mut op_proofs = leading_op_proofs.into_inner();
     op_proofs.extend(transfer_proofs);
+    let op_proofs = OpsProofs::new_unchecked(op_proofs);
 
     let signed_tx = SignedMantleTx::new(mantle_tx, op_proofs)?;
     let spent_fee = signed_tx
@@ -48,15 +49,16 @@ pub(super) fn sign_prepared_wallet_transaction(
 pub fn transfer_proofs_for_funded_wallet_tx(
     tx: &MantleTx,
     signing_key: &ZkKey,
-) -> Result<Vec<OpProof>, WalletTransactionError> {
+) -> Result<OpsProofs, WalletTransactionError> {
     let tx_hash = tx.hash();
-    tx.ops()
+    let proofs = tx
+        .ops()
         .iter()
         .filter_map(|op| match op {
             Op::Transfer(transfer_op) => Some(transfer_op),
             _ => None,
         })
-        .map(|transfer_op| {
+        .map(|transfer_op| -> Result<OpProof, WalletTransactionError> {
             let signing_keys = transfer_op
                 .inputs
                 .iter()
@@ -67,20 +69,22 @@ pub fn transfer_proofs_for_funded_wallet_tx(
                 &tx_hash.to_fr(),
             )?))
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(OpsProofs::try_from(proofs).expect("transaction proofs are bounded"))
 }
 
 pub(super) fn build_transfer_proofs(
     ops: &[Op],
     tx_hash: &TxHash,
     transfer_signers: &WalletTransferSigners,
-) -> Result<Vec<OpProof>, WalletTransactionError> {
-    ops.iter()
+) -> Result<OpsProofs, WalletTransactionError> {
+    let proofs = ops
+        .iter()
         .filter_map(|op| match op {
             Op::Transfer(transfer_op) => Some(transfer_op),
             _ => None,
         })
-        .map(|transfer_op| {
+        .map(|transfer_op| -> Result<OpProof, WalletTransactionError> {
             let signing_keys = transfer_op
                 .inputs
                 .iter()
@@ -97,5 +101,6 @@ pub(super) fn build_transfer_proofs(
                 &tx_hash.to_fr(),
             )?))
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(OpsProofs::try_from(proofs).expect("transaction proofs are bounded"))
 }

--- a/tests/src/cucumber/steps/manual_mempool/actions.rs
+++ b/tests/src/cucumber/steps/manual_mempool/actions.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use lb_core::mantle::{SignedMantleTx, Transaction as _, TxHash};
+use lb_core::mantle::{SignedMantleTx, Transaction as _, TxHash, transactions::tx::OpsProofs};
 use lb_key_management_system_service::keys::ZkPublicKey;
 use lb_tx_service::{backend::PoolRecoveryState, tx::state::TxMempoolState};
 use tokio::time::{sleep, timeout};
@@ -41,7 +41,7 @@ pub async fn prepare_transfer_transaction(
     let prepared =
         prepare_user_wallet_transaction_submission(world, step, &sender_wallet_name, intent, None)
             .await?;
-    let signed = sign_prepared_user_wallet_transaction(step, prepared, Vec::new())?;
+    let signed = sign_prepared_user_wallet_transaction(step, prepared, OpsProofs::empty())?;
     let tx_hash = record_prepared_transaction(world, transaction_alias.clone(), &signed)?;
 
     report_prepared_transaction(

--- a/tests/src/cucumber/steps/manual_transactions/inscriptions.rs
+++ b/tests/src/cucumber/steps/manual_transactions/inscriptions.rs
@@ -118,7 +118,7 @@ async fn submit_inscription_transaction(
         world,
         &step.value,
         prepared,
-        vec![inscription_signature_proof(tx_hash, &signing_key)],
+        [inscription_signature_proof(tx_hash, &signing_key)].into(),
         None,
         None,
     )

--- a/tests/src/cucumber/steps/manual_transactions/tracked_transactions.rs
+++ b/tests/src/cucumber/steps/manual_transactions/tracked_transactions.rs
@@ -211,7 +211,7 @@ pub fn create_invalid_transaction() -> SignedMantleTx {
         .expect("invalid transfer proof should still be constructible");
 
     SignedMantleTx {
-        ops_proofs: vec![OpProof::ZkSig(transfer_proof)],
+        ops_proofs: [OpProof::ZkSig(transfer_proof)].into(),
         mantle_tx,
     }
 }

--- a/tests/src/cucumber/steps/manual_zone/support.rs
+++ b/tests/src/cucumber/steps/manual_zone/support.rs
@@ -26,7 +26,7 @@ use lb_core::mantle::{
         },
         transfer::TransferOp,
     },
-    transactions::builder::MantleTxBuilder,
+    transactions::{builder::MantleTxBuilder, tx::OpsProofs},
 };
 use lb_http_api_common::bodies::{
     channel::{ChannelDepositRequestBody, ChannelDepositResponseBody},
@@ -1459,11 +1459,12 @@ pub async fn submit_atomic_zone_deposit(
     let user_sig = sign_tx_zk(node_url, &tx, vec![funding_public_key]).await?;
     let signed_tx = SignedMantleTx::new(
         tx,
-        vec![
+        [
             OpProof::ZkSig(user_sig.clone()),
             OpProof::ZkSig(user_sig),
             OpProof::Ed25519Sig(sequencer_sig),
-        ],
+        ]
+        .into(),
     )
     .map_err(|error| ZoneTestError::SubmitAtomicDeposit {
         message: error.to_string(),
@@ -1526,8 +1527,15 @@ async fn build_funded_custom_tx(
     // proven by the sequencer key over the funded tx hash.
     let funded_tx = response.funded_tx;
     let signature = signing_key.sign_payload(funded_tx.hash().as_signing_bytes().as_ref());
-    let mut ops_proofs = vec![OpProof::Ed25519Sig(signature); payloads.len()];
-    ops_proofs.extend(response.transfer_proof);
+    let mut ops_proofs =
+        OpsProofs::new_unchecked(vec![OpProof::Ed25519Sig(signature); payloads.len()]);
+    if let Some(proof) = response.transfer_proof {
+        ops_proofs
+            .try_push(proof)
+            .map_err(|error| ZoneTestError::BuildCustomTx {
+                message: format!("too many operation proofs: {error:?}"),
+            })?;
+    }
     let signed_tx = SignedMantleTx::new(funded_tx, ops_proofs).map_err(|error| {
         ZoneTestError::BuildCustomTx {
             message: format!("assembling the signed tx failed: {error:?}"),

--- a/tests/src/cucumber/steps/wallet_fund.rs
+++ b/tests/src/cucumber/steps/wallet_fund.rs
@@ -76,7 +76,7 @@ async fn step_fund_payment_transaction(
     }
 
     let signed_tx =
-        SignedMantleTx::new(response.funded_tx, vec![transfer_proof]).map_err(|source| {
+        SignedMantleTx::new(response.funded_tx, [transfer_proof].into()).map_err(|source| {
             StepError::LogicalError {
                 message: format!(
                     "Step `{}` error: assembling the funded transaction failed: {source:?}",
@@ -173,7 +173,7 @@ async fn step_fund_inscription_transaction(
     let signature = signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
     let signed_tx = SignedMantleTx::new(
         response.funded_tx,
-        vec![OpProof::Ed25519Sig(signature), transfer_proof],
+        [OpProof::Ed25519Sig(signature), transfer_proof].into(),
     )
     .map_err(|source| StepError::LogicalError {
         message: format!(

--- a/tests/src/cucumber/wallet/submissions.rs
+++ b/tests/src/cucumber/wallet/submissions.rs
@@ -8,7 +8,7 @@ use std::{collections::HashSet, time::Duration};
 use hex::ToHex as _;
 use lb_core::{
     codec::SerializeOp as _,
-    mantle::{OpProof, SignedMantleTx, TxHash, Utxo},
+    mantle::{SignedMantleTx, TxHash, Utxo, transactions::tx::OpsProofs},
 };
 use lb_http_api_common::bodies::wallet::transfer_funds::WalletTransferFundsRequestBody;
 use lb_key_management_system_service::keys::ZkPublicKey;
@@ -464,7 +464,7 @@ pub async fn submit_prepared_user_wallet_transaction(
     world: &mut CucumberWorld,
     step: &str,
     prepared: PreparedUserWalletSubmission,
-    extra_op_proofs: Vec<OpProof>,
+    extra_op_proofs: OpsProofs,
     best_node_info: Option<&BestNodeInfo>,
     in_memory_available_utxos: Option<&mut WalletUtxos>,
 ) -> Result<TxHash, StepError> {
@@ -499,7 +499,7 @@ pub async fn submit_prepared_user_wallet_transaction(
 pub(crate) fn sign_prepared_user_wallet_transaction(
     step: &str,
     prepared: PreparedUserWalletSubmission,
-    extra_op_proofs: Vec<OpProof>,
+    extra_op_proofs: OpsProofs,
 ) -> Result<SignedUserWalletSubmission, StepError> {
     let PreparedUserWalletSubmission { wallet, submission } = prepared;
     let signed_submission = submission
@@ -529,7 +529,7 @@ fn finalize_reserved_user_wallet_submission(
     sign_prepared_user_wallet_transaction(
         step,
         PreparedUserWalletSubmission { wallet, submission },
-        Vec::new(),
+        OpsProofs::empty(),
     )
 }
 
@@ -653,7 +653,7 @@ async fn submit_user_wallet_transaction(
         world,
         step,
         prepared,
-        Vec::new(),
+        OpsProofs::empty(),
         best_node_info,
         in_memory_available_utxos,
     )

--- a/tests/testing_framework/src/workloads/inscription/workload.rs
+++ b/tests/testing_framework/src/workloads/inscription/workload.rs
@@ -398,7 +398,7 @@ fn build_inscription_transaction(
         .signing_key
         .sign_payload(tx_hash.as_signing_bytes().as_ref());
 
-    let signed_tx = SignedMantleTx::new(mantle_tx, vec![OpProof::Ed25519Sig(ed25519_signature)])
+    let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::Ed25519Sig(ed25519_signature)].into())
         .map_err(|error| InscriptionWorkloadError::SignedTransactionBuild(error.to_string()))?;
 
     channel.next_nonce = channel.next_nonce.saturating_add(1);

--- a/tests/testing_framework/src/workloads/transaction/workload.rs
+++ b/tests/testing_framework/src/workloads/transaction/workload.rs
@@ -311,7 +311,7 @@ fn build_wallet_transaction(
     )
     .map_err(|err| format!("failed to sign transaction: {err}"))?;
 
-    SignedMantleTx::new(tx, vec![OpProof::ZkSig(signature)])
+    SignedMantleTx::new(tx, [OpProof::ZkSig(signature)].into())
         .map_err(|err| format!("failed to build signed transaction: {err}").into())
 }
 

--- a/tools/config/src/consensus.rs
+++ b/tools/config/src/consensus.rs
@@ -14,7 +14,7 @@ use lb_core::{
             },
             transfer::TransferOp,
         },
-        transactions::{GenesisTx, Ops},
+        transactions::{GenesisTx, Ops, tx::OpsProofs},
     },
     sdp::{DeclarationMessage, Locator, ProviderId, ServiceType},
 };
@@ -307,12 +307,12 @@ pub fn create_genesis_block_with_declarations(
     let mantle_tx = MantleTx(Ops::new_unchecked(ops));
 
     let mantle_tx_hash = mantle_tx.hash();
-    let mut ops_proofs = vec![
+    let mut ops_proofs = OpsProofs::from([
         OpProof::ZkSig(ZkSignature::new(CompressedGroth16Proof::from_bytes(
             &EMPTY_GROTH16_PROOF_BYTES,
         ))),
         OpProof::Ed25519Sig(Ed25519Signature::zero()),
-    ];
+    ]);
 
     for provider in providers {
         let zk_sig =
@@ -321,10 +321,12 @@ pub fn create_genesis_block_with_declarations(
         let ed25519_sig = provider
             .provider_sk
             .sign_payload(mantle_tx_hash.as_signing_bytes().as_ref());
-        ops_proofs.push(OpProof::ZkAndEd25519Sigs {
-            zk_sig,
-            ed25519_sig,
-        });
+        ops_proofs
+            .try_push(OpProof::ZkAndEd25519Sigs {
+                zk_sig,
+                ed25519_sig,
+            })
+            .expect("genesis transaction proofs are bounded");
     }
 
     let signed_mantle_tx = SignedMantleTx {

--- a/utils/src/bounded/vec.rs
+++ b/utils/src/bounded/vec.rs
@@ -100,6 +100,24 @@ impl<T, const MIN: usize, const MAX: usize> Bounded<Vec<T>, MIN, MAX> {
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         self.0.iter_mut()
     }
+
+    pub fn try_from_iter<I>(iterable: I) -> Result<Self, BoundedError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut values = Vec::new();
+
+        for value in iterable {
+            if values.len() == MAX {
+                return Err(BoundedError::TooManyItems {
+                    count: MAX + 1,
+                    max: MAX,
+                });
+            }
+            values.push(value);
+        }
+        Self::try_from(values)
+    }
 }
 
 impl<T, const MIN: usize, const MAX: usize> Default for Bounded<Vec<T>, MIN, MAX> {
@@ -537,5 +555,41 @@ mod tests {
 
         assert_eq!(bv.as_slice(), &[1, 2, 3]);
         assert_eq!(bv.len(), 3);
+    }
+
+    #[test]
+    fn try_from_iter_accepts_items_within_bounds() {
+        let bounded = TestBoundedVectorMin0::try_from_iter([1, 2, 3]).unwrap();
+
+        assert_eq!(bounded.as_slice(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn try_from_iter_accepts_an_empty_iterator_when_minimum_is_zero() {
+        let bounded = TestBoundedVectorMin0::try_from_iter(std::iter::empty()).unwrap();
+
+        assert!(bounded.is_empty());
+    }
+
+    #[test]
+    fn try_from_iter_rejects_items_above_maximum() {
+        let result = TestBoundedVectorMin0::try_from_iter([1, 2, 3, 4, 5]);
+
+        assert_eq!(result, Err(BoundedError::TooManyItems { count: 5, max: 4 }));
+    }
+
+    #[test]
+    fn try_from_iter_rejects_items_below_minimum() {
+        let result = TestBoundedVectorMin2::try_from_iter([1]);
+
+        assert_eq!(result, Err(BoundedError::TooFewItems { count: 1, min: 2 }));
+    }
+
+    #[test]
+    fn try_from_iter_preserves_iterator_order() {
+        let input = (0..4).map(|value| value * 2);
+        let bounded = TestBoundedVectorMin0::try_from_iter(input).unwrap();
+
+        assert_eq!(bounded.as_slice(), &[0, 2, 4, 6]);
     }
 }

--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -613,7 +613,7 @@ mod tests {
                     withdraw::ChannelWithdrawOp,
                 },
             },
-            transactions::Ops,
+            transactions::{Ops, tx::OpsProofs},
         },
         proofs::leader_proof::Groth16LeaderProof,
     };
@@ -643,7 +643,7 @@ mod tests {
         let mantle_tx = MantleTx(Ops::try_from(ops).unwrap());
         SignedMantleTx::new_unverified(
             mantle_tx,
-            vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n],
+            OpsProofs::new_unchecked(vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n]),
         )
     }
 
@@ -699,13 +699,14 @@ mod tests {
         // Sign the `MantleTx`
         let signed_tx = SignedMantleTx::new(
             tx.clone(),
-            vec![
+            [
                 OpProof::ZkSig(
                     ZkKey::multi_sign(std::slice::from_ref(&sk), &tx.clone().hash().to_fr())
                         .unwrap(),
                 ),
                 OpProof::Ed25519Sig(inscription_sig),
-            ],
+            ]
+            .into(),
         )
         .unwrap();
 
@@ -1002,7 +1003,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let signed_tx = SignedMantleTx {
             mantle_tx,
-            ops_proofs: Vec::new(),
+            ops_proofs: OpsProofs::empty(),
         };
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
@@ -1037,7 +1038,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let signed_tx = SignedMantleTx {
             mantle_tx,
-            ops_proofs: Vec::new(),
+            ops_proofs: OpsProofs::empty(),
         };
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());
@@ -1065,7 +1066,7 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let signed_tx = SignedMantleTx {
             mantle_tx,
-            ops_proofs: Vec::new(),
+            ops_proofs: OpsProofs::empty(),
         };
 
         let mut state = TxState::new(HeaderId::from([0; 32]), MsgId::root());

--- a/zone-sdk/src/sequencer/block_fetch.rs
+++ b/zone-sdk/src/sequencer/block_fetch.rs
@@ -763,7 +763,7 @@ mod tests {
                 withdraw::ChannelWithdrawOp,
             },
         },
-        transactions::Ops,
+        transactions::{Ops, tx::OpsProofs},
     };
     use lb_groth16::Fr;
     use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature};
@@ -778,7 +778,7 @@ mod tests {
         let mantle_tx = MantleTx(Ops::try_from(ops).unwrap());
         SignedMantleTx::new_unverified(
             mantle_tx,
-            vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n],
+            OpsProofs::new_unchecked(vec![OpProof::Ed25519Sig(Ed25519Signature::zero()); n]),
         )
     }
 
@@ -1152,7 +1152,7 @@ mod tests {
         );
         SignedMantleTx::new_unverified(
             mantle_tx,
-            vec![OpProof::Ed25519Sig(Ed25519Signature::zero())],
+            [OpProof::Ed25519Sig(Ed25519Signature::zero())].into(),
         )
     }
 

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -968,6 +968,7 @@ impl TxState {
 mod tests {
     use lb_core::mantle::{
         MantleTx, Op::ChannelInscribe, Transaction as _, ops::channel::inscribe::InscriptionOp,
+        transactions::tx::OpsProofs,
     };
     use lb_key_management_system_service::keys::Ed25519PublicKey;
 
@@ -990,7 +991,7 @@ mod tests {
             .into(),
         );
         SignedMantleTx {
-            ops_proofs: vec![],
+            ops_proofs: OpsProofs::empty(),
             mantle_tx,
         }
     }

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -10,7 +10,7 @@ use lb_core::{
                 inscribe::{Inscription, InscriptionOp},
             },
         },
-        transactions::{MantleTxBuilder, Ops, TxHash},
+        transactions::{MantleTxBuilder, Ops, TxHash, tx::OpsProofs},
     },
     proofs::channel_multi_sig_proof::{ChannelMultiSigProof, IndexedSignature},
 };
@@ -74,9 +74,9 @@ where
 /// op; a fee-less transaction carries none).
 pub(super) fn attach_transfer_proof(
     tx: &MantleTx,
-    mut channel_proofs: Vec<OpProof>,
+    mut channel_proofs: OpsProofs,
     transfer_proof: Option<OpProof>,
-) -> Result<Vec<OpProof>, Error> {
+) -> Result<OpsProofs, Error> {
     let transfer_count = tx
         .ops()
         .iter()
@@ -84,7 +84,9 @@ pub(super) fn attach_transfer_proof(
         .count();
     match (transfer_count, transfer_proof) {
         (0, _) => {}
-        (1, Some(proof)) => channel_proofs.push(proof),
+        (1, Some(proof)) => channel_proofs
+            .try_push(proof)
+            .map_err(|e| Error::Network(format!("too many operation proofs: {e:?}")))?,
         (1, None) => {
             return Err(Error::Network(
                 "funded transaction carries a fee transfer but no transfer proof".into(),
@@ -114,19 +116,25 @@ pub(super) fn build_atomic_withdraw_ops_proofs(
     own_key_index: ChannelKeyIndex,
     own_sig: Ed25519Signature,
     transfer_proof: Option<&OpProof>,
-) -> Result<Vec<OpProof>, Error> {
+) -> Result<OpsProofs, Error> {
     let withdraw_proof =
         ChannelMultiSigProof::try_new([IndexedSignature::new(own_key_index, own_sig)].into())
             .map_err(|e| Error::Network(format!("multi-sig proof assembly failed: {e:?}")))?;
-    let mut ops_proofs = Vec::with_capacity(tx.ops().len());
+    let mut ops_proofs = OpsProofs::empty();
     for op in tx.ops() {
         match op {
             Op::ChannelWithdraw(_) => {
-                ops_proofs.push(OpProof::ChannelMultiSigProof(withdraw_proof.clone()));
+                ops_proofs
+                    .try_push(OpProof::ChannelMultiSigProof(withdraw_proof.clone()))
+                    .map_err(|e| Error::Network(format!("too many operation proofs: {e:?}")))?;
             }
-            Op::ChannelInscribe(_) => ops_proofs.push(OpProof::Ed25519Sig(own_sig)),
+            Op::ChannelInscribe(_) => ops_proofs
+                .try_push(OpProof::Ed25519Sig(own_sig))
+                .map_err(|e| Error::Network(format!("too many operation proofs: {e:?}")))?,
             Op::Transfer(_) => match transfer_proof {
-                Some(proof) => ops_proofs.push(proof.clone()),
+                Some(proof) => ops_proofs
+                    .try_push(proof.clone())
+                    .map_err(|e| Error::Network(format!("too many operation proofs: {e:?}")))?,
                 None => {
                     return Err(Error::Network(
                         "funded transaction carries a fee transfer but no transfer proof".into(),
@@ -192,7 +200,7 @@ where
     let signature = sign_tx(tx_hash, signing_key);
     let ops_proofs = attach_transfer_proof(
         &inscribe_tx,
-        vec![OpProof::Ed25519Sig(signature)],
+        [OpProof::Ed25519Sig(signature)].into(),
         transfer_proof,
     )?;
 
@@ -250,7 +258,7 @@ where
     let proof = ChannelMultiSigProof::try_new(signatures).unwrap();
     let ops_proofs = attach_transfer_proof(
         &config_tx,
-        vec![OpProof::ChannelMultiSigProof(proof)],
+        [OpProof::ChannelMultiSigProof(proof)].into(),
         transfer_proof,
     )?;
 


### PR DESCRIPTION

## 1. What does this PR implement?

Converted `pub ops_proofs: Vec<OpProof>,` to `pub ops_proofs: OpsProofs,` with 
```rust
pub type OpsProofs = UpperBoundedVec<OpProof, MAX_OPS_PER_TX>;
```
 and changed all relevant call sites.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
