### PR TITLE
chore: add bounded sdp declaration handling to genesis block

### DIFF
--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 use lb_cryptarchia_engine::Slot;
 use lb_groth16::CompressedGroth16Proof;
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
-use lb_utils::bounded::BoundedError;
+use lb_utils::bounded::{BoundedError, UpperBoundedVec};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
         MantleTx, Note, Op, OpProof, SignedMantleTx,
         ledger::{BoundedOutputs, Inputs, Outputs},
         ops::{channel::inscribe::InscriptionOp, sdp::SDPDeclareOp, transfer::TransferOp},
-        transactions::{GenesisTx, Ops, VerificationError, genesis_tx},
+        transactions::{GenesisTx, MAX_OPS_PER_TX, Ops, VerificationError, genesis_tx},
     },
 };
 
@@ -183,6 +183,13 @@ impl core::ops::Deref for GenesisBlock {
 // ── Typestate markers
 // ─────────────────────────────────────────────────────────
 
+/// The genesis transaction structure is always `Transfer` + `ChannelInscribe` +
+/// zero or more `SDPDeclareOp`, with maximum operations bounded in `Ops`.
+const GENESIS_REQUIRED_OPS: usize = 2;
+
+pub const MAX_GENESIS_DECLARATIONS: usize = MAX_OPS_PER_TX - GENESIS_REQUIRED_OPS; // 253
+pub type GenesisSDPDeclareOps = UpperBoundedVec<SDPDeclareOp, MAX_GENESIS_DECLARATIONS>;
+
 /// Typestate marker: builder has no input yet.
 pub struct Empty;
 
@@ -203,7 +210,7 @@ pub struct WithInscription {
 
 /// Typestate marker: builder has SDP service-declaration ops only.
 pub struct WithDeclarations {
-    sdp_declarations: Vec<SDPDeclareOp>,
+    sdp_declarations: GenesisSDPDeclareOps,
 }
 
 /// Typestate marker: builder has genesis notes and an inscription.
@@ -215,13 +222,13 @@ pub struct WithNotesAndInscription {
 /// Typestate marker: builder has genesis notes and SDP declarations.
 pub struct WithNotesAndDeclarations {
     notes: BoundedOutputs,
-    sdp_declarations: Vec<SDPDeclareOp>,
+    sdp_declarations: GenesisSDPDeclareOps,
 }
 
 /// Typestate marker: builder has a genesis inscription and SDP declarations.
 pub struct WithInscriptionAndDeclarations {
     inscription: InscriptionOp,
-    sdp_declarations: Vec<SDPDeclareOp>,
+    sdp_declarations: GenesisSDPDeclareOps,
 }
 
 #[expect(
@@ -229,12 +236,12 @@ pub struct WithInscriptionAndDeclarations {
     reason = "Necessary documentation"
 )]
 /// Typestate marker: builder holds all three pieces required to assemble a
-/// [`GenesisTx`] — notes, an inscription, and at least one SDP declaration.
+/// [`GenesisTx`] — notes, an inscription, and optional SDP declaration.
 /// This is the only state that exposes [`GenesisBlockBuilder::build`].
 pub struct WithAll {
     notes: BoundedOutputs,
     inscription: InscriptionOp,
-    sdp_declarations: Vec<SDPDeclareOp>,
+    sdp_declarations: GenesisSDPDeclareOps,
 }
 
 // ── Builder
@@ -362,7 +369,7 @@ impl GenesisBlockBuilder<Empty> {
     ) -> GenesisBlockBuilder<WithDeclarations> {
         GenesisBlockBuilder {
             state: WithDeclarations {
-                sdp_declarations: vec![declaration],
+                sdp_declarations: [declaration].into(),
             },
         }
     }
@@ -370,24 +377,21 @@ impl GenesisBlockBuilder<Empty> {
     /// Add multiple SDP service-declaration ops at once, transitioning to
     /// [`WithDeclarations`].
     ///
-    /// # Panics
+    /// # Panics and Errors
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
+    /// Returns an error if the number of declarations exceeds the maximum
+    /// allowed.
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> GenesisBlockBuilder<WithDeclarations> {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
-        GenesisBlockBuilder {
+    ) -> Result<GenesisBlockBuilder<WithDeclarations>> {
+        let iter = require_non_empty(declarations, "add_declarations");
+        Ok(GenesisBlockBuilder {
             state: WithDeclarations {
-                sdp_declarations: iter.map(Into::into).collect(),
+                sdp_declarations: try_collect_sdp_declarations(iter)?,
             },
-        }
+        })
     }
 }
 
@@ -448,7 +452,7 @@ impl GenesisBlockBuilder<WithNotes> {
         GenesisBlockBuilder {
             state: WithNotesAndDeclarations {
                 notes,
-                sdp_declarations: vec![declaration],
+                sdp_declarations: [declaration].into(),
             },
         }
     }
@@ -456,28 +460,24 @@ impl GenesisBlockBuilder<WithNotes> {
     /// Add multiple SDP declarations at once, transitioning to
     /// [`WithNotesAndDeclarations`].
     ///
-    /// # Panics
+    /// # Panics and Errors
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
+    /// Errors if the number of declarations exceeds the maximum allowed.
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> GenesisBlockBuilder<WithNotesAndDeclarations> {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<GenesisBlockBuilder<WithNotesAndDeclarations>> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
             state: WithNotes { notes },
         } = self;
-        GenesisBlockBuilder {
+        Ok(GenesisBlockBuilder {
             state: WithNotesAndDeclarations {
                 notes,
-                sdp_declarations: iter.map(Into::into).collect(),
+                sdp_declarations: try_collect_sdp_declarations(iter)?,
             },
-        }
+        })
     }
 }
 
@@ -556,7 +556,7 @@ impl GenesisBlockBuilder<WithInscription> {
         GenesisBlockBuilder {
             state: WithInscriptionAndDeclarations {
                 inscription,
-                sdp_declarations: vec![declaration],
+                sdp_declarations: [declaration].into(),
             },
         }
     }
@@ -564,28 +564,24 @@ impl GenesisBlockBuilder<WithInscription> {
     /// Add multiple SDP declarations at once, transitioning to
     /// [`WithInscriptionAndDeclarations`].
     ///
-    /// # Panics
+    /// # Panics and Errors
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
+    /// Errors if the number of declarations exceeds the maximum allowed.
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> GenesisBlockBuilder<WithInscriptionAndDeclarations> {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<GenesisBlockBuilder<WithInscriptionAndDeclarations>> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
             state: WithInscription { inscription },
         } = self;
-        GenesisBlockBuilder {
+        Ok(GenesisBlockBuilder {
             state: WithInscriptionAndDeclarations {
                 inscription,
-                sdp_declarations: iter.map(Into::into).collect(),
+                sdp_declarations: try_collect_sdp_declarations(iter)?,
             },
-        }
+        })
     }
 }
 
@@ -662,17 +658,14 @@ impl GenesisBlockBuilder<WithDeclarations> {
     }
 
     /// Append another SDP declaration.
-    #[must_use]
-    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Self {
+    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Result<Self> {
         let Self {
-            state: WithDeclarations {
-                mut sdp_declarations,
-            },
-        } = self;
-        sdp_declarations.push(declaration);
-        Self {
             state: WithDeclarations { sdp_declarations },
-        }
+        } = self;
+        let sdp_declarations = try_push_genesis_declaration(sdp_declarations, declaration)?;
+        Ok(Self {
+            state: WithDeclarations { sdp_declarations },
+        })
     }
 
     /// Append multiple SDP declarations at once.
@@ -680,25 +673,19 @@ impl GenesisBlockBuilder<WithDeclarations> {
     /// # Panics
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> Self {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<Self> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
-            state: WithDeclarations {
-                mut sdp_declarations,
-            },
-        } = self;
-        sdp_declarations.extend(iter.map(Into::into));
-        Self {
             state: WithDeclarations { sdp_declarations },
-        }
+        } = self;
+        let sdp_declarations =
+            try_extend_genesis_declarations(sdp_declarations, iter.map(Into::into))?;
+        Ok(Self {
+            state: WithDeclarations { sdp_declarations },
+        })
     }
 }
 
@@ -761,7 +748,7 @@ impl GenesisBlockBuilder<WithNotesAndInscription> {
             state: WithAll {
                 notes,
                 inscription,
-                sdp_declarations: vec![declaration],
+                sdp_declarations: [declaration].into(),
             },
         }
     }
@@ -769,29 +756,25 @@ impl GenesisBlockBuilder<WithNotesAndInscription> {
     /// Add multiple SDP declarations at once, completing all three pieces and
     /// transitioning to [`WithAll`].
     ///
-    /// # Panics
+    /// # Panics and Errors
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
+    /// Errors if the number of declarations exceeds the maximum allowed.
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> GenesisBlockBuilder<WithAll> {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<GenesisBlockBuilder<WithAll>> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
             state: WithNotesAndInscription { notes, inscription },
         } = self;
-        GenesisBlockBuilder {
+        Ok(GenesisBlockBuilder {
             state: WithAll {
                 notes,
                 inscription,
-                sdp_declarations: iter.map(Into::into).collect(),
+                sdp_declarations: try_collect_sdp_declarations(iter)?,
             },
-        }
+        })
     }
 
     // Build a block with empty declarations but properly set inscription and
@@ -801,11 +784,72 @@ impl GenesisBlockBuilder<WithNotesAndInscription> {
             state: WithAll {
                 notes: self.state.notes,
                 inscription: self.state.inscription,
-                sdp_declarations: vec![],
+                sdp_declarations: GenesisSDPDeclareOps::empty(),
             },
         }
         .build()
     }
+}
+
+// ── Helpers
+// ──────────────────────────────────────────────────
+
+fn require_non_empty<I>(iterable: I, context: &'static str) -> impl Iterator<Item = I::Item>
+where
+    I: IntoIterator,
+{
+    let mut iter = iterable.into_iter();
+
+    let Some(first) = iter.next() else {
+        panic!("{context} called with empty iterator");
+    };
+
+    std::iter::once(first).chain(iter)
+}
+
+fn try_collect_sdp_declarations<I, D>(declarations: I) -> Result<GenesisSDPDeclareOps>
+where
+    I: IntoIterator<Item = D>,
+    D: Into<SDPDeclareOp>,
+{
+    let declarations: Vec<SDPDeclareOp> = declarations.into_iter().map(Into::into).collect();
+
+    let attempted_op_count = GENESIS_REQUIRED_OPS + declarations.len();
+
+    GenesisSDPDeclareOps::try_from(declarations).map_err(|_| {
+        Error::InvalidGenesisTx(genesis_tx::Error::TooManyOps {
+            count: attempted_op_count,
+        })
+    })
+}
+
+fn try_push_genesis_declaration(
+    mut declarations: GenesisSDPDeclareOps,
+    declaration: SDPDeclareOp,
+) -> Result<GenesisSDPDeclareOps> {
+    declarations.try_push(declaration).map_err(|_| {
+        Error::InvalidGenesisTx(genesis_tx::Error::TooManyOps {
+            count: GENESIS_REQUIRED_OPS + declarations.len() + 1,
+        })
+    })?;
+    Ok(declarations)
+}
+
+fn try_extend_genesis_declarations<I>(
+    mut declarations: GenesisSDPDeclareOps,
+    new_items: I,
+) -> Result<GenesisSDPDeclareOps>
+where
+    I: IntoIterator<Item = SDPDeclareOp>,
+{
+    for item in new_items {
+        declarations.try_push(item).map_err(|_| {
+            Error::InvalidGenesisTx(genesis_tx::Error::TooManyOps {
+                count: GENESIS_REQUIRED_OPS + declarations.len() + 1,
+            })
+        })?;
+    }
+    Ok(declarations)
 }
 
 // ── WithNotesAndDeclarations
@@ -872,8 +916,7 @@ impl GenesisBlockBuilder<WithNotesAndDeclarations> {
     }
 
     /// Append another SDP declaration.
-    #[must_use]
-    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Self {
+    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Result<Self> {
         let Self {
             state:
                 WithNotesAndDeclarations {
@@ -881,13 +924,13 @@ impl GenesisBlockBuilder<WithNotesAndDeclarations> {
                     mut sdp_declarations,
                 },
         } = self;
-        sdp_declarations.push(declaration);
-        Self {
+        sdp_declarations = try_push_genesis_declaration(sdp_declarations, declaration)?;
+        Ok(Self {
             state: WithNotesAndDeclarations {
                 notes,
                 sdp_declarations,
             },
-        }
+        })
     }
 
     /// Append multiple SDP declarations at once.
@@ -895,16 +938,11 @@ impl GenesisBlockBuilder<WithNotesAndDeclarations> {
     /// # Panics
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> Self {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<Self> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
             state:
                 WithNotesAndDeclarations {
@@ -912,13 +950,13 @@ impl GenesisBlockBuilder<WithNotesAndDeclarations> {
                     mut sdp_declarations,
                 },
         } = self;
-        sdp_declarations.extend(iter.map(Into::into));
-        Self {
+        sdp_declarations = try_extend_genesis_declarations(sdp_declarations, iter.map(Into::into))?;
+        Ok(Self {
             state: WithNotesAndDeclarations {
                 notes,
                 sdp_declarations,
             },
-        }
+        })
     }
 }
 
@@ -990,8 +1028,7 @@ impl GenesisBlockBuilder<WithInscriptionAndDeclarations> {
     }
 
     /// Append another SDP declaration.
-    #[must_use]
-    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Self {
+    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Result<Self> {
         let Self {
             state:
                 WithInscriptionAndDeclarations {
@@ -999,13 +1036,13 @@ impl GenesisBlockBuilder<WithInscriptionAndDeclarations> {
                     mut sdp_declarations,
                 },
         } = self;
-        sdp_declarations.push(declaration);
-        Self {
+        sdp_declarations = try_push_genesis_declaration(sdp_declarations, declaration)?;
+        Ok(Self {
             state: WithInscriptionAndDeclarations {
                 inscription,
                 sdp_declarations,
             },
-        }
+        })
     }
 
     /// Append multiple SDP declarations at once.
@@ -1013,30 +1050,26 @@ impl GenesisBlockBuilder<WithInscriptionAndDeclarations> {
     /// # Panics
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> Self {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<Self> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
             state:
                 WithInscriptionAndDeclarations {
                     inscription,
-                    mut sdp_declarations,
+                    sdp_declarations,
                 },
         } = self;
-        sdp_declarations.extend(iter.map(Into::into));
-        Self {
+        let sdp_declarations =
+            try_extend_genesis_declarations(sdp_declarations, iter.map(Into::into))?;
+        Ok(Self {
             state: WithInscriptionAndDeclarations {
                 inscription,
                 sdp_declarations,
             },
-        }
+        })
     }
 }
 
@@ -1108,24 +1141,23 @@ impl GenesisBlockBuilder<WithAll> {
     }
 
     /// Append another SDP declaration.
-    #[must_use]
-    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Self {
+    pub fn add_declaration(self, declaration: SDPDeclareOp) -> Result<Self> {
         let Self {
             state:
                 WithAll {
                     notes,
                     inscription,
-                    mut sdp_declarations,
+                    sdp_declarations,
                 },
         } = self;
-        sdp_declarations.push(declaration);
-        Self {
+        let sdp_declarations = try_push_genesis_declaration(sdp_declarations, declaration)?;
+        Ok(Self {
             state: WithAll {
                 notes,
                 inscription,
                 sdp_declarations,
             },
-        }
+        })
     }
 
     /// Append multiple SDP declarations at once.
@@ -1133,32 +1165,28 @@ impl GenesisBlockBuilder<WithAll> {
     /// # Panics
     ///
     /// Panics if `declarations` is empty.
-    #[must_use]
     pub fn add_declarations(
         self,
         declarations: impl IntoIterator<Item = impl Into<SDPDeclareOp>>,
-    ) -> Self {
-        let mut iter = declarations.into_iter().peekable();
-        assert!(
-            iter.peek().is_some(),
-            "add_declarations called with empty iterator"
-        );
+    ) -> Result<Self> {
+        let iter = require_non_empty(declarations, "add_declarations");
         let Self {
             state:
                 WithAll {
                     notes,
                     inscription,
-                    mut sdp_declarations,
+                    sdp_declarations,
                 },
         } = self;
-        sdp_declarations.extend(iter.map(Into::into));
-        Self {
+        let sdp_declarations =
+            try_extend_genesis_declarations(sdp_declarations, iter.map(Into::into))?;
+        Ok(Self {
             state: WithAll {
                 notes,
                 inscription,
                 sdp_declarations,
             },
-        }
+        })
     }
 
     /// Assemble the accumulated pieces into a [`GenesisTx`] and wrap it in a
@@ -1473,7 +1501,9 @@ mod tests {
             .set_inscription(valid_inscription())
             .add_declaration(make_sdp_decl(0))
             .add_declaration(make_sdp_decl(1))
+            .unwrap()
             .add_declaration(make_sdp_decl(2))
+            .unwrap()
             .build()
             .unwrap();
 
@@ -1490,6 +1520,7 @@ mod tests {
             .unwrap()
             .set_inscription(valid_inscription())
             .add_declaration(make_sdp_decl(1))
+            .unwrap()
             .add_note(make_note(30))
             .unwrap()
             .build()
@@ -1550,6 +1581,87 @@ mod tests {
     // ── add_notes / add_declarations batch helpers ────────────────────────────
 
     #[test]
+    fn add_declarations_accepts_maximum_capacity() {
+        let builder = GenesisBlockBuilder::new()
+            .add_note(make_note(100))
+            .set_inscription(valid_inscription())
+            .add_declaration(make_sdp_decl(0));
+
+        // One declaration already exists, so add the remaining declarations.
+        let builder = builder
+            .add_declarations(
+                std::iter::repeat_with(|| make_sdp_decl(0)).take(MAX_GENESIS_DECLARATIONS - 1),
+            )
+            .expect("maximum declaration capacity should be accepted");
+
+        let block = builder
+            .build()
+            .expect("maximum-size genesis block should build");
+        let tx = block.transactions().next().expect("genesis transaction");
+
+        assert_eq!(tx.sdp_declarations().count(), MAX_GENESIS_DECLARATIONS);
+        assert_eq!(tx.mantle_tx().ops().len(), MAX_OPS_PER_TX);
+    }
+
+    #[test]
+    fn add_declarations_rejects_beyond_maximum_capacity() {
+        let builder = GenesisBlockBuilder::new()
+            .add_note(make_note(100))
+            .set_inscription(valid_inscription())
+            .add_declaration(make_sdp_decl(0))
+            .add_declarations(
+                std::iter::repeat_with(|| make_sdp_decl(0)).take(MAX_GENESIS_DECLARATIONS - 1),
+            )
+            .expect("filling declaration capacity should succeed");
+
+        let error = builder
+            .add_declaration(make_sdp_decl(0))
+            .expect_err("one declaration beyond capacity should fail");
+
+        assert!(matches!(
+            error,
+            Error::InvalidGenesisTx(genesis_tx::Error::TooManyOps { count })
+                if count == MAX_OPS_PER_TX + 1
+        ));
+    }
+
+    #[test]
+    fn too_many_sdp_declarations_returns_error() {
+        let declarations = GenesisSDPDeclareOps::empty();
+
+        let error = try_extend_genesis_declarations(
+            declarations,
+            std::iter::repeat_with(|| make_sdp_decl(0)).take(MAX_GENESIS_DECLARATIONS + 1),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidGenesisTx(genesis_tx::Error::TooManyOps { count })
+                if count == MAX_OPS_PER_TX + 1
+        ));
+    }
+
+    #[test]
+    fn initial_declarations_reject_beyond_maximum_capacity() {
+        let error = GenesisBlockBuilder::new()
+            .add_declarations(
+                std::iter::repeat_with(|| make_sdp_decl(0)).take(MAX_GENESIS_DECLARATIONS + 1),
+            )
+            .expect_err("too many initial declarations should fail");
+
+        assert!(
+            matches!(
+                error,
+                Error::InvalidGenesisTx(genesis_tx::Error::TooManyOps { count })
+                    if count == MAX_OPS_PER_TX + 1
+            ),
+            "expected TooManyOps({}), got {error:?}",
+            MAX_OPS_PER_TX + 1,
+        );
+    }
+
+    #[test]
     fn add_notes_batch_preserved() {
         let block = GenesisBlockBuilder::new()
             .add_notes([make_note(10), make_note(20), make_note(30)])
@@ -1568,6 +1680,7 @@ mod tests {
             .add_note(make_note(100))
             .set_inscription(valid_inscription())
             .add_declarations([make_sdp_decl(0), make_sdp_decl(1), make_sdp_decl(2)])
+            .unwrap()
             .build()
             .unwrap();
 
@@ -1582,6 +1695,7 @@ mod tests {
             .set_inscription(valid_inscription())
             .add_declaration(make_sdp_decl(0))
             .add_declarations([make_sdp_decl(1), make_sdp_decl(2)])
+            .unwrap()
             .build()
             .unwrap();
 

--- a/tools/blockchain-tools/src/bin/genesis.rs
+++ b/tools/blockchain-tools/src/bin/genesis.rs
@@ -371,7 +371,7 @@ fn build_genesis_block(
         .set_inscription(inscription)
         .add_declaration(first_decl);
     for decl in decls_iter {
-        builder = builder.add_declaration(decl);
+        builder = builder.add_declaration(decl)?;
     }
 
     builder.build().context("failed to build genesis block")


### PR DESCRIPTION
## 1. What does this PR implement?

Added bounded SDP declaration handling to genesis block construction.
- Reserve capacity for the required transfer and inscription operations.
- Add checked collection, single-item push, and batch-extension helpers for `GenesisSDPDeclareOps`.
- Return `TooManyOps` errors instead of silently overflowing or panicking.
- Make bulk declaration builder methods fallible.
- Add boundary tests for maximum capacity and overflow cases.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
