### PR TITLE
fix(chain-leader): do not use timeout to wait for blend service readiness

### DIFF
--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -368,23 +368,23 @@ where
         );
 
         // Wait for other services to become ready, with timeout.
-        // (except Chain and ChainLeader)
+        // (except Chain, ChainNetwork, and Blend)
         wait_until_services_are_ready!(
             &self.service_resources_handle.overwatch_handle,
             Some(Duration::from_mins(1)),
-            BlendService,
             TxMempoolService<_, _, _, _>,
             TimeService<_, _>,
             Wallet,
             PreloadKmsService<_>
         )
         .await?;
-        // Wait for Chain and ChainLeader services to become ready, without timeout
+        // Wait for the remaining dependencies to become ready, without timeout
         wait_until_services_are_ready!(
             &self.service_resources_handle.overwatch_handle,
             None,
             CryptarchiaService, // becomes ready after recoverying blocks
-            ChainNetwork        // becomes ready after IBD
+            ChainNetwork,       // becomes ready after IBD
+            BlendService        // becomes ready after chain becomes online
         )
         .await?;
 


### PR DESCRIPTION
## 1. What does this PR implement?

This is a critical bug fix.

The chain leader service was waiting for the blend service readiness with 1min timeout. But, the blend service becomes ready only after the chain becomes online (after IBD+PBP). So, 1min is too short.

Devnet worked because PBP is 1s for the initial 4 nodes who skip IBD. Other nodes in the Devnet who don't skip IBD won't be able to propose blocks if IBD+PBP takes more than 1min.

So, this PR fixes the chain leader service to use no-timeout to wait for the blend service. 

We couldn't find this issue in the previous Devnets because we had disabled IBD.

## 2. Does the code have enough context to be clearly understood?

yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
