### PR TITLE
refactor(chain-service): reorganize the main event loop into phases

### DIFF
--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -13,14 +13,21 @@ pub enum State {
     NotStarted = 0x2,
 }
 
-impl From<lb_chain_service::ChainServiceMode> for State {
-    fn from(value: lb_chain_service::ChainServiceMode) -> Self {
-        match value {
-            lb_chain_service::ChainServiceMode::AwaitingStart => Self::NotStarted,
-            lb_chain_service::ChainServiceMode::Started(inner_state) => match inner_state {
-                lb_chain_service::State::Bootstrapping => Self::Bootstrapping,
-                lb_chain_service::State::Online => Self::Online,
-            },
+impl State {
+    const fn new(
+        state: lb_chain_service::State,
+        phase: lb_chain_service::ChainServicePhase,
+    ) -> Self {
+        if matches!(
+            phase,
+            lb_chain_service::ChainServicePhase::AwaitingGenesisTime
+        ) {
+            return Self::NotStarted;
+        }
+
+        match state {
+            lb_chain_service::State::Bootstrapping => Self::Bootstrapping,
+            lb_chain_service::State::Online => Self::Online,
         }
     }
 }
@@ -68,7 +75,7 @@ impl From<lb_chain_service::ChainServiceInfo> for CryptarchiaInfo {
             tip: value.cryptarchia_info.tip.into(),
             slot: u64::from(value.cryptarchia_info.slot),
             height: value.cryptarchia_info.height,
-            mode: State::from(value.mode),
+            mode: State::new(value.cryptarchia_info.state, value.phase),
         }
     }
 }

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -14,14 +14,8 @@ pub enum State {
 }
 
 impl State {
-    const fn new(
-        state: lb_chain_service::State,
-        phase: lb_chain_service::ChainServicePhase,
-    ) -> Self {
-        if matches!(
-            phase,
-            lb_chain_service::ChainServicePhase::AwaitingGenesisTime
-        ) {
+    const fn new(state: lb_chain_service::State, phase: lb_chain_service::PhaseTag) -> Self {
+        if matches!(phase, lb_chain_service::PhaseTag::AwaitingGenesisTime) {
             return Self::NotStarted;
         }
 

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -2055,6 +2055,7 @@ mod tests {
             lib_slot: Slot::new(LIB_SLOT),
             height: HEIGHT,
             tip: HeaderId::from([3; 32]),
+            state: lb_chain_service::State::Online,
         }
     }
 
@@ -2065,6 +2066,7 @@ mod tests {
             lib_slot: Slot::new(0),
             height: 1,
             tip: HeaderId::from([3; 32]),
+            state: lb_chain_service::State::Online,
         }
     }
 

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 pub use lb_chain_broadcast_service::BlockInfo;
-pub use lb_chain_service::{ChainServiceInfo, ChainServicePhase, CryptarchiaInfo, Slot, State};
+pub use lb_chain_service::{ChainServiceInfo, CryptarchiaInfo, PhaseTag, Slot, State};
 pub use lb_core::events::{Event, Events, TxEventPayload};
 use lb_core::{
     block::MAX_BLOCK_TRANSACTIONS_SIZE,

--- a/nodes/node/http-client/src/lib.rs
+++ b/nodes/node/http-client/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::{Stream, StreamExt as _, TryStreamExt as _};
 pub use lb_chain_broadcast_service::BlockInfo;
-pub use lb_chain_service::{ChainServiceInfo, ChainServiceMode, CryptarchiaInfo, Slot, State};
+pub use lb_chain_service::{ChainServiceInfo, ChainServicePhase, CryptarchiaInfo, Slot, State};
 pub use lb_core::events::{Event, Events, TxEventPayload};
 use lb_core::{
     block::MAX_BLOCK_TRANSACTIONS_SIZE,

--- a/services/api/src/http/consensus/cryptarchia.rs
+++ b/services/api/src/http/consensus/cryptarchia.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 
 use futures::{StreamExt as _, TryStreamExt as _};
-use lb_chain_service::{ChainServiceInfo, ConsensusMsg, CryptarchiaConsensus};
+use lb_chain_service::{ChainServiceInfo, CryptarchiaConsensus, Query};
 use lb_core::{
     header::HeaderId,
     mantle::{SignedMantleTx, transactions::states::Preverified},
@@ -31,9 +31,12 @@ where
     let relay = handle.relay().await?;
     let (sender, receiver) = oneshot::channel();
     relay
-        .send(ConsensusMsg::Info {
-            reply_channel: sender,
-        })
+        .send(
+            Query::Info {
+                reply_channel: sender,
+            }
+            .into(),
+        )
         .await
         .map_err(|(e, _)| e)?;
 
@@ -54,11 +57,14 @@ where
     let relay = handle.relay().await?;
     let (sender, receiver) = oneshot::channel();
     relay
-        .send(ConsensusMsg::GetHeaders {
-            from_descendant,
-            to_ancestor,
-            reply_channel: sender,
-        })
+        .send(
+            Query::GetHeaders {
+                from_descendant,
+                to_ancestor,
+                reply_channel: sender,
+            }
+            .into(),
+        )
         .await
         .map_err(|(e, _)| e)?;
 
@@ -80,10 +86,13 @@ where
     let relay = handle.relay().await?;
     let (sender, receiver) = oneshot::channel();
     relay
-        .send(ConsensusMsg::GetLedgerState {
-            block_id: cryptarchia_info.tip,
-            reply_channel: sender,
-        })
+        .send(
+            Query::GetLedgerState {
+                block_id: cryptarchia_info.tip,
+                reply_channel: sender,
+            }
+            .into(),
+        )
         .await
         .map_err(|(e, _)| e)?;
 

--- a/services/api/src/http/mantle.rs
+++ b/services/api/src/http/mantle.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt as _, future::join_all};
 use lb_chain_broadcast_service::{BlockBroadcastMsg, BlockBroadcastService, BlockInfo};
 use lb_chain_service::{
-    ConsensusMsg, CryptarchiaInfo, ProcessedBlockEvent, Slot,
+    ConsensusMsg, CryptarchiaInfo, ProcessedBlockEvent, Query, Slot,
     storage::{StorageAdapter as _, adapters::StorageAdapter},
 };
 use lb_core::{
@@ -208,7 +208,7 @@ where
     let (sender, receiver) = oneshot::channel();
 
     relay
-        .send(ConsensusMsg::NewBlockSubscribe { sender })
+        .send(Query::NewBlockSubscribe { sender }.into())
         .await
         .map_err(|(error, _)| error)?;
 
@@ -881,9 +881,12 @@ where
     let (sender, receiver) = oneshot::channel();
 
     relay
-        .send(ConsensusMsg::GetSdpDeclarations {
-            reply_channel: sender,
-        })
+        .send(
+            Query::GetSdpDeclarations {
+                reply_channel: sender,
+            }
+            .into(),
+        )
         .await
         .map_err(|(e, _)| e)?;
 
@@ -906,9 +909,12 @@ where
     let (sender, receiver) = oneshot::channel();
 
     relay
-        .send(ConsensusMsg::GetSdpSnapshot {
-            reply_channel: sender,
-        })
+        .send(
+            Query::GetSdpSnapshot {
+                reply_channel: sender,
+            }
+            .into(),
+        )
         .await
         .map_err(|(e, _)| e)?;
 

--- a/services/chain/chain-service/src/api.rs
+++ b/services/chain/chain-service/src/api.rs
@@ -8,7 +8,9 @@ use overwatch::services::{ServiceData, relay::OutboundRelay};
 use thiserror::Error;
 use tokio::sync::{broadcast, oneshot};
 
-use crate::{ChainServiceInfo, ConsensusMsg, CryptarchiaInfo, LibUpdate, ProcessedBlockEvent};
+use crate::{
+    ChainServiceInfo, ConsensusMsg, CryptarchiaInfo, LibUpdate, ProcessedBlockEvent, Query,
+};
 
 pub trait CryptarchiaServiceData:
     ServiceData<Message = ConsensusMsg<Self::Tx>> + Send + 'static
@@ -81,7 +83,7 @@ where
         let (reply_channel, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::Info { reply_channel })
+            .send(Query::Info { reply_channel }.into())
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetInfo"))
@@ -99,7 +101,7 @@ where
         let (sender, receiver) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::NewBlockSubscribe { sender })
+            .send(Query::NewBlockSubscribe { sender }.into())
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending NewBlockSubscribe"))
@@ -115,7 +117,7 @@ where
         let (sender, receiver) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::LibSubscribe { sender })
+            .send(Query::LibSubscribe { sender }.into())
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending LibSubscribe"))
@@ -139,11 +141,14 @@ where
         let (reply_channel, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::GetHeaders {
-                from_descendant: Some(from_descendant),
-                to_ancestor: Some(to_ancestor),
-                reply_channel,
-            })
+            .send(
+                Query::GetHeaders {
+                    from_descendant: Some(from_descendant),
+                    to_ancestor: Some(to_ancestor),
+                    reply_channel,
+                }
+                .into(),
+            )
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetHeaders"))
@@ -166,10 +171,13 @@ where
         let (reply_channel, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::GetLedgerState {
-                block_id,
-                reply_channel,
-            })
+            .send(
+                Query::GetLedgerState {
+                    block_id,
+                    reply_channel,
+                }
+                .into(),
+            )
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetLedgerState"))
@@ -188,10 +196,13 @@ where
         let (reply_channel, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::GetEpochState {
-                slot,
-                reply_channel,
-            })
+            .send(
+                Query::GetEpochState {
+                    slot,
+                    reply_channel,
+                }
+                .into(),
+            )
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetEpochState"))
@@ -215,7 +226,7 @@ where
         let (reply_channel, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::GetEpochConfig { reply_channel })
+            .send(Query::GetEpochConfig { reply_channel }.into())
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetEpochConfig"))
@@ -230,7 +241,7 @@ where
         let (reply_channel, rx) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::GetBlockEvents { id, reply_channel })
+            .send(Query::GetBlockEvents { id, reply_channel }.into())
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending GetBlockEvents"))
@@ -309,12 +320,12 @@ where
     }
 
     /// Wait until the chain becomes the Online mode.
-    /// For details, see [`ConsensusMsg::SubscribeChainOnline`].
+    /// For details, see [`Query::SubscribeChainOnline`].
     pub async fn wait_until_chain_becomes_online(&self) -> Result<(), ApiError> {
         let (sender, receiver) = oneshot::channel();
 
         self.relay
-            .send(ConsensusMsg::SubscribeChainOnline { sender })
+            .send(Query::SubscribeChainOnline { sender }.into())
             .await
             .map_err(|(relay_error, _)| {
                 ApiError::CommsFailure(format!("{relay_error} while sending SubscribeChainOnline"))

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -51,17 +51,14 @@ use lb_storage_service::{
 use lb_time_service::TimeService;
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
-    services::{AsServiceId, ServiceCore, ServiceData, state::StateUpdater},
+    services::{AsServiceId, ServiceCore, ServiceData, relay::InboundRelay, state::StateUpdater},
 };
 use relays::BroadcastRelay;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_with::serde_as;
 use thiserror::Error;
 use time::OffsetDateTime;
-use tokio::{
-    sync::{broadcast, mpsc, oneshot, watch},
-    time::Instant,
-};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 use tracing_futures::Instrument as _;
 
@@ -113,6 +110,8 @@ pub enum Error {
     HeaderIdNotFound(HeaderId),
     #[error("Parent header ID not found for child={0}")]
     ParentIdNotFound(HeaderId),
+    #[error("Awaiting genesis time")]
+    AwaitingGenesisTime,
 }
 
 struct InitializedCryptarchia {
@@ -210,10 +209,17 @@ pub enum Query {
 pub(crate) type HeaderIdStream =
     Pin<Box<dyn Stream<Item = Result<HeaderId, Error>> + Send + 'static>>;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ChainServiceMode {
-    AwaitingStart,
-    Started(State),
+/// The phase of the chain service, which advances one-directionally
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ChainServicePhase {
+    /// The genesis time is in the future. Only read-only queries are served.
+    AwaitingGenesisTime,
+    /// Applying blocks while waiting for Initial Block Download to complete.
+    InitialBlockDownload,
+    /// The Prolonged Bootstrap Period is running.
+    ProlongedBootstrapPeriod,
+    /// Following the chain in real time
+    Following,
 }
 
 #[serde_as]
@@ -221,7 +227,7 @@ pub enum ChainServiceMode {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChainServiceInfo {
     pub cryptarchia_info: CryptarchiaInfo,
-    pub mode: ChainServiceMode,
+    pub phase: ChainServicePhase,
 }
 
 #[serde_as]
@@ -233,6 +239,7 @@ pub struct CryptarchiaInfo {
     pub tip: HeaderId,
     pub slot: Slot,
     pub height: u64,
+    pub state: State,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -358,6 +365,7 @@ impl Cryptarchia {
             tip: tip_branch.id(),
             slot: tip_branch.slot(),
             height: tip_branch.length(),
+            state: *self.state(),
         }
     }
 
@@ -615,8 +623,7 @@ where
         })
     }
 
-    #[expect(clippy::too_many_lines, reason = "TODO: Address this at some point.")]
-    async fn run(mut self) -> Result<(), DynError> {
+    async fn run(self) -> Result<(), DynError> {
         let relays: CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId> =
             CryptarchiaConsensusRelays::from_service_resources_handle::<TimeBackend>(
                 &self.service_resources_handle,
@@ -644,24 +651,24 @@ where
         )
         .await?;
 
-        let (mut current_slot, mut slot_timer) = Self::get_slot_timer(&relays).await?;
+        let (current_slot, slot_timer) = Self::get_slot_timer(&relays).await?;
 
         let InitializedCryptarchia {
-            mut cryptarchia,
+            cryptarchia,
             pruned_blocks,
             fell_back_to_lib,
-        } = self
-            .initialize_cryptarchia(
-                &bootstrap_config,
-                ledger_config.clone(),
-                &relays,
-                current_slot,
-            )
-            .await;
+        } = Runtime::initialize_cryptarchia(
+            &self,
+            &bootstrap_config,
+            ledger_config.clone(),
+            &relays,
+            current_slot,
+        )
+        .await;
 
         // These are blocks that have been pruned by the cryptarchia engine but have not
         // yet been deleted from the storage layer.
-        let mut storage_blocks_to_remove = Self::delete_stale_blocks_from_storage(
+        let storage_blocks_to_remove = Runtime::delete_stale_blocks_from_storage(
             pruned_blocks.stale_blocks().copied(),
             &self.state.storage_blocks_to_remove,
             relays.storage_adapter(),
@@ -669,7 +676,7 @@ where
         .await;
 
         if fell_back_to_lib {
-            Self::update_state(
+            persist_recovery_state(
                 &cryptarchia,
                 storage_blocks_to_remove.clone(),
                 &self.service_resources_handle.state_updater,
@@ -681,33 +688,8 @@ where
             sync_config.block_provider,
         );
 
-        // Chain start timer will prevent the chain service to process and produce
-        // blocks if the starting state is GenesisBlock and has chain start time
-        // set in future.
-        let mut chain_start_timer: Option<Pin<Box<tokio::time::Sleep>>> = None;
-
-        if let StartingState::Genesis { genesis_block } = starting_state {
-            let genesis_time: OffsetDateTime = genesis_block
-                .genesis_tx()
-                .cryptarchia_parameter()
-                .genesis_time
-                .into();
-            let now = OffsetDateTime::now_utc();
-
-            if genesis_time > now {
-                let delay = (genesis_time - now).try_into().unwrap_or_default();
-                info!("Chain configured to start in the future: {genesis_time}");
-                chain_start_timer = Some(Box::pin(tokio::time::sleep(delay)));
-            }
-        }
-
-        // The prolonged bootstrap timer will be started when chain-network notifies us
-        // that IBD has completed. This ensures we don't transition to Online mode
-        // before the node has caught up with the network.
-        let mut prolonged_bootstrap_timer: Option<Pin<Box<tokio::time::Sleep>>> = None;
-
         // Start the timer for periodic state recording for offline grace period
-        let mut state_recording_timer = tokio::time::interval(
+        let state_recording_timer = tokio::time::interval(
             bootstrap_config
                 .offline_grace_period
                 .state_recording_interval,
@@ -719,113 +701,26 @@ where
         // even while in bootstrap mode waiting for IBD+PBP to complete.
         self.notify_service_ready();
 
-        let async_loop = async {
-            loop {
-                tokio::select! {
-                    () = async { if let Some(timer) = chain_start_timer.as_mut() { timer.await; } }, if chain_start_timer.is_some() => {
-                        info!("Genesis time reached. Chain is now starting...");
-                        chain_start_timer = None;
-
-                        // Just like in the Ibd case, the bootstrap timer is started after the chain
-                        // start time began.
-                        prolonged_bootstrap_timer = Some(Box::pin(tokio::time::sleep_until(
-                            Instant::now() + bootstrap_config.prolonged_bootstrap_period,
-                        )));
-                    }
-
-                    () = async { prolonged_bootstrap_timer.as_mut().unwrap().as_mut().await }, if prolonged_bootstrap_timer.is_some() && cryptarchia.is_bootstrapping() => {
-                        info!(
-                            "Prolonged Bootstrap Period finished. Switching chain to online mode."
-                        );
-                        (cryptarchia, storage_blocks_to_remove) = Self::switch_to_online(
-                            cryptarchia,
-                            &storage_blocks_to_remove,
-                            relays.storage_adapter(),
-                            &chain_online_notifier,
-                        ).await;
-                        Self::update_state(
-                            &cryptarchia,
-                            storage_blocks_to_remove.clone(),
-                            &self.service_resources_handle.state_updater,
-                        );
-                    }
-
-                    Some(msg) = self.service_resources_handle.inbound_relay.next() => {
-                        // Handle ApplyBlock, ChainSync, and IbdCompleted separately since they need async context
-                        match msg {
-                            ConsensusMsg::IbdCompleted => {
-                                if chain_start_timer.is_none() {
-                                    info!("Initial Block Download completed. Starting Prolonged Bootstrap Period before going online.");
-                                    // Start the prolonged bootstrap timer now that IBD is complete
-                                    prolonged_bootstrap_timer = Some(Box::pin(tokio::time::sleep_until(
-                                        Instant::now() + bootstrap_config.prolonged_bootstrap_period,
-                                    )));
-                                }
-                            }
-                            // Blocks will be applied if chain start time didn't begin yet.
-                            ConsensusMsg::ApplyBlock { block, reply_channel } if chain_start_timer.is_none() => {
-                                // TODO: move this into the process_message() function after making the process_message async.
-                                match Self::process_block_and_update_state(
-                                        &mut cryptarchia,
-                                        *block,
-                                        current_slot,
-                                        &storage_blocks_to_remove,
-                                        &relays,
-                                        &self.new_block_subscription_sender,
-                                        &self.lib_subscription_sender,
-                                        &self.service_resources_handle.state_updater,
-                                    ).await {
-                                    Ok((new_storage_blocks_to_remove, reorged_txs)) => {
-                                        storage_blocks_to_remove = new_storage_blocks_to_remove;
-                                        reply_channel.send(Ok((cryptarchia.tip(), reorged_txs))).unwrap_or_else(|_| {
-                                            error!("Could not send process block result through channel");
-                                        });
-                                    }
-                                    Err(e) => {
-                                        log_process_block_error(&e);
-                                        reply_channel.send(Err(e)).unwrap_or_else(|_| {
-                                            error!("Could not send process block error through channel");
-                                        });
-                                    }
-                                }
-                            }
-                            ConsensusMsg::ChainSync(event) => {
-                                if cryptarchia.state().is_online() {
-                                    Self::handle_chainsync_event(&cryptarchia, &sync_blocks_provider, event).await;
-                                } else {
-                                    Self::reject_chain_sync_event(event).await;
-                                }
-                            }
-                            ConsensusMsg::Info { reply_channel } => {
-                                let cryptarchia_info = cryptarchia.info();
-                                let mode = match chain_start_timer {
-                                    Some(_) => ChainServiceMode::AwaitingStart,
-                                    None => ChainServiceMode::Started(*cryptarchia.state()),
-                                };
-                                reply_channel.send(ChainServiceInfo{cryptarchia_info, mode}).unwrap_or_else(|e| {
-                                    error!("Could not send consensus info through channel: {:?}", e);
-                                });
-                            }
-                            msg => {
-                                Self::process_message(&cryptarchia, &self.new_block_subscription_sender, &self.lib_subscription_sender, &chain_online_notifier, msg, relays.storage_adapter()).await;
-                            }
-                        }
-                    }
-
-                    Some(lb_time_service::SlotTick { slot: new_slot, .. }) = slot_timer.next() => {
-                        current_slot = new_slot;
-                    }
-
-                    _ = state_recording_timer.tick() => {
-                        // Periodically record the current timestamp and engine state
-                        Self::update_state(
-                            &cryptarchia,
-                            storage_blocks_to_remove.clone(),
-                            &self.service_resources_handle.state_updater,
-                        );
-                    }
-                }
-            }
+        let Self {
+            service_resources_handle,
+            new_block_subscription_sender,
+            lib_subscription_sender,
+            ..
+        } = self;
+        let runner = Runtime {
+            inbound_relay: service_resources_handle.inbound_relay,
+            state_updater: service_resources_handle.state_updater,
+            new_block_subscription_sender,
+            lib_subscription_sender,
+            cryptarchia,
+            chain_online_notifier,
+            current_slot,
+            storage_blocks_to_remove,
+            relays,
+            sync_blocks_provider,
+            slot_timer,
+            state_recording_timer,
+            prolonged_bootstrap_period: bootstrap_config.prolonged_bootstrap_period,
         };
 
         // It sucks to use `SERVICE_ID` when we have `<RuntimeServiceId as
@@ -835,7 +730,10 @@ where
         // Hypothesis:
         // 1. Probably related to too many generics.
         // 2. It seems `span` requires a `const` string literal.
-        async_loop.instrument(span!(Level::TRACE, SERVICE_ID)).await;
+        runner
+            .run(starting_state)
+            .instrument(span!(Level::TRACE, SERVICE_ID))
+            .await;
 
         Ok(())
     }
@@ -857,7 +755,7 @@ where
         + 'static,
     Storage: StorageBackend + Send + Sync + 'static,
     <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
-    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>>,
     <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
     TimeBackend: lb_time_service::backends::TimeBackend,
     RuntimeServiceId: Display + AsServiceId<Self> + 'static,
@@ -898,61 +796,326 @@ where
 
         Ok((current_slot, slot_timer))
     }
+}
 
-    #[expect(clippy::too_many_lines, reason = "TODO: refactor into funcs")]
-    async fn process_message(
-        cryptarchia: &Cryptarchia,
-        new_block_channel: &broadcast::Sender<ProcessedBlockEvent>,
-        lib_channel: &broadcast::Sender<LibUpdate>,
-        chain_online_notifier: &ChainOnlineNotifier,
-        msg: ConsensusMsg<Tx>,
-        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
+/// The runtime of the chain service,
+/// which holds everything shared by all phases.
+struct Runtime<Tx, Storage, RuntimeServiceId>
+where
+    Tx: PreverifiedMantleTx + Clone + Eq + Debug,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+{
+    inbound_relay: InboundRelay<ConsensusMsg<Tx>>,
+    state_updater: StateUpdater<Option<CryptarchiaConsensusState>>,
+    new_block_subscription_sender: broadcast::Sender<ProcessedBlockEvent>,
+    lib_subscription_sender: broadcast::Sender<LibUpdate>,
+    cryptarchia: Cryptarchia,
+    chain_online_notifier: ChainOnlineNotifier,
+    current_slot: Slot,
+    storage_blocks_to_remove: HashSet<HeaderId>,
+    relays: CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
+    sync_blocks_provider: BlockProvider<Storage, Tx>,
+    slot_timer: lb_time_service::EpochSlotTickStream,
+    state_recording_timer: tokio::time::Interval,
+    prolonged_bootstrap_period: Duration,
+}
+
+impl<Tx, Storage, RuntimeServiceId> Runtime<Tx, Storage, RuntimeServiceId>
+where
+    Tx: PreverifiedMantleTx
+        + AuthenticatedMantleTx<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    /// Run all phases in order.
+    async fn run(mut self, starting_state: StartingState) {
+        // Run `AwaitingGenesisTime` phase.
+        // `IbdCompleted` can be received during this phase if IBD has been skipped.
+        let ibd_skipped = if let Some(genesis_timer) = Self::create_genesis_timer(starting_state) {
+            self.phase_awaiting_genesis_time(genesis_timer).await
+        } else {
+            false
+        };
+
+        // Run `InitialBlockDownload` phase.
+        if !ibd_skipped {
+            self.phase_initial_block_download().await;
+        }
+
+        // Run `ProlongedBootstrapPeriod` phase
+        if self.cryptarchia.is_bootstrapping() {
+            self = self.phase_prolonged_bootstrap_period().await;
+        }
+
+        // Run `Following` phase.
+        self.phase_following().await;
+    }
+
+    /// Creates a timer that fires when the genesis time is reached,
+    /// if the starting state is `Genesis` and the genesis time is in the
+    /// future.
+    /// Returns `None`, otherwise.
+    fn create_genesis_timer(starting_state: StartingState) -> Option<Pin<Box<tokio::time::Sleep>>> {
+        if let StartingState::Genesis { genesis_block } = starting_state {
+            let genesis_time: OffsetDateTime = genesis_block
+                .genesis_tx()
+                .cryptarchia_parameter()
+                .genesis_time
+                .into();
+            let now = OffsetDateTime::now_utc();
+
+            if genesis_time > now {
+                info!(target: LOG_TARGET, %genesis_time, "genesis time is in the future");
+                let delay = (genesis_time - now).try_into().unwrap_or_default();
+                return Some(Box::pin(tokio::time::sleep(delay)));
+            }
+        }
+        None
+    }
+
+    /// `AwaitingGenesisTime` phase: Wait until the genesis time is reached.
+    /// Returns whether IBD has been skipped during this phase.
+    #[expect(clippy::cognitive_complexity, reason = "better in one fn")]
+    async fn phase_awaiting_genesis_time(
+        &mut self,
+        mut genesis_timer: Pin<Box<tokio::time::Sleep>>,
+    ) -> bool {
+        let phase = ChainServicePhase::AwaitingGenesisTime;
+        info!(target: LOG_TARGET, "entering {phase:?} phase");
+
+        let mut ibd_skipped = false;
+        loop {
+            tokio::select! {
+                () = genesis_timer.as_mut() => {
+                    info!(target: LOG_TARGET, "genesis time reached: finishing {phase:?} phase");
+                    return ibd_skipped;
+                }
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query, phase).await;
+                    }
+                    ConsensusMsg::ApplyBlock { reply_channel, .. } => {
+                        debug!(target: LOG_TARGET, "rejecting a block received during {phase:?} phase");
+                        reply_channel.send(Err(Error::AwaitingGenesisTime)).unwrap_or_else(|_| {
+                            error!(target: LOG_TARGET, "failed to send error through channel");
+                        });
+                    }
+                    ConsensusMsg::ChainSync(event) => Self::reject_chain_sync_event(event).await,
+                    ConsensusMsg::IbdCompleted => {
+                        info!(target: LOG_TARGET, "Initial Block Download has been skipped during {phase:?} phase");
+                        ibd_skipped = true;
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+
+    /// `InitialBlockDownload` phase: Apply blocks until IBD completes.
+    async fn phase_initial_block_download(&mut self) {
+        let phase = ChainServicePhase::InitialBlockDownload;
+        info!(target: LOG_TARGET, "entering {phase:?} phase");
+
+        loop {
+            tokio::select! {
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query, phase).await;
+                    }
+                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
+                        self.apply_block_and_reply(*block, reply_channel).await;
+                    }
+                    ConsensusMsg::ChainSync(event) => Self::reject_chain_sync_event(event).await,
+                    ConsensusMsg::IbdCompleted => {
+                        info!(target: LOG_TARGET, "Initial Block Download completed");
+                        return;
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+
+    /// `ProlongedBootstrapPeriod` phase: Apply blocks until PBP is over.
+    /// At the end of the phase, `Cryptarchia` is switched to online.
+    #[expect(clippy::cognitive_complexity, reason = "better in one fn")]
+    async fn phase_prolonged_bootstrap_period(mut self) -> Self {
+        let phase = ChainServicePhase::ProlongedBootstrapPeriod;
+        info!(target: LOG_TARGET, "entering {phase:?} phase");
+
+        let mut pbp_timer = Box::pin(tokio::time::sleep(self.prolonged_bootstrap_period));
+        loop {
+            tokio::select! {
+                () = pbp_timer.as_mut() => {
+                    break;
+                },
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query, phase).await;
+                    }
+                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
+                        self.apply_block_and_reply(*block, reply_channel).await;
+                    }
+                    ConsensusMsg::ChainSync(event) => Self::reject_chain_sync_event(event).await,
+                    ConsensusMsg::IbdCompleted => {
+                        debug!(target: LOG_TARGET, "ignoring IbdCompleted: already in {phase:?} phase");
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+
+        info!(target: LOG_TARGET, "Prolonged Bootstrap Period completed: switching chain to online");
+        (self.cryptarchia, self.storage_blocks_to_remove) = Self::switch_to_online(
+            self.cryptarchia,
+            &self.storage_blocks_to_remove,
+            self.relays.storage_adapter(),
+            &self.chain_online_notifier,
+        )
+        .await;
+        self.record_recovery_state();
+        self
+    }
+
+    /// `Following` phase: Follow the chain in real time. This phase never ends.
+    async fn phase_following(&mut self) {
+        let phase = ChainServicePhase::Following;
+        info!(target: LOG_TARGET, "entering {phase:?} phase");
+
+        loop {
+            tokio::select! {
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query, phase).await;
+                    }
+                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
+                        self.apply_block_and_reply(*block, reply_channel).await;
+                    }
+                    ConsensusMsg::ChainSync(event) => {
+                        Self::handle_chainsync_event(&self.cryptarchia, &self.sync_blocks_provider, event).await;
+                    }
+                    ConsensusMsg::IbdCompleted => {
+                        debug!(target: LOG_TARGET, "ignoring IbdCompleted: already in {phase:?} phase");
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+
+    /// Apply a block to the chain and reply with the result.
+    async fn apply_block_and_reply(
+        &mut self,
+        block: Block<Tx>,
+        reply_channel: oneshot::Sender<Result<(HeaderId, Vec<Tx>), Error>>,
     ) {
-        match msg {
-            ConsensusMsg::NewBlockSubscribe { sender } => {
+        match Self::process_block_and_update_state(
+            &mut self.cryptarchia,
+            block,
+            self.current_slot,
+            &self.storage_blocks_to_remove,
+            &self.relays,
+            &self.new_block_subscription_sender,
+            &self.lib_subscription_sender,
+            &self.state_updater,
+        )
+        .await
+        {
+            Ok((storage_blocks_to_remove, reorged_txs)) => {
+                self.storage_blocks_to_remove = storage_blocks_to_remove;
+                reply_channel
+                    .send(Ok((self.cryptarchia.tip(), reorged_txs)))
+                    .unwrap_or_else(|_| {
+                        error!("Could not send process block result through channel");
+                    });
+            }
+            Err(e) => {
+                log_process_block_error(&e);
+                reply_channel.send(Err(e)).unwrap_or_else(|_| {
+                    error!("Could not send process block error through channel");
+                });
+            }
+        }
+    }
+
+    /// Serve a read-only query. Available in every phase.
+    #[expect(clippy::too_many_lines, reason = "TODO: refactor into funcs")]
+    async fn process_query(&self, query: Query, phase: ChainServicePhase) {
+        match query {
+            Query::Info { reply_channel } => {
+                reply_channel
+                    .send(ChainServiceInfo {
+                        cryptarchia_info: self.cryptarchia.info(),
+                        phase,
+                    })
+                    .unwrap_or_else(|e| {
+                        error!("Could not send consensus info through channel: {:?}", e);
+                    });
+            }
+            Query::NewBlockSubscribe { sender } => {
                 sender
-                    .send(new_block_channel.subscribe())
+                    .send(self.new_block_subscription_sender.subscribe())
                     .unwrap_or_else(|_| {
                         error!("Could not subscribe to new block channel");
                     });
             }
-            ConsensusMsg::LibSubscribe { sender } => {
-                sender.send(lib_channel.subscribe()).unwrap_or_else(|_| {
-                    error!("Could not subscribe to LIB updates channel");
-                });
+            Query::LibSubscribe { sender } => {
+                sender
+                    .send(self.lib_subscription_sender.subscribe())
+                    .unwrap_or_else(|_| {
+                        error!("Could not subscribe to LIB updates channel");
+                    });
             }
-            ConsensusMsg::GetHeaders {
+            Query::GetHeaders {
                 from_descendant,
                 to_ancestor,
                 reply_channel,
             } => {
                 // default to tip block if not present
-                let from_descendant = from_descendant.unwrap_or_else(|| cryptarchia.tip());
+                let from_descendant = from_descendant.unwrap_or_else(|| self.cryptarchia.tip());
                 // default to LIB block if not present
-                let to_ancestor = to_ancestor.unwrap_or_else(|| cryptarchia.lib());
+                let to_ancestor = to_ancestor.unwrap_or_else(|| self.cryptarchia.lib());
 
                 let stream = Self::get_block_ids(
                     from_descendant,
                     to_ancestor,
-                    cryptarchia,
-                    storage_adapter.clone(),
+                    &self.cryptarchia,
+                    self.relays.storage_adapter().clone(),
                 );
                 reply_channel
                     .send(stream)
                     .unwrap_or_else(|_| error!("could not send block stream through channel"));
             }
-            ConsensusMsg::GetLedgerState {
+            Query::GetLedgerState {
                 block_id,
                 reply_channel,
             } => {
-                let ledger_state = cryptarchia.ledger.state(&block_id).cloned();
+                let ledger_state = self.cryptarchia.ledger.state(&block_id).cloned();
                 reply_channel.send(ledger_state).unwrap_or_else(|_| {
                     error!("Could not send ledger state through channel");
                 });
             }
-            ConsensusMsg::GetSdpDeclarations { reply_channel } => {
-                let tip = cryptarchia.tip();
-                let declarations = cryptarchia
+            Query::GetSdpDeclarations { reply_channel } => {
+                let tip = self.cryptarchia.tip();
+                let declarations = self
+                    .cryptarchia
                     .ledger
                     .state(&tip)
                     .map(|ledger_state| ledger_state.mantle_ledger().sdp.declarations())
@@ -968,9 +1131,10 @@ where
                     error!("Could not send SDP declarations through channel");
                 });
             }
-            ConsensusMsg::GetSdpSnapshot { reply_channel } => {
-                let tip = cryptarchia.tip();
-                let declarations = cryptarchia
+            Query::GetSdpSnapshot { reply_channel } => {
+                let tip = self.cryptarchia.tip();
+                let declarations = self
+                    .cryptarchia
                     .ledger
                     .state(&tip)
                     .map(|ledger_state| {
@@ -990,61 +1154,46 @@ where
                     error!("Could not send SDP snapshot through channel");
                 });
             }
-            ConsensusMsg::GetEpochState {
+            Query::GetEpochState {
                 slot,
                 reply_channel,
             } => {
-                let result = cryptarchia.epoch_state_for_slot(slot);
+                let result = self.cryptarchia.epoch_state_for_slot(slot);
                 reply_channel.send(result).unwrap_or_else(|_| {
                     error!("Could not send epoch state through channel");
                 });
             }
-            ConsensusMsg::GetEpochConfig { reply_channel } => {
-                let config = cryptarchia.ledger.config();
+            Query::GetEpochConfig { reply_channel } => {
+                let config = self.cryptarchia.ledger.config();
                 reply_channel
                     .send((config.epoch_config, config.consensus_config.clone()))
                     .unwrap_or_else(|_| {
                         error!("Could not send epoch config through channel");
                     });
             }
-            ConsensusMsg::GetBlockEvents { id, reply_channel } => {
-                let events = storage_adapter.get_block_events(&id).await;
+            Query::GetBlockEvents { id, reply_channel } => {
+                let events = self.relays.storage_adapter().get_block_events(&id).await;
                 reply_channel.send(events).unwrap_or_else(|_| {
                     error!("Could not send block events through channel");
                 });
             }
-            ConsensusMsg::Info { .. } => {
-                // Info is handled separately in the run loop where we have async
-                // context. This should never be reached since we filter it out
-                // before calling process_message.
-                panic!("Info should be handled in the run loop, not in process_message");
-            }
-            ConsensusMsg::ApplyBlock { .. } => {
-                // ApplyBlock is handled separately in the run loop where we have async
-                // context This should never be reached since we filter it out
-                // before calling process_message
-                panic!("ApplyBlock should be handled in the run loop, not in process_message");
-            }
-            ConsensusMsg::ChainSync(_) => {
-                // ChainSync is handled separately in the run loop where we have async
-                // context. This should never be reached since we filter it out
-                // before calling process_message
-                panic!("ChainSync should be handled in the run loop, not in process_message");
-            }
-            ConsensusMsg::IbdCompleted => {
-                // IbdCompleted is handled separately in the run loop where we need to modify
-                // the prolonged_bootstrap_timer. This should never be reached since we filter
-                // it out before calling process_message
-                panic!("IbdCompleted should be handled in the run loop, not in process_message");
-            }
-            ConsensusMsg::SubscribeChainOnline { sender } => {
+            Query::SubscribeChainOnline { sender } => {
                 sender
-                    .send(chain_online_notifier.subscribe())
+                    .send(self.chain_online_notifier.subscribe())
                     .unwrap_or_else(|_| {
                         error!("Could not subscribe to new block channel");
                     });
             }
         }
+    }
+
+    /// Record the current service state.
+    fn record_recovery_state(&self) {
+        persist_recovery_state(
+            &self.cryptarchia,
+            self.storage_blocks_to_remove.clone(),
+            &self.state_updater,
+        );
     }
 
     /// Process a block and update the state accordingly.
@@ -1078,27 +1227,9 @@ where
         )
         .await;
 
-        Self::update_state(cryptarchia, storage_blocks_to_remove.clone(), state_updater);
+        persist_recovery_state(cryptarchia, storage_blocks_to_remove.clone(), state_updater);
 
         Ok((storage_blocks_to_remove, reorged_txs))
-    }
-
-    fn update_state(
-        cryptarchia: &Cryptarchia,
-        storage_blocks_to_remove: HashSet<HeaderId>,
-        state_updater: &StateUpdater<Option<CryptarchiaConsensusState>>,
-    ) {
-        match <Self as ServiceData>::State::from_cryptarchia_and_unpruned_blocks(
-            cryptarchia,
-            storage_blocks_to_remove,
-        ) {
-            Ok(state) => {
-                state_updater.update(Some(state));
-            }
-            Err(e) => {
-                error!(target: LOG_TARGET, "Failed to update state: {}", e);
-            }
-        }
     }
 
     /// Try to add a [`Block`] to [`Cryptarchia`].
@@ -1411,34 +1542,37 @@ where
         clippy::cognitive_complexity,
         reason = "TODO: address this in a dedicated refactor"
     )]
-    async fn initialize_cryptarchia(
-        &self,
+    async fn initialize_cryptarchia<TimeBackend>(
+        service: &CryptarchiaConsensus<Tx, Storage, TimeBackend, RuntimeServiceId>,
         bootstrap_config: &BootstrapConfig,
         ledger_config: lb_ledger::Config,
         relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
         current_slot: Slot,
-    ) -> InitializedCryptarchia {
+    ) -> InitializedCryptarchia
+    where
+        TimeBackend: lb_time_service::backends::TimeBackend,
+    {
         info!(
-            target: LOG_TARGET, tip = ?self.state.tip, lib = ?self.state.lib, lib_height = self.state.lib_block_length, genesis = ?self.state.genesis_id,
+            target: LOG_TARGET, tip = ?service.state.tip, lib = ?service.state.lib, lib_height = service.state.lib_block_length, genesis = ?service.state.genesis_id,
             "recovering chain state",
         );
 
-        let lib_id = self.state.lib;
-        let genesis_id = self.state.genesis_id;
+        let lib_id = service.state.lib;
+        let genesis_id = service.state.genesis_id;
         let state = choose_engine_state(
             lib_id,
             genesis_id,
             bootstrap_config,
-            self.state.last_engine_state.as_ref(),
+            service.state.last_engine_state.as_ref(),
         );
         let mut cryptarchia = Cryptarchia::from_lib(
             lib_id,
-            self.state.lib_ledger_state.clone(),
+            service.state.lib_ledger_state.clone(),
             genesis_id,
             ledger_config,
             state,
-            self.state.lib_block_slot,
-            self.state.lib_block_length,
+            service.state.lib_block_slot,
+            service.state.lib_block_length,
         );
 
         // Stream the already applied state.
@@ -1453,20 +1587,20 @@ where
                 lib_slot: lib.slot(),
             }
         };
-        if let Err(e) = self.new_block_subscription_sender.send(init_event) {
+        if let Err(e) = service.new_block_subscription_sender.send(init_event) {
             debug!("No new-block subscribers to notify: {e}");
         }
 
         // Phase 1: Collect and load blocks in (LIB, tip].
         info!(
-            target: LOG_TARGET, lib = ?lib_id, tip = ?self.state.tip,
+            target: LOG_TARGET, lib = ?lib_id, tip = ?service.state.tip,
             "loading stored blocks for chain recovery",
         );
         let RecoveryBlocks {
             blocks,
             fell_back_to_lib,
         } = Self::load_recovery_blocks_or_fall_back_to_lib(
-            self.state.tip,
+            service.state.tip,
             lib_id,
             relays.storage_adapter().clone(),
         )
@@ -1486,8 +1620,8 @@ where
                 block,
                 current_slot,
                 relays,
-                &self.new_block_subscription_sender,
-                &self.lib_subscription_sender,
+                &service.new_block_subscription_sender,
+                &service.lib_subscription_sender,
             )
             .await
             {
@@ -1710,4 +1844,23 @@ async fn broadcast_finalized_block(
         .send(BlockBroadcastMsg::BroadcastFinalizedBlock(block_info))
         .await
         .map_err(|(error, _)| Box::new(error) as DynError)
+}
+
+/// Update and persist `CryptarchiaConsensusState`.
+fn persist_recovery_state(
+    cryptarchia: &Cryptarchia,
+    storage_blocks_to_remove: HashSet<HeaderId>,
+    state_updater: &StateUpdater<Option<CryptarchiaConsensusState>>,
+) {
+    match CryptarchiaConsensusState::from_cryptarchia_and_unpruned_blocks(
+        cryptarchia,
+        storage_blocks_to_remove,
+    ) {
+        Ok(state) => {
+            state_updater.update(Some(state));
+        }
+        Err(e) => {
+            error!(target: LOG_TARGET, "Failed to update state: {}", e);
+        }
+    }
 }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -3,6 +3,7 @@ mod bootstrap;
 mod metrics;
 mod notifier;
 mod relays;
+mod service;
 mod states;
 pub mod storage;
 mod sync;
@@ -11,7 +12,7 @@ mod tests;
 
 use core::fmt::Debug;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     fmt::Display,
     pin::Pin,
     time::Duration,
@@ -19,22 +20,21 @@ use std::{
 
 use bytes::Bytes;
 use derivative::Derivative;
-use futures::{Stream, StreamExt as _, TryStreamExt as _, future::join_all, stream};
-use lb_chain_broadcast_service::{BlockBroadcastMsg, BlockBroadcastService, BlockInfo};
+use futures::{Stream, TryStreamExt as _};
+use lb_chain_broadcast_service::BlockBroadcastService;
 use lb_core::{
     block::{Block, genesis::GenesisBlock},
     events::Events,
     header::HeaderId,
     mantle::{
         gas::MainnetGasConstants,
-        traits::{GenesisTx as _, MantleTxWithProofs, PreverifiedMantleTx},
+        traits::{MantleTxWithProofs, PreverifiedMantleTx},
         transactions::GasPrices,
     },
     sdp::{Declaration, DeclarationId},
 };
 use lb_cryptarchia_engine::{Branch, PrunedBlocks, ReorgedBlocks};
 pub use lb_cryptarchia_engine::{Epoch, Slot, State};
-use lb_cryptarchia_sync::{BlocksUnavailableReason, GetTipResponse, ProviderResponse};
 pub use lb_ledger::EpochState;
 use lb_ledger::LedgerState;
 use lb_network_service::message::ChainSyncEvent;
@@ -51,19 +51,18 @@ use lb_storage_service::{
 use lb_time_service::TimeService;
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
-    services::{AsServiceId, ServiceCore, ServiceData, relay::InboundRelay, state::StateUpdater},
+    services::{AsServiceId, ServiceCore, ServiceData},
 };
-use relays::BroadcastRelay;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_with::serde_as;
 use thiserror::Error;
-use time::OffsetDateTime;
-use tokio::sync::{broadcast, mpsc, oneshot, watch};
-use tracing::{Level, debug, error, info, instrument, span, trace, warn};
+use tokio::sync::{broadcast, oneshot, watch};
+use tracing::{Level, debug, error, info, span, trace, warn};
 use tracing_futures::Instrument as _;
 
 pub use crate::{
     bootstrap::config::{BootstrapConfig, OfflineGracePeriodConfig},
+    service::phases::PhaseTag,
     states::CryptarchiaConsensusState,
     sync::config::{BlockProviderConfig, SyncConfig},
 };
@@ -71,6 +70,10 @@ use crate::{
     bootstrap::state::choose_engine_state,
     notifier::ChainOnlineNotifier,
     relays::CryptarchiaConsensusRelays,
+    service::{
+        Service, delete_stale_blocks_from_storage, load_block_ids_from_storage,
+        persist_recovery_state, process_block,
+    },
     storage::{StorageAdapter as _, adapters::StorageAdapter},
     sync::block_provider::BlockProvider,
 };
@@ -209,25 +212,12 @@ pub enum Query {
 pub(crate) type HeaderIdStream =
     Pin<Box<dyn Stream<Item = Result<HeaderId, Error>> + Send + 'static>>;
 
-/// The phase of the chain service, which advances one-directionally
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ChainServicePhase {
-    /// The genesis time is in the future. Only read-only queries are served.
-    AwaitingGenesisTime,
-    /// Applying blocks while waiting for Initial Block Download to complete.
-    InitialBlockDownload,
-    /// The Prolonged Bootstrap Period is running.
-    ProlongedBootstrapPeriod,
-    /// Following the chain in real time
-    Following,
-}
-
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChainServiceInfo {
     pub cryptarchia_info: CryptarchiaInfo,
-    pub phase: ChainServicePhase,
+    pub phase: PhaseTag,
 }
 
 #[serde_as]
@@ -290,35 +280,6 @@ fn log_pruned_ledger_states(pruned_states_count: usize) {
         trace!(target: LOG_TARGET, "Pruned {pruned_states_count} old forks and their ledger states.");
     } else {
         debug!(target: LOG_TARGET, "Pruned {pruned_states_count} old forks and their ledger states.");
-    }
-}
-
-fn log_process_block_error(error: &Error) {
-    let error_msg = format!("Failed to process block: {error:?}");
-    if matches!(error, Error::FutureBlock { .. }) {
-        trace!(target: LOG_TARGET, "{}", error_msg);
-    } else {
-        error!(target: LOG_TARGET, "{}", error_msg);
-    }
-}
-
-fn log_lib_advanced(
-    prev_lib: &HeaderId,
-    new_lib: &HeaderId,
-    stale_blocks_count: usize,
-    immutable_blocks_count: usize,
-    reorged_blocks_count: usize,
-) {
-    if stale_blocks_count == 0 && immutable_blocks_count == 1 && reorged_blocks_count == 0 {
-        trace!(
-            target: LOG_TARGET,
-            "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={stale_blocks_count}, immutable_blocks={immutable_blocks_count}, reorged_blocks={reorged_blocks_count}",
-        );
-    } else {
-        debug!(
-            target: LOG_TARGET,
-            "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={stale_blocks_count}, immutable_blocks={immutable_blocks_count}, reorged_blocks={reorged_blocks_count}",
-        );
     }
 }
 
@@ -657,18 +618,20 @@ where
             cryptarchia,
             pruned_blocks,
             fell_back_to_lib,
-        } = Runtime::initialize_cryptarchia(
-            &self,
+        } = Self::initialize_cryptarchia(
+            &self.state,
             &bootstrap_config,
             ledger_config.clone(),
             &relays,
+            &self.new_block_subscription_sender,
+            &self.lib_subscription_sender,
             current_slot,
         )
         .await;
 
         // These are blocks that have been pruned by the cryptarchia engine but have not
         // yet been deleted from the storage layer.
-        let storage_blocks_to_remove = Runtime::delete_stale_blocks_from_storage(
+        let storage_blocks_to_remove = delete_stale_blocks_from_storage(
             pruned_blocks.stale_blocks().copied(),
             &self.state.storage_blocks_to_remove,
             relays.storage_adapter(),
@@ -707,12 +670,13 @@ where
             lib_subscription_sender,
             ..
         } = self;
-        let runner = Runtime {
-            inbound_relay: service_resources_handle.inbound_relay,
-            state_updater: service_resources_handle.state_updater,
+        let service = Service::new(
+            starting_state,
+            cryptarchia,
+            service_resources_handle.inbound_relay,
+            service_resources_handle.state_updater,
             new_block_subscription_sender,
             lib_subscription_sender,
-            cryptarchia,
             chain_online_notifier,
             current_slot,
             storage_blocks_to_remove,
@@ -720,7 +684,22 @@ where
             sync_blocks_provider,
             slot_timer,
             state_recording_timer,
-            prolonged_bootstrap_period: bootstrap_config.prolonged_bootstrap_period,
+            bootstrap_config.prolonged_bootstrap_period,
+        );
+
+        // Run all phases in order. Each phase consumes the service and
+        // returns it in the next phase, so phases can only advance
+        // one-directionally. Phases that don't apply run as no-ops.
+        let run_service = async {
+            service
+                .process_awaiting_genesis_time()
+                .await
+                .process_initial_block_download()
+                .await
+                .process_prolonged_bootstrap_period()
+                .await
+                .process_following()
+                .await;
         };
 
         // It sucks to use `SERVICE_ID` when we have `<RuntimeServiceId as
@@ -730,8 +709,7 @@ where
         // Hypothesis:
         // 1. Probably related to too many generics.
         // 2. It seems `span` requires a `const` string literal.
-        runner
-            .run(starting_state)
+        run_service
             .instrument(span!(Level::TRACE, SERVICE_ID))
             .await;
 
@@ -755,7 +733,7 @@ where
         + 'static,
     Storage: StorageBackend + Send + Sync + 'static,
     <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
-    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
     <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
     TimeBackend: lb_time_service::backends::TimeBackend,
     RuntimeServiceId: Display + AsServiceId<Self> + 'static,
@@ -796,682 +774,13 @@ where
 
         Ok((current_slot, slot_timer))
     }
-}
-
-/// The runtime of the chain service,
-/// which holds everything shared by all phases.
-struct Runtime<Tx, Storage, RuntimeServiceId>
-where
-    Tx: PreverifiedMantleTx + Clone + Eq + Debug,
-    Storage: StorageBackend + Send + Sync + 'static,
-    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
-{
-    inbound_relay: InboundRelay<ConsensusMsg<Tx>>,
-    state_updater: StateUpdater<Option<CryptarchiaConsensusState>>,
-    new_block_subscription_sender: broadcast::Sender<ProcessedBlockEvent>,
-    lib_subscription_sender: broadcast::Sender<LibUpdate>,
-    cryptarchia: Cryptarchia,
-    chain_online_notifier: ChainOnlineNotifier,
-    current_slot: Slot,
-    storage_blocks_to_remove: HashSet<HeaderId>,
-    relays: CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
-    sync_blocks_provider: BlockProvider<Storage, Tx>,
-    slot_timer: lb_time_service::EpochSlotTickStream,
-    state_recording_timer: tokio::time::Interval,
-    prolonged_bootstrap_period: Duration,
-}
-
-impl<Tx, Storage, RuntimeServiceId> Runtime<Tx, Storage, RuntimeServiceId>
-where
-    Tx: PreverifiedMantleTx
-        + AuthenticatedMantleTx<Context = GasPrices>
-        + Debug
-        + Clone
-        + Eq
-        + Serialize
-        + DeserializeOwned
-        + Send
-        + Sync
-        + Unpin
-        + 'static,
-    Storage: StorageBackend + Send + Sync + 'static,
-    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
-    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
-    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
-    RuntimeServiceId: Display + 'static,
-{
-    /// Run all phases in order.
-    async fn run(mut self, starting_state: StartingState) {
-        // Run `AwaitingGenesisTime` phase.
-        // `IbdCompleted` can be received during this phase if IBD has been skipped.
-        let ibd_skipped = if let Some(genesis_timer) = Self::create_genesis_timer(starting_state) {
-            self.phase_awaiting_genesis_time(genesis_timer).await
-        } else {
-            false
-        };
-
-        // Run `InitialBlockDownload` phase.
-        if !ibd_skipped {
-            self.phase_initial_block_download().await;
-        }
-
-        // Run `ProlongedBootstrapPeriod` phase
-        if self.cryptarchia.is_bootstrapping() {
-            self = self.phase_prolonged_bootstrap_period().await;
-        }
-
-        // Run `Following` phase.
-        self.phase_following().await;
-    }
-
-    /// Creates a timer that fires when the genesis time is reached,
-    /// if the starting state is `Genesis` and the genesis time is in the
-    /// future.
-    /// Returns `None`, otherwise.
-    fn create_genesis_timer(starting_state: StartingState) -> Option<Pin<Box<tokio::time::Sleep>>> {
-        if let StartingState::Genesis { genesis_block } = starting_state {
-            let genesis_time: OffsetDateTime = genesis_block
-                .genesis_tx()
-                .cryptarchia_parameter()
-                .genesis_time
-                .into();
-            let now = OffsetDateTime::now_utc();
-
-            if genesis_time > now {
-                info!(target: LOG_TARGET, %genesis_time, "genesis time is in the future");
-                let delay = (genesis_time - now).try_into().unwrap_or_default();
-                return Some(Box::pin(tokio::time::sleep(delay)));
-            }
-        }
-        None
-    }
-
-    /// `AwaitingGenesisTime` phase: Wait until the genesis time is reached.
-    /// Returns whether IBD has been skipped during this phase.
-    #[expect(clippy::cognitive_complexity, reason = "better in one fn")]
-    async fn phase_awaiting_genesis_time(
-        &mut self,
-        mut genesis_timer: Pin<Box<tokio::time::Sleep>>,
-    ) -> bool {
-        let phase = ChainServicePhase::AwaitingGenesisTime;
-        info!(target: LOG_TARGET, "entering {phase:?} phase");
-
-        let mut ibd_skipped = false;
-        loop {
-            tokio::select! {
-                () = genesis_timer.as_mut() => {
-                    info!(target: LOG_TARGET, "genesis time reached: finishing {phase:?} phase");
-                    return ibd_skipped;
-                }
-                Some(msg) = self.inbound_relay.next() => match msg {
-                    ConsensusMsg::Query(query) => {
-                        self.process_query(query, phase).await;
-                    }
-                    ConsensusMsg::ApplyBlock { reply_channel, .. } => {
-                        debug!(target: LOG_TARGET, "rejecting a block received during {phase:?} phase");
-                        reply_channel.send(Err(Error::AwaitingGenesisTime)).unwrap_or_else(|_| {
-                            error!(target: LOG_TARGET, "failed to send error through channel");
-                        });
-                    }
-                    ConsensusMsg::ChainSync(event) => Self::reject_chain_sync_event(event).await,
-                    ConsensusMsg::IbdCompleted => {
-                        info!(target: LOG_TARGET, "Initial Block Download has been skipped during {phase:?} phase");
-                        ibd_skipped = true;
-                    }
-                },
-                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
-                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
-            }
-        }
-    }
-
-    /// `InitialBlockDownload` phase: Apply blocks until IBD completes.
-    async fn phase_initial_block_download(&mut self) {
-        let phase = ChainServicePhase::InitialBlockDownload;
-        info!(target: LOG_TARGET, "entering {phase:?} phase");
-
-        loop {
-            tokio::select! {
-                Some(msg) = self.inbound_relay.next() => match msg {
-                    ConsensusMsg::Query(query) => {
-                        self.process_query(query, phase).await;
-                    }
-                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
-                        self.apply_block_and_reply(*block, reply_channel).await;
-                    }
-                    ConsensusMsg::ChainSync(event) => Self::reject_chain_sync_event(event).await,
-                    ConsensusMsg::IbdCompleted => {
-                        info!(target: LOG_TARGET, "Initial Block Download completed");
-                        return;
-                    }
-                },
-                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
-                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
-            }
-        }
-    }
-
-    /// `ProlongedBootstrapPeriod` phase: Apply blocks until PBP is over.
-    /// At the end of the phase, `Cryptarchia` is switched to online.
-    #[expect(clippy::cognitive_complexity, reason = "better in one fn")]
-    async fn phase_prolonged_bootstrap_period(mut self) -> Self {
-        let phase = ChainServicePhase::ProlongedBootstrapPeriod;
-        info!(target: LOG_TARGET, "entering {phase:?} phase");
-
-        let mut pbp_timer = Box::pin(tokio::time::sleep(self.prolonged_bootstrap_period));
-        loop {
-            tokio::select! {
-                () = pbp_timer.as_mut() => {
-                    break;
-                },
-                Some(msg) = self.inbound_relay.next() => match msg {
-                    ConsensusMsg::Query(query) => {
-                        self.process_query(query, phase).await;
-                    }
-                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
-                        self.apply_block_and_reply(*block, reply_channel).await;
-                    }
-                    ConsensusMsg::ChainSync(event) => Self::reject_chain_sync_event(event).await,
-                    ConsensusMsg::IbdCompleted => {
-                        debug!(target: LOG_TARGET, "ignoring IbdCompleted: already in {phase:?} phase");
-                    }
-                },
-                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
-                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
-            }
-        }
-
-        info!(target: LOG_TARGET, "Prolonged Bootstrap Period completed: switching chain to online");
-        (self.cryptarchia, self.storage_blocks_to_remove) = Self::switch_to_online(
-            self.cryptarchia,
-            &self.storage_blocks_to_remove,
-            self.relays.storage_adapter(),
-            &self.chain_online_notifier,
-        )
-        .await;
-        self.record_recovery_state();
-        self
-    }
-
-    /// `Following` phase: Follow the chain in real time. This phase never ends.
-    async fn phase_following(&mut self) {
-        let phase = ChainServicePhase::Following;
-        info!(target: LOG_TARGET, "entering {phase:?} phase");
-
-        loop {
-            tokio::select! {
-                Some(msg) = self.inbound_relay.next() => match msg {
-                    ConsensusMsg::Query(query) => {
-                        self.process_query(query, phase).await;
-                    }
-                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
-                        self.apply_block_and_reply(*block, reply_channel).await;
-                    }
-                    ConsensusMsg::ChainSync(event) => {
-                        Self::handle_chainsync_event(&self.cryptarchia, &self.sync_blocks_provider, event).await;
-                    }
-                    ConsensusMsg::IbdCompleted => {
-                        debug!(target: LOG_TARGET, "ignoring IbdCompleted: already in {phase:?} phase");
-                    }
-                },
-                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
-                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
-            }
-        }
-    }
-
-    /// Apply a block to the chain and reply with the result.
-    async fn apply_block_and_reply(
-        &mut self,
-        block: Block<Tx>,
-        reply_channel: oneshot::Sender<Result<(HeaderId, Vec<Tx>), Error>>,
-    ) {
-        match Self::process_block_and_update_state(
-            &mut self.cryptarchia,
-            block,
-            self.current_slot,
-            &self.storage_blocks_to_remove,
-            &self.relays,
-            &self.new_block_subscription_sender,
-            &self.lib_subscription_sender,
-            &self.state_updater,
-        )
-        .await
-        {
-            Ok((storage_blocks_to_remove, reorged_txs)) => {
-                self.storage_blocks_to_remove = storage_blocks_to_remove;
-                reply_channel
-                    .send(Ok((self.cryptarchia.tip(), reorged_txs)))
-                    .unwrap_or_else(|_| {
-                        error!("Could not send process block result through channel");
-                    });
-            }
-            Err(e) => {
-                log_process_block_error(&e);
-                reply_channel.send(Err(e)).unwrap_or_else(|_| {
-                    error!("Could not send process block error through channel");
-                });
-            }
-        }
-    }
-
-    /// Serve a read-only query. Available in every phase.
-    #[expect(clippy::too_many_lines, reason = "TODO: refactor into funcs")]
-    async fn process_query(&self, query: Query, phase: ChainServicePhase) {
-        match query {
-            Query::Info { reply_channel } => {
-                reply_channel
-                    .send(ChainServiceInfo {
-                        cryptarchia_info: self.cryptarchia.info(),
-                        phase,
-                    })
-                    .unwrap_or_else(|e| {
-                        error!("Could not send consensus info through channel: {:?}", e);
-                    });
-            }
-            Query::NewBlockSubscribe { sender } => {
-                sender
-                    .send(self.new_block_subscription_sender.subscribe())
-                    .unwrap_or_else(|_| {
-                        error!("Could not subscribe to new block channel");
-                    });
-            }
-            Query::LibSubscribe { sender } => {
-                sender
-                    .send(self.lib_subscription_sender.subscribe())
-                    .unwrap_or_else(|_| {
-                        error!("Could not subscribe to LIB updates channel");
-                    });
-            }
-            Query::GetHeaders {
-                from_descendant,
-                to_ancestor,
-                reply_channel,
-            } => {
-                // default to tip block if not present
-                let from_descendant = from_descendant.unwrap_or_else(|| self.cryptarchia.tip());
-                // default to LIB block if not present
-                let to_ancestor = to_ancestor.unwrap_or_else(|| self.cryptarchia.lib());
-
-                let stream = Self::get_block_ids(
-                    from_descendant,
-                    to_ancestor,
-                    &self.cryptarchia,
-                    self.relays.storage_adapter().clone(),
-                );
-                reply_channel
-                    .send(stream)
-                    .unwrap_or_else(|_| error!("could not send block stream through channel"));
-            }
-            Query::GetLedgerState {
-                block_id,
-                reply_channel,
-            } => {
-                let ledger_state = self.cryptarchia.ledger.state(&block_id).cloned();
-                reply_channel.send(ledger_state).unwrap_or_else(|_| {
-                    error!("Could not send ledger state through channel");
-                });
-            }
-            Query::GetSdpDeclarations { reply_channel } => {
-                let tip = self.cryptarchia.tip();
-                let declarations = self
-                    .cryptarchia
-                    .ledger
-                    .state(&tip)
-                    .map(|ledger_state| ledger_state.mantle_ledger().sdp.declarations())
-                    .unwrap_or_default()
-                    .iter()
-                    .flat_map(|(_, declarations)| {
-                        declarations
-                            .iter()
-                            .map(|(id, declaration)| (*id, declaration.clone()))
-                    })
-                    .collect();
-                reply_channel.send(declarations).unwrap_or_else(|_| {
-                    error!("Could not send SDP declarations through channel");
-                });
-            }
-            Query::GetSdpSnapshot { reply_channel } => {
-                let tip = self.cryptarchia.tip();
-                let declarations = self
-                    .cryptarchia
-                    .ledger
-                    .state(&tip)
-                    .map(|ledger_state| {
-                        ledger_state
-                            .epoch_state()
-                            .active_declarations
-                            .iter()
-                            .flat_map(|(_, declarations)| {
-                                declarations
-                                    .iter()
-                                    .map(|(id, declaration)| (*id, declaration.clone()))
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                reply_channel.send(declarations).unwrap_or_else(|_| {
-                    error!("Could not send SDP snapshot through channel");
-                });
-            }
-            Query::GetEpochState {
-                slot,
-                reply_channel,
-            } => {
-                let result = self.cryptarchia.epoch_state_for_slot(slot);
-                reply_channel.send(result).unwrap_or_else(|_| {
-                    error!("Could not send epoch state through channel");
-                });
-            }
-            Query::GetEpochConfig { reply_channel } => {
-                let config = self.cryptarchia.ledger.config();
-                reply_channel
-                    .send((config.epoch_config, config.consensus_config.clone()))
-                    .unwrap_or_else(|_| {
-                        error!("Could not send epoch config through channel");
-                    });
-            }
-            Query::GetBlockEvents { id, reply_channel } => {
-                let events = self.relays.storage_adapter().get_block_events(&id).await;
-                reply_channel.send(events).unwrap_or_else(|_| {
-                    error!("Could not send block events through channel");
-                });
-            }
-            Query::SubscribeChainOnline { sender } => {
-                sender
-                    .send(self.chain_online_notifier.subscribe())
-                    .unwrap_or_else(|_| {
-                        error!("Could not subscribe to new block channel");
-                    });
-            }
-        }
-    }
-
-    /// Record the current service state.
-    fn record_recovery_state(&self) {
-        persist_recovery_state(
-            &self.cryptarchia,
-            self.storage_blocks_to_remove.clone(),
-            &self.state_updater,
-        );
-    }
-
-    /// Process a block and update the state accordingly.
-    ///
-    /// On error, the `cryptarchia` is not mutated.
-    #[expect(clippy::too_many_arguments, reason = "Need all args")]
-    async fn process_block_and_update_state(
-        cryptarchia: &mut Cryptarchia,
-        block: Block<Tx>,
-        current_slot: Slot,
-        storage_blocks_to_remove: &HashSet<HeaderId>,
-        relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
-        new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
-        lib_subscription_sender: &broadcast::Sender<LibUpdate>,
-        state_updater: &StateUpdater<Option<CryptarchiaConsensusState>>,
-    ) -> Result<(HashSet<HeaderId>, Vec<Tx>), Error> {
-        let (pruned_blocks, reorged_txs) = Self::process_block(
-            cryptarchia,
-            block,
-            current_slot,
-            relays,
-            new_block_subscription_sender,
-            lib_subscription_sender,
-        )
-        .await?;
-
-        let storage_blocks_to_remove = Self::delete_stale_blocks_from_storage(
-            pruned_blocks.stale_blocks().copied(),
-            storage_blocks_to_remove,
-            relays.storage_adapter(),
-        )
-        .await;
-
-        persist_recovery_state(cryptarchia, storage_blocks_to_remove.clone(), state_updater);
-
-        Ok((storage_blocks_to_remove, reorged_txs))
-    }
-
-    /// Try to add a [`Block`] to [`Cryptarchia`].
-    ///
-    /// A [`Block`] is only added if it's valid.
-    /// Otherwise, the [`Cryptarchia`] is unchanged and an error is returned.
-    #[expect(clippy::allow_attributes_without_reason)]
-    #[instrument(
-        level = "debug",
-        skip(cryptarchia, block, relays, new_block_subscription_sender, lib_broadcaster),
-        fields(block_id = %block.header().id(), tx_count = block.transactions_iter().count(), current_slot = ?current_slot)
-    )]
-    async fn process_block(
-        cryptarchia: &mut Cryptarchia,
-        block: Block<Tx>,
-        current_slot: Slot,
-        relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
-        new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
-        lib_broadcaster: &broadcast::Sender<LibUpdate>,
-    ) -> Result<(PrunedBlocks<HeaderId>, Vec<Tx>), Error> {
-        debug!(target: LOG_TARGET, "Received proposal with ID: {:?}", block.header().id());
-        let header = block.header();
-        let prev_lib = cryptarchia.lib();
-
-        let mut candidate = cryptarchia.clone();
-        let (pruned_blocks, reorged_blocks, events) =
-            candidate.try_apply_block(&block, current_slot)?;
-        let new_lib = candidate.lib();
-
-        let tx_count = block.transactions_iter().count();
-
-        let immutable_blocks = Self::immutable_blocks_index(
-            &pruned_blocks,
-            Some(prev_lib),
-            new_lib,
-            candidate.consensus.lib_branch().slot(),
-        );
-
-        relays
-            .storage_adapter()
-            .store_block_data(
-                header.id(),
-                header.parent(),
-                block.clone(),
-                events,
-                immutable_blocks,
-            )
-            .await
-            .map_err(|e| Error::Storage(format!("Failed to store block data: {e}")))?;
-
-        *cryptarchia = candidate;
-        metrics::emit_block_transactions_metric(tx_count);
-
-        let processed_block_event = {
-            let tip = cryptarchia.tip_branch();
-            let lib = cryptarchia.lib_branch();
-            ProcessedBlockEvent {
-                block_id: header.id(),
-                tip: tip.id(),
-                tip_slot: tip.slot(),
-                lib: lib.id(),
-                lib_slot: lib.slot(),
-            }
-        };
-        if let Err(e) = new_block_subscription_sender.send(processed_block_event) {
-            debug!("No new-block subscribers to notify: {e}");
-        }
-
-        if prev_lib != new_lib {
-            log_lib_advanced(
-                &prev_lib,
-                &new_lib,
-                pruned_blocks.stale_blocks().count(),
-                pruned_blocks.immutable_blocks().len(),
-                reorged_blocks.len(),
-            );
-
-            let height = cryptarchia
-                .consensus
-                .branches()
-                .get(&cryptarchia.lib())
-                .expect("LIB branch not available")
-                .length();
-            let block_info = BlockInfo {
-                height,
-                header_id: new_lib,
-            };
-
-            if let Err(e) = broadcast_finalized_block(relays.broadcast_relay(), block_info).await {
-                warn!("Failed to notify finalized-block subscribers: {e}");
-            }
-
-            let lib_update = LibUpdate {
-                new_lib: cryptarchia.lib(),
-                pruned_blocks: PrunedBlocksInfo {
-                    stale_blocks: pruned_blocks.stale_blocks().copied().collect(),
-                    immutable_blocks: pruned_blocks.immutable_blocks().clone(),
-                },
-            };
-
-            if let Err(e) = lib_broadcaster.send(lib_update) {
-                warn!("No LIB-update subscribers to notify: {e}");
-            }
-        }
-
-        let reorged_txs: Vec<_> = join_all(
-            reorged_blocks
-                .iter()
-                .map(|id| relays.storage_adapter().get_block(id)),
-        )
-        .await
-        .into_iter()
-        .flatten()
-        .flat_map(Block::into_transactions)
-        .collect();
-
-        Ok((pruned_blocks, reorged_txs))
-    }
-
-    /// Store immutable block IDs to storage, including the new LIB if needed.
-    /// If `prev_lib` is None, always includes the new LIB.
-    /// If `prev_lib` is Some, only includes new LIB if it changed.
-    async fn store_immutable_blocks_index(
-        pruned_blocks: &PrunedBlocks<HeaderId>,
-        prev_lib: Option<HeaderId>,
-        new_lib: HeaderId,
-        new_lib_slot: Slot,
-        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> Result<(), Error> {
-        let immutable_blocks =
-            Self::immutable_blocks_index(pruned_blocks, prev_lib, new_lib, new_lib_slot);
-
-        storage_adapter
-            .store_immutable_block_ids(immutable_blocks)
-            .await
-            .map_err(|e| Error::Storage(format!("Failed to store immutable block ids: {e}")))
-    }
-
-    fn immutable_blocks_index(
-        pruned_blocks: &PrunedBlocks<HeaderId>,
-        prev_lib: Option<HeaderId>,
-        new_lib: HeaderId,
-        new_lib_slot: Slot,
-    ) -> BTreeMap<Slot, HeaderId> {
-        let mut immutable_blocks = pruned_blocks.immutable_blocks().clone();
-        // The new LIB is also immutable and should be immediately queryable by slot.
-        // prune_immutable_blocks() only returns blocks older than the new LIB,
-        // so we explicitly add the new LIB here.
-        if prev_lib.is_none_or(|prev| prev != new_lib) {
-            immutable_blocks.insert(new_lib_slot, new_lib);
-        }
-
-        immutable_blocks
-    }
-
-    /// Returns block IDs from descendant (inclusive) to ancestor
-    /// (inclusive) in child-to-parent order.
-    ///
-    /// First tries to find blocks from memory. If any block is missing from
-    /// memory, it falls back to loading all subsequent blocks from storage.
-    fn get_block_ids(
-        from_descendant: HeaderId,
-        to_ancestor: HeaderId,
-        cryptarchia: &Cryptarchia,
-        storage_adapter: StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> Pin<Box<dyn Stream<Item = Result<HeaderId, Error>> + Send>> {
-        let branches = cryptarchia.consensus.branches();
-
-        let mut in_memory = Vec::new();
-        let mut current = from_descendant;
-        while let Some(branch) = branches.get(&current) {
-            in_memory.push(Ok(branch.id()));
-
-            if branch.id() == to_ancestor {
-                // All blocks are found in memory. Return immediately
-                return Box::pin(stream::iter(in_memory));
-            }
-            if current == branch.parent() {
-                debug!(target: LOG_TARGET, ?to_ancestor, "reached genesis while looking for ancestor from memory");
-                // Return collected blocks and an error since we couldn't reach `to_ancestor`.
-                return Box::pin(stream::iter(in_memory).chain(stream::once(async move {
-                    Err(Error::ParentIdNotFound(current))
-                })));
-            }
-
-            current = branch.parent();
-        }
-
-        let storage_stream = stream::once(async move {
-            Self::load_block_ids_from_storage(current, to_ancestor, storage_adapter)
-        })
-        .flatten();
-        Box::pin(stream::iter(in_memory).chain(storage_stream))
-    }
-
-    /// Retrieves the block IDs from descendant (inclusive) to ancestor
-    /// (inclusive) from the storage, in child-to-parent order.
-    ///
-    /// This is implemented here, and not as a method of `StorageAdapter`, to
-    /// simplify the panic and error message handling.
-    #[expect(closure_returning_async_block, reason = "required by try_unfold")]
-    fn load_block_ids_from_storage(
-        from_descendant: HeaderId,
-        to_ancestor: HeaderId,
-        storage: StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> impl Stream<Item = Result<HeaderId, Error>> {
-        // Yield `from_descendant` first since we already know it,
-        // and yield subsequent parents by loading them from storage lazily.
-        stream::once(async move { Ok(from_descendant) }).chain(stream::try_unfold(
-            (from_descendant, storage),
-            move |(current, storage)| async move {
-                if current == to_ancestor {
-                    // Reached `to_ancestor`. Terminate the stream
-                    return Ok(None);
-                }
-
-                let parent = storage
-                    .get_block_parent(&current)
-                    .await
-                    .ok_or(Error::ParentIdNotFound(current))?;
-
-                if parent == current {
-                    debug!(target: LOG_TARGET, ?to_ancestor, "reached genesis while looking for ancestor from storage");
-                    // Terminate the stream with an error since we couldn't reach `to_ancestor`.
-                    return Err(Error::ParentIdNotFound(current));
-                }
-
-                debug!(
-                    target: LOG_TARGET, ?current, ?parent,
-                    "loaded block parent from storage",
-                );
-                Ok(Some((parent, (parent, storage))))
-            },
-        ))
-    }
 
     async fn load_recovery_blocks_from_storage(
         tip: HeaderId,
         lib: HeaderId,
         storage: StorageAdapter<Storage, Tx, RuntimeServiceId>,
     ) -> Result<Vec<Block<Tx>>, Error> {
-        let ids = Self::load_block_ids_from_storage(tip, lib, storage.clone())
+        let ids = load_block_ids_from_storage(tip, lib, storage.clone())
             .try_collect::<Vec<_>>()
             .await?;
 
@@ -1542,37 +851,36 @@ where
         clippy::cognitive_complexity,
         reason = "TODO: address this in a dedicated refactor"
     )]
-    async fn initialize_cryptarchia<TimeBackend>(
-        service: &CryptarchiaConsensus<Tx, Storage, TimeBackend, RuntimeServiceId>,
+    async fn initialize_cryptarchia(
+        recovery_state: &CryptarchiaConsensusState,
         bootstrap_config: &BootstrapConfig,
         ledger_config: lb_ledger::Config,
         relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
+        new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
+        lib_subscription_sender: &broadcast::Sender<LibUpdate>,
         current_slot: Slot,
-    ) -> InitializedCryptarchia
-    where
-        TimeBackend: lb_time_service::backends::TimeBackend,
-    {
+    ) -> InitializedCryptarchia {
         info!(
-            target: LOG_TARGET, tip = ?service.state.tip, lib = ?service.state.lib, lib_height = service.state.lib_block_length, genesis = ?service.state.genesis_id,
-            "recovering chain state",
+            target: LOG_TARGET, tip = ?recovery_state.tip, lib = ?recovery_state.lib, lib_height = recovery_state.lib_block_length, genesis = ?recovery_state.genesis_id,
+            "recovering Cryptarchia",
         );
 
-        let lib_id = service.state.lib;
-        let genesis_id = service.state.genesis_id;
+        let lib_id = recovery_state.lib;
+        let genesis_id = recovery_state.genesis_id;
         let state = choose_engine_state(
             lib_id,
             genesis_id,
             bootstrap_config,
-            service.state.last_engine_state.as_ref(),
+            recovery_state.last_engine_state.as_ref(),
         );
         let mut cryptarchia = Cryptarchia::from_lib(
             lib_id,
-            service.state.lib_ledger_state.clone(),
+            recovery_state.lib_ledger_state.clone(),
             genesis_id,
             ledger_config,
             state,
-            service.state.lib_block_slot,
-            service.state.lib_block_length,
+            recovery_state.lib_block_slot,
+            recovery_state.lib_block_length,
         );
 
         // Stream the already applied state.
@@ -1587,20 +895,20 @@ where
                 lib_slot: lib.slot(),
             }
         };
-        if let Err(e) = service.new_block_subscription_sender.send(init_event) {
+        if let Err(e) = new_block_subscription_sender.send(init_event) {
             debug!("No new-block subscribers to notify: {e}");
         }
 
         // Phase 1: Collect and load blocks in (LIB, tip].
         info!(
-            target: LOG_TARGET, lib = ?lib_id, tip = ?service.state.tip,
+            target: LOG_TARGET, lib = ?lib_id, tip = ?recovery_state.tip,
             "loading stored blocks for chain recovery",
         );
         let RecoveryBlocks {
             blocks,
             fell_back_to_lib,
         } = Self::load_recovery_blocks_or_fall_back_to_lib(
-            service.state.tip,
+            recovery_state.tip,
             lib_id,
             relays.storage_adapter().clone(),
         )
@@ -1615,13 +923,13 @@ where
         let mut pruned_blocks = PrunedBlocks::new();
         let n_blocks = blocks.len();
         for (i, block) in blocks.into_iter().enumerate() {
-            match Self::process_block(
+            match process_block(
                 &mut cryptarchia,
                 block,
                 current_slot,
                 relays,
-                &service.new_block_subscription_sender,
-                &service.lib_subscription_sender,
+                new_block_subscription_sender,
+                lib_subscription_sender,
             )
             .await
             {
@@ -1644,223 +952,6 @@ where
             cryptarchia,
             pruned_blocks,
             fell_back_to_lib,
-        }
-    }
-
-    /// Remove the stale blocks from the storage layer.
-    ///
-    /// Also, this removes the `additional_blocks` from the storage
-    /// layer. These blocks might belong to previous pruning operations and
-    /// that failed to be removed from the storage for some reason.
-    ///
-    /// This function returns any block that fails to be deleted from the
-    /// storage layer.
-    async fn delete_stale_blocks_from_storage(
-        stale_blocks: impl Iterator<Item = HeaderId> + Send,
-        additional_blocks: &HashSet<HeaderId>,
-        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> HashSet<HeaderId> {
-        match Self::delete_blocks_from_storage(
-            stale_blocks.chain(additional_blocks.iter().copied()),
-            storage_adapter,
-        )
-        .await
-        {
-            // No blocks failed to be deleted.
-            Ok(()) => HashSet::new(),
-            // We retain the blocks that failed to be deleted.
-            Err(failed_blocks) => failed_blocks
-                .into_iter()
-                .map(|(block_id, _)| block_id)
-                .collect(),
-        }
-    }
-
-    /// Send a bulk blocks deletion request to the storage adapter.
-    ///
-    /// If no request fails, the method returns `Ok()`.
-    /// If any request fails, the header ID and the generated error for each
-    /// failing request are collected and returned as part of the `Err`
-    /// result.
-    async fn delete_blocks_from_storage<Headers>(
-        block_headers: Headers,
-        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-    ) -> Result<(), Vec<(HeaderId, DynError)>>
-    where
-        Headers: Iterator<Item = HeaderId> + Send,
-    {
-        let blocks_to_delete = block_headers.collect::<Vec<_>>();
-        let block_deletion_outcomes = blocks_to_delete.iter().copied().zip(
-            storage_adapter
-                .remove_blocks(blocks_to_delete.iter().copied())
-                .await,
-        );
-
-        let errors: Vec<_> = block_deletion_outcomes
-            .filter_map(|(block_id, outcome)| match outcome {
-                Ok(Some(_)) => {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Block {block_id:#?} successfully deleted from storage."
-                    );
-                    None
-                }
-                Ok(None) => {
-                    trace!(
-                        target: LOG_TARGET,
-                        "Block {block_id:#?} was not found in storage."
-                    );
-                    None
-                }
-                Err(e) => {
-                    error!(
-                        target: LOG_TARGET,
-                        "Error deleting block {block_id:#?} from storage: {e}."
-                    );
-                    Some((block_id, e))
-                }
-            })
-            .collect();
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
-
-    async fn handle_chainsync_event(
-        cryptarchia: &Cryptarchia,
-        sync_blocks_provider: &BlockProvider<Storage, Tx>,
-        event: ChainSyncEvent,
-    ) {
-        match event {
-            ChainSyncEvent::ProvideBlocksRequest {
-                target_block,
-                local_tip,
-                latest_immutable_block,
-                additional_blocks,
-                reply_sender,
-            } => {
-                let known_blocks = vec![local_tip, latest_immutable_block]
-                    .into_iter()
-                    .chain(additional_blocks)
-                    .collect::<HashSet<_>>();
-
-                sync_blocks_provider
-                    .send_blocks(
-                        &cryptarchia.consensus,
-                        target_block,
-                        &known_blocks,
-                        reply_sender,
-                    )
-                    .await;
-            }
-            ChainSyncEvent::ProvideTipRequest { reply_sender } => {
-                let tip = cryptarchia.consensus.tip_branch();
-                let response = ProviderResponse::Available(GetTipResponse::Tip {
-                    tip: tip.id(),
-                    slot: tip.slot(),
-                    height: tip.length(),
-                });
-
-                trace!("Sending tip response: {response:?}");
-                if let Err(e) = reply_sender.send(response).await {
-                    error!("Failed to send tip header: {e}");
-                }
-            }
-        }
-    }
-
-    async fn reject_chain_sync_event(event: ChainSyncEvent) {
-        debug!(target: LOG_TARGET, "Received chainsync event while in bootstrapping state. Ignoring it.");
-        match event {
-            ChainSyncEvent::ProvideBlocksRequest { reply_sender, .. } => {
-                let response = ProviderResponse::Unavailable {
-                    reason: BlocksUnavailableReason::Unknown(
-                        "Node is not in online mode".to_owned(),
-                    ),
-                };
-                if let Err(e) = reply_sender.send(response).await {
-                    error!("Failed to send chain sync response: {e}");
-                }
-            }
-            ChainSyncEvent::ProvideTipRequest { reply_sender } => {
-                Self::send_chain_sync_rejection(reply_sender).await;
-            }
-        }
-    }
-
-    async fn send_chain_sync_rejection<ResponseType>(
-        sender: mpsc::Sender<ProviderResponse<ResponseType>>,
-    ) {
-        let response = ProviderResponse::Unavailable {
-            reason: "Node is not in online mode".to_owned(),
-        };
-        if let Err(e) = sender.send(response).await {
-            error!("Failed to send chain sync response: {e}");
-        }
-    }
-
-    async fn switch_to_online(
-        cryptarchia: Cryptarchia,
-        storage_blocks_to_remove: &HashSet<HeaderId>,
-        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
-        chain_online_notifier: &ChainOnlineNotifier,
-    ) -> (Cryptarchia, HashSet<HeaderId>) {
-        let (cryptarchia, pruned_blocks) = cryptarchia.online();
-        info!("Node is online and following the chain");
-
-        chain_online_notifier.notify();
-
-        if let Err(e) = Self::store_immutable_blocks_index(
-            &pruned_blocks,
-            None,
-            cryptarchia.lib(),
-            cryptarchia.consensus.lib_branch().slot(),
-            storage_adapter,
-        )
-        .await
-        {
-            error!("Could not store immutable block IDs: {e}");
-        }
-
-        let storage_blocks_to_remove = Self::delete_stale_blocks_from_storage(
-            pruned_blocks.stale_blocks().copied(),
-            storage_blocks_to_remove,
-            storage_adapter,
-        )
-        .await;
-
-        (cryptarchia, storage_blocks_to_remove)
-    }
-}
-
-async fn broadcast_finalized_block(
-    broadcast_relay: &BroadcastRelay,
-    block_info: BlockInfo,
-) -> Result<(), DynError> {
-    broadcast_relay
-        .send(BlockBroadcastMsg::BroadcastFinalizedBlock(block_info))
-        .await
-        .map_err(|(error, _)| Box::new(error) as DynError)
-}
-
-/// Update and persist `CryptarchiaConsensusState`.
-fn persist_recovery_state(
-    cryptarchia: &Cryptarchia,
-    storage_blocks_to_remove: HashSet<HeaderId>,
-    state_updater: &StateUpdater<Option<CryptarchiaConsensusState>>,
-) {
-    match CryptarchiaConsensusState::from_cryptarchia_and_unpruned_blocks(
-        cryptarchia,
-        storage_blocks_to_remove,
-    ) {
-        Ok(state) => {
-            state_updater.update(Some(state));
-        }
-        Err(e) => {
-            error!(target: LOG_TARGET, "Failed to update state: {}", e);
         }
     }
 }

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -129,6 +129,34 @@ struct RecoveryBlocks<Tx> {
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub enum ConsensusMsg<Tx> {
+    /// Read-only queries and subscriptions.
+    /// These are served in every service phase.
+    Query(Query),
+    /// Apply a block to the chain,
+    /// and return the tip and reorged txs if successful.
+    ApplyBlock {
+        block: Box<Block<Tx>>,
+        reply_channel: oneshot::Sender<Result<(HeaderId, Vec<Tx>), Error>>,
+    },
+    /// Forward chain sync events from the network to chain-service.
+    /// Chain-service will handle these directly and respond via the embedded
+    /// `reply_sender`.
+    ChainSync(ChainSyncEvent),
+    /// Notification from chain-network that Initial Block Download has
+    /// completed.
+    IbdCompleted,
+}
+
+impl<Tx> From<Query> for ConsensusMsg<Tx> {
+    fn from(query: Query) -> Self {
+        Self::Query(query)
+    }
+}
+
+/// Read-only queries and subscriptions, served in every service phase.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub enum Query {
     Info {
         reply_channel: oneshot::Sender<ChainServiceInfo>,
     },
@@ -170,20 +198,6 @@ pub enum ConsensusMsg<Tx> {
         id: HeaderId,
         reply_channel: oneshot::Sender<Option<Events>>,
     },
-    /// Apply a block to the chain,
-    /// and return the tip and reorged txs if successful.
-    ApplyBlock {
-        block: Box<Block<Tx>>,
-        reply_channel: oneshot::Sender<Result<(HeaderId, Vec<Tx>), Error>>,
-    },
-    /// Forward chain sync events from the network to chain-service.
-    /// Chain-service will handle these directly and respond via the embedded
-    /// `reply_sender`.
-    ChainSync(ChainSyncEvent),
-    /// Notification from chain-network that Initial Block Download has
-    /// completed. Chain-service should start the prolonged bootstrap timer
-    /// upon receiving this.
-    IbdCompleted,
     /// Subscribe to be notified when the chain becomes online mode.
     /// Since chain never goes back after entering online,
     /// the notification is delivered at most once.

--- a/services/chain/chain-service/src/service/mod.rs
+++ b/services/chain/chain-service/src/service/mod.rs
@@ -1,0 +1,777 @@
+//! The chain service and its operations, shared by all [`crate::phases`].
+
+pub mod phases;
+
+use core::fmt::{Debug, Display};
+use std::{
+    collections::{BTreeMap, HashSet},
+    pin::Pin,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt as _, future::join_all, stream};
+use lb_chain_broadcast_service::{BlockBroadcastMsg, BlockInfo};
+use lb_core::{
+    block::Block,
+    events::Events,
+    header::HeaderId,
+    mantle::{
+        traits::{MantleTxWithProofs, PreverifiedMantleTx},
+        transactions::GasPrices,
+    },
+};
+use lb_cryptarchia_engine::{PrunedBlocks, Slot};
+use lb_cryptarchia_sync::{BlocksUnavailableReason, ProviderResponse};
+use lb_network_service::message::ChainSyncEvent;
+use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use overwatch::{
+    DynError,
+    services::{relay::InboundRelay, state::StateUpdater},
+};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tracing::{debug, error, instrument, trace, warn};
+
+use crate::{
+    ChainServiceInfo, ConsensusMsg, Cryptarchia, CryptarchiaConsensusState, Error, LOG_TARGET,
+    LibUpdate, ProcessedBlockEvent, PrunedBlocksInfo, Query, metrics,
+    notifier::ChainOnlineNotifier,
+    relays::{BroadcastRelay, CryptarchiaConsensusRelays},
+    storage::{StorageAdapter as _, adapters::StorageAdapter},
+    sync::block_provider::BlockProvider,
+};
+
+/// The chain service in the phase `P`.
+pub struct Service<Phase, Tx, Storage, RuntimeServiceId>
+where
+    Phase: phases::Phase,
+    Tx: PreverifiedMantleTx + Clone + Eq + Debug,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+{
+    phase: Phase,
+    cryptarchia: Cryptarchia,
+    inbound_relay: InboundRelay<ConsensusMsg<Tx>>,
+    state_updater: StateUpdater<Option<CryptarchiaConsensusState>>,
+    new_block_subscription_sender: broadcast::Sender<ProcessedBlockEvent>,
+    lib_subscription_sender: broadcast::Sender<LibUpdate>,
+    chain_online_notifier: ChainOnlineNotifier,
+    current_slot: Slot,
+    storage_blocks_to_remove: HashSet<HeaderId>,
+    relays: CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
+    sync_blocks_provider: BlockProvider<Storage, Tx>,
+    slot_timer: lb_time_service::EpochSlotTickStream,
+    state_recording_timer: tokio::time::Interval,
+    prolonged_bootstrap_period: Duration,
+}
+
+impl<Phase, Tx, Storage, RuntimeServiceId> Service<Phase, Tx, Storage, RuntimeServiceId>
+where
+    Phase: phases::Phase,
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    /// Move to the `NextPhase`, carrying all the shared ingredients over.
+    fn with_phase<NextPhase: phases::Phase>(
+        self,
+        phase: NextPhase,
+    ) -> Service<NextPhase, Tx, Storage, RuntimeServiceId> {
+        Service {
+            phase,
+            cryptarchia: self.cryptarchia,
+            inbound_relay: self.inbound_relay,
+            state_updater: self.state_updater,
+            new_block_subscription_sender: self.new_block_subscription_sender,
+            lib_subscription_sender: self.lib_subscription_sender,
+            chain_online_notifier: self.chain_online_notifier,
+            current_slot: self.current_slot,
+            storage_blocks_to_remove: self.storage_blocks_to_remove,
+            relays: self.relays,
+            sync_blocks_provider: self.sync_blocks_provider,
+            slot_timer: self.slot_timer,
+            state_recording_timer: self.state_recording_timer,
+            prolonged_bootstrap_period: self.prolonged_bootstrap_period,
+        }
+    }
+
+    /// Apply a block to the chain and reply with the result.
+    async fn apply_block_and_reply(
+        &mut self,
+        block: Block<Tx>,
+        reply_channel: oneshot::Sender<Result<(HeaderId, Vec<Tx>), Error>>,
+    ) {
+        match self.process_block_and_update_state(block).await {
+            Ok(reorged_txs) => {
+                reply_channel
+                    .send(Ok((self.cryptarchia.tip(), reorged_txs)))
+                    .unwrap_or_else(|_| {
+                        error!("Could not send process block result through channel");
+                    });
+            }
+            Err(e) => {
+                log_process_block_error(&e);
+                reply_channel.send(Err(e)).unwrap_or_else(|_| {
+                    error!("Could not send process block error through channel");
+                });
+            }
+        }
+    }
+
+    /// Process a block and update the service state accordingly.
+    ///
+    /// On error, the service state is not mutated.
+    async fn process_block_and_update_state(&mut self, block: Block<Tx>) -> Result<Vec<Tx>, Error> {
+        let (pruned_blocks, reorged_txs) = process_block(
+            &mut self.cryptarchia,
+            block,
+            self.current_slot,
+            &self.relays,
+            &self.new_block_subscription_sender,
+            &self.lib_subscription_sender,
+        )
+        .await?;
+
+        self.storage_blocks_to_remove = delete_stale_blocks_from_storage(
+            pruned_blocks.stale_blocks().copied(),
+            &self.storage_blocks_to_remove,
+            self.relays.storage_adapter(),
+        )
+        .await;
+
+        self.record_recovery_state();
+
+        Ok(reorged_txs)
+    }
+
+    /// Serve a read-only query. Available in every phase.
+    #[expect(clippy::too_many_lines, reason = "TODO: refactor into funcs")]
+    async fn process_query(&self, query: Query) {
+        match query {
+            Query::Info { reply_channel } => {
+                reply_channel
+                    .send(ChainServiceInfo {
+                        cryptarchia_info: self.cryptarchia.info(),
+                        phase: Phase::TAG,
+                    })
+                    .unwrap_or_else(|e| {
+                        error!("Could not send consensus info through channel: {:?}", e);
+                    });
+            }
+            Query::NewBlockSubscribe { sender } => {
+                sender
+                    .send(self.new_block_subscription_sender.subscribe())
+                    .unwrap_or_else(|_| {
+                        error!("Could not subscribe to new block channel");
+                    });
+            }
+            Query::LibSubscribe { sender } => {
+                sender
+                    .send(self.lib_subscription_sender.subscribe())
+                    .unwrap_or_else(|_| {
+                        error!("Could not subscribe to LIB updates channel");
+                    });
+            }
+            Query::GetHeaders {
+                from_descendant,
+                to_ancestor,
+                reply_channel,
+            } => {
+                // default to tip block if not present
+                let from_descendant = from_descendant.unwrap_or_else(|| self.cryptarchia.tip());
+                // default to LIB block if not present
+                let to_ancestor = to_ancestor.unwrap_or_else(|| self.cryptarchia.lib());
+
+                let stream = get_block_ids(
+                    &self.cryptarchia,
+                    from_descendant,
+                    to_ancestor,
+                    self.relays.storage_adapter().clone(),
+                );
+                reply_channel
+                    .send(stream)
+                    .unwrap_or_else(|_| error!("could not send block stream through channel"));
+            }
+            Query::GetLedgerState {
+                block_id,
+                reply_channel,
+            } => {
+                let ledger_state = self.cryptarchia.ledger.state(&block_id).cloned();
+                reply_channel.send(ledger_state).unwrap_or_else(|_| {
+                    error!("Could not send ledger state through channel");
+                });
+            }
+            Query::GetSdpDeclarations { reply_channel } => {
+                let tip = self.cryptarchia.tip();
+                let declarations = self
+                    .cryptarchia
+                    .ledger
+                    .state(&tip)
+                    .map(|ledger_state| ledger_state.mantle_ledger().sdp.declarations())
+                    .unwrap_or_default()
+                    .iter()
+                    .flat_map(|(_, declarations)| {
+                        declarations
+                            .iter()
+                            .map(|(id, declaration)| (*id, declaration.clone()))
+                    })
+                    .collect();
+                reply_channel.send(declarations).unwrap_or_else(|_| {
+                    error!("Could not send SDP declarations through channel");
+                });
+            }
+            Query::GetSdpSnapshot { reply_channel } => {
+                let tip = self.cryptarchia.tip();
+                let declarations = self
+                    .cryptarchia
+                    .ledger
+                    .state(&tip)
+                    .map(|ledger_state| {
+                        ledger_state
+                            .epoch_state()
+                            .active_declarations
+                            .iter()
+                            .flat_map(|(_, declarations)| {
+                                declarations
+                                    .iter()
+                                    .map(|(id, declaration)| (*id, declaration.clone()))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                reply_channel.send(declarations).unwrap_or_else(|_| {
+                    error!("Could not send SDP snapshot through channel");
+                });
+            }
+            Query::GetEpochState {
+                slot,
+                reply_channel,
+            } => {
+                let result = self.cryptarchia.epoch_state_for_slot(slot);
+                reply_channel.send(result).unwrap_or_else(|_| {
+                    error!("Could not send epoch state through channel");
+                });
+            }
+            Query::GetEpochConfig { reply_channel } => {
+                let config = self.cryptarchia.ledger.config();
+                reply_channel
+                    .send((config.epoch_config, config.consensus_config.clone()))
+                    .unwrap_or_else(|_| {
+                        error!("Could not send epoch config through channel");
+                    });
+            }
+            Query::GetBlockEvents { id, reply_channel } => {
+                let events = self.relays.storage_adapter().get_block_events(&id).await;
+                reply_channel.send(events).unwrap_or_else(|_| {
+                    error!("Could not send block events through channel");
+                });
+            }
+            Query::SubscribeChainOnline { sender } => {
+                sender
+                    .send(self.chain_online_notifier.subscribe())
+                    .unwrap_or_else(|_| {
+                        error!("Could not subscribe to new block channel");
+                    });
+            }
+        }
+    }
+
+    /// Record the current service state.
+    fn record_recovery_state(&self) {
+        persist_recovery_state(
+            &self.cryptarchia,
+            self.storage_blocks_to_remove.clone(),
+            &self.state_updater,
+        );
+    }
+}
+
+/// Try to add a [`Block`] to [`Cryptarchia`].
+///
+/// A [`Block`] is only added if it's valid.
+/// Otherwise, the [`Cryptarchia`] is unchanged and an error is returned.
+#[expect(clippy::allow_attributes_without_reason)]
+#[instrument(
+    level = "debug",
+    skip(cryptarchia, block, relays, new_block_subscription_sender, lib_broadcaster),
+    fields(block_id = %block.header().id(), tx_count = block.transactions_iter().count(), current_slot = ?current_slot)
+)]
+pub async fn process_block<Tx, Storage, RuntimeServiceId>(
+    cryptarchia: &mut Cryptarchia,
+    block: Block<Tx>,
+    current_slot: Slot,
+    relays: &CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
+    new_block_subscription_sender: &broadcast::Sender<ProcessedBlockEvent>,
+    lib_broadcaster: &broadcast::Sender<LibUpdate>,
+) -> Result<(PrunedBlocks<HeaderId>, Vec<Tx>), Error>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    debug!(target: LOG_TARGET, "Received proposal with ID: {:?}", block.header().id());
+    let header = block.header();
+    let prev_lib = cryptarchia.lib();
+
+    let mut candidate = cryptarchia.clone();
+    let (pruned_blocks, reorged_blocks, events) =
+        candidate.try_apply_block(&block, current_slot)?;
+    let new_lib = candidate.lib();
+
+    let tx_count = block.transactions_iter().count();
+
+    let immutable_blocks = immutable_blocks_index(
+        &pruned_blocks,
+        Some(prev_lib),
+        new_lib,
+        candidate.consensus.lib_branch().slot(),
+    );
+
+    relays
+        .storage_adapter()
+        .store_block_data(
+            header.id(),
+            header.parent(),
+            block.clone(),
+            events,
+            immutable_blocks,
+        )
+        .await
+        .map_err(|e| Error::Storage(format!("Failed to store block data: {e}")))?;
+
+    *cryptarchia = candidate;
+    metrics::emit_block_transactions_metric(tx_count);
+
+    let processed_block_event = {
+        let tip = cryptarchia.tip_branch();
+        let lib = cryptarchia.lib_branch();
+        ProcessedBlockEvent {
+            block_id: header.id(),
+            tip: tip.id(),
+            tip_slot: tip.slot(),
+            lib: lib.id(),
+            lib_slot: lib.slot(),
+        }
+    };
+    if let Err(e) = new_block_subscription_sender.send(processed_block_event) {
+        debug!("No new-block subscribers to notify: {e}");
+    }
+
+    if prev_lib != new_lib {
+        log_lib_advanced(
+            &prev_lib,
+            &new_lib,
+            pruned_blocks.stale_blocks().count(),
+            pruned_blocks.immutable_blocks().len(),
+            reorged_blocks.len(),
+        );
+
+        let height = cryptarchia
+            .consensus
+            .branches()
+            .get(&cryptarchia.lib())
+            .expect("LIB branch not available")
+            .length();
+        let block_info = BlockInfo {
+            height,
+            header_id: new_lib,
+        };
+
+        if let Err(e) = broadcast_finalized_block(relays.broadcast_relay(), block_info).await {
+            warn!("Failed to notify finalized-block subscribers: {e}");
+        }
+
+        let lib_update = LibUpdate {
+            new_lib: cryptarchia.lib(),
+            pruned_blocks: PrunedBlocksInfo {
+                stale_blocks: pruned_blocks.stale_blocks().copied().collect(),
+                immutable_blocks: pruned_blocks.immutable_blocks().clone(),
+            },
+        };
+
+        if let Err(e) = lib_broadcaster.send(lib_update) {
+            warn!("No LIB-update subscribers to notify: {e}");
+        }
+    }
+
+    let reorged_txs: Vec<_> = join_all(
+        reorged_blocks
+            .iter()
+            .map(|id| relays.storage_adapter().get_block(id)),
+    )
+    .await
+    .into_iter()
+    .flatten()
+    .flat_map(Block::into_transactions)
+    .collect();
+
+    Ok((pruned_blocks, reorged_txs))
+}
+
+/// Returns block IDs from descendant (inclusive) to ancestor
+/// (inclusive) in child-to-parent order.
+///
+/// First tries to find blocks from memory. If any block is missing from
+/// memory, it falls back to loading all subsequent blocks from storage.
+pub fn get_block_ids<Tx, Storage, RuntimeServiceId>(
+    cryptarchia: &Cryptarchia,
+    from_descendant: HeaderId,
+    to_ancestor: HeaderId,
+    storage_adapter: StorageAdapter<Storage, Tx, RuntimeServiceId>,
+) -> Pin<Box<dyn Stream<Item = Result<HeaderId, Error>> + Send>>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    let branches = cryptarchia.consensus.branches();
+
+    let mut in_memory = Vec::new();
+    let mut current = from_descendant;
+    while let Some(branch) = branches.get(&current) {
+        in_memory.push(Ok(branch.id()));
+
+        if branch.id() == to_ancestor {
+            // All blocks are found in memory. Return immediately
+            return Box::pin(stream::iter(in_memory));
+        }
+        if current == branch.parent() {
+            debug!(target: LOG_TARGET, ?to_ancestor, "reached genesis while looking for ancestor from memory");
+            // Return collected blocks and an error since we couldn't reach `to_ancestor`.
+            return Box::pin(stream::iter(in_memory).chain(stream::once(async move {
+                Err(Error::ParentIdNotFound(current))
+            })));
+        }
+
+        current = branch.parent();
+    }
+
+    let storage_stream =
+        stream::once(
+            async move { load_block_ids_from_storage(current, to_ancestor, storage_adapter) },
+        )
+        .flatten();
+    Box::pin(stream::iter(in_memory).chain(storage_stream))
+}
+
+/// Retrieves the block IDs from descendant (inclusive) to ancestor
+/// (inclusive) from the storage, in child-to-parent order.
+///
+/// This is implemented here, and not as a method of `StorageAdapter`, to
+/// simplify the panic and error message handling.
+#[expect(closure_returning_async_block, reason = "required by try_unfold")]
+pub fn load_block_ids_from_storage<Tx, Storage, RuntimeServiceId>(
+    from_descendant: HeaderId,
+    to_ancestor: HeaderId,
+    storage: StorageAdapter<Storage, Tx, RuntimeServiceId>,
+) -> impl Stream<Item = Result<HeaderId, Error>>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    // Yield `from_descendant` first since we already know it,
+    // and yield subsequent parents by loading them from storage lazily.
+    stream::once(async move { Ok(from_descendant) }).chain(stream::try_unfold(
+            (from_descendant, storage),
+            move |(current, storage)| async move {
+                if current == to_ancestor {
+                    // Reached `to_ancestor`. Terminate the stream
+                    return Ok(None);
+                }
+
+                let parent = storage
+                    .get_block_parent(&current)
+                    .await
+                    .ok_or(Error::ParentIdNotFound(current))?;
+
+                if parent == current {
+                    debug!(target: LOG_TARGET, ?to_ancestor, "reached genesis while looking for ancestor from storage");
+                    // Terminate the stream with an error since we couldn't reach `to_ancestor`.
+                    return Err(Error::ParentIdNotFound(current));
+                }
+
+                debug!(
+                    target: LOG_TARGET, ?current, ?parent,
+                    "loaded block parent from storage",
+                );
+                Ok(Some((parent, (parent, storage))))
+            },
+        ))
+}
+
+/// Remove the stale blocks from the storage layer.
+///
+/// Also, this removes the `additional_blocks` from the storage
+/// layer. These blocks might belong to previous pruning operations and
+/// that failed to be removed from the storage for some reason.
+///
+/// This function returns any block that fails to be deleted from the
+/// storage layer.
+pub async fn delete_stale_blocks_from_storage<Tx, Storage, RuntimeServiceId>(
+    stale_blocks: impl Iterator<Item = HeaderId> + Send,
+    additional_blocks: &HashSet<HeaderId>,
+    storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
+) -> HashSet<HeaderId>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    match delete_blocks_from_storage(
+        stale_blocks.chain(additional_blocks.iter().copied()),
+        storage_adapter,
+    )
+    .await
+    {
+        // No blocks failed to be deleted.
+        Ok(()) => HashSet::new(),
+        // We retain the blocks that failed to be deleted.
+        Err(failed_blocks) => failed_blocks
+            .into_iter()
+            .map(|(block_id, _)| block_id)
+            .collect(),
+    }
+}
+
+/// Send a bulk blocks deletion request to the storage adapter.
+///
+/// If no request fails, the method returns `Ok()`.
+/// If any request fails, the header ID and the generated error for each
+/// failing request are collected and returned as part of the `Err`
+/// result.
+async fn delete_blocks_from_storage<Headers, Tx, Storage, RuntimeServiceId>(
+    block_headers: Headers,
+    storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
+) -> Result<(), Vec<(HeaderId, DynError)>>
+where
+    Headers: Iterator<Item = HeaderId> + Send,
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    let blocks_to_delete = block_headers.collect::<Vec<_>>();
+    let block_deletion_outcomes = blocks_to_delete.iter().copied().zip(
+        storage_adapter
+            .remove_blocks(blocks_to_delete.iter().copied())
+            .await,
+    );
+
+    let errors: Vec<_> = block_deletion_outcomes
+        .filter_map(|(block_id, outcome)| match outcome {
+            Ok(Some(_)) => {
+                debug!(
+                    target: LOG_TARGET,
+                    "Block {block_id:#?} successfully deleted from storage."
+                );
+                None
+            }
+            Ok(None) => {
+                trace!(
+                    target: LOG_TARGET,
+                    "Block {block_id:#?} was not found in storage."
+                );
+                None
+            }
+            Err(e) => {
+                error!(
+                    target: LOG_TARGET,
+                    "Error deleting block {block_id:#?} from storage: {e}."
+                );
+                Some((block_id, e))
+            }
+        })
+        .collect();
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Builds the index of immutable block IDs, including the new LIB if needed.
+/// If `prev_lib` is None, always includes the new LIB.
+/// If `prev_lib` is Some, only includes new LIB if it changed.
+fn immutable_blocks_index(
+    pruned_blocks: &PrunedBlocks<HeaderId>,
+    prev_lib: Option<HeaderId>,
+    new_lib: HeaderId,
+    new_lib_slot: Slot,
+) -> BTreeMap<Slot, HeaderId> {
+    let mut immutable_blocks = pruned_blocks.immutable_blocks().clone();
+    // The new LIB is also immutable and should be immediately queryable by slot.
+    // prune_immutable_blocks() only returns blocks older than the new LIB,
+    // so we explicitly add the new LIB here.
+    if prev_lib.is_none_or(|prev| prev != new_lib) {
+        immutable_blocks.insert(new_lib_slot, new_lib);
+    }
+
+    immutable_blocks
+}
+
+async fn broadcast_finalized_block(
+    broadcast_relay: &BroadcastRelay,
+    block_info: BlockInfo,
+) -> Result<(), DynError> {
+    broadcast_relay
+        .send(BlockBroadcastMsg::BroadcastFinalizedBlock(block_info))
+        .await
+        .map_err(|(error, _)| Box::new(error) as DynError)
+}
+
+/// Update and persist `CryptarchiaConsensusState`.
+pub fn persist_recovery_state(
+    cryptarchia: &Cryptarchia,
+    storage_blocks_to_remove: HashSet<HeaderId>,
+    state_updater: &StateUpdater<Option<CryptarchiaConsensusState>>,
+) {
+    match CryptarchiaConsensusState::from_cryptarchia_and_unpruned_blocks(
+        cryptarchia,
+        storage_blocks_to_remove,
+    ) {
+        Ok(state) => {
+            state_updater.update(Some(state));
+        }
+        Err(e) => {
+            error!(target: LOG_TARGET, "Failed to update state: {}", e);
+        }
+    }
+}
+
+// TODO: use `send_chain_sync_rejection` for both, after checking callers
+async fn reject_chain_sync_event(event: ChainSyncEvent) {
+    debug!(target: LOG_TARGET, "rejecting chainsync event");
+    match event {
+        ChainSyncEvent::ProvideBlocksRequest { reply_sender, .. } => {
+            let response = ProviderResponse::Unavailable {
+                reason: BlocksUnavailableReason::Unknown("Node is not in online mode".to_owned()),
+            };
+            if let Err(err) = reply_sender.send(response).await {
+                error!(target: LOG_TARGET, %err, "failed to send chain sync response");
+            }
+        }
+        ChainSyncEvent::ProvideTipRequest { reply_sender } => {
+            send_chain_sync_rejection(reply_sender).await;
+        }
+    }
+}
+
+async fn send_chain_sync_rejection<ResponseType>(
+    sender: mpsc::Sender<ProviderResponse<ResponseType>>,
+) {
+    let response = ProviderResponse::Unavailable {
+        reason: "Node is not in online mode".to_owned(),
+    };
+    if let Err(err) = sender.send(response).await {
+        error!(target: LOG_TARGET, %err, "failed to send chain sync response");
+    }
+}
+
+fn log_process_block_error(error: &Error) {
+    let error_msg = format!("Failed to process block: {error:?}");
+    if matches!(error, Error::FutureBlock { .. }) {
+        trace!(target: LOG_TARGET, "{}", error_msg);
+    } else {
+        error!(target: LOG_TARGET, "{}", error_msg);
+    }
+}
+
+fn log_lib_advanced(
+    prev_lib: &HeaderId,
+    new_lib: &HeaderId,
+    stale_blocks_count: usize,
+    immutable_blocks_count: usize,
+    reorged_blocks_count: usize,
+) {
+    if stale_blocks_count == 0 && immutable_blocks_count == 1 && reorged_blocks_count == 0 {
+        trace!(
+            target: LOG_TARGET,
+            "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={stale_blocks_count}, immutable_blocks={immutable_blocks_count}, reorged_blocks={reorged_blocks_count}",
+        );
+    } else {
+        debug!(
+            target: LOG_TARGET,
+            "LIB advanced from {prev_lib:?} to {new_lib:?}; stale_blocks={stale_blocks_count}, immutable_blocks={immutable_blocks_count}, reorged_blocks={reorged_blocks_count}",
+        );
+    }
+}

--- a/services/chain/chain-service/src/service/phases/awaiting_genesis_time.rs
+++ b/services/chain/chain-service/src/service/phases/awaiting_genesis_time.rs
@@ -1,0 +1,189 @@
+use core::fmt::{self, Debug, Display};
+use std::{collections::HashSet, pin::Pin, time::Duration};
+
+use bytes::Bytes;
+use futures::StreamExt as _;
+use lb_core::{
+    block::Block,
+    events::Events,
+    header::HeaderId,
+    mantle::{
+        traits::{GenesisTx as _, MantleTxWithProofs, PreverifiedMantleTx},
+        transactions::GasPrices,
+    },
+};
+use lb_cryptarchia_engine::Slot;
+use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use overwatch::services::{relay::InboundRelay, state::StateUpdater};
+use serde::{Serialize, de::DeserializeOwned};
+use time::OffsetDateTime;
+use tokio::{
+    sync::{broadcast, oneshot},
+    time::Sleep,
+};
+use tracing::{debug, error, info};
+
+use super::{InitialBlockDownload, Phase, PhaseTag};
+use crate::{
+    ConsensusMsg, Cryptarchia, CryptarchiaConsensusState, Error, LOG_TARGET, LibUpdate,
+    ProcessedBlockEvent, StartingState,
+    notifier::ChainOnlineNotifier,
+    relays::CryptarchiaConsensusRelays,
+    service::{Service, reject_chain_sync_event},
+    sync::block_provider::BlockProvider,
+};
+
+/// `AwaitingGenesisTime` phase: Wait until the genesis time is reached.
+pub struct AwaitingGenesisTime {
+    /// Fires when the genesis time is reached.
+    /// `None` if the genesis time is already in the past,
+    /// in which case the phase is a no-op.
+    genesis_timer: Option<Pin<Box<Sleep>>>,
+}
+
+impl Phase for AwaitingGenesisTime {
+    const TAG: PhaseTag = PhaseTag::AwaitingGenesisTime;
+}
+
+impl Debug for AwaitingGenesisTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Self::TAG.fmt(f)
+    }
+}
+
+impl<Tx, Storage, RuntimeServiceId> Service<AwaitingGenesisTime, Tx, Storage, RuntimeServiceId>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    /// Create a [`Service`] in its first phase.
+    #[expect(clippy::too_many_arguments, reason = "Need all ingredients")]
+    pub fn new(
+        starting_state: StartingState,
+        cryptarchia: Cryptarchia,
+        inbound_relay: InboundRelay<ConsensusMsg<Tx>>,
+        state_updater: StateUpdater<Option<CryptarchiaConsensusState>>,
+        new_block_subscription_sender: broadcast::Sender<ProcessedBlockEvent>,
+        lib_subscription_sender: broadcast::Sender<LibUpdate>,
+        chain_online_notifier: ChainOnlineNotifier,
+        current_slot: Slot,
+        storage_blocks_to_remove: HashSet<HeaderId>,
+        relays: CryptarchiaConsensusRelays<Tx, Storage, RuntimeServiceId>,
+        sync_blocks_provider: BlockProvider<Storage, Tx>,
+        slot_timer: lb_time_service::EpochSlotTickStream,
+        state_recording_timer: tokio::time::Interval,
+        prolonged_bootstrap_period: Duration,
+    ) -> Self {
+        Self {
+            phase: AwaitingGenesisTime {
+                genesis_timer: create_genesis_timer(starting_state),
+            },
+            cryptarchia,
+            inbound_relay,
+            state_updater,
+            new_block_subscription_sender,
+            lib_subscription_sender,
+            chain_online_notifier,
+            current_slot,
+            storage_blocks_to_remove,
+            relays,
+            sync_blocks_provider,
+            slot_timer,
+            state_recording_timer,
+            prolonged_bootstrap_period,
+        }
+    }
+
+    /// Runs the phase until the genesis time is reached.
+    /// A no-op if the genesis time is already in the past.
+    ///
+    /// `IbdCompleted` can be received during this phase if IBD has been
+    /// skipped, in which case the next phase is a no-op.
+    pub async fn process_awaiting_genesis_time(
+        mut self,
+    ) -> Service<InitialBlockDownload, Tx, Storage, RuntimeServiceId> {
+        info!(target: LOG_TARGET, "entering {:?} phase", self.phase);
+
+        let Some(genesis_timer) = self.phase.genesis_timer.take() else {
+            info!(target: LOG_TARGET, "genesis time is already in the past: finishing {:?} phase with no-op", self.phase);
+            return self.with_phase(InitialBlockDownload::new(false));
+        };
+
+        let ibd_skipped = self.run_event_loop(genesis_timer).await;
+        self.with_phase(InitialBlockDownload::new(ibd_skipped))
+    }
+
+    async fn run_event_loop(&mut self, mut genesis_timer: Pin<Box<Sleep>>) -> bool {
+        let mut ibd_skipped = false;
+        loop {
+            tokio::select! {
+                () = genesis_timer.as_mut() => {
+                    info!(target: LOG_TARGET, "genesis time reached: finishing {:?} phase", self.phase);
+                    return ibd_skipped;
+                }
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query).await;
+                    }
+                    ConsensusMsg::ApplyBlock { reply_channel, .. } => {
+                        self.reject_apply_block_msg(reply_channel);
+                    }
+                    ConsensusMsg::ChainSync(event) => reject_chain_sync_event(event).await,
+                    ConsensusMsg::IbdCompleted => {
+                        info!(target: LOG_TARGET, "Initial Block Download has been skipped during {:?} phase", self.phase);
+                        ibd_skipped = true;
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+
+    fn reject_apply_block_msg(
+        &self,
+        reply_channel: oneshot::Sender<Result<(HeaderId, Vec<Tx>), Error>>,
+    ) {
+        debug!(target: LOG_TARGET, "rejecting a block received during {:?} phase", self.phase);
+        reply_channel
+            .send(Err(Error::AwaitingGenesisTime))
+            .unwrap_or_else(|_| {
+                error!(target: LOG_TARGET, "failed to send error through channel");
+            });
+    }
+}
+
+/// Creates a timer that fires when the genesis time is reached,
+/// if the starting state is `Genesis` and the genesis time is in the future.
+/// Returns `None`, otherwise.
+fn create_genesis_timer(starting_state: StartingState) -> Option<Pin<Box<Sleep>>> {
+    if let StartingState::Genesis { genesis_block } = starting_state {
+        let genesis_time: OffsetDateTime = genesis_block
+            .genesis_tx()
+            .cryptarchia_parameter()
+            .genesis_time
+            .into();
+        let now = OffsetDateTime::now_utc();
+
+        if genesis_time > now {
+            info!(target: LOG_TARGET, %genesis_time, "genesis time is in the future");
+            let delay = (genesis_time - now).try_into().unwrap_or_default();
+            return Some(Box::pin(tokio::time::sleep(delay)));
+        }
+    }
+    None
+}

--- a/services/chain/chain-service/src/service/phases/following.rs
+++ b/services/chain/chain-service/src/service/phases/following.rs
@@ -1,0 +1,120 @@
+use core::fmt::{self, Debug, Display};
+use std::collections::HashSet;
+
+use bytes::Bytes;
+use futures::StreamExt as _;
+use lb_core::{
+    block::Block,
+    events::Events,
+    mantle::{
+        traits::{MantleTxWithProofs, PreverifiedMantleTx},
+        transactions::GasPrices,
+    },
+};
+use lb_cryptarchia_sync::{GetTipResponse, ProviderResponse};
+use lb_network_service::message::ChainSyncEvent;
+use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use serde::{Serialize, de::DeserializeOwned};
+use tracing::{debug, error, info, trace};
+
+use super::{Phase, PhaseTag};
+use crate::{ConsensusMsg, LOG_TARGET, service::Service};
+
+/// `Following` phase: Follow the chain in real time. This phase never ends.
+pub struct Following;
+
+impl Phase for Following {
+    const TAG: PhaseTag = PhaseTag::Following;
+}
+
+impl Debug for Following {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Self::TAG.fmt(f)
+    }
+}
+
+impl<Tx, Storage, RuntimeServiceId> Service<Following, Tx, Storage, RuntimeServiceId>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    /// Runs the phase forever.
+    pub async fn process_following(mut self) {
+        info!(target: LOG_TARGET, "entering {:?} phase", self.phase);
+
+        loop {
+            tokio::select! {
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query).await;
+                    }
+                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
+                        self.apply_block_and_reply(*block, reply_channel).await;
+                    }
+                    ConsensusMsg::ChainSync(event) => {
+                        self.handle_chainsync_event(event).await;
+                    }
+                    ConsensusMsg::IbdCompleted => {
+                        debug!(target: LOG_TARGET, "ignoring IbdCompleted: already in {:?} phase", self.phase);
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+
+    /// Serve a chainsync request from a peer.
+    async fn handle_chainsync_event(&self, event: ChainSyncEvent) {
+        match event {
+            ChainSyncEvent::ProvideBlocksRequest {
+                target_block,
+                local_tip,
+                latest_immutable_block,
+                additional_blocks,
+                reply_sender,
+            } => {
+                let known_blocks = vec![local_tip, latest_immutable_block]
+                    .into_iter()
+                    .chain(additional_blocks)
+                    .collect::<HashSet<_>>();
+
+                self.sync_blocks_provider
+                    .send_blocks(
+                        &self.cryptarchia.consensus,
+                        target_block,
+                        &known_blocks,
+                        reply_sender,
+                    )
+                    .await;
+            }
+            ChainSyncEvent::ProvideTipRequest { reply_sender } => {
+                let tip = self.cryptarchia.tip_branch();
+                let response = ProviderResponse::Available(GetTipResponse::Tip {
+                    tip: tip.id(),
+                    slot: tip.slot(),
+                    height: tip.length(),
+                });
+
+                trace!(target: LOG_TARGET, ?response, "sending tip response");
+                if let Err(err) = reply_sender.send(response).await {
+                    error!(target: LOG_TARGET, %err, "failed to send tip header");
+                }
+            }
+        }
+    }
+}

--- a/services/chain/chain-service/src/service/phases/ibd.rs
+++ b/services/chain/chain-service/src/service/phases/ibd.rs
@@ -1,0 +1,102 @@
+use core::fmt::{self, Debug, Display};
+
+use bytes::Bytes;
+use futures::StreamExt as _;
+use lb_core::{
+    block::Block,
+    events::Events,
+    mantle::{
+        traits::{MantleTxWithProofs, PreverifiedMantleTx},
+        transactions::GasPrices,
+    },
+};
+use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use serde::{Serialize, de::DeserializeOwned};
+use tracing::info;
+
+use super::{Phase, PhaseTag, ProlongedBootstrapPeriod};
+use crate::{
+    ConsensusMsg, LOG_TARGET,
+    service::{Service, reject_chain_sync_event},
+};
+
+/// `InitialBlockDownload` phase: Apply blocks until IBD completes.
+pub struct InitialBlockDownload {
+    /// Whether IBD has been skipped during `AwaitingGenesisTime`,
+    /// in which case the phase is a no-op.
+    ibd_skipped: bool,
+}
+
+impl InitialBlockDownload {
+    pub(crate) const fn new(ibd_skipped: bool) -> Self {
+        Self { ibd_skipped }
+    }
+}
+
+impl Phase for InitialBlockDownload {
+    const TAG: PhaseTag = PhaseTag::InitialBlockDownload;
+}
+
+impl Debug for InitialBlockDownload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Self::TAG.fmt(f)
+    }
+}
+
+impl<Tx, Storage, RuntimeServiceId> Service<InitialBlockDownload, Tx, Storage, RuntimeServiceId>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    /// Runs the phase until IBD completes.
+    /// A no-op if IBD has been already skipped during previous phases.
+    pub async fn process_initial_block_download(
+        mut self,
+    ) -> Service<ProlongedBootstrapPeriod, Tx, Storage, RuntimeServiceId> {
+        info!(target: LOG_TARGET, "entering {:?} phase", self.phase);
+
+        if self.phase.ibd_skipped {
+            info!(target: LOG_TARGET, "IBD has been already skipped: finishing {:?} phase", self.phase);
+            return self.with_phase(ProlongedBootstrapPeriod);
+        }
+
+        self.run_event_loop().await;
+        self.with_phase(ProlongedBootstrapPeriod)
+    }
+
+    async fn run_event_loop(&mut self) {
+        loop {
+            tokio::select! {
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query).await;
+                    }
+                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
+                        self.apply_block_and_reply(*block, reply_channel).await;
+                    }
+                    ConsensusMsg::ChainSync(event) => reject_chain_sync_event(event).await,
+                    ConsensusMsg::IbdCompleted => {
+                        info!(target: LOG_TARGET, "IBD completed: finishing {:?} phase", self.phase);
+                        return;
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+}

--- a/services/chain/chain-service/src/service/phases/mod.rs
+++ b/services/chain/chain-service/src/service/phases/mod.rs
@@ -1,0 +1,31 @@
+mod awaiting_genesis_time;
+mod following;
+mod ibd;
+mod pbp;
+
+use core::fmt::Debug;
+
+pub use following::Following;
+pub use ibd::InitialBlockDownload;
+pub use pbp::ProlongedBootstrapPeriod;
+use serde::{Deserialize, Serialize};
+
+/// A phase of the chain service.
+pub trait Phase: Send + Sync + Debug {
+    /// The tag reported by [`Query::Info`](crate::Query::Info) while this
+    /// phase is running.
+    const TAG: PhaseTag;
+}
+
+/// Phase tags
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PhaseTag {
+    /// The genesis time is in the future. Only read-only queries are served.
+    AwaitingGenesisTime,
+    /// Applying blocks while waiting for Initial Block Download to complete.
+    InitialBlockDownload,
+    /// The Prolonged Bootstrap Period is running.
+    ProlongedBootstrapPeriod,
+    /// Following the chain in real time
+    Following,
+}

--- a/services/chain/chain-service/src/service/phases/pbp.rs
+++ b/services/chain/chain-service/src/service/phases/pbp.rs
@@ -1,0 +1,157 @@
+use core::fmt::{self, Debug, Display};
+
+use bytes::Bytes;
+use futures::StreamExt as _;
+use lb_core::{
+    block::Block,
+    events::Events,
+    mantle::{
+        traits::{MantleTxWithProofs, PreverifiedMantleTx},
+        transactions::GasPrices,
+    },
+};
+use lb_cryptarchia_engine::{PrunedBlocks, Slot};
+use lb_cryptarchia_sync::HeaderId;
+use lb_storage_service::{api::chain::StorageChainApi, backends::StorageBackend};
+use serde::{Serialize, de::DeserializeOwned};
+use tracing::{debug, error, info};
+
+use super::{Following, Phase, PhaseTag};
+use crate::{
+    ConsensusMsg, Error, LOG_TARGET,
+    service::{
+        Service, delete_stale_blocks_from_storage, immutable_blocks_index, reject_chain_sync_event,
+    },
+    storage::{StorageAdapter as _, adapters::StorageAdapter},
+};
+
+/// `ProlongedBootstrapPeriod` phase: Apply blocks until PBP is over.
+/// A no-op if `Cryptarchia` was initialized as online.
+pub struct ProlongedBootstrapPeriod;
+
+impl Phase for ProlongedBootstrapPeriod {
+    const TAG: PhaseTag = PhaseTag::ProlongedBootstrapPeriod;
+}
+
+impl Debug for ProlongedBootstrapPeriod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Self::TAG.fmt(f)
+    }
+}
+
+impl<Tx, Storage, RuntimeServiceId> Service<ProlongedBootstrapPeriod, Tx, Storage, RuntimeServiceId>
+where
+    Tx: PreverifiedMantleTx
+        + MantleTxWithProofs<Context = GasPrices>
+        + Debug
+        + Clone
+        + Eq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Unpin
+        + 'static,
+    Storage: StorageBackend + Send + Sync + 'static,
+    <Storage as StorageChainApi>::Tx: From<Bytes> + AsRef<[u8]>,
+    <Storage as StorageChainApi>::Block: TryFrom<Block<Tx>> + TryInto<Block<Tx>> + Into<Bytes>,
+    <Storage as StorageChainApi>::Events: TryFrom<Events> + TryInto<Events>,
+    RuntimeServiceId: Display + 'static,
+{
+    /// Runs the phase until PBP is over,
+    /// and then switches `Cryptarchia` to online.
+    /// A no-op if `Cryptarchia` was initialized as online.
+    pub async fn process_prolonged_bootstrap_period(
+        mut self,
+    ) -> Service<Following, Tx, Storage, RuntimeServiceId> {
+        info!(target: LOG_TARGET, "entering {:?} phase", self.phase);
+
+        if !self.cryptarchia.is_bootstrapping() {
+            info!(target: LOG_TARGET, "chain is already not in bootstrapping state: finishing {:?} phase", self.phase);
+            return self.with_phase(Following);
+        }
+
+        self.run_event_loop().await;
+
+        info!(target: LOG_TARGET, "Prolonged Bootstrap Period completed: switching chain to online");
+        self = self.switch_to_online().await;
+        self.record_recovery_state();
+
+        self.with_phase(Following)
+    }
+
+    async fn run_event_loop(&mut self) {
+        let mut pbp_timer = Box::pin(tokio::time::sleep(self.prolonged_bootstrap_period));
+        loop {
+            tokio::select! {
+                () = pbp_timer.as_mut() => {
+                    return;
+                },
+                Some(msg) = self.inbound_relay.next() => match msg {
+                    ConsensusMsg::Query(query) => {
+                        self.process_query(query).await;
+                    }
+                    ConsensusMsg::ApplyBlock { block, reply_channel } => {
+                        self.apply_block_and_reply(*block, reply_channel).await;
+                    }
+                    ConsensusMsg::ChainSync(event) => reject_chain_sync_event(event).await,
+                    ConsensusMsg::IbdCompleted => {
+                        debug!(target: LOG_TARGET, "ignoring IbdCompleted: already in {:?} phase", self.phase);
+                    }
+                },
+                Some(tick) = self.slot_timer.next() => self.current_slot = tick.slot,
+                _ = self.state_recording_timer.tick() => self.record_recovery_state(),
+            }
+        }
+    }
+
+    /// Switch `Cryptarchia` to online, notify subscribers,
+    /// and prune the stale part of the chain from memory and storage.
+    async fn switch_to_online(mut self) -> Self {
+        let (cryptarchia, pruned_blocks) = self.cryptarchia.online();
+        self.cryptarchia = cryptarchia;
+        info!(target: LOG_TARGET, "chain switched to online");
+
+        self.chain_online_notifier.notify();
+
+        if let Err(err) = Self::store_immutable_blocks_index(
+            &pruned_blocks,
+            None,
+            self.cryptarchia.lib(),
+            self.cryptarchia.lib_branch().slot(),
+            self.relays.storage_adapter(),
+        )
+        .await
+        {
+            error!(target: LOG_TARGET, %err, "failed to store immutable block IDs");
+        }
+
+        self.storage_blocks_to_remove = delete_stale_blocks_from_storage(
+            pruned_blocks.stale_blocks().copied(),
+            &self.storage_blocks_to_remove,
+            self.relays.storage_adapter(),
+        )
+        .await;
+
+        self
+    }
+
+    /// Store immutable block IDs to storage, including the new LIB if needed.
+    /// If `prev_lib` is None, always includes the new LIB.
+    /// If `prev_lib` is Some, only includes new LIB if it changed.
+    async fn store_immutable_blocks_index(
+        pruned_blocks: &PrunedBlocks<HeaderId>,
+        prev_lib: Option<HeaderId>,
+        new_lib: HeaderId,
+        new_lib_slot: Slot,
+        storage_adapter: &StorageAdapter<Storage, Tx, RuntimeServiceId>,
+    ) -> Result<(), Error> {
+        let immutable_blocks =
+            immutable_blocks_index(pruned_blocks, prev_lib, new_lib, new_lib_slot);
+
+        storage_adapter
+            .store_immutable_block_ids(immutable_blocks)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to store immutable block ids: {e}")))
+    }
+}

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -41,7 +41,9 @@ use tokio::{
     task::JoinHandle,
 };
 
-use crate::{Cryptarchia, CryptarchiaConsensus, Error, relays::CryptarchiaConsensusRelays};
+use crate::{
+    Cryptarchia, CryptarchiaConsensus, Error, Runtime, relays::CryptarchiaConsensusRelays,
+};
 
 #[test]
 fn cryptarchia_switch_to_online() {
@@ -146,7 +148,7 @@ async fn get_block_ids() {
     let mut block_ids = vec![genesis_id];
     for _ in 0..2 {
         let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
-        CryptarchiaConsensus::<_, RocksBackend, SystemTimeBackend, TestRuntimeServiceId>::process_block_and_update_state(
+        Runtime::<_, RocksBackend, TestRuntimeServiceId>::process_block_and_update_state(
             &mut cryptarchia,
             block.clone(),
             block.header().slot(),
@@ -163,7 +165,7 @@ async fn get_block_ids() {
     }
 
     // get_block_ids when all blocks are in memory.
-    let mut stream = CryptarchiaConsensus::get_block_ids(
+    let mut stream = Runtime::get_block_ids(
         block_ids[2],
         block_ids[0],
         &cryptarchia,
@@ -175,7 +177,7 @@ async fn get_block_ids() {
     assert!(stream.next().await.is_none());
 
     // Hitting genesis before reaching `to_ancestor`
-    let mut stream = CryptarchiaConsensus::get_block_ids(
+    let mut stream = Runtime::get_block_ids(
         block_ids[2],
         [99; 32].into(), // unknown block ID
         &cryptarchia,
@@ -193,7 +195,7 @@ async fn get_block_ids() {
     // Now G, b1 are in storage, and b2~5 are in memory.
     for _ in 0..3 {
         let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
-        CryptarchiaConsensus::<_, RocksBackend, SystemTimeBackend, TestRuntimeServiceId>::process_block_and_update_state(
+        Runtime::<_, RocksBackend, TestRuntimeServiceId>::process_block_and_update_state(
             &mut cryptarchia,
             block.clone(),
             block.header().slot(),
@@ -210,7 +212,7 @@ async fn get_block_ids() {
     }
 
     // All blocks are loaded from memory + storage.
-    let mut stream = CryptarchiaConsensus::get_block_ids(
+    let mut stream = Runtime::get_block_ids(
         block_ids[5],
         block_ids[0],
         &cryptarchia,
@@ -225,7 +227,7 @@ async fn get_block_ids() {
     assert!(stream.next().await.is_none());
 
     // Hitting genesis in storage before reaching `to_ancestor`
-    let mut stream = CryptarchiaConsensus::get_block_ids(
+    let mut stream = Runtime::get_block_ids(
         block_ids[1],
         [99; 32].into(), // unknown block ID
         &cryptarchia,
@@ -245,7 +247,11 @@ async fn recovery_blocks_fall_back_to_lib_when_tip_missing_from_storage() {
     let (storage_tx, storage_rx) = mpsc::channel(10);
     let _storage_svc = spawn_storage_service(storage_rx);
     let (time_tx, _time_rx) = mpsc::channel(10);
-    let relays = CryptarchiaConsensusRelays::<_, RocksBackend, TestRuntimeServiceId>::new(
+    let relays = CryptarchiaConsensusRelays::<
+        SignedMantleTx<Preverified>,
+        RocksBackend,
+        TestRuntimeServiceId,
+    >::new(
         OutboundRelay::new(broadcast_tx),
         OutboundRelay::new(storage_tx),
         OutboundRelay::new(time_tx),
@@ -255,15 +261,13 @@ async fn recovery_blocks_fall_back_to_lib_when_tip_missing_from_storage() {
     let lib = [0; 32].into();
     let missing_tip = [1; 32].into();
 
-    let recovery_blocks = CryptarchiaConsensus::<
-        _,
-        RocksBackend,
-        SystemTimeBackend,
-        TestRuntimeServiceId,
-    >::load_recovery_blocks_or_fall_back_to_lib(
-        missing_tip, lib, relays.storage_adapter().clone()
-    )
-    .await;
+    let recovery_blocks =
+        Runtime::<_, RocksBackend, TestRuntimeServiceId>::load_recovery_blocks_or_fall_back_to_lib(
+            missing_tip,
+            lib,
+            relays.storage_adapter().clone(),
+        )
+        .await;
 
     assert!(recovery_blocks.fell_back_to_lib);
     assert!(recovery_blocks.blocks.is_empty());
@@ -294,12 +298,7 @@ async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     let initial_info = cryptarchia.info();
     let block_slot = block.header().slot();
 
-    let result = CryptarchiaConsensus::<
-        _,
-        RocksBackend,
-        SystemTimeBackend,
-        TestRuntimeServiceId,
-    >::process_block(
+    let result = Runtime::<_, RocksBackend, TestRuntimeServiceId>::process_block(
         &mut cryptarchia,
         block,
         block_slot,

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -33,16 +33,18 @@ use lb_storage_service::{
 };
 use lb_time_service::backends::SystemTimeBackend;
 use lb_utils::math::NonNegativeRatio;
-use overwatch::services::{AsServiceId, relay::OutboundRelay, state::StateUpdater};
+use overwatch::services::{AsServiceId, relay::OutboundRelay};
 use rand::{RngCore as _, thread_rng};
 use tempfile::TempDir;
 use tokio::{
-    sync::{broadcast, mpsc, watch},
+    sync::{broadcast, mpsc},
     task::JoinHandle,
 };
 
 use crate::{
-    Cryptarchia, CryptarchiaConsensus, Error, Runtime, relays::CryptarchiaConsensusRelays,
+    Cryptarchia, CryptarchiaConsensus, Error,
+    relays::CryptarchiaConsensusRelays,
+    service::{get_block_ids, process_block},
 };
 
 #[test]
@@ -111,7 +113,7 @@ fn cryptarchia_switch_to_online() {
     clippy::too_many_lines,
     reason = "better to have one comprehensive test"
 )]
-async fn get_block_ids() {
+async fn get_block_ids_from_memory_and_storage() {
     // Init dummy relays for chain service
     let (broadcast_tx, _broadcast_rx) = mpsc::channel(10);
     let (storage_tx, storage_rx) = mpsc::channel(10);
@@ -123,8 +125,6 @@ async fn get_block_ids() {
         OutboundRelay::new(time_tx),
     )
     .await;
-    let (state_tx, _state_rx) = watch::channel(None);
-    let state_updater = StateUpdater::new(Arc::new(state_tx));
     let (new_block_tx, _new_block_rx) = broadcast::channel(10);
     let (lib_tx, _lib_rx) = broadcast::channel(10);
 
@@ -148,15 +148,13 @@ async fn get_block_ids() {
     let mut block_ids = vec![genesis_id];
     for _ in 0..2 {
         let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
-        Runtime::<_, RocksBackend, TestRuntimeServiceId>::process_block_and_update_state(
+        process_block(
             &mut cryptarchia,
             block.clone(),
             block.header().slot(),
-            &HashSet::new(),
             &relays,
             &new_block_tx,
             &lib_tx,
-            &state_updater,
         )
         .await
         .unwrap();
@@ -165,10 +163,10 @@ async fn get_block_ids() {
     }
 
     // get_block_ids when all blocks are in memory.
-    let mut stream = Runtime::get_block_ids(
+    let mut stream = get_block_ids(
+        &cryptarchia,
         block_ids[2],
         block_ids[0],
-        &cryptarchia,
         relays.storage_adapter().clone(),
     );
     assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[2]);
@@ -177,10 +175,10 @@ async fn get_block_ids() {
     assert!(stream.next().await.is_none());
 
     // Hitting genesis before reaching `to_ancestor`
-    let mut stream = Runtime::get_block_ids(
+    let mut stream = get_block_ids(
+        &cryptarchia,
         block_ids[2],
         [99; 32].into(), // unknown block ID
-        &cryptarchia,
         relays.storage_adapter().clone(),
     );
     assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[2]);
@@ -195,15 +193,13 @@ async fn get_block_ids() {
     // Now G, b1 are in storage, and b2~5 are in memory.
     for _ in 0..3 {
         let block = try_build_block(&cryptarchia, cryptarchia.tip(), utxo, &zk_key, slot).unwrap();
-        Runtime::<_, RocksBackend, TestRuntimeServiceId>::process_block_and_update_state(
+        process_block(
             &mut cryptarchia,
             block.clone(),
             block.header().slot(),
-            &HashSet::new(),
             &relays,
             &new_block_tx,
             &lib_tx,
-            &state_updater,
         )
         .await
         .unwrap();
@@ -212,10 +208,10 @@ async fn get_block_ids() {
     }
 
     // All blocks are loaded from memory + storage.
-    let mut stream = Runtime::get_block_ids(
+    let mut stream = get_block_ids(
+        &cryptarchia,
         block_ids[5],
         block_ids[0],
-        &cryptarchia,
         relays.storage_adapter().clone(),
     );
     assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[5]);
@@ -227,10 +223,10 @@ async fn get_block_ids() {
     assert!(stream.next().await.is_none());
 
     // Hitting genesis in storage before reaching `to_ancestor`
-    let mut stream = Runtime::get_block_ids(
+    let mut stream = get_block_ids(
+        &cryptarchia,
         block_ids[1],
         [99; 32].into(), // unknown block ID
-        &cryptarchia,
         relays.storage_adapter().clone(),
     );
     assert_eq!(stream.next().await.unwrap().unwrap(), block_ids[1]);
@@ -261,13 +257,15 @@ async fn recovery_blocks_fall_back_to_lib_when_tip_missing_from_storage() {
     let lib = [0; 32].into();
     let missing_tip = [1; 32].into();
 
-    let recovery_blocks =
-        Runtime::<_, RocksBackend, TestRuntimeServiceId>::load_recovery_blocks_or_fall_back_to_lib(
-            missing_tip,
-            lib,
-            relays.storage_adapter().clone(),
-        )
-        .await;
+    let recovery_blocks = CryptarchiaConsensus::<
+        _,
+        RocksBackend,
+        SystemTimeBackend,
+        TestRuntimeServiceId,
+    >::load_recovery_blocks_or_fall_back_to_lib(
+        missing_tip, lib, relays.storage_adapter().clone()
+    )
+    .await;
 
     assert!(recovery_blocks.fell_back_to_lib);
     assert!(recovery_blocks.blocks.is_empty());
@@ -298,7 +296,7 @@ async fn process_block_does_not_mutate_state_when_storage_send_fails() {
     let initial_info = cryptarchia.info();
     let block_slot = block.header().slot();
 
-    let result = Runtime::<_, RocksBackend, TestRuntimeServiceId>::process_block(
+    let result = process_block(
         &mut cryptarchia,
         block,
         block_slot,

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -9,7 +9,7 @@ use std::{
 use cucumber::gherkin::Table;
 use futures::future::try_join_all;
 use hex::ToHex as _;
-use lb_chain_service::{ChainServiceInfo, ChainServiceMode, CryptarchiaInfo, State};
+use lb_chain_service::{ChainServiceInfo, ChainServicePhase, CryptarchiaInfo};
 use lb_core::mantle::{Utxo, ops::OpId as _, traits::GenesisTx as _};
 use lb_http_api_common::paths::CRYPTARCHIA_INFO;
 use lb_libp2p::PeerId;
@@ -1140,7 +1140,7 @@ async fn verify_online(
         let mut mode_online = false;
         match client.consensus_info().await {
             Ok(val) => {
-                if matches!(val.mode, ChainServiceMode::Started(State::Online)) {
+                if matches!(val.phase, ChainServicePhase::Following) {
                     mode_online = true;
                 }
             }
@@ -1832,7 +1832,7 @@ pub(crate) async fn get_cryptarchia_info_all_nodes(world: &CucumberWorld, step: 
         };
         match node_info.started_node.client.consensus_info().await {
             Ok(consensus) => {
-                let mode = if matches!(consensus.mode, ChainServiceMode::Started(State::Online)) {
+                let mode = if matches!(consensus.phase, ChainServicePhase::Following) {
                     "Online"
                 } else {
                     "Bootstrapping"

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -9,7 +9,7 @@ use std::{
 use cucumber::gherkin::Table;
 use futures::future::try_join_all;
 use hex::ToHex as _;
-use lb_chain_service::{ChainServiceInfo, ChainServicePhase, CryptarchiaInfo};
+use lb_chain_service::{ChainServiceInfo, CryptarchiaInfo, PhaseTag};
 use lb_core::mantle::{Utxo, ops::OpId as _, traits::GenesisTx as _};
 use lb_http_api_common::paths::CRYPTARCHIA_INFO;
 use lb_libp2p::PeerId;
@@ -1140,7 +1140,7 @@ async fn verify_online(
         let mut mode_online = false;
         match client.consensus_info().await {
             Ok(val) => {
-                if matches!(val.phase, ChainServicePhase::Following) {
+                if matches!(val.phase, PhaseTag::Following) {
                     mode_online = true;
                 }
             }
@@ -1832,7 +1832,7 @@ pub(crate) async fn get_cryptarchia_info_all_nodes(world: &CucumberWorld, step: 
         };
         match node_info.started_node.client.consensus_info().await {
             Ok(consensus) => {
-                let mode = if matches!(consensus.phase, ChainServicePhase::Following) {
+                let mode = if matches!(consensus.phase, PhaseTag::Following) {
                     "Online"
                 } else {
                     "Bootstrapping"

--- a/tests/src/tests/mantle/chain_start.rs
+++ b/tests/src/tests/mantle/chain_start.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZero, path::PathBuf, time::Duration};
 
-use lb_chain_service::ChainServicePhase;
+use lb_chain_service::PhaseTag;
 use lb_core::{
     block::genesis::GenesisBlockBuilder,
     mantle::{
@@ -52,21 +52,21 @@ async fn delayed_chain_start() {
 
     let info =
         wait_for_consensus_mode(&node0.client, Duration::from_secs(MODE_TIMEOUT_SECS), |i| {
-            i.phase == ChainServicePhase::AwaitingGenesisTime
+            i.phase == PhaseTag::AwaitingGenesisTime
         })
         .await
         .expect("Failed to get AwaitingGenesisTime phase");
 
-    assert_eq!(info.phase, ChainServicePhase::AwaitingGenesisTime);
+    assert_eq!(info.phase, PhaseTag::AwaitingGenesisTime);
 
     let info =
         wait_for_consensus_mode(&node0.client, Duration::from_secs(MODE_TIMEOUT_SECS), |i| {
-            matches!(i.phase, ChainServicePhase::Following)
+            matches!(i.phase, PhaseTag::Following)
         })
         .await
         .expect("Failed to reach the Following phase");
 
-    assert_eq!(info.phase, ChainServicePhase::Following);
+    assert_eq!(info.phase, PhaseTag::Following);
 
     wait_for_nodes_height(&[&node0.client], 1, Duration::from_secs(500)).await;
 }

--- a/tests/src/tests/mantle/chain_start.rs
+++ b/tests/src/tests/mantle/chain_start.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZero, path::PathBuf, time::Duration};
 
-use lb_chain_service::{ChainServiceMode, State};
+use lb_chain_service::ChainServicePhase;
 use lb_core::{
     block::genesis::GenesisBlockBuilder,
     mantle::{
@@ -52,21 +52,21 @@ async fn delayed_chain_start() {
 
     let info =
         wait_for_consensus_mode(&node0.client, Duration::from_secs(MODE_TIMEOUT_SECS), |i| {
-            i.mode == ChainServiceMode::AwaitingStart
+            i.phase == ChainServicePhase::AwaitingGenesisTime
         })
         .await
-        .expect("Failed to get AwaitingStart mode");
+        .expect("Failed to get AwaitingGenesisTime phase");
 
-    assert_eq!(info.mode, ChainServiceMode::AwaitingStart);
+    assert_eq!(info.phase, ChainServicePhase::AwaitingGenesisTime);
 
     let info =
         wait_for_consensus_mode(&node0.client, Duration::from_secs(MODE_TIMEOUT_SECS), |i| {
-            matches!(i.mode, ChainServiceMode::Started(State::Online))
+            matches!(i.phase, ChainServicePhase::Following)
         })
         .await
-        .expect("Failed to reach Started(State::Online)");
+        .expect("Failed to reach the Following phase");
 
-    assert_eq!(info.mode, ChainServiceMode::Started(State::Online));
+    assert_eq!(info.phase, ChainServicePhase::Following);
 
     wait_for_nodes_height(&[&node0.client], 1, Duration::from_secs(500)).await;
 }

--- a/tests/testing_framework/src/diagnostics.rs
+++ b/tests/testing_framework/src/diagnostics.rs
@@ -430,7 +430,7 @@ impl From<lb_chain_service::ChainServiceInfo> for ConsensusSnapshot {
         Self {
             height: value.cryptarchia_info.height,
             slot: value.cryptarchia_info.slot.into_inner(),
-            mode: format!("{:?}", value.mode),
+            mode: format!("{:?}", value.phase),
         }
     }
 }

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use futures::StreamExt as _;
 use lb_common_http_client::{
-    ApiBlock, ApiHeader, BlockInfo, ChainServiceInfo, ChainServicePhase, CryptarchiaInfo, Events,
+    ApiBlock, ApiHeader, BlockInfo, ChainServiceInfo, CryptarchiaInfo, Events, PhaseTag,
     ProcessedBlockEvent, Slot, State, TimeInfo,
 };
 use lb_core::{
@@ -106,7 +106,7 @@ impl adapter::Node for MockNode {
                 height: 0,
                 state: State::Online,
             },
-            phase: ChainServicePhase::Following,
+            phase: PhaseTag::Following,
         })
     }
 

--- a/zone-sdk/src/test_support.rs
+++ b/zone-sdk/src/test_support.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use futures::StreamExt as _;
 use lb_common_http_client::{
-    ApiBlock, ApiHeader, BlockInfo, ChainServiceInfo, ChainServiceMode, CryptarchiaInfo, Events,
+    ApiBlock, ApiHeader, BlockInfo, ChainServiceInfo, ChainServicePhase, CryptarchiaInfo, Events,
     ProcessedBlockEvent, Slot, State, TimeInfo,
 };
 use lb_core::{
@@ -104,8 +104,9 @@ impl adapter::Node for MockNode {
                 tip: self.tip,
                 slot: self.lib_slot,
                 height: 0,
+                state: State::Online,
             },
-            mode: ChainServiceMode::Started(State::Online),
+            phase: ChainServicePhase::Following,
         })
     }
 


### PR DESCRIPTION
## 1. What does this PR implement?

Refactored the chain service's complex main event loop into explicit phases.

Why? The main event loop was handling multiple channels and timers. It was very hard to read (without AI :)). Some of events becomes unnecessary after IBD or PBP completes, but we were putting everything into the main event loop. Also, we have introduce the `AwaitingStart` concept https://github.com/logos-blockchain/logos-blockchain/pull/2685 to handle the future genesis time, but putting it in the main event loop causes some potential bugs/panics (that I'm not listing here). 

How? I introduced 4 phases. They advance in one direction. Each phase handles only events relevant to it.

None of chain service's behavior changed. Only potential bugs, which could theoretically happen but didn't because of other services' behavior, have been eliminated. 

Breaking changes? Only the response of `GET /cryptarchia/info` has changed:
- Before (`mode` mixed service mode and engine state):
  ```json
  {
    "cryptarchia_info": { "lib": "0x…", "lib_slot": 10, "tip": "0x…",
  "slot": 42, "height": 30 },
    "mode": { "Started": "Online" }        // or "AwaitingStart"
  }
  ```
- After (phase = service phase; state = Cryptarchia engine state, now separate):
  ```json
  {
    "cryptarchia_info": { "lib": "0x…", "lib_slot": 10, "tip": "0x…",
  "slot": 42, "height": 30, "state": "Online" },  // `state` added
    "phase": "Following"                   // AwaitingGenesisTime |
  InitialBlockDownload | ProlongedBootstrapPeriod | Following
  }
  ```

The c-binding is not changed. It still returns the old-style response which delivers limited information (`NotStarted | Bootstrapping | Online`), but I think it's fine for now.

For reviewers, I believe this PR is not hard to read. I minimized diffs.
I didn't introduce any verbose typestate concept because the phase transition is one-direction and each phase requires exactly the same ingredients. Instead, I took the simplest approach which is short and easy to read. 
Please focus on the `run` function of chain service, first. You can also review two commits separately. I refactored the service message type first and then refactored the service. 

EDIT: After getting an approval from Daniel, I introduced typestate: 7f511bddd5a9f2ce01f306c72d8cb1dd9c0a3ff0.

## 2. Does the code have enough context to be clearly understood?
yes

boostrapping spec: https://lip.logos.co/blockchain/raw/cryptarchia-v1-bootstr-sync.html#prolonged-bootstrap-period

diagram: https://app.notion.com/p/Cryptarchia-v1-Bootstrapping-Synchronization-MIGRATED-1e58f96fb65c804aae85f84a2e94392d?source=copy_link#1e58f96fb65c8159834dfe8b434624d1

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @youngjoon-lee 

## 4. Is the specification accurate and complete?

yes

## 5. Does the implementation introduce changes in the specification?

no

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
