### PR TITLE
refactor(core): expose UTXOs on transfer operations

### DIFF
--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -5,7 +5,7 @@ use crate::{
     mantle::{
         TxHash,
         channel::{Channels, Error},
-        ledger::{Inputs, Operation, Outputs, Utxos},
+        ledger::{Inputs, Operation, Outputs, Utxo, Utxos},
         nom::{NomCodec, NomEncode as _},
         ops::{OpId, channel::ChannelId},
     },
@@ -19,6 +19,12 @@ pub struct ChannelTransferOp {
     pub channel_id: ChannelId,
     pub inputs: Inputs,
     pub outputs: Outputs,
+}
+
+impl ChannelTransferOp {
+    pub fn utxos(&self) -> impl Iterator<Item = Utxo> {
+        self.outputs.utxos(self)
+    }
 }
 
 impl OpId for ChannelTransferOp {
@@ -116,7 +122,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
 
         // Add the outputs to the ledger and register them as channel notes.
         ctx.utxos = self.outputs.execute(ctx.utxos, self);
-        for utxo in self.outputs.utxos(self) {
+        for utxo in self.utxos() {
             ctx.channels = ctx
                 .channels
                 .register_channel_note(&utxo.id(), &self.channel_id)?;

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -8,7 +8,7 @@ use crate::{
     mantle::{
         TxHash,
         channel::Channels,
-        ledger::{self, Inputs, Operation, Outputs, Utxos},
+        ledger::{self, Inputs, Operation, Outputs, Utxo, Utxos},
         nom::NomEncode as _,
         ops::OpId,
     },
@@ -30,6 +30,15 @@ impl TransferOp {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.inputs.is_empty() && self.outputs.is_empty()
+    }
+
+    pub fn utxos(&self) -> impl Iterator<Item = Utxo> {
+        self.outputs.utxos(self)
+    }
+
+    #[must_use]
+    pub fn utxo_by_index(&self, index: usize) -> Option<Utxo> {
+        self.outputs.utxo_by_index(index, self)
     }
 
     pub fn balance(&self, utxos: &Utxos) -> Result<i128, TransferError> {
@@ -117,10 +126,10 @@ mod test {
     use num_bigint::BigUint;
 
     use super::*;
-    use crate::mantle::{Note, NoteId, Utxo};
+    use crate::mantle::{Note, NoteId};
 
     #[test]
-    fn test_utxo_by_index() {
+    fn test_utxos_and_utxo_by_index() {
         let pk0 = ZkPublicKey::from(Fr::from(BigUint::from(0u8)));
         let pk1 = ZkPublicKey::from(Fr::from(BigUint::from(1u8)));
         let pk2 = ZkPublicKey::from(Fr::from(BigUint::from(2u8)));
@@ -133,7 +142,7 @@ mod test {
             ]),
         };
         assert_eq!(
-            transfer.outputs.utxo_by_index(0, &transfer),
+            transfer.utxo_by_index(0),
             Some(Utxo {
                 op_id: transfer.op_id(),
                 output_index: 0,
@@ -141,7 +150,7 @@ mod test {
             })
         );
         assert_eq!(
-            transfer.outputs.utxo_by_index(1, &transfer),
+            transfer.utxo_by_index(1),
             Some(Utxo {
                 op_id: transfer.op_id(),
                 output_index: 1,
@@ -149,7 +158,7 @@ mod test {
             })
         );
         assert_eq!(
-            transfer.outputs.utxo_by_index(2, &transfer),
+            transfer.utxo_by_index(2),
             Some(Utxo {
                 op_id: transfer.op_id(),
                 output_index: 2,
@@ -157,6 +166,6 @@ mod test {
             })
         );
 
-        assert!(transfer.outputs.utxo_by_index(3, &transfer).is_none());
+        assert!(transfer.utxo_by_index(3).is_none());
     }
 }

--- a/deployment/tui-zone/src/run_commands/unit_tests.rs
+++ b/deployment/tui-zone/src/run_commands/unit_tests.rs
@@ -162,7 +162,7 @@ mod tests {
             build_deposit_transfer(vec![test_utxo(4, 0), test_utxo(10, 1)], public_key, 7).unwrap();
 
         assert_eq!(selected, vec![test_utxo(10, 1)]);
-        let outputs = transfer.outputs.utxos(&transfer).collect::<Vec<_>>();
+        let outputs = transfer.utxos().collect::<Vec<_>>();
         assert_eq!(outputs.len(), 2);
         assert_eq!(outputs[0].note.value, 7);
         assert_eq!(outputs[1].note.value, 3);

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -625,11 +625,7 @@ impl LedgerState {
             return Err(LedgerError::InputInGenesis(first_input));
         }
 
-        Ok(Self::from_utxos(
-            transfer_op.outputs.utxos(transfer_op),
-            config,
-            epoch_nonce,
-        ))
+        Ok(Self::from_utxos(transfer_op.utxos(), config, epoch_nonce))
     }
 
     pub fn from_utxos(utxos: impl IntoIterator<Item = Utxo>, config: &Config, nonce: Fr) -> Self {

--- a/tests/src/common/manual_cluster.rs
+++ b/tests/src/common/manual_cluster.rs
@@ -358,7 +358,7 @@ pub fn genesis_wallet_utxos(config: &TopologyConfig) -> Vec<Utxo> {
         .genesis_tx();
     let genesis_transfer = genesis_tx.genesis_transfer();
 
-    genesis_transfer.outputs.utxos(genesis_transfer).collect()
+    genesis_transfer.utxos().collect()
 }
 
 #[must_use]

--- a/tests/src/common/wallet/chain/state.rs
+++ b/tests/src/common/wallet/chain/state.rs
@@ -128,10 +128,7 @@ impl WalletChainState {
                     transfer.inputs.iter().copied(),
                     &mut changes.observed_spends,
                 );
-                self.apply_owned_outputs(
-                    transfer.outputs.utxos(transfer),
-                    &mut changes.observed_outputs,
-                );
+                self.apply_owned_outputs(transfer.utxos(), &mut changes.observed_outputs);
             }
             Op::ChannelDeposit(deposit) => {
                 self.apply_spent_note_ids(

--- a/tests/src/common/wallet/scanner/accounting.rs
+++ b/tests/src/common/wallet/scanner/accounting.rs
@@ -142,7 +142,7 @@ impl ScannerAccounting {
                     for note_id in transfer.inputs.iter().copied() {
                         self.remove_spent_note(note_id);
                     }
-                    for utxo in transfer.outputs.utxos(transfer) {
+                    for utxo in transfer.utxos() {
                         self.add_owned_output(utxo);
                     }
                 }

--- a/tools/blockchain-tools/src/genesis/distribution.rs
+++ b/tools/blockchain-tools/src/genesis/distribution.rs
@@ -35,7 +35,6 @@ pub struct Faucet {
 
 pub struct GenesisTransferOp {
     transfer_op: TransferOp,
-    outputs: Outputs,
 }
 
 impl GenesisTransferOp {
@@ -48,25 +47,22 @@ impl GenesisTransferOp {
 
         let outputs = Outputs::try_new(notes)
             .expect("genesis distribution outputs must fit transfer output bounds");
-        let transfer_op = TransferOp::new(Inputs::empty(), outputs.clone());
+        let transfer_op = TransferOp::new(Inputs::empty(), outputs);
 
-        Self {
-            transfer_op,
-            outputs,
-        }
+        Self { transfer_op }
     }
 
     pub fn notes(&self) -> impl Iterator<Item = Note> {
-        self.outputs.utxos(&self.transfer_op).map(|u| u.note)
+        self.transfer_op.utxos().map(|u| u.note)
     }
 
     pub fn utxos(&self) -> impl Iterator<Item = Utxo> {
-        self.outputs.utxos(&self.transfer_op)
+        self.transfer_op.utxos()
     }
 
     #[must_use]
     pub fn utxo_by_index(&self, index: usize) -> Option<Utxo> {
-        self.outputs.utxo_by_index(index, &self.transfer_op)
+        self.transfer_op.utxo_by_index(index)
     }
 }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -369,7 +369,7 @@ impl WalletState {
                         for input_id in transfer.inputs.iter() {
                             remove_spent_utxo(input_id, &mut utxos, &mut pk_index);
                         }
-                        for utxo in transfer.outputs.utxos(transfer) {
+                        for utxo in transfer.utxos() {
                             insert_utxo_if_owned(utxo, known_keys, &mut utxos, &mut pk_index);
                         }
                     }
@@ -387,7 +387,7 @@ impl WalletState {
                             remove_spent_utxo(input_id, &mut utxos, &mut pk_index);
                             channel_notes.remove_mut(input_id);
                         }
-                        for utxo in op.outputs.utxos(op) {
+                        for utxo in op.utxos() {
                             if insert_utxo_if_owned(utxo, known_keys, &mut utxos, &mut pk_index) {
                                 channel_notes.insert_mut(utxo.id());
                             }


### PR DESCRIPTION
## 1. What does this PR implement?

Adds `utxos()` and `utxo_by_index()` directly to transfer operations, replacing calls such as `op.outputs.utxos(op)` with `op.utxos()`.

Updates the existing call sites and removes redundant output storage from the genesis distribution wrapper.

Closes #2843.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
