### PR TITLE
refactor(api): centralize typed HTTP errors

### DIFF
--- a/nodes/node/binary/src/api/errors.rs
+++ b/nodes/node/binary/src/api/errors.rs
@@ -1,10 +1,74 @@
-use axum::response::{IntoResponse, Response};
+use axum::{
+    Json,
+    response::{IntoResponse, Response},
+};
 use http::StatusCode;
 use lb_api_service::http::DynError;
+use serde::Serialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApiError {
+    #[error("{0}")]
+    BadRequest(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("Not found")]
+    NotFoundEmpty,
+    #[error("Internal server error")]
+    InternalServerError,
+    #[error("Internal server error")]
+    InternalJson(serde_json::Value),
+    #[error(transparent)]
+    Internal(#[from] DynError),
+}
+
+impl ApiError {
+    pub fn internal(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::Internal(Box::new(error))
+    }
+
+    pub fn internal_message(message: impl Into<String>) -> Self {
+        Self::Internal(DynError::from(message.into()))
+    }
+
+    pub const fn internal_json(body: serde_json::Value) -> Self {
+        Self::InternalJson(body)
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
+            Self::NotFound(message) => (StatusCode::NOT_FOUND, message).into_response(),
+            Self::NotFoundEmpty => (StatusCode::NOT_FOUND,).into_response(),
+            error @ Self::InternalServerError => {
+                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
+            }
+            Self::InternalJson(body) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+            }
+            Self::Internal(error) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
+            }
+        }
+    }
+}
+
+pub fn json_response<T, E>(result: Result<T, E>) -> Response
+where
+    T: Serialize,
+    E: Into<ApiError>,
+{
+    match result {
+        Ok(value) => (StatusCode::OK, Json(value)).into_response(),
+        Err(error) => error.into().into_response(),
+    }
+}
 
 impl IntoResponse for BlocksStreamRequestError {
     fn into_response(self) -> Response {
-        (StatusCode::BAD_REQUEST, self.to_string()).into_response()
+        ApiError::BadRequest(self.to_string()).into_response()
     }
 }
 
@@ -32,7 +96,7 @@ pub enum BlocksStreamWindowError {
 
 impl IntoResponse for BlocksStreamWindowError {
     fn into_response(self) -> Response {
-        (StatusCode::BAD_REQUEST, self.to_string()).into_response()
+        ApiError::BadRequest(self.to_string()).into_response()
     }
 }
 
@@ -54,9 +118,106 @@ impl IntoResponse for BlocksStreamHandlerError {
         match self {
             Self::Query(err) => err.into_response(),
             Self::InvalidWindow(err) => err.into_response(),
-            Self::Internal(err) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
-            }
+            Self::Internal(err) => ApiError::Internal(err).into_response(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body;
+    use http::header::CONTENT_TYPE;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn api_error_maps_variants_to_status_codes() {
+        let cases = [
+            (
+                ApiError::BadRequest("bad request".into()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                ApiError::NotFound("not found".into()),
+                StatusCode::NOT_FOUND,
+            ),
+            (ApiError::NotFoundEmpty, StatusCode::NOT_FOUND),
+            (
+                ApiError::InternalServerError,
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+
+        for (error, expected_status) in cases {
+            assert_eq!(error.into_response().status(), expected_status);
+        }
+    }
+
+    #[tokio::test]
+    async fn generic_internal_error_preserves_existing_response() {
+        let response = ApiError::InternalServerError.into_response();
+        let status = response.status();
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "Internal server error");
+    }
+
+    #[tokio::test]
+    async fn internal_error_preserves_existing_response() {
+        let response = ApiError::from(DynError::from("service unavailable")).into_response();
+        let status = response.status();
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "service unavailable");
+    }
+
+    #[tokio::test]
+    async fn empty_not_found_preserves_existing_response() {
+        let response = ApiError::NotFoundEmpty.into_response();
+        let status = response.status();
+        let content_type = response.headers().get(CONTENT_TYPE).cloned();
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(content_type, None);
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn json_error_preserves_existing_response() {
+        let response =
+            ApiError::internal_json(serde_json::json!({ "error": "failure" })).into_response();
+        let status = response.status();
+        let content_type = response.headers().get(CONTENT_TYPE).cloned();
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            content_type.as_ref().and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+        assert_eq!(body, "{\"error\":\"failure\"}");
+    }
+
+    #[tokio::test]
+    async fn json_response_preserves_success_response() {
+        let response = json_response::<_, ApiError>(Ok(vec![1, 2, 3]));
+        let status = response.status();
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "[1,2,3]");
     }
 }

--- a/nodes/node/binary/src/api/errors.rs
+++ b/nodes/node/binary/src/api/errors.rs
@@ -16,8 +16,6 @@ pub enum ApiError {
     NotFoundEmpty,
     #[error("Internal server error")]
     InternalServerError,
-    #[error("Internal server error")]
-    InternalJson(serde_json::Value),
     #[error(transparent)]
     Internal(#[from] DynError),
 }
@@ -30,26 +28,38 @@ impl ApiError {
     pub fn internal_message(message: impl Into<String>) -> Self {
         Self::Internal(DynError::from(message.into()))
     }
+}
 
-    pub const fn internal_json(body: serde_json::Value) -> Self {
-        Self::InternalJson(body)
-    }
+/// Body returned for every API error response, mirroring the
+/// `{code, message}` envelope used by the Ethereum Beacon API.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ErrorBody {
+    pub code: u16,
+    pub message: String,
+}
+
+fn error_response(status: StatusCode, message: String) -> Response {
+    (
+        status,
+        Json(ErrorBody {
+            code: status.as_u16(),
+            message,
+        }),
+    )
+        .into_response()
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         match self {
-            Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
-            Self::NotFound(message) => (StatusCode::NOT_FOUND, message).into_response(),
-            Self::NotFoundEmpty => (StatusCode::NOT_FOUND,).into_response(),
+            Self::BadRequest(message) => error_response(StatusCode::BAD_REQUEST, message),
+            Self::NotFound(message) => error_response(StatusCode::NOT_FOUND, message),
+            error @ Self::NotFoundEmpty => error_response(StatusCode::NOT_FOUND, error.to_string()),
             error @ Self::InternalServerError => {
-                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
-            }
-            Self::InternalJson(body) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+                error_response(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
             }
             Self::Internal(error) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
+                error_response(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
             }
         }
     }
@@ -153,60 +163,80 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn generic_internal_error_preserves_existing_response() {
-        let response = ApiError::InternalServerError.into_response();
+    async fn envelope_of(response: Response) -> (StatusCode, serde_json::Value) {
         let status = response.status();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
         let body = body::to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("response body should be readable");
 
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body, "Internal server error");
+        assert_eq!(content_type.as_deref(), Some("application/json"));
+        let envelope = serde_json::from_slice(&body).expect("body should be valid JSON");
+        (status, envelope)
     }
 
     #[tokio::test]
-    async fn internal_error_preserves_existing_response() {
-        let response = ApiError::from(DynError::from("service unavailable")).into_response();
-        let status = response.status();
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("response body should be readable");
+    async fn bad_request_returns_json_envelope() {
+        let response = ApiError::BadRequest("invalid query".into()).into_response();
+        let (status, envelope) = envelope_of(response).await;
 
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body, "service unavailable");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 400, "message": "invalid query" })
+        );
     }
 
     #[tokio::test]
-    async fn empty_not_found_preserves_existing_response() {
-        let response = ApiError::NotFoundEmpty.into_response();
-        let status = response.status();
-        let content_type = response.headers().get(CONTENT_TYPE).cloned();
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("response body should be readable");
+    async fn not_found_returns_json_envelope() {
+        let response = ApiError::NotFound("Block not found".into()).into_response();
+        let (status, envelope) = envelope_of(response).await;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(content_type, None);
-        assert!(body.is_empty());
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 404, "message": "Block not found" })
+        );
     }
 
     #[tokio::test]
-    async fn json_error_preserves_existing_response() {
-        let response =
-            ApiError::internal_json(serde_json::json!({ "error": "failure" })).into_response();
-        let status = response.status();
-        let content_type = response.headers().get(CONTENT_TYPE).cloned();
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("response body should be readable");
+    async fn generic_internal_error_returns_json_envelope() {
+        let response = ApiError::InternalServerError.into_response();
+        let (status, envelope) = envelope_of(response).await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(
-            content_type.as_ref().and_then(|value| value.to_str().ok()),
-            Some("application/json")
+            envelope,
+            serde_json::json!({ "code": 500, "message": "Internal server error" })
         );
-        assert_eq!(body, "{\"error\":\"failure\"}");
+    }
+
+    #[tokio::test]
+    async fn internal_error_returns_json_envelope() {
+        let response = ApiError::from(DynError::from("service unavailable")).into_response();
+        let (status, envelope) = envelope_of(response).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 500, "message": "service unavailable" })
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_not_found_returns_json_envelope() {
+        let response = ApiError::NotFoundEmpty.into_response();
+        let (status, envelope) = envelope_of(response).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 404, "message": "Not found" })
+        );
     }
 
     #[tokio::test]

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -358,7 +358,7 @@ macro_rules! make_request_and_return_response {
     path = paths::MANTLE_METRICS,
     responses(
         (status = 200, description = "Get the mempool metrics of the cl service", body = inline(schema::MempoolMetrics)),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn mantle_metrics<StorageAdapter, RuntimeServiceId>(
@@ -409,7 +409,7 @@ where
     path = paths::MANTLE_STATUS,
     responses(
         (status = 200, description = "Query the mempool status of the cl service", body = Vec<<T as Transaction>::Hash>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn mantle_status<StorageAdapter, RuntimeServiceId>(
@@ -467,7 +467,7 @@ pub struct CryptarchiaInfoQuery {
     path = paths::CRYPTARCHIA_INFO,
     responses(
         (status = 200, description = "Query consensus information", body = lb_consensus::CryptarchiaInfo),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn cryptarchia_info<RuntimeServiceId>(
@@ -485,7 +485,7 @@ where
     path = paths::TIME_INFO,
     responses(
         (status = 200, description = "Query time service information", body = TimeInfo),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn time_info<RuntimeServiceId>(
@@ -524,7 +524,7 @@ where
     path = paths::CRYPTARCHIA_HEADERS,
     responses(
         (status = 200, description = "Query header ids", body = Vec<HeaderId>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn cryptarchia_headers<RuntimeServiceId>(
@@ -546,7 +546,7 @@ where
     path = paths::CRYPTARCHIA_LIB_STREAM,
     responses(
         (status = 200, description = "Request a stream for lib blocks"),
-        (status = 500, description = "Internal server error", body = StreamBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn cryptarchia_lib_stream<RuntimeServiceId>(
@@ -568,7 +568,7 @@ where
     path = paths::NETWORK_INFO,
     responses(
         (status = 200, description = "Query the network information", body = lb_network_service::backends::libp2p::Libp2pInfo),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn libp2p_info<RuntimeServiceId>(
@@ -590,7 +590,7 @@ where
     request_body = DialPeerRequestBody,
     responses(
         (status = 200, description = "Dial a network peer", body = PeerId),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn dial_peer<RuntimeServiceId>(
@@ -616,7 +616,7 @@ where
     path = paths::BLEND_NETWORK_INFO,
     responses(
         (status = 200, description = "Query the blend network information", body = Option<lb_blend_service::message::NetworkInfo<PeerId>>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blend_info<BlendService, BroadcastSettings, RuntimeServiceId>(
@@ -644,7 +644,7 @@ where
     request_body = BlendJoinNetworkRequestBody,
     responses(
         (status = 200, description = "Join the blend network", body = Option<lb_core::sdp::DeclarationId>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blend_join_network<BlendService, BroadcastSettings, RuntimeServiceId>(
@@ -672,7 +672,7 @@ where
     path = paths::MEMPOOL_ADD_TX,
     responses(
         (status = 200, description = "Add transaction to the mempool"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn add_tx<StorageAdapter, RuntimeServiceId>(
@@ -732,7 +732,7 @@ where
     path = paths::MEMPOOL_VIEW,
     responses(
         (status = 200, description = "Get current tip mempool transaction hashes", body = Vec<TxHash>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn mempool_view<StorageAdapter, RuntimeServiceId>(
@@ -902,7 +902,7 @@ where
     path = paths::CHANNEL,
     responses(
         (status = 200, description = "Channel state"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn channel<RuntimeServiceId>(
@@ -921,7 +921,7 @@ where
     path = paths::CHANNEL_DEPOSIT,
     responses(
         (status = 200, description = "Submit a channel deposit"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn channel_deposit<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1019,7 +1019,7 @@ where
     path = paths::SDP_POST_DECLARATION,
     responses(
         (status = 200, description = "Post declaration to SDP service", body = lb_core::sdp::DeclarationId),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_declaration<
@@ -1067,7 +1067,7 @@ where
     path = paths::SDP_POST_ACTIVITY,
     responses(
         (status = 200, description = "Post activity to SDP service"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_activity<
@@ -1115,7 +1115,7 @@ where
     path = paths::SDP_POST_WITHDRAWAL,
     responses(
         (status = 200, description = "Post withdrawal to SDP service"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_withdrawal<
@@ -1163,7 +1163,7 @@ where
     path = paths::SDP_POST_SET_DECLARATION_ID,
     responses(
         (status = 200, description = "Post declaration to SDP service to be set as current", body = lb_core::sdp::DeclarationId),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_set_declaration_id<
@@ -1213,7 +1213,7 @@ where
     path = paths::MANTLE_SDP_DECLARATIONS,
     responses(
         (status = 200, description = "Get current SDP declarations keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn get_sdp_declarations<RuntimeServiceId>(
@@ -1231,7 +1231,7 @@ where
     path = paths::MANTLE_SDP_SNAPSHOT,
     responses(
         (status = 200, description = "Get the SDP snapshot for the current epoch keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn get_sdp_snapshot<RuntimeServiceId>(
@@ -1249,7 +1249,7 @@ where
     path = paths::LEADER_CLAIM,
     responses(
         (status = 200, description = "Leader claim transaction submitted", body = lb_api_service::http::consensus::leader::LeaderClaimResponseBody),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn leader_claim<ChainLeader, RuntimeServiceId>(
@@ -1268,7 +1268,7 @@ where
     params(BlockRangeQuery),
     responses(
         (status = 200, description = "Get blocks"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn immutable_blocks<StorageBackend, RuntimeServiceId>(
@@ -1304,8 +1304,8 @@ where
     path = paths::BLOCKS_DETAIL,
     responses(
         (status = 200, description = "Block found"),
-        (status = 404, description = "Block not found"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 404, description = "Block not found", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn block<HttpStorageAdapter, RuntimeServiceId>(
@@ -1337,8 +1337,8 @@ where
     path = paths::BLOCK_EVENTS,
     responses(
         (status = 200, description = "Block events", body = Events),
-        (status = 404, description = "Block not found"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 404, description = "Block not found", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn block_events<RuntimeServiceId>(
@@ -1373,7 +1373,7 @@ pub struct GasPricesQuery {
     path = paths::MANTLE_GAS_PRICES,
     responses(
         (status = 200, description = "Get the gas prices from the ledger state at the tip"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn get_gas_prices<RuntimeServiceId>(
@@ -1421,7 +1421,7 @@ where
     path = paths::BLOCKS_STREAM,
     responses(
         (status = 200, description = "Stream of processed blocks with chain state"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blocks_stream<StorageBackend, ConsensusService, RuntimeServiceId>(
@@ -1459,8 +1459,8 @@ where
         (status = 200, description = "Stream of processed blocks with chain state in slot order. \
             When immutable_only=true and slot_to is omitted, the stream anchors at LIB slot by \
             default."),
-        (status = 400, description = "Invalid request parameters", body = String),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 400, description = "Invalid request parameters", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blocks_range_stream<StorageBackend, RuntimeServiceId>(
@@ -1545,8 +1545,8 @@ where
     path = paths::TRANSACTION,
     responses(
         (status = 200, description = "Transaction found"),
-        (status = 404, description = "Transaction not found"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 404, description = "Transaction not found", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn transaction<HttpStorageAdapter, RuntimeServiceId>(
@@ -1573,13 +1573,11 @@ where
             let api_transaction = ApiSignedTransaction::from(transaction);
             (StatusCode::OK, Json(api_transaction)).into_response()
         }
-        _ => {
-            let error_body = serde_json::json!({
-                "error": "Multiple transactions found",
-                "len": transactions.len()
-            });
-            ApiError::internal_json(error_body).into_response()
-        }
+        _ => ApiError::internal_message(format!(
+            "Multiple transactions found ({})",
+            transactions.len()
+        ))
+        .into_response(),
     }
 }
 
@@ -1605,7 +1603,7 @@ pub mod wallet {
     path = paths::wallet::BALANCE,
     responses(
         (status = 200, description = "Get wallet balance"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
     )]
     pub async fn get_balance<WalletService, RuntimeServiceId>(
@@ -1650,7 +1648,7 @@ pub mod wallet {
     path = paths::LEADER_CLAIM_VOUCHERS,
     responses(
         (status = 200, description = "Get claimable wallet vouchers"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
     )]
     pub async fn get_claimable_vouchers<WalletService, RuntimeServiceId>(
@@ -1688,7 +1686,7 @@ pub mod wallet {
     path = paths::wallet::TRANSACTIONS_TRANSFER_FUNDS,
     responses(
         (status = 200, description = "Make transfer"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
     )]
     pub async fn post_transactions_transfer_funds<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1783,7 +1781,7 @@ pub mod wallet {
         path = paths::wallet::SIGN_TX_ED25519,
         responses(
             (status = 200, description = "Signed transaction"),
-            (status = 500, description = "Internal server error", body = String),
+            (status = 500, description = "Internal server error", body = ErrorBody),
         )
     )]
     pub async fn sign_tx_ed25519<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1841,7 +1839,7 @@ pub mod wallet {
         path = paths::wallet::SIGN_TX_ZK,
         responses(
             (status = 200, description = "Signed transaction"),
-            (status = 500, description = "Internal server error", body = String),
+            (status = 500, description = "Internal server error", body = ErrorBody),
         )
     )]
     pub async fn sign_tx_zk<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1899,7 +1897,7 @@ pub mod wallet {
         path = paths::wallet::FUND,
         responses(
             (status = 200, description = "Funded transaction with fee transfer proof"),
-            (status = 500, description = "Internal server error", body = String),
+            (status = 500, description = "Internal server error", body = ErrorBody),
         )
     )]
     pub async fn fund<WalletService, StorageAdapter, RuntimeServiceId>(

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -78,10 +78,10 @@ use tracing::debug;
 use crate::{
     TimeService,
     api::{
-        errors::{BlocksStreamHandlerError, BlocksStreamWindowError},
+        errors::{ApiError, BlocksStreamHandlerError, BlocksStreamWindowError},
         openapi::schema,
         queries::{BlockRangeQuery, BlocksStreamRequest},
-        responses::{self, overwatch::get_relay_or_500},
+        responses::{self, overwatch::get_relay},
         serializers::{
             blocks::{ApiBlock, ApiBlockOwned, ApiProcessedBlockEventOwned},
             transactions::ApiSignedTransaction,
@@ -350,18 +350,7 @@ where
 
 #[macro_export]
 macro_rules! make_request_and_return_response {
-    ($cond:expr) => {{
-        match $cond.await {
-            ::std::result::Result::Ok(val) => ::axum::response::IntoResponse::into_response((
-                ::axum::http::StatusCode::OK,
-                ::axum::Json(val),
-            )),
-            ::std::result::Result::Err(e) => ::axum::response::IntoResponse::into_response((
-                ::axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                e.to_string(),
-            )),
-        }
-    }};
+    ($cond:expr) => {{ $crate::api::errors::json_response($cond.await) }};
 }
 
 #[utoipa::path(
@@ -508,12 +497,12 @@ where
     let relay = match handle.relay::<TimeService>().await {
         Ok(relay) => relay,
         Err(error) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response();
+            return ApiError::internal(error).into_response();
         }
     };
     let (sender, receiver) = oneshot::channel();
     if let Err((error, _)) = relay.send(TimeServiceMessage::Info { sender }).await {
-        return (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response();
+        return ApiError::internal(error).into_response();
     }
     match receiver.await {
         Ok(Ok(service_info)) => {
@@ -525,8 +514,8 @@ where
             };
             (StatusCode::OK, Json(api_info)).into_response()
         }
-        Ok(Err(error)) => (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+        Ok(Err(error)) => ApiError::internal_message(error).into_response(),
+        Err(error) => ApiError::internal(error).into_response(),
     }
 }
 
@@ -570,7 +559,7 @@ where
     let stream = mantle::lib_block_stream(&handle).await;
     match stream {
         Ok(stream) => responses::ndjson::from_stream_result(stream),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+        Err(error) => ApiError::Internal(error).into_response(),
     }
 }
 
@@ -1328,9 +1317,9 @@ where
     RuntimeServiceId:
         AsServiceId<StorageService<RocksBackend, RuntimeServiceId>> + Debug + Sync + Display,
 {
-    let relay = match get_relay_or_500(&handle).await {
+    let relay = match get_relay(&handle).await {
         Ok(relay) => relay,
-        Err(error_response) => return error_response,
+        Err(error) => return error.into_response(),
     };
     let block = HttpStorageAdapter::get_block::<SignedMantleTx<Unverified>>(relay, id).await;
     match block {
@@ -1338,8 +1327,8 @@ where
             let api_block = ApiBlock::from(&block);
             (StatusCode::OK, Json(api_block)).into_response()
         }
-        Ok(None) => (StatusCode::NOT_FOUND,).into_response(),
-        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response(),
+        Ok(None) => ApiError::NotFoundEmpty.into_response(),
+        Err(_) => ApiError::InternalServerError.into_response(),
     }
 }
 
@@ -1360,17 +1349,17 @@ where
     RuntimeServiceId:
         AsServiceId<Cryptarchia<RuntimeServiceId>> + Debug + Sync + Display + Send + 'static,
 {
-    let relay = match get_relay_or_500(&handle).await {
+    let relay = match get_relay(&handle).await {
         Ok(relay) => relay,
-        Err(error_response) => return error_response,
+        Err(error) => return error.into_response(),
     };
     let chain_api =
         CryptarchiaServiceApi::<Cryptarchia<RuntimeServiceId>, RuntimeServiceId>::new(relay);
 
     match chain_api.get_block_events(id).await {
         Ok(Some(events)) => (StatusCode::OK, Json(events)).into_response(),
-        Ok(None) => (StatusCode::NOT_FOUND, "Block not found").into_response(),
-        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response(),
+        Ok(None) => ApiError::NotFound("Block not found".into()).into_response(),
+        Err(_) => ApiError::InternalServerError.into_response(),
     }
 }
 
@@ -1395,9 +1384,9 @@ where
     RuntimeServiceId:
         AsServiceId<Cryptarchia<RuntimeServiceId>> + Debug + Sync + Display + Send + 'static,
 {
-    let relay = match get_relay_or_500(&handle).await {
+    let relay = match get_relay(&handle).await {
         Ok(relay) => relay,
-        Err(error_response) => return error_response,
+        Err(error) => return error.into_response(),
     };
     let chain_api =
         CryptarchiaServiceApi::<Cryptarchia<RuntimeServiceId>, RuntimeServiceId>::new(relay);
@@ -1407,7 +1396,7 @@ where
         None => match consensus::cryptarchia_info::<RuntimeServiceId>(&handle).await {
             Ok(info) => info.cryptarchia_info.tip,
             Err(error) => {
-                return (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response();
+                return ApiError::Internal(error).into_response();
             }
         },
     };
@@ -1422,8 +1411,8 @@ where
             })
             .into_response()
         }
-        Ok(None) => (StatusCode::NOT_FOUND, "Ledger state not found for block").into_response(),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+        Ok(None) => ApiError::NotFound("Ledger state not found for block".into()).into_response(),
+        Err(error) => ApiError::internal(error).into_response(),
     }
 }
 
@@ -1458,7 +1447,7 @@ where
         .map(|stream| stream.map(ApiProcessedBlockEventOwned::from));
     match stream {
         Ok(stream) => responses::ndjson::from_stream(stream),
-        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+        Err(error) => ApiError::Internal(error).into_response(),
     }
 }
 
@@ -1569,17 +1558,17 @@ where
     RuntimeServiceId:
         AsServiceId<StorageService<RocksBackend, RuntimeServiceId>> + Debug + Sync + Display,
 {
-    let relay = match get_relay_or_500(&handle).await {
+    let relay = match get_relay(&handle).await {
         Ok(relay) => relay,
-        Err(error_response) => return error_response,
+        Err(error) => return error.into_response(),
     };
     let Ok(transactions) =
         HttpStorageAdapter::get_transactions::<SignedMantleTx<Unverified>>(relay, id).await
     else {
-        return (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response();
+        return ApiError::InternalServerError.into_response();
     };
     match transactions.as_slice() {
-        [] => (StatusCode::NOT_FOUND,).into_response(),
+        [] => ApiError::NotFoundEmpty.into_response(),
         [transaction] => {
             let api_transaction = ApiSignedTransaction::from(transaction);
             (StatusCode::OK, Json(api_transaction)).into_response()
@@ -1589,7 +1578,7 @@ where
                 "error": "Multiple transactions found",
                 "len": transactions.len()
             });
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(error_body)).into_response()
+            ApiError::internal_json(error_body).into_response()
         }
     }
 }
@@ -1629,9 +1618,9 @@ pub mod wallet {
         RuntimeServiceId: Debug + Send + Sync + Display + 'static + AsServiceId<WalletService>,
     {
         let wallet_api = {
-            let wallet_relay = match get_relay_or_500::<WalletService, _>(&handle).await {
+            let wallet_relay = match get_relay::<WalletService, _>(&handle).await {
                 Ok(relay) => relay,
-                Err(error_response) => return error_response,
+                Err(error) => return error.into_response(),
             };
             WalletApi::<WalletService, RuntimeServiceId>::new(wallet_relay)
         };
@@ -1648,12 +1637,11 @@ pub mod wallet {
                 address,
             }
             .into_response(),
-            Ok(lb_wallet_service::TipResponse { response: None, .. }) => (
-                StatusCode::NOT_FOUND,
-                "The requested address could not be found in the wallet",
-            )
-                .into_response(),
-            Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+            Ok(lb_wallet_service::TipResponse { response: None, .. }) => {
+                ApiError::NotFound("The requested address could not be found in the wallet".into())
+                    .into_response()
+            }
+            Err(error) => ApiError::internal(error).into_response(),
         }
     }
 
@@ -1673,9 +1661,9 @@ pub mod wallet {
         WalletService: WalletServiceData + 'static,
         RuntimeServiceId: Debug + Send + Sync + Display + 'static + AsServiceId<WalletService>,
     {
-        let wallet_relay = match get_relay_or_500::<WalletService, _>(&handle).await {
+        let wallet_relay = match get_relay::<WalletService, _>(&handle).await {
             Ok(relay) => relay,
-            Err(error_response) => return error_response,
+            Err(error) => return error.into_response(),
         };
         let wallet_api = WalletApi::<WalletService, RuntimeServiceId>::new(wallet_relay);
 
@@ -1691,7 +1679,7 @@ pub mod wallet {
 
                 WalletClaimableVouchersResponseBody { tip, vouchers }.into_response()
             }
-            Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+            Err(error) => ApiError::internal(error).into_response(),
         }
     }
 
@@ -1744,9 +1732,9 @@ pub mod wallet {
             >,
     {
         let wallet_api = {
-            let wallet_relay = match get_relay_or_500::<WalletService, _>(&handle).await {
+            let wallet_relay = match get_relay::<WalletService, _>(&handle).await {
                 Ok(relay) => relay,
-                Err(error_response) => return error_response,
+                Err(error) => return error.into_response(),
             };
             WalletApi::<WalletService, RuntimeServiceId>::new(wallet_relay)
         };
@@ -1781,12 +1769,12 @@ pub mod wallet {
                 >(&handle, transaction.clone(), Transaction::hash)
                 .await
                 {
-                    return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+                    return ApiError::Internal(e).into_response();
                 }
 
                 WalletTransferFundsResponseBody::from(transaction).into_response()
             }
-            Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+            Err(error) => ApiError::internal(error).into_response(),
         }
     }
 

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -35,7 +35,7 @@ use utoipa::OpenApi;
         crate::api::handlers::wallet::fund,
         crate::api::tracing::reload_tracing_filter,
     ),
-    components(schemas(schema::Status, schema::MempoolMetrics)),
+    components(schemas(schema::Status, schema::MempoolMetrics, crate::api::errors::ErrorBody)),
     tags()
 )]
 pub struct ApiDoc;

--- a/nodes/node/binary/src/api/responses/overwatch.rs
+++ b/nodes/node/binary/src/api/responses/overwatch.rs
@@ -1,22 +1,19 @@
 use std::fmt::{Debug, Display};
 
-use axum::response::{IntoResponse as _, Response};
-use http::StatusCode;
 use overwatch::{
     overwatch::OverwatchHandle,
     services::{AsServiceId, ServiceData, relay::OutboundRelay},
 };
 
-pub async fn get_relay_or_500<Service, RuntimeServiceId>(
+use crate::api::errors::ApiError;
+
+pub async fn get_relay<Service, RuntimeServiceId>(
     handle: &OverwatchHandle<RuntimeServiceId>,
-) -> Result<OutboundRelay<<Service as ServiceData>::Message>, Response>
+) -> Result<OutboundRelay<<Service as ServiceData>::Message>, ApiError>
 where
     Service: ServiceData,
     Service::Message: 'static,
     RuntimeServiceId: Debug + Sync + Display + AsServiceId<Service>,
 {
-    handle
-        .relay()
-        .await
-        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response())
+    handle.relay().await.map_err(ApiError::internal)
 }

--- a/nodes/node/binary/src/api/tracing.rs
+++ b/nodes/node/binary/src/api/tracing.rs
@@ -17,7 +17,7 @@ const LOG_TARGET: &str = node::api::TRACING;
     path = paths::admin::TRACING_FILTER,
     responses(
         (status = 200, description = "Tracing filter reloaded"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = crate::api::errors::ErrorBody),
     )
 )]
 pub async fn reload_tracing_filter<RuntimeServiceId>(


### PR DESCRIPTION
## 1. What does this PR implement?

Introduce a shared `ApiError` type and migrate the existing API handlers to use it.

- Removes duplicated HTTP status and response construction
- Provides a single place for mapping errors to HTTP responses
- Preserves existing status codes and bodies, covered by new unit tests

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
