### PR TITLE
fix(ffi): don't install a process::exit panic hook in the embedded cdylib

### DIFF
--- a/c-bindings/src/api/blend.rs
+++ b/c-bindings/src/api/blend.rs
@@ -82,29 +82,31 @@ pub unsafe extern "C" fn blend_join_as_core_node(
     locator: *const c_char,
     locked_note_id: *const u8,
 ) -> FfiStatusResult<DeclarationId> {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(locator);
-    return_error_if_null_pointer!(locked_note_id);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(locator);
+        return_error_if_null_pointer!(locked_note_id);
 
-    let locator = unwrap_or_return_error!(unsafe { parse_locator(locator) });
-    let locked_note_id = unwrap_or_return_error!(unsafe { parse_locked_note_id(locked_note_id) });
+        let locator = unwrap_or_return_error!(unsafe { parse_locator(locator) });
+        let locked_note_id = unwrap_or_return_error!(unsafe { parse_locked_note_id(locked_note_id) });
 
-    let node = unsafe { &*node };
+        let node = unsafe { &*node };
 
-    let result: StatusResult<sdp::DeclarationId> = node.get_runtime_handle().block_on(async {
-        lb_api_service::http::blend::blend_join_network::<
-            BlendService<RuntimeServiceId>,
-            BlendBroadcastSettings<RuntimeServiceId>,
-            RuntimeServiceId,
-        >(node.get_overwatch_handle(), locator, locked_note_id)
-        .await
-        .map_err(|error| {
-            OperationStatus::error(
-                OperationStatusCode::RelayError,
-                format!("Failed to join blend network: {error}"),
-            )
-        })
-    });
+        let result: StatusResult<sdp::DeclarationId> = node.get_runtime_handle().block_on(async {
+            lb_api_service::http::blend::blend_join_network::<
+                BlendService<RuntimeServiceId>,
+                BlendBroadcastSettings<RuntimeServiceId>,
+                RuntimeServiceId,
+            >(node.get_overwatch_handle(), locator, locked_note_id)
+            .await
+            .map_err(|error| {
+                OperationStatus::error(
+                    OperationStatusCode::RelayError,
+                    format!("Failed to join blend network: {error}"),
+                )
+            })
+        });
 
-    result.map(DeclarationId::from).into()
+        result.map(DeclarationId::from).into()
+    })
 }

--- a/c-bindings/src/api/config.rs
+++ b/c-bindings/src/api/config.rs
@@ -169,8 +169,10 @@ pub fn generate_config_sync(args: EmbeddedInitArgs) -> OperationStatus {
 #[must_use]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn generate_user_config(args: GenerateConfigArgs) -> OperationStatus {
-    let init_args = EmbeddedInitArgs::from(args);
-    generate_config_sync(init_args)
+    crate::macros::guard_ffi(|| {
+        let init_args = EmbeddedInitArgs::from(args);
+        generate_config_sync(init_args)
+    })
 }
 
 /// Updates an existing user config file with keys from a keystore file,
@@ -196,22 +198,24 @@ pub unsafe extern "C" fn update_user_config(
     user_config_path: *const c_char,
     keystore_path: *const c_char,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(user_config_path);
-    return_error_if_null_pointer!(keystore_path);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(user_config_path);
+        return_error_if_null_pointer!(keystore_path);
 
-    let args = UpdateArgs::new(
-        unsafe { cstr_to_path(user_config_path) },
-        unsafe { cstr_to_path(keystore_path) },
-        true,
-    );
+        let args = UpdateArgs::new(
+            unsafe { cstr_to_path(user_config_path) },
+            unsafe { cstr_to_path(keystore_path) },
+            true,
+        );
 
-    match lb_node::cli::config::update::run(args) {
-        Ok(()) => OperationStatus::OK,
-        Err(error) => OperationStatus::error(
-            OperationStatusCode::ConfigurationError,
-            format!("Error updating config: {error:?}"),
-        ),
-    }
+        match lb_node::cli::config::update::run(args) {
+            Ok(()) => OperationStatus::OK,
+            Err(error) => OperationStatus::error(
+                OperationStatusCode::ConfigurationError,
+                format!("Error updating config: {error:?}"),
+            ),
+        }
+    })
 }
 
 /// Generates a new user config file from an existing keystore file,
@@ -237,20 +241,22 @@ pub unsafe extern "C" fn migrate_user_config(
     output_path: *const c_char,
     keystore_path: *const c_char,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(output_path);
-    return_error_if_null_pointer!(keystore_path);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(output_path);
+        return_error_if_null_pointer!(keystore_path);
 
-    let args = MigrateArgs::new(unsafe { cstr_to_path(output_path) }, unsafe {
-        cstr_to_path(keystore_path)
-    });
+        let args = MigrateArgs::new(unsafe { cstr_to_path(output_path) }, unsafe {
+            cstr_to_path(keystore_path)
+        });
 
-    match lb_node::cli::config::migrate::run(args) {
-        Ok(()) => OperationStatus::OK,
-        Err(error) => OperationStatus::error(
-            OperationStatusCode::ConfigurationError,
-            format!("Error migrating config: {error:?}"),
-        ),
-    }
+        match lb_node::cli::config::migrate::run(args) {
+            Ok(()) => OperationStatus::OK,
+            Err(error) => OperationStatus::error(
+                OperationStatusCode::ConfigurationError,
+                format!("Error migrating config: {error:?}"),
+            ),
+        }
+    })
 }
 
 /// Migrates a 0.1.2 config file to a new user config and keystore, equivalent
@@ -279,23 +285,25 @@ pub unsafe extern "C" fn migrate_user_config_0_1_2(
     old_config_path: *const c_char,
     keystore_path: *const c_char,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(new_config_path);
-    return_error_if_null_pointer!(old_config_path);
-    return_error_if_null_pointer!(keystore_path);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(new_config_path);
+        return_error_if_null_pointer!(old_config_path);
+        return_error_if_null_pointer!(keystore_path);
 
-    let args = lb_node::cli::config::migrate_0_1_2::MigrateArgs::new(
-        unsafe { cstr_to_path(new_config_path) },
-        unsafe { cstr_to_path(old_config_path) },
-        unsafe { cstr_to_path(keystore_path) },
-    );
+        let args = lb_node::cli::config::migrate_0_1_2::MigrateArgs::new(
+            unsafe { cstr_to_path(new_config_path) },
+            unsafe { cstr_to_path(old_config_path) },
+            unsafe { cstr_to_path(keystore_path) },
+        );
 
-    match lb_node::cli::config::migrate_0_1_2::run(args) {
-        Ok(()) => OperationStatus::OK,
-        Err(error) => OperationStatus::error(
-            OperationStatusCode::ConfigurationError,
-            format!("Error migrating config: {error:?}"),
-        ),
-    }
+        match lb_node::cli::config::migrate_0_1_2::run(args) {
+            Ok(()) => OperationStatus::OK,
+            Err(error) => OperationStatus::error(
+                OperationStatusCode::ConfigurationError,
+                format!("Error migrating config: {error:?}"),
+            ),
+        }
+    })
 }
 
 /// Generates `participation_data.yaml` from a user config and keystore,
@@ -325,39 +333,41 @@ pub unsafe extern "C" fn participate(
     output_dir: *const c_char,
     external_address: *const c_char,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(config_path);
-    return_error_if_null_pointer!(keystore_path);
-    return_error_if_null_pointer!(output_dir);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(config_path);
+        return_error_if_null_pointer!(keystore_path);
+        return_error_if_null_pointer!(output_dir);
 
-    let external_address = if external_address.is_null() {
-        None
-    } else {
-        let address = unsafe { CStr::from_ptr(external_address) }.to_string_lossy();
-        match address.parse::<Ipv4Addr>() {
-            Ok(address) => Some(address),
-            Err(error) => {
-                return OperationStatus::error(
-                    OperationStatusCode::ValidationError,
-                    format!("Invalid external address '{address}': {error}"),
-                );
+        let external_address = if external_address.is_null() {
+            None
+        } else {
+            let address = unsafe { CStr::from_ptr(external_address) }.to_string_lossy();
+            match address.parse::<Ipv4Addr>() {
+                Ok(address) => Some(address),
+                Err(error) => {
+                    return OperationStatus::error(
+                        OperationStatusCode::ValidationError,
+                        format!("Invalid external address '{address}': {error}"),
+                    );
+                }
             }
+        };
+
+        let args = ParticipateArgs {
+            config: unsafe { cstr_to_path(config_path) },
+            keystore: unsafe { cstr_to_path(keystore_path) },
+            output: unsafe { cstr_to_path(output_dir) },
+            external_address,
+        };
+
+        match lb_node::cli::participate::run(&args) {
+            Ok(()) => OperationStatus::OK,
+            Err(error) => OperationStatus::error(
+                OperationStatusCode::ConfigurationError,
+                format!("Error generating participation data: {error:?}"),
+            ),
         }
-    };
-
-    let args = ParticipateArgs {
-        config: unsafe { cstr_to_path(config_path) },
-        keystore: unsafe { cstr_to_path(keystore_path) },
-        output: unsafe { cstr_to_path(output_dir) },
-        external_address,
-    };
-
-    match lb_node::cli::participate::run(&args) {
-        Ok(()) => OperationStatus::OK,
-        Err(error) => OperationStatus::error(
-            OperationStatusCode::ConfigurationError,
-            format!("Error generating participation data: {error:?}"),
-        ),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/c-bindings/src/api/cryptarchia.rs
+++ b/c-bindings/src/api/cryptarchia.rs
@@ -133,12 +133,18 @@ pub type FfiCryptarchiaInfoResult = FfiStatusResult<*mut CryptarchiaInfo>;
 pub unsafe extern "C" fn get_cryptarchia_info(
     node: *const LogosBlockchainNode,
 ) -> FfiCryptarchiaInfoResult {
-    return_error_if_null_pointer!(node);
-    let node = unsafe { &*node };
-    let service_info = unwrap_or_return_error!(get_cryptarchia_info_sync(node));
-    let c_info = CryptarchiaInfo::from(service_info);
+    // Guard against panics unwinding across the `extern "C"` boundary: a panic in
+    // the async query (e.g. a relay/consensus path while the node is still
+    // bootstrapping) is turned into an `OperationStatus` error the caller can
+    // handle, instead of aborting the host process.
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        let node = unsafe { &*node };
+        let service_info = unwrap_or_return_error!(get_cryptarchia_info_sync(node));
+        let c_info = CryptarchiaInfo::from(service_info);
 
-    FfiCryptarchiaInfoResult::from_value(c_info)
+        FfiCryptarchiaInfoResult::from_value(c_info)
+    })
 }
 
 /// Frees the memory allocated for a [`CryptarchiaInfo`] struct.

--- a/c-bindings/src/api/keys.rs
+++ b/c-bindings/src/api/keys.rs
@@ -77,34 +77,36 @@ pub unsafe extern "C" fn generate_key(
     key_type: KeyType,
     key_title: *const c_char,
 ) -> FfiGenerateKeyResult {
-    return_error_if_null_pointer!(user_config_path);
-    return_error_if_null_pointer!(keystore_path);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(user_config_path);
+        return_error_if_null_pointer!(keystore_path);
 
-    let args = GenerateKeyArgs::new(
-        unsafe { cstr_to_path(user_config_path) },
-        unsafe { cstr_to_path(keystore_path) },
-        key_type.into(),
-        unsafe { key_title_from_ptr(key_title) },
-        true,
-    );
+        let args = GenerateKeyArgs::new(
+            unsafe { cstr_to_path(user_config_path) },
+            unsafe { cstr_to_path(keystore_path) },
+            key_type.into(),
+            unsafe { key_title_from_ptr(key_title) },
+            true,
+        );
 
-    let key_id = match lb_node::cli::keys::generate_key(args) {
-        Ok(key_id) => key_id,
-        Err(error) => {
-            return FfiGenerateKeyResult::err(OperationStatus::error(
-                OperationStatusCode::ConfigurationError,
-                format!("Error generating key: {error:?}"),
-            ));
+        let key_id = match lb_node::cli::keys::generate_key(args) {
+            Ok(key_id) => key_id,
+            Err(error) => {
+                return FfiGenerateKeyResult::err(OperationStatus::error(
+                    OperationStatusCode::ConfigurationError,
+                    format!("Error generating key: {error:?}"),
+                ));
+            }
+        };
+
+        match CString::new(key_id) {
+            Ok(key_id) => FfiGenerateKeyResult::ok(key_id.into_raw()),
+            Err(error) => FfiGenerateKeyResult::err(OperationStatus::error(
+                OperationStatusCode::RuntimeError,
+                format!("Failed to create CString: {error}"),
+            )),
         }
-    };
-
-    match CString::new(key_id) {
-        Ok(key_id) => FfiGenerateKeyResult::ok(key_id.into_raw()),
-        Err(error) => FfiGenerateKeyResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            format!("Failed to create CString: {error}"),
-        )),
-    }
+    })
 }
 
 /// Adds an existing key to the keystore and user config files, equivalent to
@@ -136,37 +138,39 @@ pub unsafe extern "C" fn add_key(
     key_hex: *const c_char,
     key_title: *const c_char,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(user_config_path);
-    return_error_if_null_pointer!(keystore_path);
-    return_error_if_null_pointer!(key_hex);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(user_config_path);
+        return_error_if_null_pointer!(keystore_path);
+        return_error_if_null_pointer!(key_hex);
 
-    let key_hex = unsafe { CStr::from_ptr(key_hex) }.to_string_lossy();
+        let key_hex = unsafe { CStr::from_ptr(key_hex) }.to_string_lossy();
 
-    let key = match parse_key_hex(key_type, &key_hex) {
-        Ok(key) => key,
-        Err(error) => {
-            return OperationStatus::error(
-                OperationStatusCode::ValidationError,
-                format!("Invalid key: {error}"),
-            );
+        let key = match parse_key_hex(key_type, &key_hex) {
+            Ok(key) => key,
+            Err(error) => {
+                return OperationStatus::error(
+                    OperationStatusCode::ValidationError,
+                    format!("Invalid key: {error}"),
+                );
+            }
+        };
+
+        let args = AddKeyArgs::new(
+            unsafe { cstr_to_path(user_config_path) },
+            unsafe { cstr_to_path(keystore_path) },
+            unsafe { key_title_from_ptr(key_title) },
+            &key,
+            true,
+        );
+
+        match run_add_key(args) {
+            Ok(()) => OperationStatus::OK,
+            Err(error) => OperationStatus::error(
+                OperationStatusCode::ConfigurationError,
+                format!("Error adding key: {error:?}"),
+            ),
         }
-    };
-
-    let args = AddKeyArgs::new(
-        unsafe { cstr_to_path(user_config_path) },
-        unsafe { cstr_to_path(keystore_path) },
-        unsafe { key_title_from_ptr(key_title) },
-        &key,
-        true,
-    );
-
-    match run_add_key(args) {
-        Ok(()) => OperationStatus::OK,
-        Err(error) => OperationStatus::error(
-            OperationStatusCode::ConfigurationError,
-            format!("Error adding key: {error:?}"),
-        ),
-    }
+    })
 }
 
 /// Parses a hex-encoded secret key of the given type into a [`Key`].
@@ -211,26 +215,28 @@ pub unsafe extern "C" fn remove_key(
     keystore_path: *const c_char,
     key_title: *const c_char,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(user_config_path);
-    return_error_if_null_pointer!(keystore_path);
-    return_error_if_null_pointer!(key_title);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(user_config_path);
+        return_error_if_null_pointer!(keystore_path);
+        return_error_if_null_pointer!(key_title);
 
-    let key_title = unsafe { CStr::from_ptr(key_title) }
-        .to_string_lossy()
-        .to_string();
+        let key_title = unsafe { CStr::from_ptr(key_title) }
+            .to_string_lossy()
+            .to_string();
 
-    let args = RemoveKeyArgs::new(
-        unsafe { cstr_to_path(user_config_path) },
-        unsafe { cstr_to_path(keystore_path) },
-        key_title,
-        true,
-    );
+        let args = RemoveKeyArgs::new(
+            unsafe { cstr_to_path(user_config_path) },
+            unsafe { cstr_to_path(keystore_path) },
+            key_title,
+            true,
+        );
 
-    match run_remove_key(args) {
-        Ok(()) => OperationStatus::OK,
-        Err(error) => OperationStatus::error(
-            OperationStatusCode::ConfigurationError,
-            format!("Error removing key: {error:?}"),
-        ),
-    }
+        match run_remove_key(args) {
+            Ok(()) => OperationStatus::OK,
+            Err(error) => OperationStatus::error(
+                OperationStatusCode::ConfigurationError,
+                format!("Error removing key: {error:?}"),
+            ),
+        }
+    })
 }

--- a/c-bindings/src/api/leader.rs
+++ b/c-bindings/src/api/leader.rs
@@ -82,19 +82,21 @@ pub type FfiLeaderClaimResult = FfiStatusResult<TxHash>;
 /// [`LogosBlockchainNode`] instance.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn leader_claim(node: *const LogosBlockchainNode) -> FfiLeaderClaimResult {
-    return_error_if_null_pointer!(node);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
 
-    let node = unsafe { &*node };
-    let tx_hash = unwrap_or_return_error!(leader_claim_sync(node));
+        let node = unsafe { &*node };
+        let tx_hash = unwrap_or_return_error!(leader_claim_sync(node));
 
-    let Ok(tx_hash_array): Result<Hash, _> =
-        tx_hash.as_signing_bytes().iter().as_slice().try_into()
-    else {
-        return FfiLeaderClaimResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            "Failed to convert transaction hash to array.",
-        ));
-    };
+        let Ok(tx_hash_array): Result<Hash, _> =
+            tx_hash.as_signing_bytes().iter().as_slice().try_into()
+        else {
+            return FfiLeaderClaimResult::err(OperationStatus::error(
+                OperationStatusCode::RuntimeError,
+                "Failed to convert transaction hash to array.",
+            ));
+        };
 
-    FfiLeaderClaimResult::ok(tx_hash_array)
+        FfiLeaderClaimResult::ok(tx_hash_array)
+    })
 }

--- a/c-bindings/src/api/lifecycle.rs
+++ b/c-bindings/src/api/lifecycle.rs
@@ -38,10 +38,12 @@ pub extern "C" fn start_lb_node(
     config_path: *const c_char,
     custom_deployment_path: *const c_char,
 ) -> FfiInitializedLogosBlockchainNodeResult {
-    initialize_lb_node(config_path, custom_deployment_path).map_or_else(
-        FfiInitializedLogosBlockchainNodeResult::err,
-        FfiInitializedLogosBlockchainNodeResult::from_value,
-    )
+    crate::macros::guard_ffi(|| {
+        initialize_lb_node(config_path, custom_deployment_path).map_or_else(
+            FfiInitializedLogosBlockchainNodeResult::err,
+            FfiInitializedLogosBlockchainNodeResult::from_value,
+        )
+    })
 }
 
 /// Initializes and starts a Logos blockchain node based on the provided
@@ -167,9 +169,11 @@ fn get_deployment_config(
 /// - The pointer will not be used after this function returns
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn shutdown_node(node: *mut LogosBlockchainNode) -> OperationStatus {
-    return_error_if_null_pointer!(node);
-    let node = unsafe { Box::from_raw(node) };
-    node.shutdown()
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        let node = unsafe { Box::from_raw(node) };
+        node.shutdown()
+    })
 }
 
 #[cfg(test)]

--- a/c-bindings/src/api/peer.rs
+++ b/c-bindings/src/api/peer.rs
@@ -34,25 +34,27 @@ pub type FfiGetPeerIdResult = FfiStatusResult<*mut c_char>;
 #[must_use]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn get_peer_id(config_path: *const c_char) -> FfiGetPeerIdResult {
-    return_error_if_null_pointer!(config_path);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(config_path);
 
-    let config_path = unsafe { cstr_to_path(config_path) };
+        let config_path = unsafe { cstr_to_path(config_path) };
 
-    let peer_id = match lb_node::cli::get_peer_id::peer_id_from_config(&config_path) {
-        Ok(peer_id) => peer_id,
-        Err(error) => {
-            return FfiGetPeerIdResult::err(OperationStatus::error(
-                OperationStatusCode::ConfigurationError,
-                format!("Error deriving peer id: {error:?}"),
-            ));
+        let peer_id = match lb_node::cli::get_peer_id::peer_id_from_config(&config_path) {
+            Ok(peer_id) => peer_id,
+            Err(error) => {
+                return FfiGetPeerIdResult::err(OperationStatus::error(
+                    OperationStatusCode::ConfigurationError,
+                    format!("Error deriving peer id: {error:?}"),
+                ));
+            }
+        };
+
+        match CString::new(peer_id.to_string()) {
+            Ok(peer_id) => FfiGetPeerIdResult::ok(peer_id.into_raw()),
+            Err(error) => FfiGetPeerIdResult::err(OperationStatus::error(
+                OperationStatusCode::RuntimeError,
+                format!("Failed to create CString: {error}"),
+            )),
         }
-    };
-
-    match CString::new(peer_id.to_string()) {
-        Ok(peer_id) => FfiGetPeerIdResult::ok(peer_id.into_raw()),
-        Err(error) => FfiGetPeerIdResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            format!("Failed to create CString: {error}"),
-        )),
-    }
+    })
 }

--- a/c-bindings/src/api/storage.rs
+++ b/c-bindings/src/api/storage.rs
@@ -107,13 +107,15 @@ pub unsafe extern "C" fn get_block(
     node: *const LogosBlockchainNode,
     header_id: *const HeaderId,
 ) -> FfiGetBlockResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(header_id);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(header_id);
 
-    let header_id = unsafe { *header_id };
-    let node = unsafe { &*node };
-    let json_cstring = unwrap_or_return_error!(get_block_sync(node, header_id));
-    FfiGetBlockResult::ok(json_cstring.into_raw())
+        let header_id = unsafe { *header_id };
+        let node = unsafe { &*node };
+        let json_cstring = unwrap_or_return_error!(get_block_sync(node, header_id));
+        FfiGetBlockResult::ok(json_cstring.into_raw())
+    })
 }
 
 /// Gets a transaction by its hash as a JSON string.
@@ -210,13 +212,15 @@ pub unsafe extern "C" fn get_transaction(
     node: *const LogosBlockchainNode,
     tx_hash: *const TxHash,
 ) -> FfiGetTransactionResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(tx_hash);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(tx_hash);
 
-    let node = unsafe { &*node };
-    let tx_hash = unsafe { into_tx_hash(tx_hash) };
-    let json_cstring = unwrap_or_return_error!(get_transaction_sync(node, tx_hash));
-    FfiGetTransactionResult::ok(json_cstring.into_raw())
+        let node = unsafe { &*node };
+        let tx_hash = unsafe { into_tx_hash(tx_hash) };
+        let json_cstring = unwrap_or_return_error!(get_transaction_sync(node, tx_hash));
+        FfiGetTransactionResult::ok(json_cstring.into_raw())
+    })
 }
 
 /// Gets blocks in a slot range as a JSON array string.
@@ -306,22 +310,24 @@ pub unsafe extern "C" fn get_blocks(
     from_slot: u64,
     to_slot: u64,
 ) -> FfiGetBlocksResult {
-    return_error_if_null_pointer!(node);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
 
-    let Ok(from_slot) = usize::try_from(from_slot) else {
-        return FfiGetBlocksResult::err(OperationStatus::error(
-            OperationStatusCode::ValidationError,
-            "from_slot overflow.",
-        ));
-    };
-    let Ok(to_slot) = usize::try_from(to_slot) else {
-        return FfiGetBlocksResult::err(OperationStatus::error(
-            OperationStatusCode::ValidationError,
-            "to_slot overflow.",
-        ));
-    };
+        let Ok(from_slot) = usize::try_from(from_slot) else {
+            return FfiGetBlocksResult::err(OperationStatus::error(
+                OperationStatusCode::ValidationError,
+                "from_slot overflow.",
+            ));
+        };
+        let Ok(to_slot) = usize::try_from(to_slot) else {
+            return FfiGetBlocksResult::err(OperationStatus::error(
+                OperationStatusCode::ValidationError,
+                "to_slot overflow.",
+            ));
+        };
 
-    let node = unsafe { &*node };
-    let json_cstring = unwrap_or_return_error!(get_blocks_sync(node, from_slot, to_slot));
-    FfiGetBlocksResult::ok(json_cstring.into_raw())
+        let node = unsafe { &*node };
+        let json_cstring = unwrap_or_return_error!(get_blocks_sync(node, from_slot, to_slot));
+        FfiGetBlocksResult::ok(json_cstring.into_raw())
+    })
 }

--- a/c-bindings/src/api/subscriptions.rs
+++ b/c-bindings/src/api/subscriptions.rs
@@ -146,8 +146,10 @@ pub unsafe extern "C" fn subscribe_to_new_blocks(
     node: *const LogosBlockchainNode,
     callback_per_block: CCallback<*const c_char>,
 ) -> OperationStatus {
-    return_error_if_null_pointer!(node);
-    let node = unsafe { &*node };
-    let callback_per_block = into_boxed_callback(callback_per_block);
-    subscribe_to_new_blocks_sync(node, callback_per_block)
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        let node = unsafe { &*node };
+        let callback_per_block = into_boxed_callback(callback_per_block);
+        subscribe_to_new_blocks_sync(node, callback_per_block)
+    })
 }

--- a/c-bindings/src/api/wallet.rs
+++ b/c-bindings/src/api/wallet.rs
@@ -157,24 +157,26 @@ pub type FfiKnownAddressesResult = FfiStatusResult<KnownAddresses>;
 pub unsafe extern "C" fn get_known_addresses(
     node: *const LogosBlockchainNode,
 ) -> FfiKnownAddressesResult {
-    return_error_if_null_pointer!(node);
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
 
-    let node = unsafe { &*node };
-    let addresses = unwrap_or_return_error!(get_known_addresses_sync(node));
+        let node = unsafe { &*node };
+        let addresses = unwrap_or_return_error!(get_known_addresses_sync(node));
 
-    let address_pointers: Vec<*mut u8> = addresses
-        .into_iter()
-        .map(|pk| {
-            let bytes = fr_to_bytes(pk.as_fr());
-            Box::into_raw(Box::new(bytes)).cast::<u8>()
+        let address_pointers: Vec<*mut u8> = addresses
+            .into_iter()
+            .map(|pk| {
+                let bytes = fr_to_bytes(pk.as_fr());
+                Box::into_raw(Box::new(bytes)).cast::<u8>()
+            })
+            .collect();
+        let len = address_pointers.len();
+        let addresses_ptr = Box::leak(address_pointers.into_boxed_slice()).as_mut_ptr();
+
+        FfiKnownAddressesResult::ok(KnownAddresses {
+            addresses: addresses_ptr,
+            len,
         })
-        .collect();
-    let len = address_pointers.len();
-    let addresses_ptr = Box::leak(address_pointers.into_boxed_slice()).as_mut_ptr();
-
-    FfiKnownAddressesResult::ok(KnownAddresses {
-        addresses: addresses_ptr,
-        len,
     })
 }
 
@@ -311,34 +313,36 @@ pub unsafe extern "C" fn get_claimable_vouchers(
     node: *const LogosBlockchainNode,
     optional_tip: *const HeaderId,
 ) -> FfiClaimableVouchersResult {
-    return_error_if_null_pointer!(node);
-    let node = unsafe { &*node };
-    let tip = if optional_tip.is_null() {
-        None
-    } else {
-        Some(CoreHeaderId::from(unsafe { *optional_tip }))
-    };
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        let node = unsafe { &*node };
+        let tip = if optional_tip.is_null() {
+            None
+        } else {
+            Some(CoreHeaderId::from(unsafe { *optional_tip }))
+        };
 
-    let response = unwrap_or_return_error!(get_claimable_vouchers_sync(node, tip));
-    let vouchers: Vec<ClaimableVoucher> = response
-        .response
-        .into_iter()
-        .map(|voucher| {
-            let nullifier = voucher.nullifier.into();
-            ClaimableVoucher {
-                commitment: voucher.commitment.to_bytes(),
-                nullifier: fr_to_bytes(&nullifier),
-            }
+        let response = unwrap_or_return_error!(get_claimable_vouchers_sync(node, tip));
+        let vouchers: Vec<ClaimableVoucher> = response
+            .response
+            .into_iter()
+            .map(|voucher| {
+                let nullifier = voucher.nullifier.into();
+                ClaimableVoucher {
+                    commitment: voucher.commitment.to_bytes(),
+                    nullifier: fr_to_bytes(&nullifier),
+                }
+            })
+            .collect();
+
+        let len = vouchers.len();
+        let vouchers_ptr = Box::leak(vouchers.into_boxed_slice()).as_mut_ptr();
+
+        FfiClaimableVouchersResult::ok(ClaimableVouchers {
+            tip: response.tip.into(),
+            vouchers: vouchers_ptr,
+            len,
         })
-        .collect();
-
-    let len = vouchers.len();
-    let vouchers_ptr = Box::leak(vouchers.into_boxed_slice()).as_mut_ptr();
-
-    FfiClaimableVouchersResult::ok(ClaimableVouchers {
-        tip: response.tip.into(),
-        vouchers: vouchers_ptr,
-        len,
     })
 }
 
@@ -433,36 +437,38 @@ pub unsafe extern "C" fn get_balance(
     wallet_address: *const u8,
     optional_tip: *const HeaderId,
 ) -> FfiBalanceResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(wallet_address);
-    let node = unsafe { &*node };
-    let tip = if optional_tip.is_null() {
-        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
-            .cryptarchia_info
-            .tip
-    } else {
-        lb_core::header::HeaderId::from(unsafe { *optional_tip })
-    };
-    let wallet_address_bytes = unsafe { std::slice::from_raw_parts(wallet_address, 32) };
-    let wallet_address = unwrap_or_return_error!(
-        fr_from_bytes(wallet_address_bytes)
-            .map(ZkPublicKey::new)
-            .map_err(|error| {
-                OperationStatus::error(
-                    OperationStatusCode::DynError,
-                    format!("Invalid wallet address: {error:?}"),
-                )
-            })
-    );
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(wallet_address);
+        let node = unsafe { &*node };
+        let tip = if optional_tip.is_null() {
+            unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+                .cryptarchia_info
+                .tip
+        } else {
+            lb_core::header::HeaderId::from(unsafe { *optional_tip })
+        };
+        let wallet_address_bytes = unsafe { std::slice::from_raw_parts(wallet_address, 32) };
+        let wallet_address = unwrap_or_return_error!(
+            fr_from_bytes(wallet_address_bytes)
+                .map(ZkPublicKey::new)
+                .map_err(|error| {
+                    OperationStatus::error(
+                        OperationStatusCode::DynError,
+                        format!("Invalid wallet address: {error:?}"),
+                    )
+                })
+        );
 
-    match get_balance_sync(node, tip, wallet_address) {
-        Ok(Some(balance)) => FfiBalanceResult::ok(balance),
-        Ok(None) => FfiBalanceResult::err(OperationStatus::error(
-            OperationStatusCode::NotFound,
-            "Unknown wallet address.",
-        )),
-        Err(status) => FfiBalanceResult::err(status),
-    }
+        match get_balance_sync(node, tip, wallet_address) {
+            Ok(Some(balance)) => FfiBalanceResult::ok(balance),
+            Ok(None) => FfiBalanceResult::err(OperationStatus::error(
+                OperationStatusCode::NotFound,
+                "Unknown wallet address.",
+            )),
+            Err(status) => FfiBalanceResult::err(status),
+        }
+    })
 }
 
 /// Gets the spendable notes (UTXOs) of a wallet address.
@@ -541,51 +547,53 @@ pub unsafe extern "C" fn get_wallet_notes(
     wallet_address: *const u8,
     optional_tip: *const HeaderId,
 ) -> FfiWalletNotesResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(wallet_address);
-    let node = unsafe { &*node };
-    let tip = if optional_tip.is_null() {
-        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
-            .cryptarchia_info
-            .tip
-    } else {
-        lb_core::header::HeaderId::from(unsafe { *optional_tip })
-    };
-    let wallet_address_bytes = unsafe { std::slice::from_raw_parts(wallet_address, 32) };
-    let wallet_address = unwrap_or_return_error!(
-        fr_from_bytes(wallet_address_bytes)
-            .map(ZkPublicKey::new)
-            .map_err(|error| {
-                OperationStatus::error(
-                    OperationStatusCode::DynError,
-                    format!("Invalid wallet address: {error:?}"),
-                )
-            })
-    );
-
-    match get_wallet_notes_sync(node, tip, wallet_address) {
-        Ok(Some((resolved_tip, notes))) => {
-            let notes: Vec<WalletNote> = notes
-                .into_iter()
-                .map(|(id, value)| WalletNote {
-                    id: fr_to_bytes(id.as_fr()),
-                    value,
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(wallet_address);
+        let node = unsafe { &*node };
+        let tip = if optional_tip.is_null() {
+            unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+                .cryptarchia_info
+                .tip
+        } else {
+            lb_core::header::HeaderId::from(unsafe { *optional_tip })
+        };
+        let wallet_address_bytes = unsafe { std::slice::from_raw_parts(wallet_address, 32) };
+        let wallet_address = unwrap_or_return_error!(
+            fr_from_bytes(wallet_address_bytes)
+                .map(ZkPublicKey::new)
+                .map_err(|error| {
+                    OperationStatus::error(
+                        OperationStatusCode::DynError,
+                        format!("Invalid wallet address: {error:?}"),
+                    )
                 })
-                .collect();
-            let len = notes.len();
-            let notes_ptr = Box::leak(notes.into_boxed_slice()).as_mut_ptr();
-            FfiWalletNotesResult::ok(WalletNotes {
-                tip: resolved_tip.into(),
-                notes: notes_ptr,
-                len,
-            })
+        );
+
+        match get_wallet_notes_sync(node, tip, wallet_address) {
+            Ok(Some((resolved_tip, notes))) => {
+                let notes: Vec<WalletNote> = notes
+                    .into_iter()
+                    .map(|(id, value)| WalletNote {
+                        id: fr_to_bytes(id.as_fr()),
+                        value,
+                    })
+                    .collect();
+                let len = notes.len();
+                let notes_ptr = Box::leak(notes.into_boxed_slice()).as_mut_ptr();
+                FfiWalletNotesResult::ok(WalletNotes {
+                    tip: resolved_tip.into(),
+                    notes: notes_ptr,
+                    len,
+                })
+            }
+            Ok(None) => FfiWalletNotesResult::err(OperationStatus::error(
+                OperationStatusCode::NotFound,
+                "Unknown wallet address.",
+            )),
+            Err(status) => FfiWalletNotesResult::err(status),
         }
-        Ok(None) => FfiWalletNotesResult::err(OperationStatus::error(
-            OperationStatusCode::NotFound,
-            "Unknown wallet address.",
-        )),
-        Err(status) => FfiWalletNotesResult::err(status),
-    }
+    })
 }
 
 /// Frees the memory allocated for a [`WalletNotes`] structure.
@@ -750,57 +758,59 @@ pub unsafe extern "C" fn transfer_funds(
     node: *const LogosBlockchainNode,
     arguments: *const TransferFundsArguments,
 ) -> FfiTransferFundsResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(arguments);
-    let arguments = unsafe { &*arguments };
-    unwrap_or_return_error!(unsafe { arguments.validate() });
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(arguments);
+        let arguments = unsafe { &*arguments };
+        unwrap_or_return_error!(unsafe { arguments.validate() });
 
-    let node = unsafe { &*node };
-    let tip = if arguments.optional_tip.is_null() {
-        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
-            .cryptarchia_info
-            .tip
-    } else {
-        lb_core::header::HeaderId::from(unsafe { *arguments.optional_tip })
-    };
-    let change_public_key =
-        unwrap_or_return_error!(unsafe { parse_public_key(arguments.change_public_key) });
-    let funding_public_keys = {
-        let funding_public_keys_pointers = unsafe {
-            std::slice::from_raw_parts(
-                arguments.funding_public_keys,
-                arguments.funding_public_keys_len,
+        let node = unsafe { &*node };
+        let tip = if arguments.optional_tip.is_null() {
+            unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+                .cryptarchia_info
+                .tip
+        } else {
+            lb_core::header::HeaderId::from(unsafe { *arguments.optional_tip })
+        };
+        let change_public_key =
+            unwrap_or_return_error!(unsafe { parse_public_key(arguments.change_public_key) });
+        let funding_public_keys = {
+            let funding_public_keys_pointers = unsafe {
+                std::slice::from_raw_parts(
+                    arguments.funding_public_keys,
+                    arguments.funding_public_keys_len,
+                )
+            };
+            unwrap_or_return_error!(
+                funding_public_keys_pointers
+                    .iter()
+                    .map(|funding_public_key_pointer| unsafe {
+                        parse_public_key(*funding_public_key_pointer)
+                    })
+                    .collect::<StatusResult<Vec<_>>>()
             )
         };
-        unwrap_or_return_error!(
-            funding_public_keys_pointers
-                .iter()
-                .map(|funding_public_key_pointer| unsafe {
-                    parse_public_key(*funding_public_key_pointer)
-                })
-                .collect::<StatusResult<Vec<_>>>()
-        )
-    };
-    let recipient_public_key =
-        unwrap_or_return_error!(unsafe { parse_public_key(arguments.recipient_public_key) });
-    let amount = Value::from(arguments.amount);
+        let recipient_public_key =
+            unwrap_or_return_error!(unsafe { parse_public_key(arguments.recipient_public_key) });
+        let amount = Value::from(arguments.amount);
 
-    let transaction = unwrap_or_return_error!(transfer_funds_sync(
-        node,
-        tip,
-        change_public_key,
-        funding_public_keys,
-        recipient_public_key,
-        amount,
-    ));
-    let transaction_hash = transaction.hash().as_signing_bytes();
-    let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
-        return FfiTransferFundsResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            "Failed to convert transaction hash to array.",
+        let transaction = unwrap_or_return_error!(transfer_funds_sync(
+            node,
+            tip,
+            change_public_key,
+            funding_public_keys,
+            recipient_public_key,
+            amount,
         ));
-    };
-    FfiTransferFundsResult::ok(transaction_hash_array)
+        let transaction_hash = transaction.hash().as_signing_bytes();
+        let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
+            return FfiTransferFundsResult::err(OperationStatus::error(
+                OperationStatusCode::RuntimeError,
+                "Failed to convert transaction hash to array.",
+            ));
+        };
+        FfiTransferFundsResult::ok(transaction_hash_array)
+    })
 }
 
 /// Parses a 32-byte little-endian buffer into a [`ZkPublicKey`].
@@ -1038,104 +1048,106 @@ pub unsafe extern "C" fn channel_deposit_with_notes(
     node: *const LogosBlockchainNode,
     arguments: *const ChannelDepositWithNotesArguments,
 ) -> FfiChannelDepositResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(arguments);
-    let arguments = unsafe { &*arguments };
-    unwrap_or_return_error!(unsafe { arguments.validate() });
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(arguments);
+        let arguments = unsafe { &*arguments };
+        unwrap_or_return_error!(unsafe { arguments.validate() });
 
-    let node = unsafe { &*node };
-    let tip = if arguments.optional_tip.is_null() {
-        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
-            .cryptarchia_info
-            .tip
-    } else {
-        CoreHeaderId::from(unsafe { *arguments.optional_tip })
-    };
+        let node = unsafe { &*node };
+        let tip = if arguments.optional_tip.is_null() {
+            unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+                .cryptarchia_info
+                .tip
+        } else {
+            CoreHeaderId::from(unsafe { *arguments.optional_tip })
+        };
 
-    let channel_id = {
-        let bytes = unsafe { std::slice::from_raw_parts(arguments.channel_id, 32) };
-        let Ok(array): Result<[u8; 32], _> = bytes.try_into() else {
+        let channel_id = {
+            let bytes = unsafe { std::slice::from_raw_parts(arguments.channel_id, 32) };
+            let Ok(array): Result<[u8; 32], _> = bytes.try_into() else {
+                return FfiChannelDepositResult::err(OperationStatus::error(
+                    OperationStatusCode::RuntimeError,
+                    "Invalid channel_id length.",
+                ));
+            };
+            ChannelId::from(array)
+        };
+
+        let input_note_ids = unsafe {
+            std::slice::from_raw_parts(arguments.input_note_ids, arguments.input_note_ids_len)
+        };
+        let mut note_ids = Vec::with_capacity(arguments.input_note_ids_len);
+        for note_id_bytes in input_note_ids {
+            let note_id =
+                unwrap_or_return_error!(fr_from_bytes(note_id_bytes).map(CoreNoteId).map_err(
+                    |error| {
+                        OperationStatus::error(
+                            OperationStatusCode::DynError,
+                            format!("Invalid note ID: {error:?}"),
+                        )
+                    }
+                ));
+            note_ids.push(note_id);
+        }
+        let inputs = unwrap_or_return_error!(Inputs::try_new(note_ids).map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::DynError,
+                format!("Invalid deposit inputs: {error:?}"),
+            )
+        }));
+
+        let metadata_bytes = if arguments.metadata_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(arguments.metadata, arguments.metadata_len) }.to_vec()
+        };
+        let metadata = unwrap_or_return_error!(Metadata::try_from(metadata_bytes).map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::DynError,
+                format!("Invalid metadata: {error:?}"),
+            )
+        }));
+
+        let deposit = DepositOp {
+            channel_id,
+            inputs,
+            metadata,
+        };
+
+        let change_public_key =
+            unwrap_or_return_error!(unsafe { parse_public_key(arguments.change_public_key) });
+        let funding_public_key_pointers = unsafe {
+            std::slice::from_raw_parts(
+                arguments.funding_public_keys,
+                arguments.funding_public_keys_len,
+            )
+        };
+        let funding_public_keys = unwrap_or_return_error!(
+            funding_public_key_pointers
+                .iter()
+                .map(|pointer| unsafe { parse_public_key(*pointer) })
+                .collect::<StatusResult<Vec<_>>>()
+        );
+        let max_tx_fee = GasCost::new(arguments.max_tx_fee);
+
+        let transaction = unwrap_or_return_error!(channel_deposit_with_notes_sync(
+            node,
+            tip,
+            deposit,
+            change_public_key,
+            funding_public_keys,
+            max_tx_fee,
+        ));
+        let transaction_hash = transaction.hash().as_signing_bytes();
+        let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
             return FfiChannelDepositResult::err(OperationStatus::error(
                 OperationStatusCode::RuntimeError,
-                "Invalid channel_id length.",
+                "Failed to convert transaction hash to array.",
             ));
         };
-        ChannelId::from(array)
-    };
-
-    let input_note_ids = unsafe {
-        std::slice::from_raw_parts(arguments.input_note_ids, arguments.input_note_ids_len)
-    };
-    let mut note_ids = Vec::with_capacity(arguments.input_note_ids_len);
-    for note_id_bytes in input_note_ids {
-        let note_id =
-            unwrap_or_return_error!(fr_from_bytes(note_id_bytes).map(CoreNoteId).map_err(
-                |error| {
-                    OperationStatus::error(
-                        OperationStatusCode::DynError,
-                        format!("Invalid note ID: {error:?}"),
-                    )
-                }
-            ));
-        note_ids.push(note_id);
-    }
-    let inputs = unwrap_or_return_error!(Inputs::try_new(note_ids).map_err(|error| {
-        OperationStatus::error(
-            OperationStatusCode::DynError,
-            format!("Invalid deposit inputs: {error:?}"),
-        )
-    }));
-
-    let metadata_bytes = if arguments.metadata_len == 0 {
-        Vec::new()
-    } else {
-        unsafe { std::slice::from_raw_parts(arguments.metadata, arguments.metadata_len) }.to_vec()
-    };
-    let metadata = unwrap_or_return_error!(Metadata::try_from(metadata_bytes).map_err(|error| {
-        OperationStatus::error(
-            OperationStatusCode::DynError,
-            format!("Invalid metadata: {error:?}"),
-        )
-    }));
-
-    let deposit = DepositOp {
-        channel_id,
-        inputs,
-        metadata,
-    };
-
-    let change_public_key =
-        unwrap_or_return_error!(unsafe { parse_public_key(arguments.change_public_key) });
-    let funding_public_key_pointers = unsafe {
-        std::slice::from_raw_parts(
-            arguments.funding_public_keys,
-            arguments.funding_public_keys_len,
-        )
-    };
-    let funding_public_keys = unwrap_or_return_error!(
-        funding_public_key_pointers
-            .iter()
-            .map(|pointer| unsafe { parse_public_key(*pointer) })
-            .collect::<StatusResult<Vec<_>>>()
-    );
-    let max_tx_fee = GasCost::new(arguments.max_tx_fee);
-
-    let transaction = unwrap_or_return_error!(channel_deposit_with_notes_sync(
-        node,
-        tip,
-        deposit,
-        change_public_key,
-        funding_public_keys,
-        max_tx_fee,
-    ));
-    let transaction_hash = transaction.hash().as_signing_bytes();
-    let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
-        return FfiChannelDepositResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            "Failed to convert transaction hash to array.",
-        ));
-    };
-    FfiChannelDepositResult::ok(transaction_hash_array)
+        FfiChannelDepositResult::ok(transaction_hash_array)
+    })
 }
 
 /// Selects notes (largest-first) whose combined value covers `amount`.
@@ -1387,62 +1399,64 @@ pub unsafe extern "C" fn channel_deposit(
     node: *const LogosBlockchainNode,
     arguments: *const ChannelDepositArguments,
 ) -> FfiChannelDepositResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(arguments);
-    let arguments = unsafe { &*arguments };
-    unwrap_or_return_error!(unsafe { arguments.validate() });
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(arguments);
+        let arguments = unsafe { &*arguments };
+        unwrap_or_return_error!(unsafe { arguments.validate() });
 
-    let node = unsafe { &*node };
-    let tip = if arguments.optional_tip.is_null() {
-        unwrap_or_return_error!(get_cryptarchia_info_sync(node))
-            .cryptarchia_info
-            .tip
-    } else {
-        lb_core::header::HeaderId::from(unsafe { *arguments.optional_tip })
-    };
+        let node = unsafe { &*node };
+        let tip = if arguments.optional_tip.is_null() {
+            unwrap_or_return_error!(get_cryptarchia_info_sync(node))
+                .cryptarchia_info
+                .tip
+        } else {
+            lb_core::header::HeaderId::from(unsafe { *arguments.optional_tip })
+        };
 
-    let channel_id = {
-        let bytes = unsafe { std::slice::from_raw_parts(arguments.channel_id, 32) };
-        let Ok(array): Result<[u8; 32], _> = bytes.try_into() else {
+        let channel_id = {
+            let bytes = unsafe { std::slice::from_raw_parts(arguments.channel_id, 32) };
+            let Ok(array): Result<[u8; 32], _> = bytes.try_into() else {
+                return FfiChannelDepositResult::err(OperationStatus::error(
+                    OperationStatusCode::RuntimeError,
+                    "Invalid channel_id length.",
+                ));
+            };
+            ChannelId::from(array)
+        };
+        let funding_public_key =
+            unwrap_or_return_error!(unsafe { parse_public_key(arguments.funding_public_key) });
+        let amount = Value::from(arguments.amount);
+
+        let metadata_bytes = if arguments.metadata_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(arguments.metadata, arguments.metadata_len) }.to_vec()
+        };
+        let metadata = unwrap_or_return_error!(Metadata::try_from(metadata_bytes).map_err(|error| {
+            OperationStatus::error(
+                OperationStatusCode::DynError,
+                format!("Invalid metadata: {error:?}"),
+            )
+        }));
+
+        let transaction = unwrap_or_return_error!(channel_deposit_sync(
+            node,
+            tip,
+            channel_id,
+            funding_public_key,
+            amount,
+            metadata,
+        ));
+        let transaction_hash = transaction.hash().as_signing_bytes();
+        let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
             return FfiChannelDepositResult::err(OperationStatus::error(
                 OperationStatusCode::RuntimeError,
-                "Invalid channel_id length.",
+                "Failed to convert transaction hash to array.",
             ));
         };
-        ChannelId::from(array)
-    };
-    let funding_public_key =
-        unwrap_or_return_error!(unsafe { parse_public_key(arguments.funding_public_key) });
-    let amount = Value::from(arguments.amount);
-
-    let metadata_bytes = if arguments.metadata_len == 0 {
-        Vec::new()
-    } else {
-        unsafe { std::slice::from_raw_parts(arguments.metadata, arguments.metadata_len) }.to_vec()
-    };
-    let metadata = unwrap_or_return_error!(Metadata::try_from(metadata_bytes).map_err(|error| {
-        OperationStatus::error(
-            OperationStatusCode::DynError,
-            format!("Invalid metadata: {error:?}"),
-        )
-    }));
-
-    let transaction = unwrap_or_return_error!(channel_deposit_sync(
-        node,
-        tip,
-        channel_id,
-        funding_public_key,
-        amount,
-        metadata,
-    ));
-    let transaction_hash = transaction.hash().as_signing_bytes();
-    let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
-        return FfiChannelDepositResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            "Failed to convert transaction hash to array.",
-        ));
-    };
-    FfiChannelDepositResult::ok(transaction_hash_array)
+        FfiChannelDepositResult::ok(transaction_hash_array)
+    })
 }
 
 /// Funds a transaction from the node's wallet.
@@ -1574,47 +1588,49 @@ pub unsafe extern "C" fn wallet_fund_tx(
     node: *const LogosBlockchainNode,
     request_json: *const c_char,
 ) -> FfiWalletFundResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(request_json);
-    let node = unsafe { &*node };
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(request_json);
+        let node = unsafe { &*node };
 
-    let request_json = match unsafe { CStr::from_ptr(request_json) }.to_str() {
-        Ok(request_json) => request_json,
-        Err(error) => {
-            return FfiWalletFundResult::err(OperationStatus::error(
-                OperationStatusCode::ValidationError,
-                format!("Request is not valid UTF-8: {error}"),
-            ));
-        }
-    };
-    let request: WalletFundRequestBody = match serde_json::from_str(request_json) {
-        Ok(request) => request,
-        Err(error) => {
-            return FfiWalletFundResult::err(OperationStatus::error(
-                OperationStatusCode::ValidationError,
-                format!("Failed to parse fund request: {error}"),
-            ));
-        }
-    };
+        let request_json = match unsafe { CStr::from_ptr(request_json) }.to_str() {
+            Ok(request_json) => request_json,
+            Err(error) => {
+                return FfiWalletFundResult::err(OperationStatus::error(
+                    OperationStatusCode::ValidationError,
+                    format!("Request is not valid UTF-8: {error}"),
+                ));
+            }
+        };
+        let request: WalletFundRequestBody = match serde_json::from_str(request_json) {
+            Ok(request) => request,
+            Err(error) => {
+                return FfiWalletFundResult::err(OperationStatus::error(
+                    OperationStatusCode::ValidationError,
+                    format!("Failed to parse fund request: {error}"),
+                ));
+            }
+        };
 
-    let response = unwrap_or_return_error!(wallet_fund_tx_sync(node, request));
+        let response = unwrap_or_return_error!(wallet_fund_tx_sync(node, request));
 
-    let response_json = match serde_json::to_string(&response) {
-        Ok(response_json) => response_json,
-        Err(error) => {
-            return FfiWalletFundResult::err(OperationStatus::error(
+        let response_json = match serde_json::to_string(&response) {
+            Ok(response_json) => response_json,
+            Err(error) => {
+                return FfiWalletFundResult::err(OperationStatus::error(
+                    OperationStatusCode::RuntimeError,
+                    format!("Failed to serialize fund response: {error}"),
+                ));
+            }
+        };
+        match CString::new(response_json) {
+            Ok(response_json) => FfiWalletFundResult::ok(response_json.into_raw()),
+            Err(error) => FfiWalletFundResult::err(OperationStatus::error(
                 OperationStatusCode::RuntimeError,
-                format!("Failed to serialize fund response: {error}"),
-            ));
+                format!("Failed to create response CString: {error}"),
+            )),
         }
-    };
-    match CString::new(response_json) {
-        Ok(response_json) => FfiWalletFundResult::ok(response_json.into_raw()),
-        Err(error) => FfiWalletFundResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            format!("Failed to create response CString: {error}"),
-        )),
-    }
+    })
 }
 
 pub type FfiSubmitTransactionResult = FfiStatusResult<Hash>;
@@ -1646,62 +1662,64 @@ pub unsafe extern "C" fn submit_signed_transaction(
     node: *const LogosBlockchainNode,
     signed_tx_json: *const c_char,
 ) -> FfiSubmitTransactionResult {
-    return_error_if_null_pointer!(node);
-    return_error_if_null_pointer!(signed_tx_json);
-    let node = unsafe { &*node };
+    crate::macros::guard_ffi(|| {
+        return_error_if_null_pointer!(node);
+        return_error_if_null_pointer!(signed_tx_json);
+        let node = unsafe { &*node };
 
-    let preverified_tx = {
-        let signed_tx_json = match unsafe { CStr::from_ptr(signed_tx_json) }.to_str() {
-            Ok(signed_tx_json) => signed_tx_json,
-            Err(error) => {
-                return FfiSubmitTransactionResult::err(OperationStatus::error(
-                    OperationStatusCode::ValidationError,
-                    format!("Transaction is not valid UTF-8: {error}"),
-                ));
+        let preverified_tx = {
+            let signed_tx_json = match unsafe { CStr::from_ptr(signed_tx_json) }.to_str() {
+                Ok(signed_tx_json) => signed_tx_json,
+                Err(error) => {
+                    return FfiSubmitTransactionResult::err(OperationStatus::error(
+                        OperationStatusCode::ValidationError,
+                        format!("Transaction is not valid UTF-8: {error}"),
+                    ));
+                }
+            };
+            let signed_tx: SignedMantleTx<Unverified> = match serde_json::from_str(signed_tx_json) {
+                Ok(signed_tx) => signed_tx,
+                Err(error) => {
+                    return FfiSubmitTransactionResult::err(OperationStatus::error(
+                        OperationStatusCode::ValidationError,
+                        format!("Failed to parse signed transaction: {error}"),
+                    ));
+                }
+            };
+            match signed_tx.preverify() {
+                Ok(preverified_tx) => preverified_tx,
+                Err(error) => {
+                    return FfiSubmitTransactionResult::err(OperationStatus::error(
+                        OperationStatusCode::ValidationError,
+                        format!("Failed to preverify signed transaction: {error}"),
+                    ));
+                }
             }
         };
-        let signed_tx: SignedMantleTx<Unverified> = match serde_json::from_str(signed_tx_json) {
-            Ok(signed_tx) => signed_tx,
-            Err(error) => {
-                return FfiSubmitTransactionResult::err(OperationStatus::error(
-                    OperationStatusCode::ValidationError,
-                    format!("Failed to parse signed transaction: {error}"),
-                ));
-            }
-        };
-        match signed_tx.preverify() {
-            Ok(preverified_tx) => preverified_tx,
-            Err(error) => {
-                return FfiSubmitTransactionResult::err(OperationStatus::error(
-                    OperationStatusCode::ValidationError,
-                    format!("Failed to preverify signed transaction: {error}"),
-                ));
-            }
+
+        let transaction_hash = preverified_tx.hash().as_signing_bytes();
+        let runtime_handle = node.get_runtime_handle();
+        let submit_result = runtime_handle.block_on(async {
+            mempool::add_tx(
+                node.get_overwatch_handle(),
+                preverified_tx,
+                Transaction::hash,
+            )
+            .await
+        });
+        if let Err(error) = submit_result {
+            return FfiSubmitTransactionResult::err(OperationStatus::error(
+                OperationStatusCode::DynError,
+                format!("Failed to add transaction to mempool: {error}"),
+            ));
         }
-    };
 
-    let transaction_hash = preverified_tx.hash().as_signing_bytes();
-    let runtime_handle = node.get_runtime_handle();
-    let submit_result = runtime_handle.block_on(async {
-        mempool::add_tx(
-            node.get_overwatch_handle(),
-            preverified_tx,
-            Transaction::hash,
-        )
-        .await
-    });
-    if let Err(error) = submit_result {
-        return FfiSubmitTransactionResult::err(OperationStatus::error(
-            OperationStatusCode::DynError,
-            format!("Failed to add transaction to mempool: {error}"),
-        ));
-    }
-
-    let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
-        return FfiSubmitTransactionResult::err(OperationStatus::error(
-            OperationStatusCode::RuntimeError,
-            "Failed to convert transaction hash to array.",
-        ));
-    };
-    FfiSubmitTransactionResult::ok(transaction_hash_array)
+        let Ok(transaction_hash_array) = transaction_hash.iter().as_slice().try_into() else {
+            return FfiSubmitTransactionResult::err(OperationStatus::error(
+                OperationStatusCode::RuntimeError,
+                "Failed to convert transaction hash to array.",
+            ));
+        };
+        FfiSubmitTransactionResult::ok(transaction_hash_array)
+    })
 }

--- a/c-bindings/src/macros.rs
+++ b/c-bindings/src/macros.rs
@@ -1,4 +1,9 @@
-use crate::{errors::OperationStatus, result::FfiResult};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use crate::{
+    errors::{OperationStatus, OperationStatusCode},
+    result::FfiResult,
+};
 
 /// Checks if a pointer is null and returns from the calling function with a
 /// null-pointer error status.
@@ -69,4 +74,26 @@ impl FfiReturn for OperationStatus {
 
 impl FfiReturn for () {
     fn from_operation_status(_status: OperationStatus) -> Self {}
+}
+
+/// Runs an FFI entry-point body, converting any panic into an [`OperationStatus`]
+/// error instead of letting it unwind across the `extern "C"` boundary.
+///
+/// A panic that unwinds out of an `extern "C"` function aborts the process, so
+/// every entry point that can panic — in practice anything that drives the async
+/// runtime via `block_on` — should wrap its body in `guard_ffi`. A caught panic
+/// is reported as [`OperationStatusCode::RuntimeError`]; the standard panic hook
+/// still runs first, so the panic is logged with its backtrace as usual.
+///
+/// Note: this only makes panics recoverable once the process is *not* running the
+/// `log_and_exit_hook` panic hook (which calls `process::exit`). The embedded
+/// cdylib intentionally leaves that hook uninstalled — see
+/// `logos_blockchain_node::install_panic_hook`.
+pub fn guard_ffi<R: FfiReturn>(body: impl FnOnce() -> R) -> R {
+    catch_unwind(AssertUnwindSafe(body)).unwrap_or_else(|_| {
+        R::from_operation_status(OperationStatus::error(
+            OperationStatusCode::RuntimeError,
+            "A panic occurred while executing a node operation.",
+        ))
+    })
 }

--- a/nodes/node/binary/src/lib.rs
+++ b/nodes/node/binary/src/lib.rs
@@ -135,6 +135,21 @@ pub struct LogosBlockchain {
     tracing: TracingService,
 }
 
+/// Installs the process-wide panic hook that logs the panic and then terminates
+/// the process via [`std::process::exit`].
+///
+/// This is meant for the **standalone node binary only**. It must NOT be called
+/// from the embedded C bindings (`logos_blockchain` cdylib): `set_hook` is
+/// process-global, so a panic on any thread would tear down the host process the
+/// node is embedded in. Worse, because `exit()` runs the host's C++ static
+/// destructors, it re-enters the node's own shutdown path on a thread whose
+/// thread-locals are already being destroyed, turning a recoverable panic into a
+/// double-panic `abort`. Embedded callers rely on the default panic behavior plus
+/// the FFI layer's per-call `catch_unwind` guards instead.
+pub fn install_panic_hook() {
+    set_hook(Box::new(log_and_exit_hook));
+}
+
 pub fn run_node_from_config(
     config: RunConfig,
     handle: Option<runtime::Handle>,
@@ -206,8 +221,6 @@ pub fn run_node_from_config(
     };
 
     let http_config = api_config.backend_settings();
-
-    set_hook(Box::new(log_and_exit_hook));
 
     let app = OverwatchRunner::<LogosBlockchain>::run(
         LogosBlockchainServiceSettings {

--- a/nodes/node/binary/src/main.rs
+++ b/nodes/node/binary/src/main.rs
@@ -90,6 +90,10 @@ async fn main() -> Result<()> {
         build_run_config(user_config, cli_args)?
     };
 
+    // Standalone daemon: on panic, log and exit the process. The embedded C
+    // bindings deliberately do NOT install this hook (see `install_panic_hook`).
+    logos_blockchain_node::install_panic_hook();
+
     let app = run_node_from_config(run_config, None)
         .map_err(|e| eyre!("{e}"))
         .inspect_err(|e| {


### PR DESCRIPTION
## Problem

A host process embedding the node via the `logos_blockchain` cdylib dies with **SIGABRT** on a routine, read-only query. Observed in Logos Basecamp: `logos_host` aborts inside `get_cryptarchia_info`, which the blockchain UI polls **every 2 seconds** while a node is running.

Symptom in the log is a double panic:

```
panicked at library/std/src/thread/local.rs:428:25:
thread panicked while processing panic. aborting.
FATAL: module 'blockchain_module' crashed (signal 6)
```

## Root cause

`run_node_from_config` unconditionally installed the `log_and_exit_hook` panic hook, which calls `std::process::exit(1)`. That is correct for the standalone daemon — but the same function also backs the cdylib's `start_lb_node`, and `std::panic::set_hook` is **process-global**. So once a host started an embedded node, a panic on *any* thread terminated the entire host.

It gets worse than a plain exit. `exit()` runs the host's C++ static destructors, which call back into the node's own `stop_node`/`shutdown_node` FFI — on a thread whose thread-locals are already being destroyed. That second panic during panic is what turns it into an `abort`:

```
get_cryptarchia_info (FFI)
  -> panic
  -> log_and_exit_hook -> std::process::exit(1)
     -> __cxa_finalize_ranges          [C runtime]
        -> ~LogosBlockchainModule()    [host C++]
           -> stop_node (FFI)          [re-enters tokio mid-teardown]
              -> panic during panic -> abort()
```

### What actually panics

The panic originates upstream, in Overwatch (`ae887f41`, `overwatch/src/overwatch/handle.rs:78-86`):

```rust
let Ok(()) = self.send(OverwatchCommand::Relay(..)).await else {
    unreachable!("Service relay should always be available");
};
```

`send` is a tokio mpsc send that returns `Err` as soon as the receiver is dropped — i.e. once Overwatch begins shutting down. So this is a race: any `cryptarchia_info` poll landing during/after shutdown hits that `unreachable!`. (`handle.rs:118` has the same issue in `status_watcher`.) Worth fixing there too by returning a `RelayError`, but the embedded node should not be fatally sensitive to it either way.

## Changes

**1. Don't install a `process::exit` panic hook from library code.** The hook moves out of `run_node_from_config` into a documented `install_panic_hook()`, called only from the standalone binary. Behaviour there is unchanged — still installed only on the node-run path, not for CLI subcommands.

**2. Stop panics unwinding across the FFI boundary.** New `guard_ffi` helper wraps a body in `catch_unwind` and converts a panic into an `OperationStatus` (`RuntimeError`) instead of unwinding out of an `extern "C"` fn (which aborts). Applied to all **27 FFI operation entry points**.

The pure `free_*` deallocators and the `is_ok`/`is_error` accessors are intentionally left unwrapped: they run no node logic.

Both parts are needed. (1) alone would still abort at the `extern "C"` boundary; (2) alone wouldn't help while the exit hook runs first. Together, the query returns a recoverable error and the host stays alive.

## Verification

Toolchain 1.96.0, matching `rust-toolchain.toml`:

- `cargo check -p logos-blockchain-c -p logos-blockchain-node` — exit 0
- `cargo clippy -p logos-blockchain-c -p logos-blockchain-node --all-targets` — exit 0, **zero warnings in any touched file** (`--all-targets` also type-checks test code)

Applies identically to the `0.2.0` tag if a `0.2.x` backport is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)