### PR TITLE
test(cucumber): recover wallet scanner from reorged snapshot seed tips

### DIFF
--- a/tests/src/common/wallet/scanner/config.rs
+++ b/tests/src/common/wallet/scanner/config.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use lb_core::{header::HeaderId, mantle::Utxo};
 use lb_testing_framework::NodeHttpClient;
 
-use super::state::SharedWalletScannerState;
+use super::state::{ScannerStateCheckpoint, SharedWalletScannerState};
 use crate::{
     common::wallet::{TrackedWalletKeys, WalletUtxos},
     cucumber::{
@@ -57,6 +57,9 @@ pub enum ScannerSeed {
         source_node_names: Vec<String>,
         /// Number of trailing slots to verify before tailing from the seed tip.
         rescan_blocks: u64,
+        /// Older checkpoints to fall back to when the seed tip is not found on
+        /// the restored chain, newest first.
+        fallback_checkpoints: Vec<ScannerStateCheckpoint>,
     },
 }
 
@@ -71,6 +74,7 @@ impl ScannerSeed {
             slot,
             source_node_names,
             rescan_blocks,
+            fallback_checkpoints,
         } = self
         else {
             return Self::Genesis;
@@ -80,10 +84,24 @@ impl ScannerSeed {
             .iter()
             .map(|wallet| wallet.wallet_id().clone())
             .collect::<std::collections::HashSet<_>>();
-        let wallet_utxos = wallet_utxos
+
+        let filter_utxos = |utxos: &WalletUtxos| {
+            utxos
+                .iter()
+                .filter(|(wallet_id, _)| wallet_ids.contains(*wallet_id))
+                .map(|(wallet_id, utxos)| (wallet_id.clone(), utxos.clone()))
+                .collect::<WalletUtxos>()
+        };
+
+        let wallet_utxos = filter_utxos(wallet_utxos);
+        let fallback_checkpoints = fallback_checkpoints
             .iter()
-            .filter(|(wallet_id, _)| wallet_ids.contains(*wallet_id))
-            .map(|(wallet_id, utxos)| (wallet_id.clone(), utxos.clone()))
+            .map(|checkpoint| ScannerStateCheckpoint {
+                wallet_utxos: filter_utxos(&checkpoint.wallet_utxos),
+                tip: checkpoint.tip,
+                height: checkpoint.height,
+                slot: checkpoint.slot,
+            })
             .collect();
 
         Self::Snapshot {
@@ -93,6 +111,7 @@ impl ScannerSeed {
             slot: *slot,
             source_node_names: source_node_names.clone(),
             rescan_blocks: (*rescan_blocks).min(MAX_SCANNER_SNAPSHOT_RESCAN_BLOCKS),
+            fallback_checkpoints,
         }
     }
 }

--- a/tests/src/common/wallet/scanner/group.rs
+++ b/tests/src/common/wallet/scanner/group.rs
@@ -8,7 +8,7 @@ use lb_testing_framework::NodeHttpClient;
 
 use super::{
     config::{ForkGroupScannerConfig, ScannerSeed, SharedBestNodeSelector},
-    state::{ForkGroupScannerState, SharedWalletScannerState},
+    state::{ForkGroupScannerState, ScannerStateCheckpoint, SharedWalletScannerState},
 };
 use crate::{
     common::wallet::TrackedWalletKeys,
@@ -228,6 +228,7 @@ fn scanner_seed_for_group(
             slot,
             source_node_names,
             rescan_blocks,
+            fallback_checkpoints,
         } = seed
         else {
             continue;
@@ -240,6 +241,7 @@ fn scanner_seed_for_group(
             slot,
             source_node_names: Vec::new(),
             rescan_blocks,
+            fallback_checkpoints: Vec::new(),
         });
 
         let ScannerSeed::Snapshot {
@@ -249,6 +251,7 @@ fn scanner_seed_for_group(
             slot: merged_slot,
             source_node_names: merged_source_node_names,
             rescan_blocks: merged_rescan_blocks,
+            fallback_checkpoints: merged_fallback_checkpoints,
         } = seed
         else {
             unreachable!("merged seed is always a snapshot");
@@ -266,7 +269,104 @@ fn scanner_seed_for_group(
         merged_wallet_utxos.extend(wallet_utxos);
         merged_source_node_names.extend(source_node_names);
         *merged_rescan_blocks = (*merged_rescan_blocks).max(rescan_blocks);
+        reassemble_fallback_checkpoints(merged_fallback_checkpoints, fallback_checkpoints)?;
     }
 
     Ok(merged_seed.unwrap_or(ScannerSeed::Genesis))
+}
+
+/// Reassemble the group-wide fallback checkpoint list from per-node slices.
+///
+/// The snapshot format stores one wallet-UTXO slice per node, all cut from the
+/// same scanner checkpoint list, so every slice must agree on (tip, height,
+/// slot) per entry; reassembly is a disjoint union of the wallet tables, not a
+/// reconciliation. A shorter list is allowed and extends the reassembled one.
+fn reassemble_fallback_checkpoints(
+    merged: &mut Vec<ScannerStateCheckpoint>,
+    incoming: Vec<ScannerStateCheckpoint>,
+) -> Result<(), StepError> {
+    for (index, checkpoint) in incoming.into_iter().enumerate() {
+        match merged.get_mut(index) {
+            None => merged.push(checkpoint),
+            Some(existing) => {
+                if existing.tip != checkpoint.tip
+                    || existing.height != checkpoint.height
+                    || existing.slot != checkpoint.slot
+                {
+                    return Err(StepError::LogicalError {
+                        message: format!(
+                            "wallet scanner snapshot fallback checkpoints for group diverge at \
+                             index {index}: first={}/{}/{} next={}/{}/{}",
+                            existing.tip,
+                            existing.height,
+                            existing.slot,
+                            checkpoint.tip,
+                            checkpoint.height,
+                            checkpoint.slot,
+                        ),
+                    });
+                }
+                existing.wallet_utxos.extend(checkpoint.wallet_utxos);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_core::header::HeaderId;
+
+    use super::*;
+    use crate::common::wallet::WalletId;
+
+    fn checkpoint(tip_byte: u8, height: u64, slot: u64, wallet: &str) -> ScannerStateCheckpoint {
+        ScannerStateCheckpoint {
+            wallet_utxos: std::iter::once((WalletId::new(wallet), Vec::new())).collect(),
+            tip: HeaderId::from([tip_byte; 32]),
+            height,
+            slot,
+        }
+    }
+
+    #[test]
+    fn reassemble_fallback_checkpoints_unions_wallet_utxos_per_position() {
+        let mut merged = vec![checkpoint(1, 5, 50, "wallet-a")];
+
+        reassemble_fallback_checkpoints(&mut merged, vec![checkpoint(1, 5, 50, "wallet-b")])
+            .expect("same chain positions must merge");
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].wallet_utxos.len(), 2);
+    }
+
+    #[test]
+    fn reassemble_fallback_checkpoints_extends_with_longer_list() {
+        let mut merged = vec![checkpoint(1, 5, 50, "wallet-a")];
+
+        reassemble_fallback_checkpoints(
+            &mut merged,
+            vec![
+                checkpoint(1, 5, 50, "wallet-b"),
+                checkpoint(2, 4, 49, "wallet-b"),
+            ],
+        )
+        .expect("longer list must extend the merged list");
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[1].tip, HeaderId::from([2; 32]));
+    }
+
+    #[test]
+    fn reassemble_fallback_checkpoints_rejects_diverging_positions() {
+        let mut merged = vec![checkpoint(1, 5, 50, "wallet-a")];
+
+        let result =
+            reassemble_fallback_checkpoints(&mut merged, vec![checkpoint(2, 5, 50, "wallet-b")]);
+
+        assert!(
+            result.is_err(),
+            "diverging checkpoint tips must be rejected"
+        );
+    }
 }

--- a/tests/src/common/wallet/scanner/runner.rs
+++ b/tests/src/common/wallet/scanner/runner.rs
@@ -16,7 +16,7 @@ use super::{
     accounting::ScannerAccounting,
     block_source::stream_blocks_range,
     config::{ForkGroupScannerConfig, ScannerSeed},
-    state::{ScannerStatus, SharedWalletScannerState},
+    state::{ScannerStateCheckpoint, ScannerStatus, SharedWalletScannerState},
 };
 use crate::{
     common::wallet::{
@@ -33,6 +33,7 @@ const TARGET: &str = "cucumber_wallet";
 const MIN_SCANNER_CHECKPOINTS: usize = 8;
 const MAX_SCANNER_CHECKPOINTS: usize = 128;
 const SCANNER_ROLLBACK_BLOCKS: u64 = 5;
+const PUBLISHED_SCANNER_CHECKPOINTS: usize = 8;
 
 #[derive(Clone)]
 struct ScannerCheckpoint {
@@ -73,12 +74,14 @@ struct ScannerInitialState {
     applied_tip: Option<HeaderId>,
     applied_slot: Option<u64>,
     source_node_names: Vec<String>,
+    seed_fallbacks: VecDeque<ScannerStateCheckpoint>,
 }
 
 #[derive(Debug)]
 enum ScannerIterationError {
     Step(StepError),
     Continuity(StepError),
+    SeedTipNotFound(StepError),
 }
 
 impl From<StepError> for ScannerIterationError {
@@ -216,6 +219,7 @@ fn initialize_scanner_from_seed(
                 applied_tip: None,
                 applied_slot: None,
                 source_node_names: Vec::new(),
+                seed_fallbacks: VecDeque::new(),
             })
         }
         ScannerSeed::Snapshot {
@@ -224,6 +228,7 @@ fn initialize_scanner_from_seed(
             height,
             slot,
             source_node_names,
+            fallback_checkpoints,
             ..
         } => {
             let accounting = ScannerAccounting::from_wallet_utxos(
@@ -239,6 +244,11 @@ fn initialize_scanner_from_seed(
                 applied_tip: Some(*tip),
                 applied_slot: Some(*slot),
                 source_node_names: source_node_names.clone(),
+                seed_fallbacks: fallback_checkpoints
+                    .iter()
+                    .filter(|checkpoint| checkpoint.tip != *tip)
+                    .cloned()
+                    .collect(),
             })
         }
     }
@@ -298,7 +308,12 @@ async fn run_group_scanner(config: ForkGroupScannerConfig, shutdown_requested: A
     let mut applied_tip = initial_state.applied_tip;
     let mut applied_slot = initial_state.applied_slot;
     let source_node_names = initial_state.source_node_names;
+    let mut seed_fallbacks = initial_state.seed_fallbacks;
     let mut snapshot_rescan = snapshot_rescan_from_seed(&config.seed);
+    let seed_rescan_blocks = match &config.seed {
+        ScannerSeed::Snapshot { rescan_blocks, .. } => *rescan_blocks,
+        ScannerSeed::Genesis => 0,
+    };
     let mut checkpoints = VecDeque::new();
     let mut last_msg = String::new();
     if let Some(applied_tip) = applied_tip
@@ -323,7 +338,7 @@ async fn run_group_scanner(config: ForkGroupScannerConfig, shutdown_requested: A
             applied_height,
             applied_tip,
             applied_slot,
-            source_node_names,
+            source_node_names.clone(),
         ),
     );
 
@@ -354,6 +369,43 @@ async fn run_group_scanner(config: ForkGroupScannerConfig, shutdown_requested: A
                 group.status = ScannerStatus::Error;
                 group.last_error = Some(scanner_iteration_error_message(&error));
             });
+            let error = if let ScannerIterationError::SeedTipNotFound(step_error) = error {
+                let reseeded = reseed_from_fallback_checkpoint(
+                    &config,
+                    &mut seed_fallbacks,
+                    seed_rescan_blocks,
+                    &source_node_names,
+                    &mut accounting,
+                    &mut applied_height,
+                    &mut applied_tip,
+                    &mut applied_slot,
+                    &mut checkpoints,
+                    &mut snapshot_rescan,
+                )
+                .unwrap_or_else(|reseed_error| {
+                    warn!(
+                        target: TARGET,
+                        "wallet scanner group '{}' fallback checkpoint reseed failed: {reseed_error}",
+                        display_group_key(&config.group_id),
+                    );
+                    false
+                });
+                if reseeded {
+                    if sleep_or_shutdown(
+                        &shutdown_requested,
+                        config.poll_interval,
+                        &config.group_id,
+                    )
+                    .await
+                    {
+                        return;
+                    }
+                    continue;
+                }
+                ScannerIterationError::Continuity(step_error)
+            } else {
+                error
+            };
             if matches!(error, ScannerIterationError::Continuity(_)) {
                 if let Some(checkpoint) = rollback_checkpoint(&checkpoints, applied_height)
                     .filter(|checkpoint| checkpoint.applied_height < applied_height)
@@ -440,6 +492,87 @@ fn check_shutdown(shutdown_requested: &Arc<AtomicBool>, group_id: &str) -> bool 
         return true;
     }
     false
+}
+
+/// Re-seed the scanner from the next restored fallback checkpoint.
+///
+/// Returns `Ok(true)` when a fallback was applied, `Ok(false)` when no
+/// fallback checkpoints remain.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Re-seeding owns the same explicit mutable scanner-loop state as reset."
+)]
+fn reseed_from_fallback_checkpoint(
+    config: &ForkGroupScannerConfig,
+    seed_fallbacks: &mut VecDeque<ScannerStateCheckpoint>,
+    seed_rescan_blocks: u64,
+    source_node_names: &[String],
+    accounting: &mut ScannerAccounting,
+    applied_height: &mut u64,
+    applied_tip: &mut Option<HeaderId>,
+    applied_slot: &mut Option<u64>,
+    checkpoints: &mut VecDeque<ScannerCheckpoint>,
+    snapshot_rescan: &mut Option<SnapshotRescan>,
+) -> Result<bool, StepError> {
+    let Some(checkpoint) = seed_fallbacks.pop_front() else {
+        return Ok(false);
+    };
+
+    warn!(
+        target: TARGET,
+        "wallet scanner group '{}' seed tip not found on restored chain; falling back to \
+        snapshot checkpoint {} at height {} slot {}",
+        display_group_key(&config.group_id),
+        checkpoint.tip,
+        checkpoint.height,
+        checkpoint.slot,
+    );
+
+    *accounting = ScannerAccounting::from_wallet_utxos(
+        config.wallet_keys.clone(),
+        checkpoint.wallet_utxos,
+    )
+    .map_err(|error| StepError::LogicalError {
+        message: format!(
+            "wallet scanner accounting re-initialization from fallback checkpoint failed: {error}"
+        ),
+    })?;
+    *applied_height = checkpoint.height;
+    *applied_tip = Some(checkpoint.tip);
+    *applied_slot = Some(checkpoint.slot);
+    *snapshot_rescan = (seed_rescan_blocks > 0).then_some(SnapshotRescan {
+        tip: checkpoint.tip,
+        slot: checkpoint.slot,
+        blocks: seed_rescan_blocks,
+    });
+    checkpoints.clear();
+    push_checkpoint(
+        checkpoints,
+        ScannerCheckpoint::new(
+            accounting,
+            *applied_height,
+            *applied_tip,
+            *applied_slot,
+            source_node_names.to_vec(),
+        ),
+    );
+    if !source_node_names.is_empty()
+        && let Err(error) = publish_wallet_state(
+            &config.wallets,
+            source_node_names,
+            *applied_height,
+            checkpoint.tip.to_string(),
+            accounting.wallet_utxos(),
+        )
+    {
+        warn!(
+            target: TARGET,
+            "wallet scanner group '{}' failed to publish fallback checkpoint state: {error}",
+            display_group_key(&config.group_id),
+        );
+    }
+
+    Ok(true)
 }
 
 fn reset_scanner_to_genesis(
@@ -661,6 +794,7 @@ async fn scan_group_once(
 
     publish_new_observed_transaction_hashes(config, accounting, &observed_tx_hashes_before);
 
+    let recent_checkpoints = recent_state_checkpoints(checkpoints);
     update_group_state(&config.scanner_state, &config.group_id, |group| {
         group.applied_height = *applied_height;
         group.applied_slot = *applied_slot;
@@ -669,6 +803,7 @@ async fn scan_group_once(
         group.wallet_count = accounting.tracked_wallet_count();
         group.status = ScannerStatus::Tailing;
         group.last_error = None;
+        group.recent_checkpoints = recent_checkpoints;
     });
 
     if applied_block_count > 0 {
@@ -786,16 +921,18 @@ async fn verify_snapshot_rescan(
     })?;
 
     if !found_seed_tip {
-        return Err(ScannerIterationError::Step(StepError::LogicalError {
-            message: format!(
-                "wallet scanner snapshot trailing rescan for group '{}' did not find seed tip {} \
-                 in slot range {}..={}",
-                display_group_key(&config.group_id),
-                rescan.tip,
-                slot_from,
-                rescan.slot,
-            ),
-        }));
+        return Err(ScannerIterationError::SeedTipNotFound(
+            StepError::LogicalError {
+                message: format!(
+                    "wallet scanner snapshot trailing rescan for group '{}' did not find seed tip \
+                     {} in slot range {}..={}",
+                    display_group_key(&config.group_id),
+                    rescan.tip,
+                    slot_from,
+                    rescan.slot,
+                ),
+            },
+        ));
     }
 
     info!(
@@ -810,6 +947,30 @@ async fn verify_snapshot_rescan(
     );
 
     Ok(())
+}
+
+/// Convert the newest in-memory scanner checkpoints into shareable state.
+///
+/// Newest first, capped at [`PUBLISHED_SCANNER_CHECKPOINTS`]. Checkpoints
+/// without a concrete tip and slot (the genesis placeholder) are skipped.
+fn recent_state_checkpoints(
+    checkpoints: &VecDeque<ScannerCheckpoint>,
+) -> Vec<ScannerStateCheckpoint> {
+    checkpoints
+        .iter()
+        .rev()
+        .filter_map(|checkpoint| {
+            let tip = checkpoint.applied_tip?;
+            let slot = checkpoint.applied_slot?;
+            Some(ScannerStateCheckpoint {
+                tip,
+                height: checkpoint.applied_height,
+                slot,
+                wallet_utxos: checkpoint.accounting.wallet_utxos(),
+            })
+        })
+        .take(PUBLISHED_SCANNER_CHECKPOINTS)
+        .collect()
 }
 
 fn push_checkpoint(checkpoints: &mut VecDeque<ScannerCheckpoint>, checkpoint: ScannerCheckpoint) {
@@ -857,9 +1018,9 @@ fn rollback_checkpoint(
 
 fn scanner_iteration_error_message(error: &ScannerIterationError) -> String {
     match error {
-        ScannerIterationError::Step(error) | ScannerIterationError::Continuity(error) => {
-            error.to_string()
-        }
+        ScannerIterationError::Step(error)
+        | ScannerIterationError::Continuity(error)
+        | ScannerIterationError::SeedTipNotFound(error) => error.to_string(),
     }
 }
 

--- a/tests/src/common/wallet/scanner/state.rs
+++ b/tests/src/common/wallet/scanner/state.rs
@@ -5,8 +5,27 @@ use std::{
 
 use lb_core::header::HeaderId;
 
+use crate::common::wallet::WalletUtxos;
+
 /// Shared scanner status snapshot across scanner tasks and cucumber waits.
 pub type SharedWalletScannerState = Arc<Mutex<WalletScannerState>>;
+
+#[derive(Debug, Clone)]
+/// One scanner-applied chain position with the wallet UTXOs observed at it.
+///
+/// Published by scanner tasks so snapshot-on-stop can persist a short recovery
+/// history instead of only the newest applied tip, which may be reorged out
+/// between snapshot capture and node shutdown.
+pub struct ScannerStateCheckpoint {
+    /// Scanner-applied block tip at this checkpoint.
+    pub tip: HeaderId,
+    /// Scanner-applied synthetic height at this checkpoint.
+    pub height: u64,
+    /// Scanner-applied consensus slot at this checkpoint.
+    pub slot: u64,
+    /// Wallet UTXOs as observed through this checkpoint's tip.
+    pub wallet_utxos: WalletUtxos,
+}
 
 #[derive(Debug, Default)]
 /// Status for all wallet scanner fork groups.
@@ -44,6 +63,8 @@ pub struct ForkGroupScannerState {
     pub observed_tx_hashes: usize,
     /// Number of wallets tracked by this group.
     pub wallet_count: usize,
+    /// Recent scanner-applied checkpoints, newest first.
+    pub recent_checkpoints: Vec<ScannerStateCheckpoint>,
 }
 
 impl ForkGroupScannerState {
@@ -64,6 +85,7 @@ impl ForkGroupScannerState {
             last_error: None,
             observed_tx_hashes: 0,
             wallet_count,
+            recent_checkpoints: Vec::new(),
         }
     }
 }

--- a/tests/src/cucumber/wallet/snapshot.rs
+++ b/tests/src/cucumber/wallet/snapshot.rs
@@ -13,7 +13,10 @@ use testing_framework_core::scenario::{DynError, SnapshotArtifact, SnapshotStore
 use crate::{
     common::wallet::{
         TrackedWallets, TrackedWalletsState, WalletId, WalletUtxos,
-        scanner::config::{DEFAULT_SCANNER_SNAPSHOT_RESCAN_BLOCKS, ScannerSeed},
+        scanner::{
+            config::{DEFAULT_SCANNER_SNAPSHOT_RESCAN_BLOCKS, ScannerSeed},
+            state::ScannerStateCheckpoint,
+        },
     },
     cucumber::{
         defaults::snapshots_root_dir,
@@ -44,6 +47,18 @@ struct WalletNodeSnapshot {
     height: u64,
     #[serde(default)]
     slot: Option<u64>,
+    tracked_wallets: TrackedWalletsState,
+    /// Older scanner checkpoints, newest first, used as fallback seed
+    /// positions when the snapshot tip is not found on the restored chain.
+    #[serde(default)]
+    checkpoints: Vec<WalletSnapshotCheckpoint>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct WalletSnapshotCheckpoint {
+    tip: String,
+    height: u64,
+    slot: u64,
     tracked_wallets: TrackedWalletsState,
 }
 
@@ -97,6 +112,18 @@ impl WalletSnapshot {
                 ),
             })?;
             let tip = tip.to_string();
+            let checkpoints = group
+                .recent_checkpoints
+                .iter()
+                .map(|checkpoint| WalletSnapshotCheckpoint {
+                    tip: checkpoint.tip.to_string(),
+                    height: checkpoint.height,
+                    slot: checkpoint.slot,
+                    tracked_wallets: TrackedWalletsState::from_wallet_utxos(
+                        checkpoint.wallet_utxos.clone(),
+                    ),
+                })
+                .collect::<Vec<_>>();
             let group_nodes = scanner_group_node_names(world, &group.group_id);
             for node_name in group_nodes {
                 let mut node_snapshot = WalletNodeSnapshot {
@@ -104,6 +131,7 @@ impl WalletSnapshot {
                     height: group.applied_height,
                     slot: Some(slot),
                     tracked_wallets: scanner_wallets.clone(),
+                    checkpoints: checkpoints.clone(),
                 };
                 filter_node_snapshot_wallets(world, &node_name, &mut node_snapshot)?;
                 states_by_node.insert(node_name, node_snapshot);
@@ -166,6 +194,24 @@ impl WalletSnapshot {
             Some(slot) => slot,
             None => fetch_tip_slot(client, &tip).await?,
         };
+        let fallback_checkpoints = node_snapshot
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.tip != node_snapshot.tip)
+            .map(|checkpoint| {
+                Ok(ScannerStateCheckpoint {
+                    wallet_utxos: checkpoint
+                        .tracked_wallets
+                        .to_wallet_utxos()
+                        .into_iter()
+                        .filter(|(wallet_id, _)| runtime_wallet_ids.contains(wallet_id))
+                        .collect(),
+                    tip: parse_header_id(&checkpoint.tip)?,
+                    height: checkpoint.height,
+                    slot: checkpoint.slot,
+                })
+            })
+            .collect::<Result<Vec<_>, StepError>>()?;
 
         world.with_wallets_mut(|wallets| {
             wallets.record_header_height(
@@ -190,6 +236,7 @@ impl WalletSnapshot {
                 slot,
                 source_node_names: vec![runtime_node_name.to_owned()],
                 rescan_blocks: DEFAULT_SCANNER_SNAPSHOT_RESCAN_BLOCKS,
+                fallback_checkpoints,
             },
         );
 
@@ -341,6 +388,9 @@ fn filter_node_snapshot_wallets(
     node_snapshot.tracked_wallets = node_snapshot
         .tracked_wallets
         .filtered_to_wallets(&wallet_ids);
+    for checkpoint in &mut node_snapshot.checkpoints {
+        checkpoint.tracked_wallets = checkpoint.tracked_wallets.filtered_to_wallets(&wallet_ids);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

## Problem

The wallet snapshot only stores the scanner's latest applied tip. The tip is captured while nodes are still producing blocks, so a reorg between capture and shutdown can leave the snapshot pointing at a block that got discarded. After restart the rescan looks for that tip in the canonical block stream and never finds it. There was no recovery path for this case, so the scanner just retried the same lookup forever and wallet steps timed out.

Seen in CI on both linux and macos runners — same error repeating for ~90 min across all retries of the snapshot scenarios.

## Fix

The scanner already keeps a few recent checkpoints in memory for reorg rollback, so the snapshot now stores the last 8 of those (tip, height, slot, wallet utxos) instead of a single tip. On restore, if the newest tip isn't found on the chain, seeding falls back to the next older checkpoint. If none verify, it falls through to the existing reset-to-genesis replay, so the scanner can't get stuck anymore.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
