### PR TITLE
feat(api): return structured JSON error bodies

### DIFF
--- a/nodes/node/binary/src/api/errors.rs
+++ b/nodes/node/binary/src/api/errors.rs
@@ -16,8 +16,6 @@ pub enum ApiError {
     NotFoundEmpty,
     #[error("Internal server error")]
     InternalServerError,
-    #[error("Internal server error")]
-    InternalJson(serde_json::Value),
     #[error(transparent)]
     Internal(#[from] DynError),
 }
@@ -30,26 +28,38 @@ impl ApiError {
     pub fn internal_message(message: impl Into<String>) -> Self {
         Self::Internal(DynError::from(message.into()))
     }
+}
 
-    pub const fn internal_json(body: serde_json::Value) -> Self {
-        Self::InternalJson(body)
-    }
+/// Body returned for every API error response, mirroring the
+/// `{code, message}` envelope used by the Ethereum Beacon API.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ErrorBody {
+    pub code: u16,
+    pub message: String,
+}
+
+fn error_response(status: StatusCode, message: String) -> Response {
+    (
+        status,
+        Json(ErrorBody {
+            code: status.as_u16(),
+            message,
+        }),
+    )
+        .into_response()
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         match self {
-            Self::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
-            Self::NotFound(message) => (StatusCode::NOT_FOUND, message).into_response(),
-            Self::NotFoundEmpty => (StatusCode::NOT_FOUND,).into_response(),
+            Self::BadRequest(message) => error_response(StatusCode::BAD_REQUEST, message),
+            Self::NotFound(message) => error_response(StatusCode::NOT_FOUND, message),
+            error @ Self::NotFoundEmpty => error_response(StatusCode::NOT_FOUND, error.to_string()),
             error @ Self::InternalServerError => {
-                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
-            }
-            Self::InternalJson(body) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+                error_response(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
             }
             Self::Internal(error) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
+                error_response(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
             }
         }
     }
@@ -153,60 +163,80 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn generic_internal_error_preserves_existing_response() {
-        let response = ApiError::InternalServerError.into_response();
+    async fn envelope_of(response: Response) -> (StatusCode, serde_json::Value) {
         let status = response.status();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
         let body = body::to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("response body should be readable");
 
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body, "Internal server error");
+        assert_eq!(content_type.as_deref(), Some("application/json"));
+        let envelope = serde_json::from_slice(&body).expect("body should be valid JSON");
+        (status, envelope)
     }
 
     #[tokio::test]
-    async fn internal_error_preserves_existing_response() {
-        let response = ApiError::from(DynError::from("service unavailable")).into_response();
-        let status = response.status();
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("response body should be readable");
+    async fn bad_request_returns_json_envelope() {
+        let response = ApiError::BadRequest("invalid query".into()).into_response();
+        let (status, envelope) = envelope_of(response).await;
 
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body, "service unavailable");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 400, "message": "invalid query" })
+        );
     }
 
     #[tokio::test]
-    async fn empty_not_found_preserves_existing_response() {
-        let response = ApiError::NotFoundEmpty.into_response();
-        let status = response.status();
-        let content_type = response.headers().get(CONTENT_TYPE).cloned();
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("response body should be readable");
+    async fn not_found_returns_json_envelope() {
+        let response = ApiError::NotFound("Block not found".into()).into_response();
+        let (status, envelope) = envelope_of(response).await;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(content_type, None);
-        assert!(body.is_empty());
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 404, "message": "Block not found" })
+        );
     }
 
     #[tokio::test]
-    async fn json_error_preserves_existing_response() {
-        let response =
-            ApiError::internal_json(serde_json::json!({ "error": "failure" })).into_response();
-        let status = response.status();
-        let content_type = response.headers().get(CONTENT_TYPE).cloned();
-        let body = body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("response body should be readable");
+    async fn generic_internal_error_returns_json_envelope() {
+        let response = ApiError::InternalServerError.into_response();
+        let (status, envelope) = envelope_of(response).await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(
-            content_type.as_ref().and_then(|value| value.to_str().ok()),
-            Some("application/json")
+            envelope,
+            serde_json::json!({ "code": 500, "message": "Internal server error" })
         );
-        assert_eq!(body, "{\"error\":\"failure\"}");
+    }
+
+    #[tokio::test]
+    async fn internal_error_returns_json_envelope() {
+        let response = ApiError::from(DynError::from("service unavailable")).into_response();
+        let (status, envelope) = envelope_of(response).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 500, "message": "service unavailable" })
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_not_found_returns_json_envelope() {
+        let response = ApiError::NotFoundEmpty.into_response();
+        let (status, envelope) = envelope_of(response).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            envelope,
+            serde_json::json!({ "code": 404, "message": "Not found" })
+        );
     }
 
     #[tokio::test]

--- a/nodes/node/binary/src/api/handlers.rs
+++ b/nodes/node/binary/src/api/handlers.rs
@@ -358,7 +358,7 @@ macro_rules! make_request_and_return_response {
     path = paths::MANTLE_METRICS,
     responses(
         (status = 200, description = "Get the mempool metrics of the cl service", body = inline(schema::MempoolMetrics)),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn mantle_metrics<StorageAdapter, RuntimeServiceId>(
@@ -409,7 +409,7 @@ where
     path = paths::MANTLE_STATUS,
     responses(
         (status = 200, description = "Query the mempool status of the cl service", body = Vec<<T as Transaction>::Hash>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn mantle_status<StorageAdapter, RuntimeServiceId>(
@@ -467,7 +467,7 @@ pub struct CryptarchiaInfoQuery {
     path = paths::CRYPTARCHIA_INFO,
     responses(
         (status = 200, description = "Query consensus information", body = lb_consensus::CryptarchiaInfo),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn cryptarchia_info<RuntimeServiceId>(
@@ -485,7 +485,7 @@ where
     path = paths::TIME_INFO,
     responses(
         (status = 200, description = "Query time service information", body = TimeInfo),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn time_info<RuntimeServiceId>(
@@ -524,7 +524,7 @@ where
     path = paths::CRYPTARCHIA_HEADERS,
     responses(
         (status = 200, description = "Query header ids", body = Vec<HeaderId>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn cryptarchia_headers<RuntimeServiceId>(
@@ -546,7 +546,7 @@ where
     path = paths::CRYPTARCHIA_LIB_STREAM,
     responses(
         (status = 200, description = "Request a stream for lib blocks"),
-        (status = 500, description = "Internal server error", body = StreamBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn cryptarchia_lib_stream<RuntimeServiceId>(
@@ -568,7 +568,7 @@ where
     path = paths::NETWORK_INFO,
     responses(
         (status = 200, description = "Query the network information", body = lb_network_service::backends::libp2p::Libp2pInfo),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn libp2p_info<RuntimeServiceId>(
@@ -590,7 +590,7 @@ where
     request_body = DialPeerRequestBody,
     responses(
         (status = 200, description = "Dial a network peer", body = PeerId),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn dial_peer<RuntimeServiceId>(
@@ -616,7 +616,7 @@ where
     path = paths::BLEND_NETWORK_INFO,
     responses(
         (status = 200, description = "Query the blend network information", body = Option<lb_blend_service::message::NetworkInfo<PeerId>>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blend_info<BlendService, BroadcastSettings, RuntimeServiceId>(
@@ -644,7 +644,7 @@ where
     request_body = BlendJoinNetworkRequestBody,
     responses(
         (status = 200, description = "Join the blend network", body = Option<lb_core::sdp::DeclarationId>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blend_join_network<BlendService, BroadcastSettings, RuntimeServiceId>(
@@ -672,7 +672,7 @@ where
     path = paths::MEMPOOL_ADD_TX,
     responses(
         (status = 200, description = "Add transaction to the mempool"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn add_tx<StorageAdapter, RuntimeServiceId>(
@@ -732,7 +732,7 @@ where
     path = paths::MEMPOOL_VIEW,
     responses(
         (status = 200, description = "Get current tip mempool transaction hashes", body = Vec<TxHash>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn mempool_view<StorageAdapter, RuntimeServiceId>(
@@ -902,7 +902,7 @@ where
     path = paths::CHANNEL,
     responses(
         (status = 200, description = "Channel state"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn channel<RuntimeServiceId>(
@@ -921,7 +921,7 @@ where
     path = paths::CHANNEL_DEPOSIT,
     responses(
         (status = 200, description = "Submit a channel deposit"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn channel_deposit<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1019,7 +1019,7 @@ where
     path = paths::SDP_POST_DECLARATION,
     responses(
         (status = 200, description = "Post declaration to SDP service", body = lb_core::sdp::DeclarationId),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_declaration<
@@ -1067,7 +1067,7 @@ where
     path = paths::SDP_POST_ACTIVITY,
     responses(
         (status = 200, description = "Post activity to SDP service"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_activity<
@@ -1115,7 +1115,7 @@ where
     path = paths::SDP_POST_WITHDRAWAL,
     responses(
         (status = 200, description = "Post withdrawal to SDP service"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_withdrawal<
@@ -1163,7 +1163,7 @@ where
     path = paths::SDP_POST_SET_DECLARATION_ID,
     responses(
         (status = 200, description = "Post declaration to SDP service to be set as current", body = lb_core::sdp::DeclarationId),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn post_set_declaration_id<
@@ -1213,7 +1213,7 @@ where
     path = paths::MANTLE_SDP_DECLARATIONS,
     responses(
         (status = 200, description = "Get current SDP declarations keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn get_sdp_declarations<RuntimeServiceId>(
@@ -1231,7 +1231,7 @@ where
     path = paths::MANTLE_SDP_SNAPSHOT,
     responses(
         (status = 200, description = "Get the SDP snapshot for the current epoch keyed by declaration id", body = std::collections::HashMap<lb_core::sdp::DeclarationId, lb_core::sdp::Declaration>),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn get_sdp_snapshot<RuntimeServiceId>(
@@ -1249,7 +1249,7 @@ where
     path = paths::LEADER_CLAIM,
     responses(
         (status = 200, description = "Leader claim transaction submitted", body = lb_api_service::http::consensus::leader::LeaderClaimResponseBody),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn leader_claim<ChainLeader, RuntimeServiceId>(
@@ -1268,7 +1268,7 @@ where
     params(BlockRangeQuery),
     responses(
         (status = 200, description = "Get blocks"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn immutable_blocks<StorageBackend, RuntimeServiceId>(
@@ -1304,8 +1304,8 @@ where
     path = paths::BLOCKS_DETAIL,
     responses(
         (status = 200, description = "Block found"),
-        (status = 404, description = "Block not found"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 404, description = "Block not found", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn block<HttpStorageAdapter, RuntimeServiceId>(
@@ -1337,8 +1337,8 @@ where
     path = paths::BLOCK_EVENTS,
     responses(
         (status = 200, description = "Block events", body = Events),
-        (status = 404, description = "Block not found"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 404, description = "Block not found", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn block_events<RuntimeServiceId>(
@@ -1373,7 +1373,7 @@ pub struct GasPricesQuery {
     path = paths::MANTLE_GAS_PRICES,
     responses(
         (status = 200, description = "Get the gas prices from the ledger state at the tip"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn get_gas_prices<RuntimeServiceId>(
@@ -1421,7 +1421,7 @@ where
     path = paths::BLOCKS_STREAM,
     responses(
         (status = 200, description = "Stream of processed blocks with chain state"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blocks_stream<StorageBackend, ConsensusService, RuntimeServiceId>(
@@ -1459,8 +1459,8 @@ where
         (status = 200, description = "Stream of processed blocks with chain state in slot order. \
             When immutable_only=true and slot_to is omitted, the stream anchors at LIB slot by \
             default."),
-        (status = 400, description = "Invalid request parameters", body = String),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 400, description = "Invalid request parameters", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn blocks_range_stream<StorageBackend, RuntimeServiceId>(
@@ -1545,8 +1545,8 @@ where
     path = paths::TRANSACTION,
     responses(
         (status = 200, description = "Transaction found"),
-        (status = 404, description = "Transaction not found"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 404, description = "Transaction not found", body = ErrorBody),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
 )]
 pub async fn transaction<HttpStorageAdapter, RuntimeServiceId>(
@@ -1573,13 +1573,11 @@ where
             let api_transaction = ApiSignedTransaction::from(transaction);
             (StatusCode::OK, Json(api_transaction)).into_response()
         }
-        _ => {
-            let error_body = serde_json::json!({
-                "error": "Multiple transactions found",
-                "len": transactions.len()
-            });
-            ApiError::internal_json(error_body).into_response()
-        }
+        _ => ApiError::internal_message(format!(
+            "Multiple transactions found ({})",
+            transactions.len()
+        ))
+        .into_response(),
     }
 }
 
@@ -1605,7 +1603,7 @@ pub mod wallet {
     path = paths::wallet::BALANCE,
     responses(
         (status = 200, description = "Get wallet balance"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
     )]
     pub async fn get_balance<WalletService, RuntimeServiceId>(
@@ -1650,7 +1648,7 @@ pub mod wallet {
     path = paths::LEADER_CLAIM_VOUCHERS,
     responses(
         (status = 200, description = "Get claimable wallet vouchers"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
     )]
     pub async fn get_claimable_vouchers<WalletService, RuntimeServiceId>(
@@ -1688,7 +1686,7 @@ pub mod wallet {
     path = paths::wallet::TRANSACTIONS_TRANSFER_FUNDS,
     responses(
         (status = 200, description = "Make transfer"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = ErrorBody),
     )
     )]
     pub async fn post_transactions_transfer_funds<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1783,7 +1781,7 @@ pub mod wallet {
         path = paths::wallet::SIGN_TX_ED25519,
         responses(
             (status = 200, description = "Signed transaction"),
-            (status = 500, description = "Internal server error", body = String),
+            (status = 500, description = "Internal server error", body = ErrorBody),
         )
     )]
     pub async fn sign_tx_ed25519<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1841,7 +1839,7 @@ pub mod wallet {
         path = paths::wallet::SIGN_TX_ZK,
         responses(
             (status = 200, description = "Signed transaction"),
-            (status = 500, description = "Internal server error", body = String),
+            (status = 500, description = "Internal server error", body = ErrorBody),
         )
     )]
     pub async fn sign_tx_zk<WalletService, StorageAdapter, RuntimeServiceId>(
@@ -1899,7 +1897,7 @@ pub mod wallet {
         path = paths::wallet::FUND,
         responses(
             (status = 200, description = "Funded transaction with fee transfer proof"),
-            (status = 500, description = "Internal server error", body = String),
+            (status = 500, description = "Internal server error", body = ErrorBody),
         )
     )]
     pub async fn fund<WalletService, StorageAdapter, RuntimeServiceId>(

--- a/nodes/node/binary/src/api/openapi.rs
+++ b/nodes/node/binary/src/api/openapi.rs
@@ -35,7 +35,7 @@ use utoipa::OpenApi;
         crate::api::handlers::wallet::fund,
         crate::api::tracing::reload_tracing_filter,
     ),
-    components(schemas(schema::Status, schema::MempoolMetrics)),
+    components(schemas(schema::Status, schema::MempoolMetrics, crate::api::errors::ErrorBody)),
     tags()
 )]
 pub struct ApiDoc;

--- a/nodes/node/binary/src/api/tracing.rs
+++ b/nodes/node/binary/src/api/tracing.rs
@@ -17,7 +17,7 @@ const LOG_TARGET: &str = node::api::TRACING;
     path = paths::admin::TRACING_FILTER,
     responses(
         (status = 200, description = "Tracing filter reloaded"),
-        (status = 500, description = "Internal server error", body = String),
+        (status = 500, description = "Internal server error", body = crate::api::errors::ErrorBody),
     )
 )]
 pub async fn reload_tracing_filter<RuntimeServiceId>(


### PR DESCRIPTION
## 1. What does this PR implement?

Returns all node API error responses as a structured JSON body instead of plain text.

Error bodies were free-form strings (the bare-404 case had no body at all), so clients could only react to failures by string-matching prose. All errors now use a `{code, message}` envelope, emitted from the single `ApiError` → response mapping introduced in #3172. The OpenAPI document is updated to match (`ErrorBody` schema instead of `String`/bodyless).

Before:

```
HTTP/1.1 404 Not Found

Block not found
```

After:

```
HTTP/1.1 404 Not Found
Content-Type: application/json

{"code": 404, "message": "Block not found"}
```

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
