### PR TITLE
chore: add nextest unit tests result

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+  merge_group:
+    types: [ checks_requested ]
   push:
     branches: [ master ]
 
@@ -118,7 +120,12 @@ jobs:
 
   tests:
     name: Run test suite
-    if: ${{ !startsWith(github.event.pull_request.title, '[WIP]') && !contains(github.event.label.name,  'DO NOT MERGE') }}
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        !startsWith(github.event.pull_request.title, '[WIP]') &&
+        !contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE')
+      }}
     strategy:
       fail-fast: false # all OSes should be tested even if one fails (default: true)
       matrix:
@@ -143,11 +150,11 @@ jobs:
         with:
           command: run
           args: >-
-            --locked -p logos-blockchain-node --features testing 
+            --locked -p logos-blockchain-node --features testing
             -- nodes/node/standalone-node-config.yaml --check-config --deployment nodes/node/standalone-deployment-config.yaml
 
       - name: Install cargo-nextest
-        if: ${{ !cancelled()}}
+        if: ${{ !cancelled() }}
         uses: taiki-e/install-action@13608cbb45b01feb47ef444ab1a42dc41ad56f1a # Version 2.79.11
         with:
           tool: cargo-nextest
@@ -176,3 +183,33 @@ jobs:
           name: integration-test-artifacts-${{ runner.os }}-${{ github.sha }}
           include-hidden-files: true
           path: tests/.run_*
+
+  # Stable required check for nextest unit tests.
+  #
+  # On pull requests and pushes to master, this job succeeds only when both
+  # self-hosted nextest unit tests matrix jobs succeeded.
+  #
+  # On merge_group, the real nextest unit tests matrix is skipped and this lightweight
+  # check succeeds because nextest unit tests was already required before queue admission.
+  nextest-unit-tests-result:
+    name: Nextest unit tests result
+    needs: tests
+    if: ${{ always() && github.event_name != 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check nextest unit tests result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+        run: |
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            echo "Nextest unit tests already passed before merge-queue admission"
+            exit 0
+          fi
+
+          if [ "$TESTS_RESULT" = "success" ]; then
+            exit 0
+          fi
+
+          echo "Nextest unit tests did not pass: $TESTS_RESULT"
+          exit 1


### PR DESCRIPTION
## 1. What does this PR implement?

Added "Nextest unit tests result" for merge queue management.

### CI and merge flow

#### 1. Pull request opened or updated

Opening a pull request, reopening it, or pushing a new commit triggers the normal `pull_request` workflows.

The following `code-check.yml` jobs run against the PR revision:

- Formatting
- `cargo-deny`
- Workspace dependency policy checks
- Unused dependency checks on Linux and macOS
- Rust lints on Linux and macOS
- Nextest unit tests on the self-hosted Linux and macOS runners

The nextest unit-test matrix runs only during this stage. It does not run again in the merge queue or after the change reaches `master`.

The `Nextest unit tests result` job waits for the entire unit-test matrix:

- Linux success and macOS success: the result passes
- Either runner fails, is cancelled, or is skipped: the result fails

This stable result is the required branch-protection check. The individual OS-specific `Run test suite` checks are not required separately.

#### 2. Heavy integration tests are deferred

The Cucumber and E2E workflows are also triggered by the pull request, but their expensive matrix jobs are skipped.

Their lightweight aggregate jobs still report:

- `Cucumber result`: success
- `E2E result`: success

At this stage, these successes mean that the heavy suites have been deferred to the merge queue. They do not mean that the Cucumber or E2E tests have already executed.

This allows the PR to receive normal review and approval without occupying the self-hosted runners with speculative integration-test runs.

#### 3. Pull request requirements are satisfied

Before the PR can enter the merge queue, it must satisfy the repository's pull-request requirements, including:

- Required approval and Code Owner review
- `Nextest unit tests result`
- `Check Rust lints (ubuntu-latest)`
- `Check Rust lints (macos-latest)`
- `Cucumber result`
- `E2E result`

The real nextest unit tests have therefore passed before the PR is admitted to the merge queue.

A user can select `Merge when ready` before every requirement is complete, but GitHub waits until the remaining requirements are satisfied before adding the PR to the queue.

#### 4. GitHub creates a merge-group commit

When the PR enters the merge queue, GitHub creates a temporary merge-group commit.

This commit contains:

- The latest version of `master`
- The pull request's changes
- Any changes from pull requests ahead of it in the queue

The merge-group commit has a different SHA from the PR revision. It represents the exact combined state GitHub intends to merge into `master`.

GitHub then emits a `merge_group` event with the `checks_requested` action.

#### 5. Code checks run against the merge group

The `merge_group` event triggers `code-check.yml` against the temporary merge-group commit.

The regular code-quality jobs run against the combined state, including the required Linux and macOS Rust lint jobs.

The real nextest unit-test matrix is skipped because it already passed on the PR revision.

`Nextest unit tests result` still reports success for the merge-group commit. This supplies the required status that GitHub expects on the new merge-group SHA without running the unit-test matrix a second time.

#### 6. E2E integration tests run in the merge queue

The `merge_group` event triggers `end-to-end-integration-tests.yml`.

The E2E suite uses nextest, but it is separate from the nextest unit-test suite in `code-check.yml`.

The E2E tests run on both self-hosted matrix runners:

- Linux
- macOS

The `E2E result` aggregate job waits for both runners to conclude. The result passes when at least one runner succeeds:

| Linux | macOS | `E2E result` |
|---|---|---|
| Success | Success | Success |
| Success | Failure | Success |
| Failure | Success | Success |
| Failure | Failure | Failure |

Only `E2E result` is required by branch protection. The individual OS-specific E2E jobs are not required.

#### 7. Cucumber integration tests run in the merge queue

The `merge_group` event also triggers `cucumber-integration-tests.yml`.

The Cucumber tests run on both self-hosted matrix runners:

- Linux
- macOS

The `Cucumber result` aggregate job waits for both runners to conclude. As with E2E, the result passes when at least one runner succeeds:

| Linux | macOS | `Cucumber result` |
|---|---|---|
| Success | Success | Success |
| Success | Failure | Success |
| Failure | Success | Success |
| Failure | Failure | Failure |

Only `Cucumber result` is required by branch protection. The individual OS-specific Cucumber jobs are not required.

#### 8. GitHub evaluates the merge-group results

The merge-group commit can proceed when all required checks have reported success:

- `Nextest unit tests result`
- `Check Rust lints (ubuntu-latest)`
- `Check Rust lints (macos-latest)`
- `Cucumber result`
- `E2E result`

The unit-test result represents the unit tests that passed before queue admission. The lint, E2E, and Cucumber results validate the combined merge-group state.

#### 9. Successful merge

When all required merge-group checks pass, GitHub merges the already validated merge-group commit into `master`.

The PR author does not need to rebase the PR branch or rerun the heavy integration suites whenever `master` changes. The queue creates and validates the correct combined commit automatically.

#### 10. Failed merge-queue checks

If a required merge-group check fails or times out:

- The PR is not merged
- `master` remains unchanged
- GitHub removes the affected PR from the merge queue
- The PR timeline records why it was removed
- Pull requests behind it are rebuilt without the failing change
- The affected PR can be fixed or retried and then added to the queue again

A single failed E2E or Cucumber OS runner does not remove the PR when the other runner succeeds. Both runners for that suite must fail for its aggregate required check to fail.

#### 11. Post-merge `master` workflow

Merging the PR updates `master`, which triggers the existing `push` event in `code-check.yml`.

The non-unit code checks may run again against `master`, preserving the existing post-merge workflow behavior.

The nextest unit-test matrix is skipped on this event, and `Nextest unit tests result` is also skipped. The unit tests therefore run only once per PR revision.

The E2E and Cucumber workflows do not respond to the `master` push, so their heavy suites are not repeated after the successful merge.

### Required repository settings

After this workflow is available on `master`, the branch-protection rule should:

- Require `Nextest unit tests result`
- Require `Check Rust lints (ubuntu-latest)`
- Require `Check Rust lints (macos-latest)`
- Require `Cucumber result`
- Require `E2E result`
- Not require the OS-specific `Run test suite` checks
- Not require the OS-specific E2E checks
- Not require the OS-specific Cucumber checks
- Disable `Require branches to be up to date before merging`
- Enable `Require merge queue`
- Continue requiring pull-request approval and Code Owner review

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal, @danielSanchezQ 

## 4. Is the specification accurate and complete?

YEs

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
