### PR TITLE
refactor(transactions): Split verification

### DIFF
--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -75,7 +75,7 @@ pub enum Error {
     },
     #[error("Channel {channel_id:?} not found")]
     ChannelNotFound { channel_id: ChannelId },
-    #[error("The Channel Config isn't well formed")]
+    #[error("The Channel Config isn't well-formed")]
     InvalidChannelConfig,
     #[error("Channel transfer inputs and outputs have different total value")]
     UnbalancedTransfer,
@@ -267,9 +267,10 @@ impl ChannelState {
     // Returns the new sequencer index and its starting slot
     #[must_use]
     pub fn round_robin(&self, block_slot: Slot) -> (u16, Slot) {
-        let elapsed_slot_since_last_tip = (block_slot.saturating_sub(self.tip_slot)).into_inner();
-        let tip_sequencer_duration =
-            (block_slot.saturating_sub(self.tip_sequencer_starting_slot)).into_inner();
+        let elapsed_slot_since_last_tip = block_slot.saturating_sub(self.tip_slot).into_inner();
+        let tip_sequencer_duration = block_slot
+            .saturating_sub(self.tip_sequencer_starting_slot)
+            .into_inner();
         let posting_timeframe = u64::from(self.posting_timeframe.0);
         let posting_timeout = u64::from(self.posting_timeout.0);
         let num_sequencers = self.accredited_keys.len() as u64; // bounded by ChannelKeyIndex::MAX

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -75,7 +75,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
             ctx.helper,
             ctx.op_index,
         )
-        .map_err(|_error| Error::InvalidSignature)?; // FIXME: Pattern is recursive
+        .map_err(|_error| Error::InvalidSignature)?; // FIXME: Discards error details
 
         // Check that the channel exist
         let channel =

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +11,7 @@ use crate::{
             OpId,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
-        transactions::OperationVerificationHelper,
+        transactions::{OperationVerificationHelper, hash::TxHashView},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -49,7 +48,7 @@ pub struct ChannelTransferValidationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
-    pub tx_hash_bytes: &'a Bytes,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ChannelMultiSigProof,
     pub op_index: usize,
     pub helper: &'a dyn OperationVerificationHelper,
@@ -72,7 +71,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
         verify_channel_multi_sig(
             &self.channel_id,
             ctx.proof,
-            ctx.tx_hash_bytes,
+            ctx.tx_hash_view.as_bytes(),
             ctx.helper,
             ctx.op_index,
         )
@@ -117,7 +116,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
                 .accredited_keys
                 .get(sig.channel_key_index as usize)
                 .ok_or(Error::InvalidSignature)?
-                .verify(ctx.tx_hash_bytes, &sig.signature)
+                .verify(ctx.tx_hash_view.as_bytes(), &sig.signature)
                 .is_err()
             {
                 return Err(Error::InvalidSignature);

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +8,11 @@ use crate::{
         TxHash,
         channel::{Channels, Error},
         ledger::{Inputs, Operation, Outputs, Utxo, Utxos},
-        ops::{OpId, channel::ChannelId},
+        ops::{
+            OpId,
+            channel::{ChannelId, verification::verify_channel_multi_sig},
+        },
+        transactions::OperationVerificationHelper,
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -25,6 +30,13 @@ impl ChannelTransferOp {
     pub fn utxos(&self) -> impl Iterator<Item = Utxo> {
         self.outputs.utxos(self)
     }
+
+    pub fn verify_stateless(&self) -> Result<(), Error> {
+        // Check that the outputs are valid
+        self.outputs.validate()?;
+
+        Ok(())
+    }
 }
 
 impl OpId for ChannelTransferOp {
@@ -37,8 +49,10 @@ pub struct ChannelTransferValidationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
-    pub tx_hash: &'a TxHash,
-    pub transfer_sigs: &'a ChannelMultiSigProof,
+    pub tx_hash_bytes: &'a Bytes,
+    pub proof: &'a ChannelMultiSigProof,
+    pub op_index: usize,
+    pub helper: &'a dyn OperationVerificationHelper,
 }
 
 pub struct ChannelTransferExecutionContext {
@@ -55,8 +69,14 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
     type Error = Error;
 
     fn validate(&self, ctx: &ChannelTransferValidationContext<'_>) -> Result<(), Self::Error> {
-        // Check that the outputs are valid
-        self.outputs.validate()?;
+        verify_channel_multi_sig(
+            &self.channel_id,
+            ctx.proof,
+            ctx.tx_hash_bytes,
+            ctx.helper,
+            ctx.op_index,
+        )
+        .map_err(|_error| Error::InvalidSignature)?; // FIXME: Pattern is recursive
 
         // Check that the channel exist
         let channel =
@@ -82,7 +102,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
         }
 
         // Check there is enough signatures
-        let signatures = ctx.transfer_sigs.signatures();
+        let signatures = ctx.proof.signatures();
         if signatures.len() != channel.transfer_threshold as usize {
             return Err(Error::ThresholdUnmet {
                 channel_id: self.channel_id,
@@ -97,7 +117,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
                 .accredited_keys
                 .get(sig.channel_key_index as usize)
                 .ok_or(Error::InvalidSignature)?
-                .verify(ctx.tx_hash.as_signing_bytes().as_ref(), &sig.signature)
+                .verify(ctx.tx_hash_bytes, &sig.signature)
                 .is_err()
             {
                 return Err(Error::InvalidSignature);

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -8,6 +8,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     events::TxEvent,
     mantle::{
+        VerificationError,
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
         ledger::Operation,
         transactions::hash::TxHash,
@@ -34,6 +35,10 @@ impl ChannelConfigOp {
         let mut hasher = Hasher::new();
         hasher.update(self.encode());
         MsgId(hasher.finalize().into())
+    }
+
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
     }
 }
 

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use lb_cryptarchia_engine::Slot;
 use lb_utils::bounded::NonEmptyBoundedVec;
@@ -11,6 +10,7 @@ use crate::{
     mantle::{
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
         ledger::Operation,
+        transactions::hash::TxHashView,
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
 };
@@ -48,7 +48,7 @@ impl ChannelConfigOp {
 
 pub struct ChannelConfigValidationContext<'a> {
     pub channels: &'a Channels,
-    pub tx_hash_bytes: &'a Bytes,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ChannelMultiSigProof,
 }
 
@@ -89,7 +89,7 @@ impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
                         sequencers: channel.accredited_keys.len(),
                         index: signature.channel_key_index,
                     })?
-                    .verify(ctx.tx_hash_bytes, &signature.signature)
+                    .verify(ctx.tx_hash_view.as_bytes(), &signature.signature)
                     .is_err()
                 {
                     return Err(Error::InvalidSignature);

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use lb_cryptarchia_engine::Slot;
 use lb_utils::bounded::NonEmptyBoundedVec;
@@ -8,10 +9,8 @@ use crate::{
     crypto::{Digest as _, Hasher},
     events::TxEvent,
     mantle::{
-        VerificationError,
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
         ledger::Operation,
-        transactions::hash::TxHash,
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
 };
@@ -37,15 +36,20 @@ impl ChannelConfigOp {
         MsgId(hasher.finalize().into())
     }
 
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub const fn verify_stateless(&self) -> Result<(), Error> {
+        // Check config is well-formed
+        if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
+        {
+            return Err(Error::InvalidChannelConfig);
+        }
         Ok(())
     }
 }
 
 pub struct ChannelConfigValidationContext<'a> {
     pub channels: &'a Channels,
-    pub tx_hash: &'a TxHash,
-    pub config_sigs: &'a ChannelMultiSigProof,
+    pub tx_hash_bytes: &'a Bytes,
+    pub proof: &'a ChannelMultiSigProof,
 }
 
 pub struct ChannelConfigExecutionContext {
@@ -64,34 +68,28 @@ impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
         // Check that the indexes are unique and there is the same number of proof and
         // index. This is enforced by the proof structure that enforces it.
 
-        // Check config wellformness
-        if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
-        {
-            return Err(Error::InvalidChannelConfig);
-        }
-
         if let Some(channel) = ctx.channels.channel_state(&self.channel) {
             // Check there is enough signatures
-            let signatures = ctx.config_sigs.signatures();
+            let signatures = ctx.proof.signatures();
             if signatures.len() != channel.configuration_threshold as usize {
                 return Err(Error::ThresholdUnmet {
                     channel_id: self.channel,
                     threshold: channel.configuration_threshold,
-                    actual: ctx.config_sigs.signatures().len(),
+                    actual: ctx.proof.signatures().len(),
                 });
             }
 
             // Check the signatures
-            for sig in signatures {
+            for signature in signatures {
                 if channel
                     .accredited_keys
-                    .get(sig.channel_key_index as usize)
+                    .get(signature.channel_key_index as usize)
                     .ok_or_else(|| Error::InvalidSignatureIndex {
                         channel_id: self.channel,
                         sequencers: channel.accredited_keys.len(),
-                        index: sig.channel_key_index,
+                        index: signature.channel_key_index,
                     })?
-                    .verify(ctx.tx_hash.as_signing_bytes().as_ref(), &sig.signature)
+                    .verify(ctx.tx_hash_bytes, &signature.signature)
                     .is_err()
                 {
                     return Err(Error::InvalidSignature);

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -1,5 +1,4 @@
 use lb_codec::{BinaryCodec, BinaryEncode as _};
-use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
@@ -10,7 +9,7 @@ use crate::{
         channel::{Channels, Error},
         ledger::{Inputs, InputsError, Operation, Outputs, Utxos},
         ops::{OpId, channel::ChannelId},
-        transactions::hash::TxHash,
+        transactions::hash::{TxHash, TxHashView},
     },
     sdp::locked_notes::LockedNotes,
 };
@@ -57,7 +56,7 @@ pub struct DepositValidationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
-    pub tx_hash_fr: &'a Fr,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ZkSignature,
 }
 
@@ -88,7 +87,7 @@ impl Operation<DepositValidationContext<'_>> for DepositOp {
 
         // Check the signature
         let public_keys = self.inputs.get_pk(ctx.utxos)?;
-        if !ZkPublicKey::verify_multi(&public_keys, ctx.tx_hash_fr, ctx.proof) {
+        if !ZkPublicKey::verify_multi(&public_keys, ctx.tx_hash_view.as_fr(), ctx.proof) {
             return Err(Error::InvalidSignature);
         }
 

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::{DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
+        VerificationError,
         channel::{Channels, Error},
         ledger::{Inputs, InputsError, Operation, Outputs, Utxos},
         ops::{OpId, channel::ChannelId},
@@ -39,6 +40,10 @@ impl DepositOp {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Outputs::try_new(notes)?)
+    }
+
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
     }
 }
 

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -1,4 +1,5 @@
 use lb_codec::{BinaryCodec, BinaryEncode as _};
+use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use lb_utils::bounded::UpperBoundedVec;
 use serde::{Deserialize, Serialize};
@@ -6,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::{DepositRecreatedNotes, TxEvent, TxEventPayload},
     mantle::{
-        VerificationError,
         channel::{Channels, Error},
         ledger::{Inputs, InputsError, Operation, Outputs, Utxos},
         ops::{OpId, channel::ChannelId},
@@ -42,7 +42,7 @@ impl DepositOp {
         Ok(Outputs::try_new(notes)?)
     }
 
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub const fn verify_stateless(&self) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -57,8 +57,8 @@ pub struct DepositValidationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
-    pub tx_hash: &'a TxHash,
-    pub deposit_sig: &'a ZkSignature,
+    pub tx_hash_fr: &'a Fr,
+    pub proof: &'a ZkSignature,
 }
 
 pub struct DepositExecutionContext {
@@ -87,8 +87,8 @@ impl Operation<DepositValidationContext<'_>> for DepositOp {
             .validate_not_in_channel(ctx.locked_notes, ctx.channels, ctx.utxos)?;
 
         // Check the signature
-        let pks = self.inputs.get_pk(ctx.utxos)?;
-        if !ZkPublicKey::verify_multi(&pks, &ctx.tx_hash.to_fr(), ctx.deposit_sig) {
+        let public_keys = self.inputs.get_pk(ctx.utxos)?;
+        if !ZkPublicKey::verify_multi(&public_keys, ctx.tx_hash_fr, ctx.proof) {
             return Err(Error::InvalidSignature);
         }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -15,6 +15,7 @@ use crate::{
         channel::{ChannelState, Channels, Error},
         ledger::Operation,
         ops::channel::config::Keys,
+        transactions::hash::TxHashView,
     },
 };
 
@@ -45,12 +46,12 @@ impl InscriptionOp {
 
     pub fn verify_stateless(
         &self,
-        tx_hash_bytes: &[u8],
+        tx_hash_view: &TxHashView,
         proof: &Ed25519Signature,
     ) -> Result<(), Error> {
         // Check the signature
         self.signer
-            .verify(tx_hash_bytes, proof)
+            .verify(tx_hash_view.as_bytes(), proof)
             .map_err(|_error| Error::InvalidSignature)?;
 
         Ok(())

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -12,6 +12,7 @@ use crate::{
     crypto::{Digest as _, Hasher},
     events::TxEvent,
     mantle::{
+        VerificationError,
         channel::{ChannelState, Channels, Error},
         ledger::Operation,
         ops::channel::config::Keys,
@@ -42,6 +43,17 @@ impl InscriptionOp {
         let mut hasher = Hasher::new();
         hasher.update(self.encode().as_ref());
         MsgId(hasher.finalize().into())
+    }
+
+    pub fn verify_stateless(
+        &self,
+        tx_hash_bytes: &[u8],
+        proof: &Ed25519Signature,
+        op_index: usize,
+    ) -> Result<(), VerificationError> {
+        self.signer
+            .verify(tx_hash_bytes, proof)
+            .map_err(|_| VerificationError::InvalidSignature { op_index })
     }
 }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -12,11 +12,9 @@ use crate::{
     crypto::{Digest as _, Hasher},
     events::TxEvent,
     mantle::{
-        VerificationError,
         channel::{ChannelState, Channels, Error},
         ledger::Operation,
         ops::channel::config::Keys,
-        transactions::hash::TxHash,
     },
 };
 
@@ -49,18 +47,18 @@ impl InscriptionOp {
         &self,
         tx_hash_bytes: &[u8],
         proof: &Ed25519Signature,
-        op_index: usize,
-    ) -> Result<(), VerificationError> {
+    ) -> Result<(), Error> {
+        // Check the signature
         self.signer
             .verify(tx_hash_bytes, proof)
-            .map_err(|_| VerificationError::InvalidSignature { op_index })
+            .map_err(|_error| Error::InvalidSignature)?;
+
+        Ok(())
     }
 }
 
 pub struct InscriptionValidationContext<'a> {
     pub channels: &'a Channels,
-    pub tx_hash: &'a TxHash,
-    pub inscribe_sig: &'a Ed25519Signature,
     pub block_slot: Slot,
 }
 
@@ -105,15 +103,6 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
                 parent: self.parent.into(),
                 actual: MsgId::root().into(),
             });
-        }
-
-        // Check the signature
-        if self
-            .signer
-            .verify(ctx.tx_hash.as_signing_bytes().as_ref(), ctx.inscribe_sig)
-            .is_err()
-        {
-            return Err(Error::InvalidSignature);
         }
 
         Ok(())

--- a/core/src/mantle/ops/channel/verification.rs
+++ b/core/src/mantle/ops/channel/verification.rs
@@ -13,7 +13,7 @@ pub fn verify_channel_multi_sig(
     channel_id: &ChannelId,
     proof: &ChannelMultiSigProof,
     tx_hash_bytes: &Bytes,
-    helper: &impl OperationVerificationHelper,
+    helper: &dyn OperationVerificationHelper,
     op_index: usize,
 ) -> Result<(), VerificationError> {
     let transfer_threshold = helper.get_channel_transfer_threshold(channel_id)?;
@@ -80,5 +80,121 @@ pub mod test_utils {
             .try_into()
             .unwrap();
         ChannelMultiSigProof::try_new(signatures).unwrap()
+    }
+}
+
+// `verify_channel_multi_sig` is the owner of the distinction between these
+// failure modes; callers (e.g. `ChannelWithdrawOp::validate`) currently
+// collapse them into a single `Error::InvalidSignature` (see the "Pattern is
+// recursive" FIXMEs in withdraw.rs/channel_transfer.rs), so this is the only
+// place that can still assert the precise reason a proof was rejected.
+//
+// `ChannelMultiSigProofDuplicateIndices` has no test here:
+// `ChannelMultiSigProof` enforces strictly-increasing indices at construction
+// (`try_new`), so a proof with duplicate indices cannot exist to be passed in —
+// that branch is unreachable dead code.
+#[cfg(test)]
+mod tests {
+    use lb_key_management_system_keys::keys::Ed25519Key;
+
+    use super::{test_utils::create_channel_multi_sig_proof, verify_channel_multi_sig};
+    use crate::mantle::{
+        VerificationError,
+        channel::Channels,
+        ops::channel::ChannelId,
+        transactions::{
+            TxHash, signed_mantle_tx::test_utils::make_channel_state,
+            verification_helper::test_utils::TestOperationVerificationHelper,
+        },
+    };
+
+    #[test]
+    fn rejects_missing_channel() {
+        let channel_id = ChannelId::from([1u8; 32]);
+        let tx_hash = TxHash::from([9u8; 32]);
+        let tx_hash_bytes = tx_hash.as_signing_bytes();
+        let key0 = Ed25519Key::from_bytes(&[0; 32]);
+        let proof = create_channel_multi_sig_proof(&tx_hash, &[&key0]);
+
+        let helper = TestOperationVerificationHelper::new(Channels::new(), []);
+
+        let result = verify_channel_multi_sig(&channel_id, &proof, &tx_hash_bytes, &helper, 0);
+
+        assert_eq!(
+            result,
+            Err(VerificationError::ChannelNotFound { channel_id })
+        );
+    }
+
+    #[test]
+    fn rejects_not_enough_signatures() {
+        let channel_id = ChannelId::from([2u8; 32]);
+        let tx_hash = TxHash::from([9u8; 32]);
+        let tx_hash_bytes = tx_hash.as_signing_bytes();
+        let key0 = Ed25519Key::from_bytes(&[0; 32]);
+        let proof = create_channel_multi_sig_proof(&tx_hash, &[&key0]);
+
+        let channels = Channels::new().set_channel_state(&channel_id, make_channel_state(2, None));
+        let helper =
+            TestOperationVerificationHelper::new(channels, [((channel_id, 0), key0.public_key())]);
+
+        let result = verify_channel_multi_sig(&channel_id, &proof, &tx_hash_bytes, &helper, 0);
+
+        assert_eq!(
+            result,
+            Err(VerificationError::ChannelMultiSigProofNotEnoughSignatures {
+                op_index: 0,
+                actual: 1,
+                required: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_missing_key() {
+        let channel_id = ChannelId::from([3u8; 32]);
+        let tx_hash = TxHash::from([9u8; 32]);
+        let tx_hash_bytes = tx_hash.as_signing_bytes();
+        let key0 = Ed25519Key::from_bytes(&[0; 32]);
+        let proof = create_channel_multi_sig_proof(&tx_hash, &[&key0]);
+
+        let channels = Channels::new().set_channel_state(&channel_id, make_channel_state(1, None));
+        let helper = TestOperationVerificationHelper::new(channels, []);
+
+        let result = verify_channel_multi_sig(&channel_id, &proof, &tx_hash_bytes, &helper, 0);
+
+        assert_eq!(
+            result,
+            Err(VerificationError::KeyNotFound {
+                channel_id,
+                key_index: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_signature() {
+        let channel_id = ChannelId::from([4u8; 32]);
+        let tx_hash = TxHash::from([9u8; 32]);
+        let tx_hash_bytes = tx_hash.as_signing_bytes();
+        let expected_key = Ed25519Key::from_bytes(&[0; 32]);
+        let wrong_key = Ed25519Key::from_bytes(&[9; 32]);
+        let proof = create_channel_multi_sig_proof(&tx_hash, &[&wrong_key]);
+
+        let channels = Channels::new().set_channel_state(&channel_id, make_channel_state(1, None));
+        let helper = TestOperationVerificationHelper::new(
+            channels,
+            [((channel_id, 0), expected_key.public_key())],
+        );
+
+        let result = verify_channel_multi_sig(&channel_id, &proof, &tx_hash_bytes, &helper, 0);
+
+        assert_eq!(
+            result,
+            Err(VerificationError::ChannelMultiSigProofInvalidSignature {
+                op_index: 0,
+                signature_index: 0,
+            })
+        );
     }
 }

--- a/core/src/mantle/ops/channel/verification.rs
+++ b/core/src/mantle/ops/channel/verification.rs
@@ -40,7 +40,7 @@ pub fn verify_channel_multi_sig(
     for (i, signature) in signatures.iter().enumerate() {
         let public_key =
             helper.get_key_from_channel_at_index(channel_id, &signature.channel_key_index)?;
-        if let Err(_error) = public_key.verify(tx_hash_bytes.as_ref(), &signature.signature) {
+        if let Err(_error) = public_key.verify(tx_hash_bytes, &signature.signature) {
             return Err(VerificationError::ChannelMultiSigProofInvalidSignature {
                 op_index,
                 signature_index: i,

--- a/core/src/mantle/ops/channel/verification.rs
+++ b/core/src/mantle/ops/channel/verification.rs
@@ -83,16 +83,11 @@ pub mod test_utils {
     }
 }
 
-// `verify_channel_multi_sig` is the owner of the distinction between these
-// failure modes; callers (e.g. `ChannelWithdrawOp::validate`) currently
-// collapse them into a single `Error::InvalidSignature` (see the "Pattern is
-// recursive" FIXMEs in withdraw.rs/channel_transfer.rs), so this is the only
-// place that can still assert the precise reason a proof was rejected.
-//
-// `ChannelMultiSigProofDuplicateIndices` has no test here:
-// `ChannelMultiSigProof` enforces strictly-increasing indices at construction
-// (`try_new`), so a proof with duplicate indices cannot exist to be passed in —
-// that branch is unreachable dead code.
+// `verify_channel_multi_sig` is the responsible of the distinction between
+// `NotEnoughSignatures`, `DuplicateIndices`, and `InvalidSignature` errors.
+// Callers (e.g. `ChannelWithdrawOp::validate`) currently collapse all three
+// into `Error::InvalidSignature`, so this is the only place that can still
+// assert the precise reason a proof was rejected.
 #[cfg(test)]
 mod tests {
     use lb_key_management_system_keys::keys::Ed25519Key;

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -1,14 +1,17 @@
+use bytes::Bytes;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     events::TxEvent,
     mantle::{
-        VerificationError,
         channel::{Channels, Error},
         ledger::{Inputs, Operation, Utxos},
-        ops::{OpId, channel::ChannelId},
-        transactions::TxHash,
+        ops::{
+            OpId,
+            channel::{ChannelId, verification::verify_channel_multi_sig},
+        },
+        transactions::{OperationVerificationHelper, TxHash},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -22,7 +25,7 @@ pub struct ChannelWithdrawOp {
 }
 
 impl ChannelWithdrawOp {
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub const fn verify_stateless(&self) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -37,8 +40,10 @@ pub struct WithdrawValidationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
-    pub tx_hash: &'a TxHash,
-    pub withdraw_sigs: &'a ChannelMultiSigProof,
+    pub tx_hash_bytes: &'a Bytes,
+    pub proof: &'a ChannelMultiSigProof,
+    pub op_index: usize,
+    pub helper: &'a dyn OperationVerificationHelper,
 }
 
 pub struct WithdrawExecutionContext {
@@ -54,6 +59,15 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
     type Error = Error;
 
     fn validate(&self, ctx: &WithdrawValidationContext<'_>) -> Result<(), Self::Error> {
+        verify_channel_multi_sig(
+            &self.channel_id,
+            ctx.proof,
+            ctx.tx_hash_bytes,
+            ctx.helper,
+            ctx.op_index,
+        )
+        .map_err(|_error| Error::InvalidSignature)?; // FIXME: Pattern is recursive
+
         // Check that the channel exists
         let channel =
             ctx.channels
@@ -71,7 +85,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
         )?;
 
         // Check there is enough signatures
-        let signatures = ctx.withdraw_sigs.signatures();
+        let signatures = ctx.proof.signatures();
         if signatures.len() != channel.transfer_threshold as usize {
             return Err(Error::ThresholdUnmet {
                 channel_id: self.channel_id,
@@ -86,7 +100,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
                 .accredited_keys
                 .get(sig.channel_key_index as usize)
                 .ok_or(Error::InvalidSignature)?
-                .verify(ctx.tx_hash.as_signing_bytes().as_ref(), &sig.signature)
+                .verify(ctx.tx_hash_bytes, &sig.signature)
                 .is_err()
             {
                 return Err(Error::InvalidSignature);

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -1,17 +1,17 @@
-use bytes::Bytes;
 use lb_codec::{BinaryCodec, BinaryEncode as _};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     events::TxEvent,
     mantle::{
+        TxHash,
         channel::{Channels, Error},
         ledger::{Inputs, Operation, Utxos},
         ops::{
             OpId,
             channel::{ChannelId, verification::verify_channel_multi_sig},
         },
-        transactions::{OperationVerificationHelper, TxHash},
+        transactions::{OperationVerificationHelper, hash::TxHashView},
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
     sdp::locked_notes::LockedNotes,
@@ -40,7 +40,7 @@ pub struct WithdrawValidationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
-    pub tx_hash_bytes: &'a Bytes,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ChannelMultiSigProof,
     pub op_index: usize,
     pub helper: &'a dyn OperationVerificationHelper,
@@ -62,7 +62,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
         verify_channel_multi_sig(
             &self.channel_id,
             ctx.proof,
-            ctx.tx_hash_bytes,
+            ctx.tx_hash_view.as_bytes(),
             ctx.helper,
             ctx.op_index,
         )
@@ -100,7 +100,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
                 .accredited_keys
                 .get(sig.channel_key_index as usize)
                 .ok_or(Error::InvalidSignature)?
-                .verify(ctx.tx_hash_bytes, &sig.signature)
+                .verify(ctx.tx_hash_view.as_bytes(), &sig.signature)
                 .is_err()
             {
                 return Err(Error::InvalidSignature);

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -66,7 +66,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
             ctx.helper,
             ctx.op_index,
         )
-        .map_err(|_error| Error::InvalidSignature)?; // FIXME: Pattern is recursive
+        .map_err(|_error| Error::InvalidSignature)?; // FIXME: Discards error details
 
         // Check that the channel exists
         let channel =

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     events::TxEvent,
     mantle::{
+        VerificationError,
         channel::{Channels, Error},
         ledger::{Inputs, Operation, Utxos},
         ops::{OpId, channel::ChannelId},
@@ -18,6 +19,12 @@ use crate::{
 pub struct ChannelWithdrawOp {
     pub channel_id: ChannelId,
     pub inputs: Inputs,
+}
+
+impl ChannelWithdrawOp {
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
+    }
 }
 
 impl OpId for ChannelWithdrawOp {

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -12,7 +12,7 @@ use crate::{
     crypto::{Hash, ZkHasher},
     events::{TxEvent, TxEventPayload},
     mantle::{
-        Note, Utxo, Value, VerificationError,
+        Note, Utxo, Value,
         ledger::{Operation, Utxos},
         ops::OpId,
         transactions::hash::TxHash,
@@ -80,8 +80,7 @@ impl LeaderClaimOp {
         &self,
         tx_hash: &TxHash,
         proof: &Groth16LeaderClaimProof,
-        op_index: usize,
-    ) -> Result<(), VerificationError> {
+    ) -> Result<(), LeaderClaimError> {
         let is_verified = proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: self.rewards_root.into(),
@@ -91,7 +90,7 @@ impl LeaderClaimOp {
         if is_verified {
             Ok(())
         } else {
-            Err(VerificationError::InvalidProofOfClaim { op_index })
+            Err(LeaderClaimError::InvalidPoC)
         }
     }
 }
@@ -194,8 +193,8 @@ pub enum LeaderClaimError {
 pub struct LeaderClaimValidationContext<'a> {
     pub nullifiers: &'a VoucherNullifiers,
     pub claimable_vouchers_root: &'a RewardsRoot,
-    pub proof_of_claim: &'a Groth16LeaderClaimProof,
-    pub tx_hash: &'a TxHash,
+    pub proof: &'a Groth16LeaderClaimProof,
+    pub tx_hash_fr: &'a Fr,
 }
 
 pub struct LeaderClaimExecutionContext {
@@ -225,10 +224,10 @@ impl Operation<LeaderClaimValidationContext<'_>> for LeaderClaimOp {
         }
 
         // Check the proof of claim
-        if !ctx.proof_of_claim.verify(&LeaderClaimPublic {
+        if !ctx.proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: ctx.claimable_vouchers_root.0,
-            mantle_tx_hash: ctx.tx_hash.to_fr(),
+            mantle_tx_hash: *ctx.tx_hash_fr,
         }) {
             return Err(LeaderClaimError::InvalidPoC);
         }
@@ -303,8 +302,8 @@ mod tests {
         let ctx = LeaderClaimValidationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
-            proof_of_claim: &proof,
-            tx_hash: &tx_hash,
+            proof: &proof,
+            tx_hash_fr: &tx_hash.to_fr(),
         };
 
         assert_eq!(op.validate(&ctx), Ok(()));
@@ -403,8 +402,8 @@ mod tests {
         let ctx = LeaderClaimValidationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
-            proof_of_claim: &proof,
-            tx_hash: &tx_hash,
+            proof: &proof,
+            tx_hash_fr: &tx_hash.to_fr(),
         };
 
         // The proof is verified against `op.voucher_nullifier`, which does not

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -12,7 +12,7 @@ use crate::{
     crypto::{Hash, ZkHasher},
     events::{TxEvent, TxEventPayload},
     mantle::{
-        Note, Utxo, Value,
+        Note, Utxo, Value, VerificationError,
         ledger::{Operation, Utxos},
         ops::OpId,
         transactions::hash::TxHash,
@@ -73,6 +73,25 @@ impl LeaderClaimOp {
                 value: amount,
                 pk: self.pk,
             },
+        }
+    }
+
+    pub fn verify_stateless(
+        &self,
+        tx_hash: &TxHash,
+        proof: &Groth16LeaderClaimProof,
+        op_index: usize,
+    ) -> Result<(), VerificationError> {
+        let is_verified = proof.verify(&LeaderClaimPublic {
+            voucher_nullifier: self.voucher_nullifier.into(),
+            voucher_root: self.rewards_root.into(),
+            mantle_tx_hash: tx_hash.to_fr(),
+        });
+
+        if is_verified {
+            Ok(())
+        } else {
+            Err(VerificationError::InvalidProofOfClaim { op_index })
         }
     }
 }

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -15,7 +15,7 @@ use crate::{
         Note, Utxo, Value,
         ledger::{Operation, Utxos},
         ops::OpId,
-        transactions::hash::TxHash,
+        transactions::hash::{TxHash, TxHashView},
     },
     proofs::leader_claim_proof::{
         Groth16LeaderClaimProof, LeaderClaimProof as _, LeaderClaimPublic,
@@ -78,13 +78,13 @@ impl LeaderClaimOp {
 
     pub fn verify_stateless(
         &self,
-        tx_hash: &TxHash,
+        tx_hash_view: &TxHashView,
         proof: &Groth16LeaderClaimProof,
     ) -> Result<(), LeaderClaimError> {
         let is_verified = proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: self.rewards_root.into(),
-            mantle_tx_hash: tx_hash.to_fr(),
+            mantle_tx_hash: *tx_hash_view.as_fr(),
         });
 
         if is_verified {
@@ -194,7 +194,7 @@ pub struct LeaderClaimValidationContext<'a> {
     pub nullifiers: &'a VoucherNullifiers,
     pub claimable_vouchers_root: &'a RewardsRoot,
     pub proof: &'a Groth16LeaderClaimProof,
-    pub tx_hash_fr: &'a Fr,
+    pub tx_hash_view: &'a TxHashView,
 }
 
 pub struct LeaderClaimExecutionContext {
@@ -227,7 +227,7 @@ impl Operation<LeaderClaimValidationContext<'_>> for LeaderClaimOp {
         if !ctx.proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: ctx.claimable_vouchers_root.0,
-            mantle_tx_hash: *ctx.tx_hash_fr,
+            mantle_tx_hash: *ctx.tx_hash_view.as_fr(),
         }) {
             return Err(LeaderClaimError::InvalidPoC);
         }
@@ -299,11 +299,12 @@ mod tests {
             pk: ZkPublicKey::zero(),
         };
         let nullifiers = VoucherNullifiers::new();
+        let tx_hash_view = TxHashView::from(tx_hash);
         let ctx = LeaderClaimValidationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
             proof: &proof,
-            tx_hash_fr: &tx_hash.to_fr(),
+            tx_hash_view: &tx_hash_view,
         };
 
         assert_eq!(op.validate(&ctx), Ok(()));
@@ -399,11 +400,12 @@ mod tests {
             pk: ZkPublicKey::zero(),
         };
         let nullifiers = VoucherNullifiers::new();
+        let tx_hash_view = TxHashView::from(tx_hash);
         let ctx = LeaderClaimValidationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
             proof: &proof,
-            tx_hash_fr: &tx_hash.to_fr(),
+            tx_hash_view: &tx_hash_view,
         };
 
         // The proof is verified against `op.voucher_nullifier`, which does not

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -1,5 +1,4 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use lb_log_targets::mantle;
 use tracing::info;
@@ -7,14 +6,17 @@ use tracing::info;
 use super::{SDPActiveOp, SdpError};
 use crate::{
     events::TxEvent,
-    mantle::ledger::{Declarations, Operation},
+    mantle::{
+        ledger::{Declarations, Operation},
+        transactions::hash::TxHashView,
+    },
 };
 
 const LOG_TARGET: &str = mantle::sdp::message::ACTIVE;
 
 pub struct SDPActiveValidationContext<'a> {
     pub declarations: &'a Declarations,
-    pub tx_hash_fr: &'a Fr,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ZkSignature,
     pub epoch: Epoch,
 }
@@ -57,7 +59,7 @@ impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
         }
 
         // Check the signature over the `zk_id`
-        if !ZkPublicKey::verify_multi(&[declaration.zk_id], ctx.tx_hash_fr, ctx.proof) {
+        if !ZkPublicKey::verify_multi(&[declaration.zk_id], ctx.tx_hash_view.as_fr(), ctx.proof) {
             return Err(SdpError::InvalidZkSignature);
         }
 

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -1,4 +1,5 @@
 use lb_cryptarchia_engine::Epoch;
+use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use lb_log_targets::mantle;
 use tracing::info;
@@ -6,18 +7,15 @@ use tracing::info;
 use super::{SDPActiveOp, SdpError};
 use crate::{
     events::TxEvent,
-    mantle::{
-        ledger::{Declarations, Operation},
-        transactions::hash::TxHash,
-    },
+    mantle::ledger::{Declarations, Operation},
 };
 
 const LOG_TARGET: &str = mantle::sdp::message::ACTIVE;
 
 pub struct SDPActiveValidationContext<'a> {
     pub declarations: &'a Declarations,
-    pub tx_hash: &'a TxHash,
-    pub active_sig: &'a ZkSignature,
+    pub tx_hash_fr: &'a Fr,
+    pub proof: &'a ZkSignature,
     pub epoch: Epoch,
 }
 
@@ -34,7 +32,7 @@ impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
     type Error = SdpError;
 
     fn validate(&self, ctx: &SDPActiveValidationContext<'_>) -> Result<(), Self::Error> {
-        // Check the declaration exist
+        // Check the declaration exists
         let Some(declaration) = ctx.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
         };
@@ -59,7 +57,7 @@ impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
         }
 
         // Check the signature over the `zk_id`
-        if !ZkPublicKey::verify_multi(&[declaration.zk_id], &ctx.tx_hash.to_fr(), ctx.active_sig) {
+        if !ZkPublicKey::verify_multi(&[declaration.zk_id], ctx.tx_hash_fr, ctx.proof) {
             return Err(SdpError::InvalidZkSignature);
         }
 

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -1,4 +1,5 @@
 use lb_cryptarchia_engine::Epoch;
+use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkPublicKey, ZkSignature};
 
 use super::{SDPDeclareOp, SdpError};
@@ -8,7 +9,6 @@ use crate::{
         Note,
         channel::Channels,
         ledger::{Declarations, Operation, Utxos},
-        transactions::hash::TxHash,
     },
     sdp::{Declaration, MinStake, locked_notes::LockedNotes},
 };
@@ -127,9 +127,9 @@ pub struct SDPDeclareValidationContext<'a> {
     pub utxo_tree: &'a Utxos,
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
-    pub tx_hash: &'a TxHash,
-    pub declare_zk_sig: &'a ZkSignature,
-    pub declare_eddsa_sig: &'a Ed25519Signature,
+    pub tx_hash_fr: &'a Fr,
+    pub proof_zk_signature: &'a ZkSignature,
+    pub proof_ed25519_signature: &'a Ed25519Signature,
     pub declarations: &'a Declarations,
     pub min_stake: &'a MinStake,
 }
@@ -167,20 +167,11 @@ impl Operation<SDPDeclareValidationContext<'_>> for SDPDeclareOp {
         let note = utxo.note;
         if !ZkPublicKey::verify_multi(
             &[note.pk, self.zk_id],
-            &ctx.tx_hash.to_fr(),
-            ctx.declare_zk_sig,
+            ctx.tx_hash_fr,
+            ctx.proof_zk_signature,
         ) {
             return Err(SdpError::InvalidZkSignature);
         }
-
-        // Ensure ownership over the `provider_id`
-        self.provider_id
-            .0
-            .verify(
-                ctx.tx_hash.as_signing_bytes().as_ref(),
-                ctx.declare_eddsa_sig,
-            )
-            .map_err(|_| SdpError::InvalidEddsaSignature)?;
 
         SDPDeclareValidationExt::validate(
             self,

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -1,5 +1,4 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkPublicKey, ZkSignature};
 
 use super::{SDPDeclareOp, SdpError};
@@ -9,6 +8,7 @@ use crate::{
         Note,
         channel::Channels,
         ledger::{Declarations, Operation, Utxos},
+        transactions::hash::TxHashView,
     },
     sdp::{Declaration, MinStake, locked_notes::LockedNotes},
 };
@@ -127,7 +127,7 @@ pub struct SDPDeclareValidationContext<'a> {
     pub utxo_tree: &'a Utxos,
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
-    pub tx_hash_fr: &'a Fr,
+    pub tx_hash_view: &'a TxHashView,
     pub proof_zk_signature: &'a ZkSignature,
     pub proof_ed25519_signature: &'a Ed25519Signature,
     pub declarations: &'a Declarations,
@@ -167,7 +167,7 @@ impl Operation<SDPDeclareValidationContext<'_>> for SDPDeclareOp {
         let note = utxo.note;
         if !ZkPublicKey::verify_multi(
             &[note.pk, self.zk_id],
-            ctx.tx_hash_fr,
+            ctx.tx_hash_view.as_fr(),
             ctx.proof_zk_signature,
         ) {
             return Err(SdpError::InvalidZkSignature);

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -1,4 +1,5 @@
 use lb_cryptarchia_engine::Epoch;
+use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use lb_log_targets::mantle;
 use tracing::debug;
@@ -6,10 +7,7 @@ use tracing::debug;
 use super::{SDPWithdrawOp, SdpError};
 use crate::{
     events::TxEvent,
-    mantle::{
-        ledger::{Declarations, Operation},
-        transactions::hash::TxHash,
-    },
+    mantle::ledger::{Declarations, Operation},
     sdp::{self, locked_notes::LockedNotes},
 };
 
@@ -19,8 +17,8 @@ pub struct SDPWithdrawValidationContext<'a> {
     pub declarations: &'a Declarations,
     pub epoch: Epoch,
     pub locked_notes: &'a LockedNotes,
-    pub tx_hash: &'a TxHash,
-    pub sdp_withdraw_sig: &'a ZkSignature,
+    pub tx_hash_fr: &'a Fr,
+    pub proof: &'a ZkSignature,
 }
 
 pub struct SDPWithdrawExecutionContext {
@@ -76,11 +74,7 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
             .locked_notes
             .get(&self.locked_note_id)
             .expect("The Operation has been checked above");
-        if !ZkPublicKey::verify_multi(
-            &[note.pk, declaration.zk_id],
-            &ctx.tx_hash.to_fr(),
-            ctx.sdp_withdraw_sig,
-        ) {
+        if !ZkPublicKey::verify_multi(&[note.pk, declaration.zk_id], ctx.tx_hash_fr, ctx.proof) {
             return Err(SdpError::InvalidZkSignature);
         }
 

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -1,5 +1,4 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use lb_log_targets::mantle;
 use tracing::debug;
@@ -7,7 +6,10 @@ use tracing::debug;
 use super::{SDPWithdrawOp, SdpError};
 use crate::{
     events::TxEvent,
-    mantle::ledger::{Declarations, Operation},
+    mantle::{
+        ledger::{Declarations, Operation},
+        transactions::hash::TxHashView,
+    },
     sdp::{self, locked_notes::LockedNotes},
 };
 
@@ -17,7 +19,7 @@ pub struct SDPWithdrawValidationContext<'a> {
     pub declarations: &'a Declarations,
     pub epoch: Epoch,
     pub locked_notes: &'a LockedNotes,
-    pub tx_hash_fr: &'a Fr,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ZkSignature,
 }
 
@@ -74,7 +76,11 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
             .locked_notes
             .get(&self.locked_note_id)
             .expect("The Operation has been checked above");
-        if !ZkPublicKey::verify_multi(&[note.pk, declaration.zk_id], ctx.tx_hash_fr, ctx.proof) {
+        if !ZkPublicKey::verify_multi(
+            &[note.pk, declaration.zk_id],
+            ctx.tx_hash_view.as_fr(),
+            ctx.proof,
+        ) {
             return Err(SdpError::InvalidZkSignature);
         }
 

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -1,4 +1,5 @@
 use lb_codec::{BinaryCodec, BinaryEncode as _};
+use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -6,7 +7,6 @@ use thiserror::Error;
 use crate::{
     events::TxEvent,
     mantle::{
-        TxHash, VerificationError,
         channel::Channels,
         ledger::{self, Inputs, Operation, Outputs, Utxo, Utxos},
         ops::OpId,
@@ -53,7 +53,15 @@ impl TransferOp {
         Ok(balance)
     }
 
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub fn verify_stateless(&self) -> Result<(), TransferError> {
+        // Ensure the inputs is non-empty
+        if self.inputs.is_empty() {
+            return Err(TransferError::NoInputTransfer);
+        }
+
+        // Validate Outputs
+        self.outputs.validate()?;
+
         Ok(())
     }
 }
@@ -82,8 +90,8 @@ pub struct TransferValidationContext<'a> {
     pub locked_notes: &'a LockedNotes,
     pub channels: &'a Channels,
     pub utxos: &'a Utxos,
-    pub tx_hash: &'a TxHash,
-    pub transfer_sig: &'a ZkSignature,
+    pub tx_hash_fr: &'a Fr,
+    pub proof: &'a ZkSignature,
 }
 
 impl Operation<TransferValidationContext<'_>> for TransferOp {
@@ -94,20 +102,16 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
     type Error = TransferError;
 
     fn validate(&self, ctx: &TransferValidationContext<'_>) -> Result<(), Self::Error> {
-        // Ensure the inputs is non-empty
-        if self.inputs.is_empty() {
-            return Err(TransferError::NoInputTransfer);
-        }
         // Validate Inputs
         self.inputs
             .validate_not_in_channel(ctx.locked_notes, ctx.channels, ctx.utxos)?;
-        // Validate Outputs
-        self.outputs.validate()?;
+
         // Check the transfer Proof
         let pks = self.inputs.get_pk(ctx.utxos)?;
-        if !ZkPublicKey::verify_multi(&pks, &ctx.tx_hash.to_fr(), ctx.transfer_sig) {
+        if !ZkPublicKey::verify_multi(&pks, ctx.tx_hash_fr, ctx.proof) {
             return Err(TransferError::InvalidProof);
         }
+
         Ok(())
     }
 
@@ -125,7 +129,6 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
 
 #[cfg(test)]
 mod test {
-    use lb_poseidon2::Fr;
     use num_bigint::BigUint;
 
     use super::*;

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -1,5 +1,4 @@
 use lb_codec::{BinaryCodec, BinaryEncode as _};
-use lb_groth16::Fr;
 use lb_key_management_system_keys::keys::{ZkPublicKey, ZkSignature};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -10,6 +9,7 @@ use crate::{
         channel::Channels,
         ledger::{self, Inputs, Operation, Outputs, Utxo, Utxos},
         ops::OpId,
+        transactions::hash::TxHashView,
     },
     sdp::locked_notes::LockedNotes,
 };
@@ -90,7 +90,7 @@ pub struct TransferValidationContext<'a> {
     pub locked_notes: &'a LockedNotes,
     pub channels: &'a Channels,
     pub utxos: &'a Utxos,
-    pub tx_hash_fr: &'a Fr,
+    pub tx_hash_view: &'a TxHashView,
     pub proof: &'a ZkSignature,
 }
 
@@ -108,7 +108,7 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
 
         // Check the transfer Proof
         let pks = self.inputs.get_pk(ctx.utxos)?;
-        if !ZkPublicKey::verify_multi(&pks, ctx.tx_hash_fr, ctx.proof) {
+        if !ZkPublicKey::verify_multi(&pks, ctx.tx_hash_view.as_fr(), ctx.proof) {
             return Err(TransferError::InvalidProof);
         }
 
@@ -129,6 +129,7 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
 
 #[cfg(test)]
 mod test {
+    use lb_groth16::Fr;
     use num_bigint::BigUint;
 
     use super::*;

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -129,7 +129,7 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
 
 #[cfg(test)]
 mod test {
-    use lb_groth16::Fr;
+    use lb_poseidon2::Fr;
     use num_bigint::BigUint;
 
     use super::*;

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::{
     events::TxEvent,
     mantle::{
-        TxHash,
+        TxHash, VerificationError,
         channel::Channels,
         ledger::{self, Inputs, Operation, Outputs, Utxo, Utxos},
         ops::OpId,
@@ -51,6 +51,10 @@ impl TransferOp {
             .checked_sub(i128::from(output_amount))
             .ok_or(TransferError::BalanceOverflow)?;
         Ok(balance)
+    }
+
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
     }
 }
 

--- a/core/src/mantle/transactions/errors.rs
+++ b/core/src/mantle/transactions/errors.rs
@@ -2,10 +2,6 @@ use crate::mantle::ops::channel::{ChannelId, ChannelKeyIndex};
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
 pub enum VerificationError {
-    #[error("Invalid signature for operation at index {op_index}")]
-    InvalidSignature { op_index: usize },
-    #[error("Invalid proof of claim for operation at index {op_index}")]
-    InvalidProofOfClaim { op_index: usize },
     #[error("Missing required proof for {op_type} operation at index {op_index}")]
     MissingProof {
         op_type: &'static str,
@@ -47,11 +43,10 @@ pub enum VerificationError {
         op_index: usize,
         signature_index: usize,
     },
-
     #[error("Channel verification error: {0}")]
     ChannelVerificationError(crate::mantle::channel::Error),
     #[error("Transfer verification error: {0}")]
-    TransferVerificationError(crate::mantle::ops::transfer::TransferError),
+    TransferVerificationError(#[from] crate::mantle::ops::transfer::TransferError),
     #[error("SDP verification error: {0}")]
     SDPVerificationError(crate::mantle::ops::sdp::SdpError),
     #[error("LeaderClaim verification error: {0}")]

--- a/core/src/mantle/transactions/hash.rs
+++ b/core/src/mantle/transactions/hash.rs
@@ -52,3 +52,45 @@ impl TxHash {
         Fr::from_le_bytes_mod_order(&self.0)
     }
 }
+
+/// Holds a reference to a [`TxHash`] and its corresponding [`Bytes`] and [`Fr`]
+/// representations, to avoid repeated conversions.
+pub struct TxHashView {
+    tx_hash: TxHash,
+    tx_hash_bytes: Bytes,
+    tx_hash_fr: Fr,
+}
+
+impl TxHashView {
+    #[must_use]
+    pub fn new(tx_hash: TxHash) -> Self {
+        let tx_hash_bytes = tx_hash.as_signing_bytes();
+        let tx_hash_fr = tx_hash.to_fr();
+        Self {
+            tx_hash,
+            tx_hash_bytes,
+            tx_hash_fr,
+        }
+    }
+
+    #[must_use]
+    pub const fn tx_hash(&self) -> &TxHash {
+        &self.tx_hash
+    }
+
+    #[must_use]
+    pub const fn as_bytes(&self) -> &Bytes {
+        &self.tx_hash_bytes
+    }
+
+    #[must_use]
+    pub const fn as_fr(&self) -> &Fr {
+        &self.tx_hash_fr
+    }
+}
+
+impl From<TxHash> for TxHashView {
+    fn from(value: TxHash) -> Self {
+        Self::new(value)
+    }
+}

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -35,7 +35,6 @@ use crate::{
             states::{Preverified, Unverified, VerificationState},
         },
     },
-    proofs::leader_claim_proof::{LeaderClaimProof as _, LeaderClaimPublic},
 };
 
 // TODO: Increase test coverage after type state refactor.
@@ -117,34 +116,27 @@ impl SignedMantleTx<Unverified> {
         tx_hash_bytes: &Bytes,
     ) -> Result<(), VerificationError> {
         match (op, proof) {
-            (Op::ChannelInscribe(inscribe_op), OpProof::Ed25519Sig(sig)) => inscribe_op
-                .signer
-                .verify(tx_hash_bytes.as_ref(), sig)
-                .map_err(|_| VerificationError::InvalidSignature { op_index }),
-            (Op::LeaderClaim(leader_claim_op), OpProof::PoC(poc)) => {
-                let is_verified = poc.verify(&LeaderClaimPublic {
-                    voucher_nullifier: leader_claim_op.voucher_nullifier.into(),
-                    voucher_root: leader_claim_op.rewards_root.into(),
-                    mantle_tx_hash: tx_hash.to_fr(),
-                });
-
-                if is_verified {
-                    Ok(())
-                } else {
-                    Err(VerificationError::InvalidProofOfClaim { op_index })
-                }
+            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => {
+                op.verify_stateless(tx_hash_bytes.as_ref(), proof, op_index)
             }
-            #[expect(
-                clippy::unnested_or_patterns,
-                reason = "Clarity on valid op/proof pairs."
-            )]
-            (Op::ChannelConfig(_), OpProof::ChannelMultiSigProof(_))
-            | (Op::ChannelDeposit(_), OpProof::ZkSig(_))
-            | (Op::ChannelWithdraw(_), OpProof::ChannelMultiSigProof(_))
-            | (Op::SDPDeclare(_), OpProof::ZkAndEd25519Sigs { .. })
-            | (Op::SDPWithdraw(_), OpProof::ZkSig(_))
-            | (Op::SDPActive(_), OpProof::ZkSig(_))
-            | (Op::Transfer(_), OpProof::ZkSig(_)) => Ok(()),
+            (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
+                op.verify_stateless(tx_hash, proof, op_index)
+            }
+            (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(_proof)) => op.verify_stateless(),
+            (Op::ChannelDeposit(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
+            (Op::ChannelWithdraw(op), OpProof::ChannelMultiSigProof(_proof)) => {
+                op.verify_stateless()
+            }
+            (
+                Op::SDPDeclare(op),
+                OpProof::ZkAndEd25519Sigs {
+                    zk_sig: _zk_sig,
+                    ed25519_sig: _ed25519_sig,
+                },
+            ) => op.verify_stateless(),
+            (Op::SDPWithdraw(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
+            (Op::SDPActive(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
+            (Op::Transfer(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
             _ => Err(VerificationError::IncorrectProofType {
                 op_type: op.as_str(),
                 op_index,

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use bytes::Bytes;
-use lb_groth16::Fr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -31,7 +29,7 @@ use crate::{
         transactions::{
             GasPrices, OperationVerificationHelper, OpsProofs, VerifiedOps,
             codec::{decode_signed_mantle_tx, encode_signed_mantle_tx},
-            hash::TxHash,
+            hash::{TxHash, TxHashView},
             states::{Preverified, Unverified, VerificationState},
         },
     },
@@ -112,13 +110,12 @@ impl SignedMantleTx<Unverified> {
         op_index: usize,
         op: &Op,
         proof: &OpProof,
-        tx_hash: &TxHash,
-        tx_hash_bytes: &Bytes,
+        tx_hash_view: &TxHashView,
     ) -> Result<(), VerificationError> {
         // TODO: Add more info to errors (e.g. op_index)
         match (op, proof) {
             (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => op
-                .verify_stateless(tx_hash_bytes.as_ref(), proof)
+                .verify_stateless(tx_hash_view, proof)
                 .map_err(VerificationError::ChannelVerificationError),
             (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(_proof)) => op
                 .verify_stateless()
@@ -139,7 +136,7 @@ impl SignedMantleTx<Unverified> {
                     ed25519_sig: proof_ed25519_signature,
                 },
             ) => op
-                .verify_stateless(tx_hash, proof_ed25519_signature)
+                .verify_stateless(tx_hash_view, proof_ed25519_signature)
                 .map_err(VerificationError::SDPVerificationError),
             (Op::SDPWithdraw(op), OpProof::ZkSig(_proof)) => op
                 .verify_stateless()
@@ -148,7 +145,7 @@ impl SignedMantleTx<Unverified> {
                 .verify_stateless()
                 .map_err(VerificationError::SDPVerificationError),
             (Op::LeaderClaim(op), OpProof::PoC(proof)) => op
-                .verify_stateless(tx_hash, proof)
+                .verify_stateless(tx_hash_view, proof)
                 .map_err(VerificationError::LeaderClaimVerificationError),
             (Op::Transfer(op), OpProof::ZkSig(_proof)) => op
                 .verify_stateless()
@@ -162,9 +159,9 @@ impl SignedMantleTx<Unverified> {
 
     fn verify_stateless_ops(&self) -> Result<(), VerificationError> {
         let tx_hash = self.hash();
-        let tx_hash_bytes = tx_hash.as_signing_bytes();
+        let tx_hash_view = TxHashView::new(tx_hash);
         for (op_index, (op, proof)) in self.ops_with_proof().enumerate() {
-            Self::verify_stateless_op(op_index, op, proof, &tx_hash, &tx_hash_bytes)?;
+            Self::verify_stateless_op(op_index, op, proof, &tx_hash_view)?;
         }
         Ok(())
     }
@@ -227,8 +224,7 @@ impl SignedMantleTx<Preverified> {
         op_index: usize,
         op: &Op,
         proof: &OpProof,
-        tx_hash_fr: &Fr,
-        tx_hash_bytes: &Bytes,
+        tx_hash_view: &TxHashView,
         helper: &impl OperationVerificationHelper,
     ) -> Result<(), VerificationError> {
         match (op, proof) {
@@ -243,7 +239,7 @@ impl SignedMantleTx<Preverified> {
             (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(proof)) => {
                 let channel_config_context = ChannelConfigValidationContext {
                     channels: helper.get_channels(),
-                    tx_hash_bytes,
+                    tx_hash_view,
                     proof,
                 };
                 op.validate(&channel_config_context)
@@ -254,7 +250,7 @@ impl SignedMantleTx<Preverified> {
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
                     utxos: helper.get_utxos(),
-                    tx_hash_fr,
+                    tx_hash_view,
                     proof,
                 };
                 op.validate(&channel_deposit_context)
@@ -265,7 +261,7 @@ impl SignedMantleTx<Preverified> {
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
                     utxos: helper.get_utxos(),
-                    tx_hash_bytes,
+                    tx_hash_view,
                     proof,
                     helper,
                     op_index,
@@ -279,7 +275,7 @@ impl SignedMantleTx<Preverified> {
                     locked_notes: helper.get_locked_notes(),
                     channels: helper.get_channels(),
                     utxos: helper.get_utxos(),
-                    tx_hash_bytes,
+                    tx_hash_view,
                     proof,
                     op_index,
                     helper,
@@ -298,7 +294,7 @@ impl SignedMantleTx<Preverified> {
                     utxo_tree: helper.get_utxos(),
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
-                    tx_hash_fr,
+                    tx_hash_view,
                     proof_zk_signature,
                     proof_ed25519_signature,
                     declarations: helper.get_declarations_by_service(op.service_type)?,
@@ -312,7 +308,7 @@ impl SignedMantleTx<Preverified> {
                     declarations: helper.get_declarations_by_id(&op.declaration_id)?,
                     epoch: helper.get_epoch(),
                     locked_notes: helper.get_locked_notes(),
-                    tx_hash_fr,
+                    tx_hash_view,
                     proof,
                 };
                 op.validate(&context)
@@ -321,7 +317,7 @@ impl SignedMantleTx<Preverified> {
             (Op::SDPActive(op), OpProof::ZkSig(proof)) => {
                 let context = SDPActiveValidationContext {
                     declarations: helper.get_declarations_by_id(&op.declaration_id)?,
-                    tx_hash_fr,
+                    tx_hash_view,
                     proof,
                     epoch: helper.get_epoch(),
                 };
@@ -333,7 +329,7 @@ impl SignedMantleTx<Preverified> {
                     nullifiers: helper.get_nullifiers(),
                     claimable_vouchers_root: helper.get_claimable_vouchers_root(),
                     proof,
-                    tx_hash_fr,
+                    tx_hash_view,
                 };
                 op.validate(&context)
                     .map_err(VerificationError::LeaderClaimVerificationError)
@@ -343,7 +339,7 @@ impl SignedMantleTx<Preverified> {
                     locked_notes: helper.get_locked_notes(),
                     channels: helper.get_channels(),
                     utxos: helper.get_utxos(),
-                    tx_hash_fr,
+                    tx_hash_view,
                     proof,
                 };
                 op.validate(&context)
@@ -623,6 +619,7 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use lb_groth16::Fr;
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
     use num_bigint::BigUint;
 

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use bytes::Bytes;
+use lb_groth16::Fr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -14,8 +15,7 @@ use crate::{
             channel::{
                 channel_transfer::ChannelTransferValidationContext,
                 config::ChannelConfigValidationContext, deposit::DepositValidationContext,
-                inscribe::InscriptionValidationContext, verification::verify_channel_multi_sig,
-                withdraw::WithdrawValidationContext,
+                inscribe::InscriptionValidationContext, withdraw::WithdrawValidationContext,
             },
             leader_claim::LeaderClaimValidationContext,
             sdp::{
@@ -115,28 +115,44 @@ impl SignedMantleTx<Unverified> {
         tx_hash: &TxHash,
         tx_hash_bytes: &Bytes,
     ) -> Result<(), VerificationError> {
+        // TODO: Add more info to errors (e.g. op_index)
         match (op, proof) {
-            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => {
-                op.verify_stateless(tx_hash_bytes.as_ref(), proof, op_index)
-            }
-            (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
-                op.verify_stateless(tx_hash, proof, op_index)
-            }
-            (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(_proof)) => op.verify_stateless(),
-            (Op::ChannelDeposit(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
-            (Op::ChannelWithdraw(op), OpProof::ChannelMultiSigProof(_proof)) => {
-                op.verify_stateless()
-            }
+            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => op
+                .verify_stateless(tx_hash_bytes.as_ref(), proof)
+                .map_err(VerificationError::ChannelVerificationError),
+            (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::ChannelVerificationError),
+            (Op::ChannelDeposit(op), OpProof::ZkSig(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::ChannelVerificationError),
+            (Op::ChannelWithdraw(op), OpProof::ChannelMultiSigProof(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::ChannelVerificationError),
+            (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::ChannelVerificationError),
             (
                 Op::SDPDeclare(op),
                 OpProof::ZkAndEd25519Sigs {
                     zk_sig: _zk_sig,
-                    ed25519_sig: _ed25519_sig,
+                    ed25519_sig: proof_ed25519_signature,
                 },
-            ) => op.verify_stateless(),
-            (Op::SDPWithdraw(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
-            (Op::SDPActive(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
-            (Op::Transfer(op), OpProof::ZkSig(_proof)) => op.verify_stateless(),
+            ) => op
+                .verify_stateless(tx_hash, proof_ed25519_signature)
+                .map_err(VerificationError::SDPVerificationError),
+            (Op::SDPWithdraw(op), OpProof::ZkSig(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::SDPVerificationError),
+            (Op::SDPActive(op), OpProof::ZkSig(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::SDPVerificationError),
+            (Op::LeaderClaim(op), OpProof::PoC(proof)) => op
+                .verify_stateless(tx_hash, proof)
+                .map_err(VerificationError::LeaderClaimVerificationError),
+            (Op::Transfer(op), OpProof::ZkSig(_proof)) => op
+                .verify_stateless()
+                .map_err(VerificationError::TransferVerificationError),
             _ => Err(VerificationError::IncorrectProofType {
                 op_type: op.as_str(),
                 op_index,
@@ -211,164 +227,126 @@ impl SignedMantleTx<Preverified> {
         op_index: usize,
         op: &Op,
         proof: &OpProof,
-        tx_hash: &TxHash,
+        tx_hash_fr: &Fr,
         tx_hash_bytes: &Bytes,
         helper: &impl OperationVerificationHelper,
     ) -> Result<(), VerificationError> {
         match (op, proof) {
-            (
-                Op::ChannelInscribe(channel_inscribe_op),
-                OpProof::Ed25519Sig(channel_inscribe_sig),
-            ) => {
+            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(_proof)) => {
                 let channel_inscribe_context = InscriptionValidationContext {
                     channels: helper.get_channels(),
-                    tx_hash,
-                    inscribe_sig: channel_inscribe_sig,
                     block_slot: helper.get_block_slot(),
                 };
-                channel_inscribe_op
-                    .validate(&channel_inscribe_context)
+                op.validate(&channel_inscribe_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
-            (
-                Op::ChannelConfig(channel_config_op),
-                OpProof::ChannelMultiSigProof(channel_config_proof),
-            ) => {
+            (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(proof)) => {
                 let channel_config_context = ChannelConfigValidationContext {
                     channels: helper.get_channels(),
-                    tx_hash,
-                    config_sigs: channel_config_proof,
+                    tx_hash_bytes,
+                    proof,
                 };
-                channel_config_op
-                    .validate(&channel_config_context)
+                op.validate(&channel_config_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
-            (Op::ChannelDeposit(channel_deposit_op), OpProof::ZkSig(channel_deposit_proof)) => {
+            (Op::ChannelDeposit(op), OpProof::ZkSig(proof)) => {
                 let channel_deposit_context = DepositValidationContext {
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
                     utxos: helper.get_utxos(),
-                    tx_hash,
-                    deposit_sig: channel_deposit_proof,
+                    tx_hash_fr,
+                    proof,
                 };
-                channel_deposit_op
-                    .validate(&channel_deposit_context)
+                op.validate(&channel_deposit_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
-            // TODO: Duplicate check. `verify_channel_withdraw` and `ChannelWithdrawOp::validate`,
-            //   both called in this arm, overlap in functionality. We probably need to purge the
-            //   `verify_channel_withdraw` function.
-            (
-                Op::ChannelWithdraw(channel_withdraw_op),
-                OpProof::ChannelMultiSigProof(channel_withdraw_proof),
-            ) => {
-                verify_channel_multi_sig(
-                    &channel_withdraw_op.channel_id,
-                    channel_withdraw_proof,
-                    tx_hash_bytes,
-                    helper,
-                    op_index,
-                )?;
+            (Op::ChannelWithdraw(channel_withdraw_op), OpProof::ChannelMultiSigProof(proof)) => {
                 let channel_withdraw_context = WithdrawValidationContext {
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
                     utxos: helper.get_utxos(),
-                    tx_hash,
-                    withdraw_sigs: channel_withdraw_proof,
+                    tx_hash_bytes,
+                    proof,
+                    helper,
+                    op_index,
                 };
                 channel_withdraw_op
                     .validate(&channel_withdraw_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
-            (
-                Op::ChannelTransfer(channel_transfer_op),
-                OpProof::ChannelMultiSigProof(channel_transfer_proof),
-            ) => {
-                verify_channel_multi_sig(
-                    &channel_transfer_op.channel_id,
-                    channel_transfer_proof,
-                    tx_hash_bytes,
-                    helper,
-                    op_index,
-                )?;
-
+            (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(proof)) => {
                 let context = ChannelTransferValidationContext {
                     locked_notes: helper.get_locked_notes(),
                     channels: helper.get_channels(),
                     utxos: helper.get_utxos(),
-                    tx_hash,
-                    transfer_sigs: channel_transfer_proof,
+                    tx_hash_bytes,
+                    proof,
+                    op_index,
+                    helper,
                 };
-                channel_transfer_op
-                    .validate(&context)
+                op.validate(&context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (
-                Op::SDPDeclare(sdp_declare_op),
+                Op::SDPDeclare(op),
                 OpProof::ZkAndEd25519Sigs {
-                    zk_sig,
-                    ed25519_sig,
+                    zk_sig: proof_zk_signature,
+                    ed25519_sig: proof_ed25519_signature,
                 },
             ) => {
                 let context = SDPDeclareValidationContext {
                     utxo_tree: helper.get_utxos(),
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
-                    tx_hash,
-                    declare_zk_sig: zk_sig,
-                    declare_eddsa_sig: ed25519_sig,
-                    declarations: helper
-                        .get_declarations_by_service(sdp_declare_op.service_type)?,
+                    tx_hash_fr,
+                    proof_zk_signature,
+                    proof_ed25519_signature,
+                    declarations: helper.get_declarations_by_service(op.service_type)?,
                     min_stake: helper.get_min_stake(),
                 };
-                sdp_declare_op
-                    .validate(&context)
+                op.validate(&context)
                     .map_err(VerificationError::SDPVerificationError)
             }
-            (Op::SDPWithdraw(sdp_withdraw_op), OpProof::ZkSig(sdp_withdraw_proof)) => {
+            (Op::SDPWithdraw(op), OpProof::ZkSig(proof)) => {
                 let context = SDPWithdrawValidationContext {
-                    declarations: helper.get_declarations_by_id(&sdp_withdraw_op.declaration_id)?,
+                    declarations: helper.get_declarations_by_id(&op.declaration_id)?,
                     epoch: helper.get_epoch(),
                     locked_notes: helper.get_locked_notes(),
-                    tx_hash,
-                    sdp_withdraw_sig: sdp_withdraw_proof,
+                    tx_hash_fr,
+                    proof,
                 };
-                sdp_withdraw_op
-                    .validate(&context)
+                op.validate(&context)
                     .map_err(VerificationError::SDPVerificationError)
             }
-            (Op::SDPActive(sdp_active_op), OpProof::ZkSig(sdp_active_proof)) => {
+            (Op::SDPActive(op), OpProof::ZkSig(proof)) => {
                 let context = SDPActiveValidationContext {
-                    declarations: helper.get_declarations_by_id(&sdp_active_op.declaration_id)?,
-                    tx_hash,
-                    active_sig: sdp_active_proof,
+                    declarations: helper.get_declarations_by_id(&op.declaration_id)?,
+                    tx_hash_fr,
+                    proof,
                     epoch: helper.get_epoch(),
                 };
-                sdp_active_op
-                    .validate(&context)
+                op.validate(&context)
                     .map_err(VerificationError::SDPVerificationError)
             }
-            (Op::LeaderClaim(leader_claim_op), OpProof::PoC(leader_claim_proof)) => {
+            (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
                 let context = LeaderClaimValidationContext {
                     nullifiers: helper.get_nullifiers(),
                     claimable_vouchers_root: helper.get_claimable_vouchers_root(),
-                    proof_of_claim: leader_claim_proof,
-                    tx_hash,
+                    proof,
+                    tx_hash_fr,
                 };
-                leader_claim_op
-                    .validate(&context)
+                op.validate(&context)
                     .map_err(VerificationError::LeaderClaimVerificationError)
             }
-            (Op::Transfer(transfer_op), OpProof::ZkSig(transfer_proof)) => {
+            (Op::Transfer(op), OpProof::ZkSig(proof)) => {
                 let context = TransferValidationContext {
                     locked_notes: helper.get_locked_notes(),
                     channels: helper.get_channels(),
                     utxos: helper.get_utxos(),
-                    tx_hash,
-                    transfer_sig: transfer_proof,
+                    tx_hash_fr,
+                    proof,
                 };
-                transfer_op
-                    .validate(&context)
+                op.validate(&context)
                     .map_err(VerificationError::TransferVerificationError)
             }
             // SignedMantleTx<Preverified> invariant: Op/Proof pairs have been verified in
@@ -645,17 +623,22 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use lb_groth16::Fr;
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
+    use num_bigint::BigUint;
 
     use super::*;
     use crate::mantle::{
-        NoteId,
+        Note, NoteId, Utxo,
+        channel::Error,
         gas::MainnetGasConstants,
-        ledger::Inputs,
-        ops::channel::{
-            ChannelId, config::ChannelConfigOp, deposit::DepositOp,
-            verification::test_utils::create_channel_multi_sig_proof, withdraw::ChannelWithdrawOp,
+        ledger::{Inputs, Outputs, OutputsError},
+        ops::{
+            channel::{
+                ChannelId, config::ChannelConfigOp, deposit::DepositOp,
+                verification::test_utils::create_channel_multi_sig_proof,
+                withdraw::ChannelWithdrawOp,
+            },
+            transfer::{TransferError, TransferOp},
         },
         transactions::{
             MantleTxGasContext,
@@ -825,7 +808,9 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(VerificationError::InvalidSignature { op_index: 0 })
+            Err(VerificationError::ChannelVerificationError(
+                Error::InvalidSignature
+            ))
         ));
     }
 
@@ -901,8 +886,37 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(VerificationError::InvalidSignature { op_index: 1 })
+            Err(VerificationError::ChannelVerificationError(
+                Error::InvalidSignature
+            ))
         ));
+    }
+
+    #[test]
+    fn test_signed_mantle_tx_new_rejects_zero_value_transfer_output() {
+        let input_sk = ZkKey::from(BigUint::from(1u8));
+        let input_utxo = Utxo {
+            op_id: [1u8; 32],
+            output_index: 0,
+            note: Note::new(10000, input_sk.to_public_key()),
+        };
+
+        let transfer_op = TransferOp::new(
+            Inputs::new([input_utxo.id()]),
+            Outputs::new([Note::new(0, Fr::from(BigUint::from(2u8)).into())]),
+        );
+        let mantle_tx = create_test_mantle_tx(vec![Op::Transfer(transfer_op)]);
+        let transfer_sig = ZkKey::multi_sign(&[input_sk], &mantle_tx.hash().to_fr())
+            .expect("Signing should succeed");
+        let result =
+            SignedMantleTx::new(mantle_tx, [OpProof::ZkSig(transfer_sig)].into()).preverify();
+
+        assert_eq!(
+            result,
+            Err(VerificationError::TransferVerificationError(
+                TransferError::Outputs(OutputsError::ZeroValueNote)
+            ))
+        );
     }
 
     #[test]

--- a/core/src/mantle/transactions/verified_ops.rs
+++ b/core/src/mantle/transactions/verified_ops.rs
@@ -1,18 +1,13 @@
-use bytes::Bytes;
-use lb_groth16::Fr;
-
 use crate::mantle::{
-    Op, OpProof, SignedMantleTx, TxHash, VerificationError,
+    Op, OpProof, SignedMantleTx, VerificationError,
     traits::Hashable as _,
-    transactions::{OperationVerificationHelper, states::Preverified},
+    transactions::{OperationVerificationHelper, hash::TxHashView, states::Preverified},
 };
 
 pub struct VerifiedOps<'tx> {
     ops: &'tx [Op],
     proofs: &'tx [OpProof],
-    tx_hash: TxHash,
-    tx_hash_fr: Fr,
-    tx_hash_bytes: Bytes,
+    tx_hash_view: TxHashView,
     index: usize,
 }
 
@@ -22,12 +17,11 @@ impl<'tx> VerifiedOps<'tx> {
         let ops = transaction.mantle_tx.ops();
         let proofs = transaction.ops_proofs();
         let tx_hash = transaction.hash();
+        let tx_hash_view = TxHashView::from(tx_hash);
         Self {
             ops,
             proofs,
-            tx_hash,
-            tx_hash_fr: tx_hash.to_fr(),
-            tx_hash_bytes: tx_hash.as_signing_bytes(),
+            tx_hash_view,
             index: 0,
         }
     }
@@ -60,8 +54,7 @@ impl<'tx> VerifiedOps<'tx> {
             index,
             op,
             proof,
-            &self.tx_hash_fr,
-            &self.tx_hash_bytes,
+            &self.tx_hash_view,
             helper,
         ) {
             return Some(Err(error));
@@ -71,13 +64,8 @@ impl<'tx> VerifiedOps<'tx> {
     }
 
     #[must_use]
-    pub const fn tx_hash(&self) -> &TxHash {
-        &self.tx_hash
-    }
-
-    #[must_use]
-    pub const fn tx_hash_bytes(&self) -> &Bytes {
-        &self.tx_hash_bytes
+    pub const fn tx_hash_view(&self) -> &TxHashView {
+        &self.tx_hash_view
     }
 }
 

--- a/core/src/mantle/transactions/verified_ops.rs
+++ b/core/src/mantle/transactions/verified_ops.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use lb_groth16::Fr;
 
 use crate::mantle::{
     Op, OpProof, SignedMantleTx, TxHash, VerificationError,
@@ -10,6 +11,7 @@ pub struct VerifiedOps<'tx> {
     ops: &'tx [Op],
     proofs: &'tx [OpProof],
     tx_hash: TxHash,
+    tx_hash_fr: Fr,
     tx_hash_bytes: Bytes,
     index: usize,
 }
@@ -24,6 +26,7 @@ impl<'tx> VerifiedOps<'tx> {
             ops,
             proofs,
             tx_hash,
+            tx_hash_fr: tx_hash.to_fr(),
             tx_hash_bytes: tx_hash.as_signing_bytes(),
             index: 0,
         }
@@ -57,7 +60,7 @@ impl<'tx> VerifiedOps<'tx> {
             index,
             op,
             proof,
-            &self.tx_hash,
+            &self.tx_hash_fr,
             &self.tx_hash_bytes,
             helper,
         ) {
@@ -86,23 +89,16 @@ impl<'tx> From<&'tx SignedMantleTx<Preverified>> for VerifiedOps<'tx> {
 
 #[cfg(test)]
 mod tests {
-    use lb_groth16::Fr;
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkKey};
     use num_bigint::BigUint;
 
     use crate::mantle::{
-        Note, Op, OpProof, SignedMantleTx, Utxo, VerificationError,
-        channel::Channels,
-        ledger::{Inputs, Outputs, OutputsError},
-        ops::{
-            channel::{ChannelId, config::Keys},
-            transfer::{TransferError, TransferOp},
-        },
-        traits::Hashable as _,
+        Note, Utxo, VerificationError,
+        channel::{Channels, Error},
+        ledger::Inputs,
+        ops::channel::{ChannelId, config::Keys},
         transactions::{
-            signed_mantle_tx::test_utils::{
-                create_test_mantle_tx, create_withdraw_tx, make_channel_state,
-            },
+            signed_mantle_tx::test_utils::{create_withdraw_tx, make_channel_state},
             verification_helper::test_utils::TestOperationVerificationHelper,
         },
     };
@@ -150,133 +146,24 @@ mod tests {
             .expect("WithdrawOp should verify");
     }
 
+    /// Only checks that a failing op's error reaches the cursor unchanged.
+    /// The specific reasons a channel-withdraw proof can be rejected (missing
+    /// channel/key, threshold, bad signature) are covered where that logic
+    /// lives, in `ops::channel::verification::tests`.
     #[test]
-    fn helper_backed_verification_rejects_zero_value_transfer_output() {
-        let input_sk = ZkKey::from(BigUint::from(1u8));
-        let input_utxo = Utxo {
-            op_id: [1u8; 32],
-            output_index: 0,
-            note: Note::new(10000, input_sk.to_public_key()),
-        };
+    fn helper_backed_verification_surfaces_op_validation_error() {
+        let channel_id = ChannelId::from([10u8; 32]);
+        let key0 = Ed25519Key::from_bytes(&[0; 32]);
+        let signed_tx = create_withdraw_tx(channel_id, &[&key0], None);
 
-        let signed_tx = {
-            let transfer_op = TransferOp::new(
-                Inputs::new([input_utxo.id()]),
-                Outputs::new([Note::new(0, Fr::from(BigUint::from(2u8)).into())]),
-            );
-            let mantle_tx = create_test_mantle_tx(vec![Op::Transfer(transfer_op)]);
-            let transfer_sig = ZkKey::multi_sign(&[input_sk], &mantle_tx.hash().to_fr())
-                .expect("Signing should succeed");
-            SignedMantleTx::new(mantle_tx, [OpProof::ZkSig(transfer_sig)].into())
-                .preverify()
-                .expect("Transfer transaction should preverify")
-        };
+        let helper = TestOperationVerificationHelper::new(Channels::new(), []);
 
-        let helper =
-            TestOperationVerificationHelper::new(Channels::new(), []).with_utxos([input_utxo]);
-
-        let verification_result = signed_tx
-            .verified_ops()
-            .next(&helper)
-            .expect("Cursor should yield the TransferOp");
+        let verification_result = signed_tx.verified_ops().next(&helper).unwrap();
         assert_eq!(
             verification_result,
-            Err(VerificationError::TransferVerificationError(
-                TransferError::Outputs(OutputsError::ZeroValueNote)
+            Err(VerificationError::ChannelVerificationError(
+                Error::InvalidSignature
             ))
-        );
-    }
-
-    #[test]
-    fn helper_backed_verification_rejects_missing_channel() {
-        let channel_id = ChannelId::from([10u8; 32]);
-        let key0 = Ed25519Key::from_bytes(&[0; 32]);
-        let signed_tx = create_withdraw_tx(channel_id, &[&key0], None);
-
-        let channels = Channels::new();
-        let helper = TestOperationVerificationHelper::new(channels, []);
-
-        let verification_result = signed_tx.verified_ops().next(&helper).unwrap();
-        assert_eq!(
-            verification_result,
-            Err(VerificationError::ChannelNotFound { channel_id })
-        );
-    }
-
-    #[test]
-    fn helper_backed_verification_rejects_missing_key() {
-        let channel_id = ChannelId::from([10u8; 32]);
-        let key0 = Ed25519Key::from_bytes(&[0; 32]);
-        let key1 = Ed25519Key::from_bytes(&[1; 32]);
-        let signed_tx = create_withdraw_tx(channel_id, &[&key0, &key1], None);
-
-        let channels = {
-            let channels = Channels::new();
-            let channel_state = make_channel_state(2, None);
-            channels.set_channel_state(&channel_id, channel_state)
-        };
-        let helper =
-            TestOperationVerificationHelper::new(channels, [((channel_id, 0), key0.public_key())]);
-
-        let verification_result = signed_tx.verified_ops().next(&helper).unwrap();
-        assert_eq!(
-            verification_result,
-            Err(VerificationError::KeyNotFound {
-                channel_id,
-                key_index: 1
-            })
-        );
-    }
-
-    #[test]
-    fn helper_backed_verification_rejects_not_enough_signatures() {
-        let channel_id = ChannelId::from([10u8; 32]);
-        let key0 = Ed25519Key::from_bytes(&[0; 32]);
-        let signed_tx = create_withdraw_tx(channel_id, &[&key0], None);
-
-        let channels = {
-            let channels = Channels::new();
-            let channel_state = make_channel_state(2, None);
-            channels.set_channel_state(&channel_id, channel_state)
-        };
-        let helper =
-            TestOperationVerificationHelper::new(channels, [((channel_id, 0), key0.public_key())]);
-
-        let verification_result = signed_tx.verified_ops().next(&helper).unwrap();
-        assert_eq!(
-            verification_result,
-            Err(VerificationError::ChannelMultiSigProofNotEnoughSignatures {
-                op_index: 0,
-                actual: 1,
-                required: 2
-            })
-        );
-    }
-
-    #[test]
-    fn helper_backed_verification_rejects_invalid_signature() {
-        let channel_id = ChannelId::from([10u8; 32]);
-        let expected_key = Ed25519Key::from_bytes(&[0; 32]);
-        let wrong_key = Ed25519Key::from_bytes(&[9; 32]);
-        let signed_tx = create_withdraw_tx(channel_id, &[&wrong_key], None);
-
-        let channels = {
-            let channels = Channels::new();
-            let channel_state = make_channel_state(1, None);
-            channels.set_channel_state(&channel_id, channel_state)
-        };
-        let helper = TestOperationVerificationHelper::new(
-            channels,
-            [((channel_id, 0), expected_key.public_key())],
-        );
-
-        let verification_result = signed_tx.verified_ops().next(&helper).unwrap();
-        assert_eq!(
-            verification_result,
-            Err(VerificationError::ChannelMultiSigProofInvalidSignature {
-                op_index: 0,
-                signature_index: 0
-            })
         );
     }
 }

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -23,7 +23,10 @@ use crate::{
     block::BlockNumber,
     codec::{self, DeserializeOp as _, SerializeOp as _},
     crypto::{Hash, Hasher},
-    mantle::{NoteId, ledger::Declarations as ServiceDeclarations, ops::channel::Ed25519PublicKey},
+    mantle::{
+        NoteId, VerificationError, ledger::Declarations as ServiceDeclarations,
+        ops::channel::Ed25519PublicKey,
+    },
     utils::{display_hex_bytes_newtype, serde_bytes_newtype},
 };
 
@@ -504,6 +507,10 @@ impl DeclarationMessage {
 
         DeclarationId(hasher.finalize().into())
     }
+
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, BinaryCodec)]
@@ -513,12 +520,24 @@ pub struct WithdrawMessage {
     pub locked_note_id: NoteId,
 }
 
+impl WithdrawMessage {
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
+    }
+}
+
 // ActiveMessage = DeclarationId Nonce Metadata — plain field-order concat.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, BinaryCodec)]
 pub struct ActiveMessage {
     pub declaration_id: DeclarationId,
     pub nonce: Nonce,
     pub metadata: ActivityMetadata,
+}
+
+impl ActiveMessage {
+    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -13,7 +13,7 @@ use lb_blake2btree::LeafHash;
 use lb_codec::{BinaryCodec, BinaryDecode, BinaryEncode, DecodeError};
 use lb_cryptarchia_engine::Epoch;
 use lb_groth16::fr_to_bytes;
-use lb_key_management_system_keys::keys::ZkPublicKey;
+use lb_key_management_system_keys::keys::{Ed25519Signature, ZkPublicKey};
 use lb_utils::bounded::{BoundedVec, NonEmptyBoundedVec};
 use multiaddr::{Multiaddr, Protocol};
 use serde::{Deserialize, Serialize};
@@ -24,8 +24,9 @@ use crate::{
     codec::{self, DeserializeOp as _, SerializeOp as _},
     crypto::{Hash, Hasher},
     mantle::{
-        NoteId, VerificationError, ledger::Declarations as ServiceDeclarations,
-        ops::channel::Ed25519PublicKey,
+        NoteId, TxHash,
+        ledger::Declarations as ServiceDeclarations,
+        ops::{channel::Ed25519PublicKey, sdp::SdpError},
     },
     utils::{display_hex_bytes_newtype, serde_bytes_newtype},
 };
@@ -508,7 +509,17 @@ impl DeclarationMessage {
         DeclarationId(hasher.finalize().into())
     }
 
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub fn verify_stateless(
+        &self,
+        tx_hash: &TxHash,
+        proof_eddsa_signature: &Ed25519Signature,
+    ) -> Result<(), SdpError> {
+        // Ensure ownership over the `provider_id`
+        self.provider_id
+            .0
+            .verify(tx_hash.as_signing_bytes().as_ref(), proof_eddsa_signature)
+            .map_err(|_| SdpError::InvalidEddsaSignature)?;
+
         Ok(())
     }
 }
@@ -521,7 +532,7 @@ pub struct WithdrawMessage {
 }
 
 impl WithdrawMessage {
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub const fn verify_stateless(&self) -> Result<(), SdpError> {
         Ok(())
     }
 }
@@ -535,7 +546,7 @@ pub struct ActiveMessage {
 }
 
 impl ActiveMessage {
-    pub const fn verify_stateless(&self) -> Result<(), VerificationError> {
+    pub const fn verify_stateless(&self) -> Result<(), SdpError> {
         Ok(())
     }
 }

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -24,9 +24,10 @@ use crate::{
     codec::{self, DeserializeOp as _, SerializeOp as _},
     crypto::{Hash, Hasher},
     mantle::{
-        NoteId, TxHash,
+        NoteId,
         ledger::Declarations as ServiceDeclarations,
         ops::{channel::Ed25519PublicKey, sdp::SdpError},
+        transactions::hash::TxHashView,
     },
     utils::{display_hex_bytes_newtype, serde_bytes_newtype},
 };
@@ -511,13 +512,13 @@ impl DeclarationMessage {
 
     pub fn verify_stateless(
         &self,
-        tx_hash: &TxHash,
+        tx_hash_view: &TxHashView,
         proof_eddsa_signature: &Ed25519Signature,
     ) -> Result<(), SdpError> {
         // Ensure ownership over the `provider_id`
         self.provider_id
             .0
-            .verify(tx_hash.as_signing_bytes().as_ref(), proof_eddsa_signature)
+            .verify(tx_hash_view.as_bytes(), proof_eddsa_signature)
             .map_err(|_| SdpError::InvalidEddsaSignature)?;
 
         Ok(())

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -707,7 +707,7 @@ impl LedgerState {
             (self, balance, tx_events) = self.try_apply_op::<_, Constants>(
                 op,
                 config,
-                verified_ops.tx_hash(),
+                verified_ops.tx_hash_view().tx_hash(),
                 balance,
                 tx_events,
             )?;
@@ -742,6 +742,7 @@ mod tests {
             traits::Hashable as _,
             transactions::{
                 Ops, OpsProofs,
+                hash::TxHashView,
                 states::{Preverified, Unverified},
             },
         },
@@ -1925,6 +1926,7 @@ mod tests {
 
         // Try to claim the reward using the same nullifier.
         let tx_hash = TxHash::from([0u8; 32]);
+        let tx_hash_view = TxHashView::from(tx_hash);
         let err = op
             .validate(&LeaderClaimValidationContext {
                 nullifiers: leaders.nullifiers(),
@@ -1933,7 +1935,7 @@ mod tests {
                 proof: &Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(
                     &[0u8; 128],
                 )),
-                tx_hash_fr: &tx_hash.to_fr(),
+                tx_hash_view: &tx_hash_view,
             })
             .unwrap_err();
         assert_eq!(err, LeaderClaimError::DuplicatedVoucherNullifier);

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1378,12 +1378,9 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            LedgerError::VerificationError(
-                VerificationError::ChannelMultiSigProofInvalidSignature {
-                    op_index: 0,
-                    signature_index: 0,
-                }
-            )
+            LedgerError::VerificationError(VerificationError::ChannelVerificationError(
+                mantle::channel::Error::InvalidSignature
+            ))
         );
 
         // The rejected withdraw left the note owned by the channel
@@ -1927,15 +1924,16 @@ mod tests {
         assert_eq!(utxo.note.value, 100);
 
         // Try to claim the reward using the same nullifier.
+        let tx_hash = TxHash::from([0u8; 32]);
         let err = op
             .validate(&LeaderClaimValidationContext {
                 nullifiers: leaders.nullifiers(),
                 claimable_vouchers_root: leaders.vouchers_snapshot_root(),
                 // Use a dummy proof since duplication is detected before proof verification
-                proof_of_claim: &Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(
+                proof: &Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(
                     &[0u8; 128],
                 )),
-                tx_hash: &TxHash::from([0u8; 32]),
+                tx_hash_fr: &tx_hash.to_fr(),
             })
             .unwrap_err();
         assert_eq!(err, LeaderClaimError::DuplicatedVoucherNullifier);

--- a/tests/cucumber_tests/features/transactions.feature
+++ b/tests/cucumber_tests/features/transactions.feature
@@ -452,6 +452,20 @@ Feature: Transactions
     Then I stop all nodes
 
   @transactions_ci
+  Scenario: Preverification rejects a structurally invalid transaction
+    Given the genesis block has the following wallet resources:
+      | account_index | token_count | token_amount |
+      | 1             | 2           | 1000         |
+    And I have a cluster with capacity of 1 nodes
+    And I start nodes with wallet resources:
+      | node_name | account_index | wallet_name | connected_to |
+      | NODE_1    | 1             | WALLET_1A   |              |
+    When node "NODE_1" is at height 2 in 240 seconds
+    And I submit a stateless-invalid transfer transaction "BAD_TX" to node "NODE_1"
+    Then transaction "BAD_TX" is rejected during preverification
+    Then I stop all nodes
+
+  @transactions_ci
   Scenario: Invalid transactions do not block valid transactions
     Given the genesis block has the following wallet resources:
       | account_index | token_count | token_amount |

--- a/tests/src/cucumber/steps/manual_mempool/actions.rs
+++ b/tests/src/cucumber/steps/manual_mempool/actions.rs
@@ -26,7 +26,9 @@ use crate::{
     cucumber::{
         error::StepError,
         fee_reserve::DEFAULT_STORAGE_GAS_PRICE,
-        steps::{TARGET, manual_transactions::tracked_transactions::create_invalid_transaction},
+        steps::{
+            TARGET, manual_transactions::tracked_transactions::create_stateless_invalid_transaction,
+        },
         utils::{tx_hash_to_hex, user_config_from_node_yaml},
         wallet::submissions::{
             SignedUserWalletSubmission, prepare_user_wallet_transaction_submission,
@@ -100,7 +102,7 @@ pub async fn try_submit_invalid_transaction(
         .inspect_err(|e| {
             warn!(target: TARGET, "Step `{step}` error: {e}");
         })?;
-    let signed_tx = create_invalid_transaction();
+    let signed_tx = create_stateless_invalid_transaction();
     let tx_hash = signed_tx.hash();
 
     world.remember_submitted_transaction(transaction_alias.clone(), tx_hash);

--- a/tests/src/cucumber/steps/manual_transactions/steps.rs
+++ b/tests/src/cucumber/steps/manual_transactions/steps.rs
@@ -21,7 +21,9 @@ use crate::{
                 drain_wallets::{drain_all_node_wallets, drain_node_wallet, drain_user_wallet},
                 tracked_transactions::{
                     submit_funded_transfer_transaction, submit_invalid_transfer_transaction,
+                    submit_stateless_invalid_transfer_transaction,
                     transaction_is_not_included_in_seconds,
+                    transaction_is_rejected_during_preverification,
                 },
                 utils,
                 utils::{
@@ -546,6 +548,33 @@ async fn step_submit_invalid_transfer_transaction(
     node_name: String,
 ) -> StepResult {
     submit_invalid_transfer_transaction(world, &step.value, transaction_alias, node_name).await
+}
+
+#[when(expr = "I submit a stateless-invalid transfer transaction {string} to node {string}")]
+async fn step_submit_stateless_invalid_transfer_transaction(
+    world: &mut CucumberWorld,
+    step: &Step,
+    transaction_alias: String,
+    node_name: String,
+) -> StepResult {
+    submit_stateless_invalid_transfer_transaction(world, &step.value, transaction_alias, node_name)
+        .await
+}
+
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "Cucumber step functions require `&mut World` as the first parameter"
+)]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step captures are always owned `String`s, even when the step only needs to borrow them"
+)]
+#[then(expr = "transaction {string} is rejected during preverification")]
+fn step_transaction_is_rejected_during_preverification(
+    world: &mut CucumberWorld,
+    transaction_alias: String,
+) -> StepResult {
+    transaction_is_rejected_during_preverification(world, &transaction_alias)
 }
 
 #[when(

--- a/tests/src/cucumber/steps/manual_transactions/tracked_transactions.rs
+++ b/tests/src/cucumber/steps/manual_transactions/tracked_transactions.rs
@@ -2,12 +2,13 @@ use std::{collections::HashSet, time::Duration};
 
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
-    Note, Op, OpProof, SignedMantleTx,
+    Note, NoteId, Op, OpProof, SignedMantleTx,
     ledger::{Inputs, Outputs},
     ops::transfer::TransferOp,
     traits::Hashable as _,
     transactions::{hash::TxHash, mantle_tx::MantleTx, states::Unverified},
 };
+use lb_groth16::Fr;
 use lb_key_management_system_service::keys::{ZkKey, ZkPublicKey};
 use tokio::time::{sleep, timeout};
 use tracing::{info, warn};
@@ -25,6 +26,8 @@ use crate::{
     },
 };
 
+/// Submit a transaction that passes stateless validation but is invalid against
+/// ledger state.
 pub async fn submit_invalid_transfer_transaction(
     world: &mut CucumberWorld,
     step: &str,
@@ -37,7 +40,7 @@ pub async fn submit_invalid_transfer_transaction(
             warn!(target: TARGET, "Step `{step}` error: {e}");
         })?;
 
-    let signed_tx = create_invalid_transaction();
+    let signed_tx = create_stateful_invalid_transaction();
     let tx_hash = signed_tx.hash();
 
     node.submit_transaction(&signed_tx).await.inspect_err(|e| {
@@ -52,6 +55,56 @@ pub async fn submit_invalid_transfer_transaction(
     );
 
     Ok(())
+}
+
+/// Submit a transaction that fails stateless validation.
+pub async fn submit_stateless_invalid_transfer_transaction(
+    world: &mut CucumberWorld,
+    step: &str,
+    transaction_alias: String,
+    node_name: String,
+) -> Result<(), StepError> {
+    let node = world
+        .resolve_node_http_client(&node_name)
+        .inspect_err(|e| {
+            warn!(target: TARGET, "Step `{step}` error: {e}");
+        })?;
+
+    let signed_tx = create_stateless_invalid_transaction();
+    let outcome = node
+        .submit_transaction(&signed_tx)
+        .await
+        .map_err(|e| e.to_string());
+
+    info!(
+        target: TARGET,
+        "Submitted stateless-invalid transfer transaction `{transaction_alias}` to `{node_name}`: {outcome:?}"
+    );
+
+    world.remember_submission_outcome(transaction_alias, outcome);
+
+    Ok(())
+}
+
+/// Assert that a previously submitted transaction was rejected during
+/// preverification.
+pub fn transaction_is_rejected_during_preverification(
+    world: &CucumberWorld,
+    transaction_alias: &str,
+) -> Result<(), StepError> {
+    match world.resolve_submission_outcome(transaction_alias)? {
+        Ok(()) => Err(StepError::LogicalError {
+            message: format!(
+                "expected transaction `{transaction_alias}` to be rejected during preverification, but it was accepted"
+            ),
+        }),
+        Err(message) if message.contains("doesn't have any input") => Ok(()),
+        Err(other) => Err(StepError::LogicalError {
+            message: format!(
+                "expected transaction `{transaction_alias}` to be rejected mentioning 'doesn't have any input', got: {other}"
+            ),
+        }),
+    }
 }
 
 pub async fn submit_funded_transfer_transaction(
@@ -197,14 +250,29 @@ async fn transaction_is_in_chain(
     .is_some()
 }
 
-pub fn create_invalid_transaction() -> SignedMantleTx<Unverified> {
+/// Builds a transaction that fails stateless validation: a `TransferOp` with no
+/// inputs.
+pub fn create_stateless_invalid_transaction() -> SignedMantleTx<Unverified> {
+    let output_note = Note::new(1000, ZkPublicKey::new(1u8.into()));
+    let transfer_op = TransferOp::new(Inputs::empty(), Outputs::new([output_note]));
+
+    build_signed_transfer(transfer_op)
+}
+
+/// Builds a transaction that passes stateless validation but is invalid against
+/// ledger state: its input note id does not correspond to any real UTXO.
+fn create_stateful_invalid_transaction() -> SignedMantleTx<Unverified> {
+    let nonexistent_input = NoteId(Fr::from(0xDEAD_BEEFu64));
     let output_note = Note::new(1000, ZkPublicKey::new(1u8.into()));
     let transfer_op = TransferOp::new(
-        Inputs::empty(),
-        // Outputs::new([output_note]),
+        Inputs::new([nonexistent_input]),
         Outputs::new([output_note]),
     );
 
+    build_signed_transfer(transfer_op)
+}
+
+fn build_signed_transfer(transfer_op: TransferOp) -> SignedMantleTx<Unverified> {
     let mantle_tx = MantleTx([Op::Transfer(transfer_op)].into());
 
     let transfer_proof = ZkKey::multi_sign(&[], &mantle_tx.hash().to_fr())

--- a/tests/src/cucumber/world.rs
+++ b/tests/src/cucumber/world.rs
@@ -914,6 +914,10 @@ pub struct CucumberWorld {
     pub wallets: SharedTrackedWallets,
     /// Manual: Mapping of scenario transaction aliases to submitted hashes.
     pub submitted_transactions: HashMap<String, TxHash>,
+    /// Manual: Outcome of a transaction submission attempt, keyed by scenario
+    /// alias, for scenarios that assert on submission being rejected rather
+    /// than on later inclusion.
+    pub submission_outcomes: HashMap<String, Result<(), String>>,
     /// Manual: Exact signed transactions prepared for later submission.
     pub prepared_transactions: HashMap<String, SignedMantleTx<Preverified>>,
     /// Manual: Transaction hashes observed in blocks by the wallet scanner.
@@ -1109,6 +1113,7 @@ impl Debug for CucumberWorld {
             .field("scenario_fee_state", &fee_state_summary(&self.fee_state))
             .field("wallets", &"SharedTrackedWallets")
             .field("submitted_transactions", &self.submitted_transactions.len())
+            .field("submission_outcomes", &self.submission_outcomes.len())
             .field("prepared_transactions", &self.prepared_transactions.len())
             .field(
                 "observed_transaction_hashes",
@@ -1971,6 +1976,21 @@ impl CucumberWorld {
 
     pub fn remember_submitted_transaction(&mut self, alias: String, tx_hash: TxHash) {
         self.submitted_transactions.insert(alias, tx_hash);
+    }
+
+    pub fn remember_submission_outcome(&mut self, alias: String, outcome: Result<(), String>) {
+        self.submission_outcomes.insert(alias, outcome);
+    }
+
+    pub fn resolve_submission_outcome(
+        &self,
+        alias: &str,
+    ) -> Result<&Result<(), String>, StepError> {
+        self.submission_outcomes
+            .get(alias)
+            .ok_or_else(|| StepError::LogicalError {
+                message: format!("Submission outcome for alias '{alias}' not found in world state"),
+            })
     }
 
     #[must_use]


### PR DESCRIPTION
## 1. What does this PR implement?
Split transaction's verification process into stateless and stateful (e.g. ledger).
Add `TxHashView` to simplify the `Bytes` and `Fr` views of a `TxHash`.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
