### PR TITLE
chore: replace bounded vec with fixed sized array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5347,10 +5347,10 @@ dependencies = [
  "logos-blockchain-log-targets",
  "logos-blockchain-poseidon2",
  "logos-blockchain-proofs-error",
- "logos-blockchain-utils",
  "num-bigint",
  "rand 0.8.6",
  "serde",
+ "serde-big-array",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
@@ -7613,6 +7613,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/zk/proofs/zksign/Cargo.toml
+++ b/zk/proofs/zksign/Cargo.toml
@@ -14,12 +14,12 @@ lb-circuits-prover = { workspace = true }
 lb-groth16         = { workspace = true }
 lb-log-targets     = { workspace = true }
 lb-poseidon2       = { workspace = true }
-lb-utils           = { workspace = true }
 lbc-signature-sys  = { features = ["prebuilt"], workspace = true }
 lbc-types          = { workspace = true }
 lbp-error          = { workspace = true }
 num-bigint         = { workspace = true }
 serde              = { features = ["derive"], workspace = true }
+serde-big-array    = { workspace = true }
 serde_json         = { workspace = true }
 thiserror          = { workspace = true }
 tracing            = { workspace = true }

--- a/zk/proofs/zksign/src/public.rs
+++ b/zk/proofs/zksign/src/public.rs
@@ -1,6 +1,6 @@
 use lb_groth16::{AdditiveGroup as _, Fr, Groth16Input, Groth16InputDeser};
-use lb_utils::bounded::BoundedVec;
 use serde::Deserialize;
+use serde_big_array::BigArray;
 
 #[derive(Clone, Debug)]
 pub struct ZkSignVerifierInputs {
@@ -19,7 +19,7 @@ impl ZkSignVerifierInputs {
 
 #[derive(Deserialize)]
 #[serde(transparent)]
-pub struct ZkSignVerifierInputsJson(BoundedVec<Groth16InputDeser, 33, 33>);
+pub struct ZkSignVerifierInputsJson(#[serde(with = "BigArray")] [Groth16InputDeser; 33]);
 
 #[derive(Debug, thiserror::Error)]
 pub enum ZkSignVerifierInputsJsonTryFromError {
@@ -31,21 +31,19 @@ impl TryFrom<ZkSignVerifierInputsJson> for ZkSignVerifierInputs {
     type Error = ZkSignVerifierInputsJsonTryFromError;
 
     fn try_from(value: ZkSignVerifierInputsJson) -> Result<Self, Self::Error> {
-        let mut inputs = value.0.into_inner();
+        let [public_key_inputs @ .., msg_input] = value.0;
 
-        let msg = inputs
-            .pop()
-            .expect("ZkSignVerifierInputsJson always contains 33 inputs")
-            .try_into()
-            .map_err(Self::Error::Groth16DeserError)?;
-
-        let public_keys: [Groth16Input; 32] = inputs
+        let public_keys: [Groth16Input; 32] = public_key_inputs
             .into_iter()
             .map(TryInto::try_into)
             .collect::<Result<Vec<_>, _>>()
             .map_err(Self::Error::Groth16DeserError)?
             .try_into()
-            .expect("removing the message leaves exactly 32 public keys");
+            .expect("public_key_inputs always contains exactly 32 inputs");
+
+        let msg = msg_input
+            .try_into()
+            .map_err(Self::Error::Groth16DeserError)?;
 
         Ok(Self { public_keys, msg })
     }


### PR DESCRIPTION
## 1. What does this PR implement?

Replaced bounded vec in `ZkSignVerifierInputsJson` with a fixed sized array.

See [discussion](https://github.com/logos-blockchain/logos-blockchain/pull/3167#discussion_r3657118372).

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
