### PR TITLE
fix: workflow merge queue final steps

### DIFF
--- a/.github/workflows/cucumber-integration-tests.yml
+++ b/.github/workflows/cucumber-integration-tests.yml
@@ -217,7 +217,7 @@ jobs:
   cucumber-result:
     name: Cucumber result
     needs: tests
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check Cucumber result

--- a/.github/workflows/end-to-end-integration-tests.yml
+++ b/.github/workflows/end-to-end-integration-tests.yml
@@ -181,7 +181,7 @@ jobs:
   e2e-result:
     name: E2E result
     needs: tests
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check E2E result


### PR DESCRIPTION
## 1. What does this PR implement?

Fix `Cucumber result` and `E2E result` workflow steps to be cancel-able in the merge queue. GitHub recommends `if: ${{ !cancelled() }}` for a job that must run after either success or failure but should not run after workflow cancellation.

See https://github.com/logos-blockchain/logos-blockchain/pull/3176#discussion_r3655195285 and https://github.com/logos-blockchain/logos-blockchain/pull/3176#discussion_r3655196853.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@hansieodendaal @ntn-x2 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
