### PR TITLE
feat(mantle): switch channels and channel notes to Blake2bTree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "divan",
  "hasher",
  "hex",
+ "logos-blockchain-blake2btree",
  "logos-blockchain-blend-proofs",
  "logos-blockchain-core-macros",
  "logos-blockchain-cryptarchia-engine",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ blake2                        = { workspace = true }
 bytes                         = { workspace = true }
 const-hex                     = { features = ["alloc"], workspace = true }
 hex                           = { features = ["alloc"], workspace = true }
+lb-blake2btree                = { workspace = true }
 lb-blend-proofs               = { workspace = true }
 lb-core-macros                = { workspace = true }
 lb-cryptarchia-engine         = { workspace = true }

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -156,6 +156,15 @@ impl Default for Channels {
     }
 }
 
+impl<'a> IntoIterator for &'a Channels {
+    type Item = (&'a ChannelId, &'a ChannelState);
+    type IntoIter = <&'a Blake2bTree<ChannelId, ChannelState> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.channels.into_iter()
+    }
+}
+
 impl Channels {
     pub fn from_genesis(op: &InscriptionOp) -> Result<(Self, Vec<TxEvent>), Error> {
         let (ctx, events) = op.execute(InscriptionExecutionContext {
@@ -183,8 +192,9 @@ impl Channels {
         self.channels.contains(channel_id)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&ChannelId, &ChannelState)> {
-        self.channels.iter()
+    #[must_use]
+    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        self.into_iter()
     }
 
     /// Creates `channel_id` with `channel`, or replaces its state if it already

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -184,10 +184,7 @@ impl Channels {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&ChannelId, &ChannelState)> {
-        self.channels
-            .items()
-            .iter()
-            .map(|(channel_id, (channel, _))| (channel_id, channel))
+        self.channels.iter()
     }
 
     /// Creates `channel_id` with `channel`, or replaces its state if it already

--- a/core/src/mantle/channel.rs
+++ b/core/src/mantle/channel.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
+use lb_blake2btree::{Blake2bTree, LeafHash};
 use lb_cryptarchia_engine::Slot;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    crypto::{Digest as _, Hash, Hasher},
     events::TxEvent,
     mantle::{
         NoteId,
@@ -95,7 +97,7 @@ pub enum Error {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Channels {
-    pub channels: rpds::HashTrieMapSync<ChannelId, ChannelState>,
+    channels: Blake2bTree<ChannelId, ChannelState>,
     channel_notes: ChannelNotes,
 }
 
@@ -124,6 +126,28 @@ pub struct ChannelState {
                                               * channel */
 }
 
+// The leaf binds the channel id to its whole state, so that any configuration
+// or sequencing update changes the root.
+impl LeafHash<ChannelId> for ChannelState {
+    fn leaf_hash(&self, channel_id: &ChannelId) -> Hash {
+        let mut h = Hasher::new();
+        h.update(b"CHANNEL_HASH_V1");
+        h.update(channel_id.as_ref());
+        for key in self.accredited_keys.iter() {
+            h.update(key.as_bytes());
+        }
+        h.update(self.configuration_threshold.to_le_bytes());
+        h.update(self.tip_message.as_ref());
+        h.update(self.tip_slot.to_le_bytes());
+        h.update(self.tip_sequencer.to_le_bytes());
+        h.update(self.tip_sequencer_starting_slot.to_le_bytes());
+        h.update(self.posting_timeframe.0.to_le_bytes());
+        h.update(self.posting_timeout.0.to_le_bytes());
+        h.update(self.transfer_threshold.to_le_bytes());
+        h.finalize().into()
+    }
+}
+
 pub(crate) const DEFAULT_TRANSFER_THRESHOLD: ChannelKeyIndex = 1;
 
 impl Default for Channels {
@@ -144,14 +168,53 @@ impl Channels {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            channels: rpds::HashTrieMapSync::new_sync(),
+            channels: Blake2bTree::new(),
             channel_notes: ChannelNotes::new(),
         }
     }
 
     #[must_use]
     pub fn channel_state(&self, channel_id: &ChannelId) -> Option<&ChannelState> {
-        self.channels.get(channel_id)
+        self.channels.get_ref(channel_id)
+    }
+
+    #[must_use]
+    pub fn contains_channel(&self, channel_id: &ChannelId) -> bool {
+        self.channels.contains(channel_id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&ChannelId, &ChannelState)> {
+        self.channels
+            .items()
+            .iter()
+            .map(|(channel_id, (channel, _))| (channel_id, channel))
+    }
+
+    /// Creates `channel_id` with `channel`, or replaces its state if it already
+    /// exists.
+    pub(crate) fn set_channel_state(
+        mut self,
+        channel_id: &ChannelId,
+        channel: ChannelState,
+    ) -> Self {
+        self.channels = if self.channels.contains(channel_id) {
+            self.channels
+                .update(channel_id, channel)
+                .expect("channel is in the tree")
+        } else {
+            self.channels.insert(*channel_id, channel).0
+        };
+        self
+    }
+
+    #[must_use]
+    pub fn channels_root(&self) -> Hash {
+        self.channels.root()
+    }
+
+    #[must_use]
+    pub fn channel_notes_root(&self) -> Hash {
+        self.channel_notes.root()
     }
 
     /// Returns `true` if `note_id` is owned by any channel.
@@ -163,7 +226,7 @@ impl Channels {
     /// Returns the channel owning `note_id`, if it is a channel note.
     #[must_use]
     pub fn get_channel(&self, note_id: &NoteId) -> Option<ChannelId> {
-        self.channel_notes.get(note_id).copied()
+        self.channel_notes.get(note_id)
     }
 
     /// Returns `true` if `note_id` is a channel note owned by `channel_id`.
@@ -327,39 +390,35 @@ mod tests {
         let second_id = ChannelId::from([2u8; 32]);
         let missing_id = ChannelId::from([0u8; 32]);
 
-        let channels = Channels {
-            channels: rpds::HashTrieMapSync::new_sync()
-                .insert(
-                    first_id,
-                    ChannelState {
-                        accredited_keys: Keys::from(test_public_key(11)).into(),
-                        configuration_threshold: 1,
-                        tip_message: MsgId::root(),
-                        tip_slot: Slot::default(),
-                        tip_sequencer: 0,
-                        tip_sequencer_starting_slot: Slot::default(),
-                        posting_timeframe: 0u32.into(),
-                        transfer_threshold: 1,
-                        posting_timeout: 0u32.into(),
-                    },
-                )
-                .insert(
-                    second_id,
-                    ChannelState {
-                        accredited_keys: Keys::from([test_public_key(22), test_public_key(23)])
-                            .into(),
-                        configuration_threshold: 1,
-                        tip_message: MsgId::root(),
-                        tip_slot: Slot::default(),
-                        tip_sequencer: 0,
-                        tip_sequencer_starting_slot: Slot::default(),
-                        posting_timeframe: 0.into(),
-                        transfer_threshold: 2,
-                        posting_timeout: 0.into(),
-                    },
-                ),
-            channel_notes: ChannelNotes::new(),
-        };
+        let channels = Channels::new()
+            .set_channel_state(
+                &first_id,
+                ChannelState {
+                    accredited_keys: Keys::from(test_public_key(11)).into(),
+                    configuration_threshold: 1,
+                    tip_message: MsgId::root(),
+                    tip_slot: Slot::default(),
+                    tip_sequencer: 0,
+                    tip_sequencer_starting_slot: Slot::default(),
+                    posting_timeframe: 0u32.into(),
+                    transfer_threshold: 1,
+                    posting_timeout: 0u32.into(),
+                },
+            )
+            .set_channel_state(
+                &second_id,
+                ChannelState {
+                    accredited_keys: Keys::from([test_public_key(22), test_public_key(23)]).into(),
+                    configuration_threshold: 1,
+                    tip_message: MsgId::root(),
+                    tip_slot: Slot::default(),
+                    tip_sequencer: 0,
+                    tip_sequencer_starting_slot: Slot::default(),
+                    posting_timeframe: 0.into(),
+                    transfer_threshold: 2,
+                    posting_timeout: 0.into(),
+                },
+            );
 
         let gas_context = MantleTxGasContext::from_channels(&channels, GasPrices::new(0, 0));
 
@@ -682,5 +741,130 @@ mod tests {
     fn zero_elapsed_no_change() {
         let channel = make_channel(100, 3, 95, 10, 20, 5);
         assert_eq!(channel.round_robin(100.into()), (3, 95.into()));
+    }
+
+    // Leaf commitment
+    fn leaf_channel_state() -> ChannelState {
+        ChannelState {
+            accredited_keys: Keys::from([test_public_key(1), test_public_key(2)]).into(),
+            configuration_threshold: 2,
+            tip_message: MsgId::from([3u8; 32]),
+            tip_slot: Slot::new(42),
+            tip_sequencer: 1,
+            tip_sequencer_starting_slot: Slot::new(7),
+            posting_timeframe: SlotTimeframe(10),
+            posting_timeout: SlotTimeout(20),
+            transfer_threshold: 2,
+        }
+    }
+
+    // The encoding is spelled out field by field, so any change to `leaf_hash`
+    // has to be mirrored here and in the specification.
+    #[test]
+    fn channel_leaf_matches_the_specified_encoding() {
+        let channel_id = ChannelId::from([0u8; 32]);
+        let channel = leaf_channel_state();
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"CHANNEL_HASH_V1");
+        bytes.extend_from_slice(channel_id.as_ref());
+        bytes.extend_from_slice(test_public_key(1).as_bytes());
+        bytes.extend_from_slice(test_public_key(2).as_bytes());
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+        bytes.extend_from_slice(&[3u8; 32]);
+        bytes.extend_from_slice(&42u64.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&7u64.to_le_bytes());
+        bytes.extend_from_slice(&10u32.to_le_bytes());
+        bytes.extend_from_slice(&20u32.to_le_bytes());
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+
+        let expected: Hash = Hasher::digest(&bytes).into();
+        assert_eq!(channel.leaf_hash(&channel_id), expected);
+    }
+
+    #[test]
+    fn channel_leaf_binds_the_channel_id() {
+        let channel = leaf_channel_state();
+
+        assert_ne!(
+            channel.leaf_hash(&ChannelId::from([0u8; 32])),
+            channel.leaf_hash(&ChannelId::from([1u8; 32]))
+        );
+    }
+
+    #[test]
+    fn channel_leaf_binds_every_field() {
+        let channel_id = ChannelId::from([0u8; 32]);
+        let channel = leaf_channel_state();
+        let leaf = channel.leaf_hash(&channel_id);
+
+        let mutations = [
+            ChannelState {
+                accredited_keys: Keys::from(test_public_key(9)).into(),
+                ..channel.clone()
+            },
+            ChannelState {
+                configuration_threshold: 1,
+                ..channel.clone()
+            },
+            ChannelState {
+                tip_message: MsgId::root(),
+                ..channel.clone()
+            },
+            ChannelState {
+                tip_slot: Slot::new(43),
+                ..channel.clone()
+            },
+            ChannelState {
+                tip_sequencer: 0,
+                ..channel.clone()
+            },
+            ChannelState {
+                tip_sequencer_starting_slot: Slot::new(8),
+                ..channel.clone()
+            },
+            ChannelState {
+                posting_timeframe: SlotTimeframe(11),
+                ..channel.clone()
+            },
+            ChannelState {
+                posting_timeout: SlotTimeout(21),
+                ..channel.clone()
+            },
+            ChannelState {
+                transfer_threshold: 1,
+                ..channel
+            },
+        ];
+
+        for mutated in mutations {
+            assert_ne!(mutated.leaf_hash(&channel_id), leaf);
+        }
+    }
+
+    #[test]
+    fn channels_root_tracks_insertions_and_updates() {
+        let channel_id = ChannelId::from([0u8; 32]);
+        let channels = Channels::new();
+        let empty_root = channels.channels_root();
+
+        let channels = channels.set_channel_state(&channel_id, leaf_channel_state());
+        let root = channels.channels_root();
+        assert_ne!(root, empty_root);
+
+        let channels = channels.set_channel_state(
+            &channel_id,
+            ChannelState {
+                tip_slot: Slot::new(43),
+                ..leaf_channel_state()
+            },
+        );
+        assert_ne!(channels.channels_root(), root);
+
+        // The state is updated in place, so restoring it restores the root
+        // instead of committing to a second leaf.
+        let channels = channels.set_channel_state(&channel_id, leaf_channel_state());
+        assert_eq!(channels.channels_root(), root);
     }
 }

--- a/core/src/mantle/channel_notes.rs
+++ b/core/src/mantle/channel_notes.rs
@@ -1,6 +1,10 @@
+use lb_blake2btree::{Blake2bTree, LeafHash};
 use serde::{Deserialize, Serialize};
 
-use crate::mantle::{NoteId, ops::channel::ChannelId};
+use crate::{
+    crypto::{Digest as _, Hash, Hasher},
+    mantle::{NoteId, ops::channel::ChannelId},
+};
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
 pub enum Error {
@@ -18,27 +22,43 @@ pub enum Error {
     },
 }
 
+// The leaf binds a note to the channel owning it, so that releasing it or
+// handing it over to another channel changes the root.
+impl LeafHash<NoteId> for ChannelId {
+    fn leaf_hash(&self, note_id: &NoteId) -> Hash {
+        let mut h = Hasher::new();
+        h.update(note_id.as_bytes());
+        h.update(self.as_ref());
+        h.finalize().into()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ChannelNotes {
-    channel_notes: rpds::HashTrieMapSync<NoteId, ChannelId>,
+    channel_notes: Blake2bTree<NoteId, ChannelId>,
 }
 
 impl ChannelNotes {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            channel_notes: rpds::HashTrieMapSync::new_sync(),
+            channel_notes: Blake2bTree::new(),
         }
     }
 
     #[must_use]
+    pub fn root(&self) -> Hash {
+        self.channel_notes.root()
+    }
+
+    #[must_use]
     pub fn contains(&self, id: &NoteId) -> bool {
-        self.channel_notes.contains_key(id)
+        self.channel_notes.contains(id)
     }
 
     /// Returns the channel owning `id`, if it is a channel note.
     #[must_use]
-    pub fn get(&self, id: &NoteId) -> Option<&ChannelId> {
+    pub fn get(&self, id: &NoteId) -> Option<ChannelId> {
         self.channel_notes.get(id)
     }
 
@@ -46,23 +66,26 @@ impl ChannelNotes {
         if let Some(channel) = self.channel_notes.get(note_id) {
             return Err(Error::AlreadyAChannelNote {
                 note_id: *note_id,
-                channel_id: *channel,
+                channel_id: channel,
             });
         }
-        self.channel_notes = self.channel_notes.insert(*note_id, *channel_id);
+        self.channel_notes = self.channel_notes.insert(*note_id, *channel_id).0;
 
         Ok(self)
     }
 
     #[must_use]
     pub fn is_a_channel(&self, note_id: &NoteId, channel_id: &ChannelId) -> bool {
-        self.channel_notes.get(note_id) == Some(channel_id)
+        self.channel_notes.get_ref(note_id) == Some(channel_id)
     }
 
     pub fn into_bedrock(mut self, note_id: &NoteId, channel_id: &ChannelId) -> Result<Self, Error> {
         match self.channel_notes.get(note_id) {
-            Some(channel) if channel == channel_id => {
-                self.channel_notes = self.channel_notes.remove(note_id);
+            Some(channel) if channel == *channel_id => {
+                (self.channel_notes, _) = self
+                    .channel_notes
+                    .remove(note_id)
+                    .expect("channel note is in the tree");
                 Ok(self)
             }
             Some(_) => Err(Error::NotAChannelNote {
@@ -71,5 +94,79 @@ impl ChannelNotes {
             }),
             None => Err(Error::NotInChannel(*note_id)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lb_groth16::Fr;
+
+    use super::*;
+
+    fn note_id(seed: u64) -> NoteId {
+        NoteId::from(Fr::from(seed))
+    }
+
+    // The encoding is spelled out field by field, so any change to `leaf_hash`
+    // has to be mirrored here and in the specification.
+    #[test]
+    fn channel_note_leaf_matches_the_specified_encoding() {
+        let note_id = note_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&note_id.as_bytes());
+        bytes.extend_from_slice(channel_id.as_ref());
+
+        let expected: Hash = Hasher::digest(&bytes).into();
+        assert_eq!(channel_id.leaf_hash(&note_id), expected);
+    }
+
+    #[test]
+    fn channel_note_leaf_binds_the_owning_channel() {
+        let note_id = note_id(1);
+
+        assert_ne!(
+            ChannelId::from([0u8; 32]).leaf_hash(&note_id),
+            ChannelId::from([1u8; 32]).leaf_hash(&note_id)
+        );
+    }
+
+    #[test]
+    fn releasing_a_note_restores_the_root() {
+        let note_id = note_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+
+        let channel_notes = ChannelNotes::new();
+        let empty_root = channel_notes.root();
+
+        let channel_notes = channel_notes.into_channel(&note_id, &channel_id).unwrap();
+        assert_ne!(channel_notes.root(), empty_root);
+
+        let channel_notes = channel_notes.into_bedrock(&note_id, &channel_id).unwrap();
+        assert_eq!(channel_notes.root(), empty_root);
+    }
+
+    // The slot freed by a removal is reused, so the same notes registered in the
+    // same order commit to the same root whatever happened in between.
+    #[test]
+    fn root_follows_the_order_of_apparition() {
+        let first = note_id(1);
+        let second = note_id(2);
+        let channel_id = ChannelId::from([0u8; 32]);
+
+        let channel_notes = ChannelNotes::new()
+            .into_channel(&first, &channel_id)
+            .unwrap()
+            .into_channel(&second, &channel_id)
+            .unwrap();
+
+        let reordered = ChannelNotes::new()
+            .into_channel(&second, &channel_id)
+            .unwrap()
+            .into_channel(&first, &channel_id)
+            .unwrap();
+
+        assert_ne!(channel_notes.root(), reordered.root());
     }
 }

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -61,8 +61,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
         // Check that the channel exist
         let channel =
             ctx.channels
-                .channels
-                .get(&self.channel_id)
+                .channel_state(&self.channel_id)
                 .ok_or(Error::ChannelNotFound {
                     channel_id: self.channel_id,
                 })?;

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -65,7 +65,7 @@ impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
             return Err(Error::InvalidChannelConfig);
         }
 
-        if let Some(channel) = ctx.channels.channels.get(&self.channel).cloned() {
+        if let Some(channel) = ctx.channels.channel_state(&self.channel) {
             // Check there is enough signatures
             let signatures = ctx.config_sigs.signatures();
             if signatures.len() != channel.configuration_threshold as usize {
@@ -101,33 +101,20 @@ impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
         &self,
         mut ctx: Self::ExecutionContext<'_>,
     ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+        let channel = ChannelState {
+            accredited_keys: self.keys.clone().into(),
+            configuration_threshold: self.configuration_threshold,
+            tip_message: self.id(),
+            tip_slot: ctx.block_slot,
+            tip_sequencer: 0,
+            tip_sequencer_starting_slot: ctx.block_slot,
+            posting_timeframe: self.posting_timeframe.clone(),
+            transfer_threshold: self.transfer_threshold,
+            posting_timeout: self.posting_timeout.clone(),
+        };
+
         // if the channel doesn't exist, create it otherwise just update the config
-        if let Some(channel) = ctx.channels.channels.get_mut(&self.channel) {
-            channel.accredited_keys = self.keys.clone().into();
-            channel.configuration_threshold = self.configuration_threshold;
-            channel.tip_sequencer = 0;
-            channel.tip_sequencer_starting_slot = ctx.block_slot;
-            channel.posting_timeframe = self.posting_timeframe.clone();
-            channel.posting_timeout = self.posting_timeout.clone();
-            channel.transfer_threshold = self.transfer_threshold;
-            channel.tip_slot = ctx.block_slot;
-            channel.tip_message = self.id();
-        } else {
-            ctx.channels.channels = ctx.channels.channels.insert(
-                self.channel,
-                ChannelState {
-                    accredited_keys: self.keys.clone().into(),
-                    configuration_threshold: self.configuration_threshold,
-                    tip_message: self.id(),
-                    tip_slot: ctx.block_slot,
-                    tip_sequencer: 0,
-                    tip_sequencer_starting_slot: ctx.block_slot,
-                    posting_timeframe: self.posting_timeframe.clone(),
-                    transfer_threshold: self.transfer_threshold,
-                    posting_timeout: self.posting_timeout.clone(),
-                },
-            );
-        }
+        ctx.channels = ctx.channels.set_channel_state(&self.channel, channel);
         Ok((ctx, Vec::new()))
     }
 }

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -71,7 +71,7 @@ impl Operation<DepositValidationContext<'_>> for DepositOp {
 
     fn validate(&self, ctx: &DepositValidationContext<'_>) -> Result<(), Self::Error> {
         // Check that the channel exist
-        if !ctx.channels.channels.contains_key(&self.channel_id) {
+        if !ctx.channels.contains_channel(&self.channel_id) {
             return Err(Error::ChannelNotFound {
                 channel_id: self.channel_id,
             });

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -67,7 +67,7 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
     fn validate(&self, ctx: &InscriptionValidationContext<'_>) -> Result<(), Self::Error> {
         // Check if the channel exist otherwise the inscription is valid only if and
         // only if parent == ZERO
-        if let Some(channel) = ctx.channels.channels.get(&self.channel_id).cloned() {
+        if let Some(channel) = ctx.channels.channel_state(&self.channel_id) {
             // Check the parent corresponds to the payload
             if self.parent != channel.tip_message {
                 return Err(Error::InvalidParent {
@@ -114,8 +114,7 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
         // if the channel doesn't exist, create it
         let channel = ctx
             .channels
-            .channels
-            .get(&self.channel_id)
+            .channel_state(&self.channel_id)
             .cloned()
             .unwrap_or_else(|| ChannelState {
                 accredited_keys: Keys::from(self.signer).into(),
@@ -132,17 +131,15 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
         // Update the channel sequencer, its starting slot, the tip message and the tip
         // slot
         let (new_sequencer, new_starting_slot) = channel.round_robin(ctx.block_slot);
-        ctx.channels.channels = ctx.channels.channels.insert(
-            self.channel_id,
-            ChannelState {
-                tip_message: self.id(),
-                accredited_keys: Arc::clone(&channel.accredited_keys),
-                tip_sequencer: new_sequencer,
-                tip_sequencer_starting_slot: new_starting_slot,
-                tip_slot: ctx.block_slot,
-                ..channel
-            },
-        );
+        let updated = ChannelState {
+            tip_message: self.id(),
+            accredited_keys: Arc::clone(&channel.accredited_keys),
+            tip_sequencer: new_sequencer,
+            tip_sequencer_starting_slot: new_starting_slot,
+            tip_slot: ctx.block_slot,
+            ..channel
+        };
+        ctx.channels = ctx.channels.set_channel_state(&self.channel_id, updated);
         Ok((ctx, Vec::new()))
     }
 }

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -50,8 +50,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
         // Check that the channel exists
         let channel =
             ctx.channels
-                .channels
-                .get(&self.channel_id)
+                .channel_state(&self.channel_id)
                 .ok_or(Error::ChannelNotFound {
                     channel_id: self.channel_id,
                 })?;

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -227,7 +227,7 @@ impl MantleTxGasContext {
     #[must_use]
     pub fn from_channels(channels: &Channels, base_prices: GasPrices) -> Self {
         let (transfer_thresholds, configuration_thresholds) = channels
-            .iter()
+            .into_iter()
             .map(|(channel_id, channel)| {
                 (
                     (*channel_id, channel.transfer_threshold),

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -225,17 +225,16 @@ impl MantleTxGasContext {
     }
 
     #[must_use]
-    pub fn from_channels(value: &Channels, base_prices: GasPrices) -> Self {
-        let transfer_thresholds = value
-            .channels
+    pub fn from_channels(channels: &Channels, base_prices: GasPrices) -> Self {
+        let (transfer_thresholds, configuration_thresholds) = channels
             .iter()
-            .map(|(channel_id, channel)| (*channel_id, channel.transfer_threshold))
-            .collect();
-        let configuration_thresholds = value
-            .channels
-            .iter()
-            .map(|(channel_id, channel)| (*channel_id, channel.configuration_threshold))
-            .collect();
+            .map(|(channel_id, channel)| {
+                (
+                    (*channel_id, channel.transfer_threshold),
+                    (*channel_id, channel.configuration_threshold),
+                )
+            })
+            .unzip();
         Self::new(transfer_thresholds, configuration_thresholds, base_prices)
     }
 

--- a/core/src/mantle/transactions/verification_helper.rs
+++ b/core/src/mantle/transactions/verification_helper.rs
@@ -171,8 +171,7 @@ pub mod test_utils {
             channel_id: &ChannelId,
         ) -> Result<ChannelKeyIndex, VerificationError> {
             self.channels
-                .channels
-                .get(channel_id)
+                .channel_state(channel_id)
                 .ok_or(VerificationError::ChannelNotFound {
                     channel_id: *channel_id,
                 })

--- a/core/src/mantle/transactions/verified_ops.rs
+++ b/core/src/mantle/transactions/verified_ops.rs
@@ -126,10 +126,10 @@ mod tests {
         let signed_tx = create_withdraw_tx(channel_id, &[&key0, &key1], Some(withdraw_inputs));
 
         let channels = {
-            let mut channels = Channels::new();
+            let channels = Channels::new();
             let channel_state = make_channel_state(2, Some(keys));
-            channels.channels.insert_mut(channel_id, channel_state);
             channels
+                .set_channel_state(&channel_id, channel_state)
                 .register_channel_note(&note_id, &channel_id)
                 .expect("Note should be registered.")
         };
@@ -211,10 +211,9 @@ mod tests {
         let signed_tx = create_withdraw_tx(channel_id, &[&key0, &key1], None);
 
         let channels = {
-            let mut channels = Channels::new();
+            let channels = Channels::new();
             let channel_state = make_channel_state(2, None);
-            channels.channels.insert_mut(channel_id, channel_state);
-            channels
+            channels.set_channel_state(&channel_id, channel_state)
         };
         let helper =
             TestOperationVerificationHelper::new(channels, [((channel_id, 0), key0.public_key())]);
@@ -236,10 +235,9 @@ mod tests {
         let signed_tx = create_withdraw_tx(channel_id, &[&key0], None);
 
         let channels = {
-            let mut channels = Channels::new();
+            let channels = Channels::new();
             let channel_state = make_channel_state(2, None);
-            channels.channels.insert_mut(channel_id, channel_state);
-            channels
+            channels.set_channel_state(&channel_id, channel_state)
         };
         let helper =
             TestOperationVerificationHelper::new(channels, [((channel_id, 0), key0.public_key())]);
@@ -263,10 +261,9 @@ mod tests {
         let signed_tx = create_withdraw_tx(channel_id, &[&wrong_key], None);
 
         let channels = {
-            let mut channels = Channels::new();
+            let channels = Channels::new();
             let channel_state = make_channel_state(1, None);
-            channels.channels.insert_mut(channel_id, channel_state);
-            channels
+            channels.set_channel_state(&channel_id, channel_state)
         };
         let helper = TestOperationVerificationHelper::new(
             channels,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1032,8 +1032,7 @@ mod tests {
             new_state
                 .mantle_ledger
                 .channels()
-                .channels
-                .contains_key(&channel_id)
+                .contains_channel(&channel_id)
         );
         assert!(events.is_empty());
     }
@@ -1077,15 +1076,13 @@ mod tests {
             new_state
                 .mantle_ledger
                 .channels()
-                .channels
-                .contains_key(&channel_id)
+                .contains_channel(&channel_id)
         );
         assert_eq!(
             *new_state
                 .mantle_ledger
                 .channels()
-                .channels
-                .get(&channel_id)
+                .channel_state(&channel_id)
                 .unwrap()
                 .accredited_keys,
             verifying_key.into()
@@ -1113,8 +1110,7 @@ mod tests {
             ledger_state
                 .mantle_ledger()
                 .channels()
-                .channels
-                .contains_key(&channel_id)
+                .contains_channel(&channel_id)
         );
 
         // Submit a deposit operation
@@ -1601,26 +1597,13 @@ mod tests {
             .unwrap()
             .0;
 
-        assert!(
-            result
-                .mantle_ledger
-                .channels()
-                .channels
-                .contains_key(&channel1)
-        );
-        assert!(
-            result
-                .mantle_ledger
-                .channels()
-                .channels
-                .contains_key(&channel2)
-        );
+        assert!(result.mantle_ledger.channels().contains_channel(&channel1));
+        assert!(result.mantle_ledger.channels().contains_channel(&channel2));
         assert_eq!(
             result
                 .mantle_ledger
                 .channels()
-                .channels
-                .get(&channel1)
+                .channel_state(&channel1)
                 .unwrap()
                 .tip_message,
             inscribe_op3.id()

--- a/merkle/blake2btree/src/lib.rs
+++ b/merkle/blake2btree/src/lib.rs
@@ -414,6 +414,25 @@ mod tests {
         assert_eq!(tree.get_ref(&TestLeaf::from_usize(2)), None);
     }
 
+    // Iteration yields the surviving items, whatever position they occupy.
+    #[test]
+    fn test_iter_skips_removed_items() {
+        let tree: Blake2bTree<TestLeaf, TestLeaf> = Blake2bTree::new();
+
+        let mut current_tree = tree;
+        let keys = (0..3).map(TestLeaf::from_usize).collect::<Vec<_>>();
+        for key in &keys {
+            current_tree = current_tree.insert(*key, *key).0;
+        }
+        let (current_tree, _) = current_tree.remove(&keys[1]).unwrap();
+
+        let items = current_tree.iter().collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 2);
+        assert!(items.contains(&(&keys[0], &keys[0])));
+        assert!(items.contains(&(&keys[2], &keys[2])));
+    }
+
     #[test]
     fn test_path_for_present_and_absent_keys() {
         let tree: Blake2bTree<TestLeaf, TestLeaf> = Blake2bTree::new();

--- a/merkle/blake2btree/src/lib.rs
+++ b/merkle/blake2btree/src/lib.rs
@@ -426,7 +426,7 @@ mod tests {
         }
         let (current_tree, _) = current_tree.remove(&keys[1]).unwrap();
 
-        let items = current_tree.iter().collect::<Vec<_>>();
+        let items = current_tree.into_iter().collect::<Vec<_>>();
 
         assert_eq!(items.len(), 2);
         assert!(items.contains(&(&keys[0], &keys[0])));

--- a/merkle/tree/src/lib.rs
+++ b/merkle/tree/src/lib.rs
@@ -123,6 +123,11 @@ where
         &self.items
     }
 
+    /// Iterates over the stored `(key, item)` pairs, in no particular order
+    pub fn iter(&self) -> impl Iterator<Item = (&Key, &Item)> {
+        self.items.iter().map(|(key, (item, _))| (key, item))
+    }
+
     /// Computes the Merkle path for the key.
     /// The path is ordered from leaf to root (excluded).
     /// Returns `None` if the key does not exist or has been removed.

--- a/merkle/tree/src/lib.rs
+++ b/merkle/tree/src/lib.rs
@@ -124,8 +124,9 @@ where
     }
 
     /// Iterates over the stored `(key, item)` pairs, in no particular order
-    pub fn iter(&self) -> impl Iterator<Item = (&Key, &Item)> {
-        self.items.iter().map(|(key, (item, _))| (key, item))
+    #[must_use]
+    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        self.into_iter()
     }
 
     /// Computes the Merkle path for the key.
@@ -134,6 +135,23 @@ where
     pub fn path(&self, key: &Key) -> Option<MerklePath<<Leaf::Hasher as MerkleHasher>::Hash>> {
         let (_, pos) = self.items.get(key)?;
         self.merkle.path(*pos)
+    }
+}
+
+impl<'a, Key, Item, Leaf> IntoIterator for &'a MerkleTree<Key, Item, Leaf>
+where
+    Key: Clone + std::hash::Hash + Eq,
+    Leaf: LeafExtractor<Key, Item>,
+{
+    type Item = (&'a Key, &'a Item);
+    type IntoIter = std::iter::Map<
+        <&'a HashTrieMapSync<Key, (Item, usize)> as IntoIterator>::IntoIter,
+        fn((&'a Key, &'a (Item, usize))) -> (&'a Key, &'a Item),
+    >;
+
+    /// Iterates over the stored `(key, item)` pairs, in no particular order
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter().map(|(key, (item, _))| (key, item))
     }
 }
 


### PR DESCRIPTION
## 1. What does this PR implement?

This PR migrate channel notes and states structures to the blake2btree. This is to prepare the fast [bootstrapping RFC](<https://github.com/logos-co/logos-lips/pull/368>)

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur 

## 4. Is the specification accurate and complete?

It doesn't change anything to the specs and the behavior of the channels.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
