### PR TITLE
feat(zone-sdk): make funding priority fee configurable

### DIFF
--- a/deployment/tui-zone/src/cli.rs
+++ b/deployment/tui-zone/src/cli.rs
@@ -104,6 +104,15 @@ pub struct NodeKeyArgs {
     /// `--funding-pk`.
     #[arg(long, default_value_t = 1_000_000, env = "MAX_TX_FEE")]
     pub max_tx_fee: u64,
+
+    /// Execution tip paid on top of the mandatory fee when funding via
+    /// `--funding-pk`; capped by `--max-tx-fee`.
+    #[arg(
+        long,
+        default_value_t = lb_zone_sdk::sequencer::FundingConfig::DEFAULT_PRIORITY_FEE,
+        env = "PRIORITY_FEE"
+    )]
+    pub priority_fee: u64,
 }
 
 #[derive(Args, Debug)]

--- a/deployment/tui-zone/src/run_commands/utils.rs
+++ b/deployment/tui-zone/src/run_commands/utils.rs
@@ -346,6 +346,7 @@ pub fn funding_config(args: &NodeKeyArgs) -> RunResult<Option<FundingConfig>> {
     Ok(Some(FundingConfig {
         funding_pk: decode_zk_public_key_hex(funding_pk_hex)?,
         max_tx_fee: args.max_tx_fee.into(),
+        priority_fee: args.priority_fee,
     }))
 }
 

--- a/tests/src/cucumber/steps/manual_zone/actions.rs
+++ b/tests/src/cucumber/steps/manual_zone/actions.rs
@@ -65,6 +65,7 @@ const SEQUENCER_READY_TIMEOUT: Duration = Duration::from_mins(2);
 const SEQUENCER_READY_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 const SEQUENCER_READY_HEIGHT_ADVANCE_TIMEOUT: Duration = Duration::from_secs(30);
 const ZONE_SECURITY_PARAM: u32 = 5;
+const ZONE_TEST_PRIORITY_FEE: u64 = 400;
 
 pub(super) enum DriveMode {
     Passive {
@@ -781,6 +782,7 @@ async fn start_named_sequencer_with_config(
         .map(|funding_pk| FundingConfig {
             funding_pk,
             max_tx_fee: GasCost::new(u64::MAX),
+            priority_fee: ZONE_TEST_PRIORITY_FEE,
         })
         .ok();
     let config = lb_zone_sdk::sequencer::SequencerConfig { funding, ..config };

--- a/zone-sdk/src/sequencer/tx_builder.rs
+++ b/zone-sdk/src/sequencer/tx_builder.rs
@@ -1,6 +1,6 @@
 use lb_core::{
     mantle::{
-        SignedMantleTx, TxHash, Value,
+        SignedMantleTx, TxHash,
         channel::{ChannelState, SlotTimeframe, SlotTimeout},
         ops::{
             Op, OpProof,
@@ -20,14 +20,6 @@ use lb_key_management_system_service::keys::{Ed25519Key, Ed25519Signature};
 
 use super::types::{Error, FundingConfig};
 use crate::adapter;
-
-/// Execution tip paid on top of the mandatory fee when funding a transaction,
-/// buffering gas-price movement between funding and inclusion: in the current
-/// spec the base fee moves at most 12.5% per block, so this covers a few
-/// blocks of drift at current fee levels.
-///
-/// TODO: promote to [`FundingConfig`] if clients need to tune it.
-const PRIORITY_FEE: Value = 200;
 
 /// Assemble the ops for a transaction, funding it from the node's wallet when
 /// a [`FundingConfig`] is present.
@@ -62,7 +54,7 @@ where
             change_public_key: funding.funding_pk,
             funding_public_keys: vec![funding.funding_pk],
             max_tx_fee: funding.max_tx_fee,
-            priority_fee: PRIORITY_FEE,
+            priority_fee: funding.priority_fee,
         })
         .await
         .map_err(|e| Error::Network(format!("funding failed: {e}")))?;

--- a/zone-sdk/src/sequencer/types.rs
+++ b/zone-sdk/src/sequencer/types.rs
@@ -135,6 +135,14 @@ pub struct FundingConfig {
     pub funding_pk: ZkPublicKey,
     /// Hard cap on the fee of a single transaction.
     pub max_tx_fee: GasCost,
+    /// Execution tip paid on top of the mandatory fee when funding a
+    /// transaction. [`Self::max_tx_fee`] caps the total.
+    pub priority_fee: Value,
+}
+
+impl FundingConfig {
+    /// Default execution tip.
+    pub const DEFAULT_PRIORITY_FEE: Value = 200;
 }
 
 /// Configuration for the zone sequencer.


### PR DESCRIPTION
## 1. What does this PR implement?

The zone SDK funds transactions with a hardcoded tip of 200 on top of the fee. This PR turns it into a config option (`FundingConfig::priority_fee`, plus a `--priority-fee` flag in tui-zone). 

Background: the balance of a funded tx is fixed when it's signed, but the ledger prices it at inclusion time. If gas prices rise by more than the tip in between, the tx becomes invalid and can never be included. The fundamental problem is that the zone cannot detect this — nothing in the network reports a failed transaction, so the SDK keeps re-submitting the same a transaction that can't currently be included forever and the publish never completes. One of the zone cucumber tests fails on the gas price fix branch because of this. A configurable tip lets tests and deployments set a buffer sized for the price movement they expect.

A larger tip only makes this failure less likely. A transaction that still becomes invalid, for this or any other reason, will be re-submitted forever. Possible follow-ups — tip as a percentage of the fee, re-funding stuck transactions when prices change.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
