### PR TITLE
refactor(transactions): unify Op preverification

### DIFF
--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -39,16 +39,29 @@ pub type BoundedUtxos = UpperBoundedVec<Utxo, MAX_TRANSACTION_INPUTS>;
 pub type BoundedInputs = UpperBoundedVec<NoteId, MAX_TRANSACTION_INPUTS>;
 pub type BoundedOutputs = UpperBoundedVec<Note, MAX_TRANSACTION_OUTPUTS>;
 
-pub trait Operation<ValidationContext> {
+// TODO: Specific proof type check?
+pub trait Operation<VerificationContext> {
+    type PreverificationContext<'a>
+    where
+        Self: 'a;
     type ExecutionContext<'a>
     where
         Self: 'a;
-    type Error;
-    fn validate(&self, ctx: &ValidationContext) -> Result<(), Self::Error>;
+
+    type VerificationError;
+    type ExecutionError;
+
+    fn preverify(
+        &self,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError>;
+
+    fn verify(&self, context: &VerificationContext) -> Result<(), Self::VerificationError>;
+
     fn execute(
         &self,
-        ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error>;
+        context: Self::ExecutionContext<'_>,
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError>;
 }
 
 pub type Utxos = UtxoTree<NoteId, Utxo, ZkHasher>;

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -61,13 +61,28 @@ pub struct ChannelTransferExecutionContext {
 }
 
 impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = ChannelTransferExecutionContext
     where
         Self: 'a;
-    type Error = Error;
+    type VerificationError = Error;
+    type ExecutionError = Error;
 
-    fn validate(&self, ctx: &ChannelTransferValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(
+        &self,
+        ctx: &ChannelTransferValidationContext<'_>,
+    ) -> Result<(), Self::ExecutionError> {
         verify_channel_multi_sig(
             &self.channel_id,
             ctx.proof,
@@ -129,7 +144,7 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         // Remove the inputs from the ledger and from the channel.
         ctx.utxos = self.inputs.execute(ctx.utxos)?;
         for note_id in self.inputs.iter() {

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -29,13 +29,6 @@ impl ChannelTransferOp {
     pub fn utxos(&self) -> impl Iterator<Item = Utxo> {
         self.outputs.utxos(self)
     }
-
-    pub fn verify_stateless(&self) -> Result<(), Error> {
-        // Check that the outputs are valid
-        self.outputs.validate()?;
-
-        Ok(())
-    }
 }
 
 impl OpId for ChannelTransferOp {
@@ -76,7 +69,10 @@ impl Operation<ChannelTransferValidationContext<'_>> for ChannelTransferOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        // Check that the outputs are valid
+        self.outputs.validate()?;
+
+        Ok(())
     }
 
     fn verify(

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -35,15 +35,6 @@ impl ChannelConfigOp {
         hasher.update(self.encode());
         MsgId(hasher.finalize().into())
     }
-
-    pub const fn verify_stateless(&self) -> Result<(), Error> {
-        // Check config is well-formed
-        if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
-        {
-            return Err(Error::InvalidChannelConfig);
-        }
-        Ok(())
-    }
 }
 
 pub struct ChannelConfigValidationContext<'a> {
@@ -73,7 +64,13 @@ impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        // Check config is well-formed
+        if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
+        {
+            return Err(Error::InvalidChannelConfig);
+        }
+
+        Ok(())
     }
 
     fn verify(&self, ctx: &ChannelConfigValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -58,13 +58,25 @@ pub struct ChannelConfigExecutionContext {
 }
 
 impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = ChannelConfigExecutionContext
     where
         Self: 'a;
-    type Error = Error;
+    type VerificationError = Error;
+    type ExecutionError = Error;
 
-    fn validate(&self, ctx: &ChannelConfigValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(&self, ctx: &ChannelConfigValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check that the indexes are unique and there is the same number of proof and
         // index. This is enforced by the proof structure that enforces it.
 
@@ -103,7 +115,7 @@ impl Operation<ChannelConfigValidationContext<'_>> for ChannelConfigOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         let channel = ChannelState {
             accredited_keys: self.keys.clone().into(),
             configuration_threshold: self.configuration_threshold,

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -67,13 +67,25 @@ pub struct DepositExecutionContext {
 }
 
 impl Operation<DepositValidationContext<'_>> for DepositOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = DepositExecutionContext
     where
         Self: 'a;
-    type Error = Error;
+    type VerificationError = Error;
+    type ExecutionError = Error;
 
-    fn validate(&self, ctx: &DepositValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(&self, ctx: &DepositValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check that the channel exist
         if !ctx.channels.contains_channel(&self.channel_id) {
             return Err(Error::ChannelNotFound {
@@ -97,7 +109,7 @@ impl Operation<DepositValidationContext<'_>> for DepositOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         // Get the amount deposited for the event payload
         let amount_deposited = self.inputs.amount(&ctx.utxos)?;
         let outputs = self.outputs(&ctx.utxos)?;

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -40,10 +40,6 @@ impl DepositOp {
 
         Ok(Outputs::try_new(notes)?)
     }
-
-    pub const fn verify_stateless(&self) -> Result<(), Error> {
-        Ok(())
-    }
 }
 
 impl OpId for DepositOp {
@@ -82,7 +78,7 @@ impl Operation<DepositValidationContext<'_>> for DepositOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        Ok(())
     }
 
     fn verify(&self, ctx: &DepositValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -59,8 +59,8 @@ impl InscriptionOp {
 }
 
 pub struct InscriptionPreverificationContext<'a> {
-    tx_hash_view: &'a TxHashView,
-    proof: &'a Ed25519Signature,
+    pub tx_hash_view: &'a TxHashView,
+    pub proof: &'a Ed25519Signature,
 }
 
 pub struct InscriptionValidationContext<'a> {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -43,19 +43,6 @@ impl InscriptionOp {
         hasher.update(self.encode().as_ref());
         MsgId(hasher.finalize().into())
     }
-
-    pub fn verify_stateless(
-        &self,
-        tx_hash_view: &TxHashView,
-        proof: &Ed25519Signature,
-    ) -> Result<(), Error> {
-        // Check the signature
-        self.signer
-            .verify(tx_hash_view.as_bytes(), proof)
-            .map_err(|_error| Error::InvalidSignature)?;
-
-        Ok(())
-    }
 }
 
 pub struct InscriptionPreverificationContext<'a> {
@@ -89,7 +76,12 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
         &self,
         context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless(context.tx_hash_view, context.proof)
+        // Check the signature
+        self.signer
+            .verify(context.tx_hash_view.as_bytes(), context.proof)
+            .map_err(|_error| Error::InvalidSignature)?;
+
+        Ok(())
     }
 
     fn verify(&self, ctx: &InscriptionValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -58,6 +58,11 @@ impl InscriptionOp {
     }
 }
 
+pub struct InscriptionPreverificationContext<'a> {
+    tx_hash_view: &'a TxHashView,
+    proof: &'a Ed25519Signature,
+}
+
 pub struct InscriptionValidationContext<'a> {
     pub channels: &'a Channels,
     pub block_slot: Slot,
@@ -69,13 +74,25 @@ pub struct InscriptionExecutionContext {
 }
 
 impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
+    type PreverificationContext<'a>
+        = InscriptionPreverificationContext<'a>
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = InscriptionExecutionContext
     where
         Self: 'a;
-    type Error = Error;
+    type VerificationError = Error;
+    type ExecutionError = Error;
 
-    fn validate(&self, ctx: &InscriptionValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless(context.tx_hash_view, context.proof)
+    }
+
+    fn verify(&self, ctx: &InscriptionValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check if the channel exist otherwise the inscription is valid only if and
         // only if parent == ZERO
         if let Some(channel) = ctx.channels.channel_state(&self.channel_id) {
@@ -112,7 +129,7 @@ impl Operation<InscriptionValidationContext<'_>> for InscriptionOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         // if the channel doesn't exist, create it
         let channel = ctx
             .channels

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -24,12 +24,6 @@ pub struct ChannelWithdrawOp {
     pub inputs: Inputs,
 }
 
-impl ChannelWithdrawOp {
-    pub const fn verify_stateless(&self) -> Result<(), Error> {
-        Ok(())
-    }
-}
-
 impl OpId for ChannelWithdrawOp {
     fn op_bytes(&self) -> Vec<u8> {
         self.encode_to_vec()
@@ -67,7 +61,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        Ok(())
     }
 
     fn verify(&self, ctx: &WithdrawValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -52,13 +52,25 @@ pub struct WithdrawExecutionContext {
 }
 
 impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = WithdrawExecutionContext
     where
         Self: 'a;
-    type Error = Error;
+    type VerificationError = Error;
+    type ExecutionError = Error;
 
-    fn validate(&self, ctx: &WithdrawValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(&self, ctx: &WithdrawValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         verify_channel_multi_sig(
             &self.channel_id,
             ctx.proof,
@@ -113,7 +125,7 @@ impl Operation<WithdrawValidationContext<'_>> for ChannelWithdrawOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         // Release the inputs from the channel. The notes keep their NoteId,
         // value and ZkPublicKey and stay in the ledger as regular notes.
         for note_id in self.inputs.iter() {

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -75,24 +75,6 @@ impl LeaderClaimOp {
             },
         }
     }
-
-    pub fn verify_stateless(
-        &self,
-        tx_hash_view: &TxHashView,
-        proof: &Groth16LeaderClaimProof,
-    ) -> Result<(), LeaderClaimError> {
-        let is_verified = proof.verify(&LeaderClaimPublic {
-            voucher_nullifier: self.voucher_nullifier.into(),
-            voucher_root: self.rewards_root.into(),
-            mantle_tx_hash: *tx_hash_view.as_fr(),
-        });
-
-        if is_verified {
-            Ok(())
-        } else {
-            Err(LeaderClaimError::InvalidPoC)
-        }
-    }
 }
 
 impl OpId for LeaderClaimOp {
@@ -224,12 +206,19 @@ impl Operation<LeaderClaimVerificationContext<'_>> for LeaderClaimOp {
 
     fn preverify(
         &self,
-        preverification_context: &Self::PreverificationContext<'_>,
+        context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless(
-            preverification_context.tx_hash_view,
-            preverification_context.proof,
-        )
+        let is_verified = context.proof.verify(&LeaderClaimPublic {
+            voucher_nullifier: self.voucher_nullifier.into(),
+            voucher_root: self.rewards_root.into(),
+            mantle_tx_hash: *context.tx_hash_view.as_fr(),
+        });
+
+        if is_verified {
+            Ok(())
+        } else {
+            Err(LeaderClaimError::InvalidPoC)
+        }
     }
 
     fn verify(&self, ctx: &LeaderClaimVerificationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -191,8 +191,8 @@ pub enum LeaderClaimError {
 }
 
 pub struct LeaderClaimPreverificationContext<'a> {
-    tx_hash_view: &'a TxHashView,
-    proof: &'a Groth16LeaderClaimProof,
+    pub tx_hash_view: &'a TxHashView,
+    pub proof: &'a Groth16LeaderClaimProof,
 }
 
 pub struct LeaderClaimVerificationContext<'a> {

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -190,7 +190,12 @@ pub enum LeaderClaimError {
     InvalidPoC,
 }
 
-pub struct LeaderClaimValidationContext<'a> {
+pub struct LeaderClaimPreverificationContext<'a> {
+    tx_hash_view: &'a TxHashView,
+    proof: &'a Groth16LeaderClaimProof,
+}
+
+pub struct LeaderClaimVerificationContext<'a> {
     pub nullifiers: &'a VoucherNullifiers,
     pub claimable_vouchers_root: &'a RewardsRoot,
     pub proof: &'a Groth16LeaderClaimProof,
@@ -205,14 +210,29 @@ pub struct LeaderClaimExecutionContext {
     pub tx_hash: TxHash,
 }
 
-impl Operation<LeaderClaimValidationContext<'_>> for LeaderClaimOp {
+impl Operation<LeaderClaimVerificationContext<'_>> for LeaderClaimOp {
+    type PreverificationContext<'a>
+        = LeaderClaimPreverificationContext<'a>
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = LeaderClaimExecutionContext
     where
         Self: 'a;
-    type Error = LeaderClaimError;
+    type VerificationError = LeaderClaimError;
+    type ExecutionError = LeaderClaimError;
 
-    fn validate(&self, ctx: &LeaderClaimValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        preverification_context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless(
+            preverification_context.tx_hash_view,
+            preverification_context.proof,
+        )
+    }
+
+    fn verify(&self, ctx: &LeaderClaimVerificationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check that the nullifier isn't in the set
         if ctx.nullifiers.contains(&self.voucher_nullifier) {
             return Err(LeaderClaimError::DuplicatedVoucherNullifier);
@@ -238,7 +258,7 @@ impl Operation<LeaderClaimValidationContext<'_>> for LeaderClaimOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         // Add the nullifier to the nullifier set
         ctx.nullifiers = ctx.nullifiers.insert(self.voucher_nullifier, ()).0;
 
@@ -300,14 +320,14 @@ mod tests {
         };
         let nullifiers = VoucherNullifiers::new();
         let tx_hash_view = TxHashView::from(tx_hash);
-        let ctx = LeaderClaimValidationContext {
+        let ctx = LeaderClaimVerificationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
             proof: &proof,
             tx_hash_view: &tx_hash_view,
         };
 
-        assert_eq!(op.validate(&ctx), Ok(()));
+        assert_eq!(op.verify(&ctx), Ok(()));
     }
 
     #[test]
@@ -401,7 +421,7 @@ mod tests {
         };
         let nullifiers = VoucherNullifiers::new();
         let tx_hash_view = TxHashView::from(tx_hash);
-        let ctx = LeaderClaimValidationContext {
+        let ctx = LeaderClaimVerificationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
             proof: &proof,
@@ -411,7 +431,7 @@ mod tests {
         // The proof is verified against `op.voucher_nullifier`, which does not
         // match the proven voucher -> rejected. A voucher cannot be claimed under
         // a substituted nullifier.
-        assert_eq!(op.validate(&ctx), Err(LeaderClaimError::InvalidPoC));
+        assert_eq!(op.verify(&ctx), Err(LeaderClaimError::InvalidPoC));
     }
 
     fn nullifier(secret: u64) -> VoucherNullifier {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -42,7 +42,7 @@ impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        Ok(())
     }
 
     fn verify(&self, ctx: &SDPActiveValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -27,13 +27,25 @@ pub struct SDPActiveExecutionContext {
 }
 
 impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = SDPActiveExecutionContext
     where
         Self: 'a;
-    type Error = SdpError;
+    type VerificationError = SdpError;
+    type ExecutionError = SdpError;
 
-    fn validate(&self, ctx: &SDPActiveValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(&self, ctx: &SDPActiveValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check the declaration exists
         let Some(declaration) = ctx.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
@@ -70,7 +82,7 @@ impl Operation<SDPActiveValidationContext<'_>> for SDPActiveOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         let mut declaration = ctx
             .declarations
             .get(&self.declaration_id)

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -124,8 +124,8 @@ fn validate_service_scoped_uniqueness(
 }
 
 pub struct SDPDeclarePreverificationContext<'a> {
-    tx_hash_view: &'a TxHashView,
-    proof: &'a Ed25519Signature,
+    pub tx_hash_view: &'a TxHashView,
+    pub proof_ed25519: &'a Ed25519Signature,
 }
 
 pub struct SDPDeclareVerificationContext<'a> {
@@ -171,7 +171,7 @@ impl Operation<SDPDeclareVerificationContext<'_>> for SDPDeclareOp {
         &self,
         context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless(context.tx_hash_view, context.proof)
+        self.verify_stateless(context.tx_hash_view, context.proof_ed25519)
     }
 
     fn verify(&self, ctx: &SDPDeclareVerificationContext<'_>) -> Result<(), Self::ExecutionError> {
@@ -224,7 +224,7 @@ impl Operation<SDPDeclareGenesisValidationContext<'_>> for SDPDeclareOp {
         &self,
         context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless(context.tx_hash_view, context.proof)
+        self.verify_stateless(context.tx_hash_view, context.proof_ed25519)
     }
 
     fn verify(

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -123,7 +123,12 @@ fn validate_service_scoped_uniqueness(
         })
 }
 
-pub struct SDPDeclareValidationContext<'a> {
+pub struct SDPDeclarePreverificationContext<'a> {
+    tx_hash_view: &'a TxHashView,
+    proof: &'a Ed25519Signature,
+}
+
+pub struct SDPDeclareVerificationContext<'a> {
     pub utxo_tree: &'a Utxos,
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
@@ -150,14 +155,26 @@ pub struct SDPDeclareExecutionContext {
     pub min_stake: MinStake,
 }
 
-impl Operation<SDPDeclareValidationContext<'_>> for SDPDeclareOp {
+impl Operation<SDPDeclareVerificationContext<'_>> for SDPDeclareOp {
+    type PreverificationContext<'a>
+        = SDPDeclarePreverificationContext<'a>
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = SDPDeclareExecutionContext
     where
         Self: 'a;
-    type Error = SdpError;
+    type VerificationError = SdpError;
+    type ExecutionError = SdpError;
 
-    fn validate(&self, ctx: &SDPDeclareValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless(context.tx_hash_view, context.proof)
+    }
+
+    fn verify(&self, ctx: &SDPDeclareVerificationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check that the note exist
         let Some((utxo, _)) = ctx.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));
@@ -186,19 +203,34 @@ impl Operation<SDPDeclareValidationContext<'_>> for SDPDeclareOp {
     fn execute(
         &self,
         ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         SDPDeclareValidationExt::execute(self, ctx)
     }
 }
 
 impl Operation<SDPDeclareGenesisValidationContext<'_>> for SDPDeclareOp {
+    type PreverificationContext<'a>
+        = SDPDeclarePreverificationContext<'a>
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = SDPDeclareExecutionContext
     where
         Self: 'a;
-    type Error = SdpError;
+    type VerificationError = SdpError;
+    type ExecutionError = SdpError;
 
-    fn validate(&self, ctx: &SDPDeclareGenesisValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless(context.tx_hash_view, context.proof)
+    }
+
+    fn verify(
+        &self,
+        ctx: &SDPDeclareGenesisValidationContext<'_>,
+    ) -> Result<(), Self::ExecutionError> {
         // Check that the note exist
         let Some((utxo, _)) = ctx.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));
@@ -218,7 +250,7 @@ impl Operation<SDPDeclareGenesisValidationContext<'_>> for SDPDeclareOp {
     fn execute(
         &self,
         ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         SDPDeclareValidationExt::execute(self, ctx)
     }
 }

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -171,7 +171,7 @@ impl Operation<SDPDeclareVerificationContext<'_>> for SDPDeclareOp {
         &self,
         context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless(context.tx_hash_view, context.proof_ed25519)
+        self.preverify(context.tx_hash_view, context.proof_ed25519)
     }
 
     fn verify(&self, ctx: &SDPDeclareVerificationContext<'_>) -> Result<(), Self::ExecutionError> {
@@ -224,7 +224,7 @@ impl Operation<SDPDeclareGenesisValidationContext<'_>> for SDPDeclareOp {
         &self,
         context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless(context.tx_hash_view, context.proof_ed25519)
+        self.preverify(context.tx_hash_view, context.proof_ed25519)
     }
 
     fn verify(

--- a/core/src/mantle/ops/sdp/mod.rs
+++ b/core/src/mantle/ops/sdp/mod.rs
@@ -3,7 +3,7 @@ pub mod declare;
 pub mod withdraw;
 
 pub use active::{SDPActiveExecutionContext, SDPActiveValidationContext};
-pub use declare::{SDPDeclareExecutionContext, SDPDeclareValidationContext};
+pub use declare::{SDPDeclareExecutionContext, SDPDeclareVerificationContext};
 use lb_cryptarchia_engine::Epoch;
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use thiserror::Error;

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -30,13 +30,25 @@ pub struct SDPWithdrawExecutionContext {
 }
 
 impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = SDPWithdrawExecutionContext
     where
         Self: 'a;
-    type Error = SdpError;
+    type VerificationError = SdpError;
+    type ExecutionError = SdpError;
 
-    fn validate(&self, ctx: &SDPWithdrawValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(&self, ctx: &SDPWithdrawValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Check that the declaration exists
         let Some(declaration) = ctx.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
@@ -98,7 +110,7 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
     fn execute(
         &self,
         mut ctx: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         let mut declaration = ctx
             .declarations
             .get(&self.declaration_id)

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -45,7 +45,7 @@ impl Operation<SDPWithdrawValidationContext<'_>> for SDPWithdrawOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        Ok(())
     }
 
     fn verify(&self, ctx: &SDPWithdrawValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -52,18 +52,6 @@ impl TransferOp {
             .ok_or(TransferError::BalanceOverflow)?;
         Ok(balance)
     }
-
-    pub fn verify_stateless(&self) -> Result<(), TransferError> {
-        // Ensure the inputs is non-empty
-        if self.inputs.is_empty() {
-            return Err(TransferError::NoInputTransfer);
-        }
-
-        // Validate Outputs
-        self.outputs.validate()?;
-
-        Ok(())
-    }
 }
 
 impl OpId for TransferOp {
@@ -110,7 +98,15 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
         &self,
         _context: &Self::PreverificationContext<'_>,
     ) -> Result<(), Self::VerificationError> {
-        self.verify_stateless()
+        // Ensure the inputs is non-empty
+        if self.inputs.is_empty() {
+            return Err(TransferError::NoInputTransfer);
+        }
+
+        // Validate Outputs
+        self.outputs.validate()?;
+
+        Ok(())
     }
 
     fn verify(&self, ctx: &TransferValidationContext<'_>) -> Result<(), Self::ExecutionError> {

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -95,13 +95,25 @@ pub struct TransferValidationContext<'a> {
 }
 
 impl Operation<TransferValidationContext<'_>> for TransferOp {
+    type PreverificationContext<'a>
+        = ()
+    where
+        Self: 'a;
     type ExecutionContext<'a>
         = Utxos
     where
         Self: 'a;
-    type Error = TransferError;
+    type VerificationError = TransferError;
+    type ExecutionError = TransferError;
 
-    fn validate(&self, ctx: &TransferValidationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::VerificationError> {
+        self.verify_stateless()
+    }
+
+    fn verify(&self, ctx: &TransferValidationContext<'_>) -> Result<(), Self::ExecutionError> {
         // Validate Inputs
         self.inputs
             .validate_not_in_channel(ctx.locked_notes, ctx.channels, ctx.utxos)?;
@@ -118,7 +130,7 @@ impl Operation<TransferValidationContext<'_>> for TransferOp {
     fn execute(
         &self,
         mut utxos: Self::ExecutionContext<'_>,
-    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
+    ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::ExecutionError> {
         // Remove inputs from the ledger
         utxos = self.inputs.execute(utxos)?;
         // Add outputs from the ledger

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -7,18 +7,20 @@ use crate::{
     mantle::{
         MantleTx, Value, VerificationError,
         gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow},
-        ledger::Operation as _,
+        ledger::Operation,
         ops::{
             Op, OpProof,
             channel::{
                 channel_transfer::ChannelTransferValidationContext,
-                config::ChannelConfigValidationContext, deposit::DepositValidationContext,
-                inscribe::InscriptionValidationContext, withdraw::WithdrawValidationContext,
+                config::ChannelConfigValidationContext,
+                deposit::DepositValidationContext,
+                inscribe::{InscriptionPreverificationContext, InscriptionValidationContext},
+                withdraw::WithdrawValidationContext,
             },
-            leader_claim::LeaderClaimVerificationContext,
+            leader_claim::{LeaderClaimPreverificationContext, LeaderClaimVerificationContext},
             sdp::{
-                SDPActiveValidationContext, SDPDeclareVerificationContext,
-                SDPWithdrawValidationContext,
+                SDPActiveValidationContext, SDPDeclareOp, SDPDeclareVerificationContext,
+                SDPWithdrawValidationContext, declare::SDPDeclarePreverificationContext,
             },
             transfer::TransferValidationContext,
         },
@@ -114,41 +116,56 @@ impl SignedMantleTx<Unverified> {
     ) -> Result<(), VerificationError> {
         // TODO: Add more info to errors (e.g. op_index)
         match (op, proof) {
-            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => op
-                .verify_stateless(tx_hash_view, proof)
-                .map_err(VerificationError::ChannelVerificationError),
+            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => {
+                let context = InscriptionPreverificationContext {
+                    tx_hash_view,
+                    proof,
+                };
+                op.preverify(&context)
+                    .map_err(VerificationError::ChannelVerificationError)
+            }
             (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::ChannelVerificationError),
             (Op::ChannelDeposit(op), OpProof::ZkSig(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::ChannelVerificationError),
             (Op::ChannelWithdraw(op), OpProof::ChannelMultiSigProof(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::ChannelVerificationError),
             (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::ChannelVerificationError),
             (
                 Op::SDPDeclare(op),
                 OpProof::ZkAndEd25519Sigs {
-                    zk_sig: _zk_sig,
-                    ed25519_sig: proof_ed25519_signature,
+                    zk_sig: _proof_zk,
+                    ed25519_sig: proof_ed25519,
                 },
-            ) => op
-                .verify_stateless(tx_hash_view, proof_ed25519_signature)
-                .map_err(VerificationError::SDPVerificationError),
+            ) => {
+                let context = SDPDeclarePreverificationContext {
+                    tx_hash_view,
+                    proof_ed25519,
+                };
+                <SDPDeclareOp as Operation<SDPDeclareVerificationContext>>::preverify(op, &context)
+                    .map_err(VerificationError::SDPVerificationError)
+            }
             (Op::SDPWithdraw(op), OpProof::ZkSig(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::SDPVerificationError),
             (Op::SDPActive(op), OpProof::ZkSig(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::SDPVerificationError),
-            (Op::LeaderClaim(op), OpProof::PoC(proof)) => op
-                .verify_stateless(tx_hash_view, proof)
-                .map_err(VerificationError::LeaderClaimVerificationError),
+            (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
+                let context = LeaderClaimPreverificationContext {
+                    tx_hash_view,
+                    proof,
+                };
+                op.preverify(&context)
+                    .map_err(VerificationError::LeaderClaimVerificationError)
+            }
             (Op::Transfer(op), OpProof::ZkSig(_proof)) => op
-                .verify_stateless()
+                .preverify(&())
                 .map_err(VerificationError::TransferVerificationError),
             _ => Err(VerificationError::IncorrectProofType {
                 op_type: op.as_str(),

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -15,9 +15,9 @@ use crate::{
                 config::ChannelConfigValidationContext, deposit::DepositValidationContext,
                 inscribe::InscriptionValidationContext, withdraw::WithdrawValidationContext,
             },
-            leader_claim::LeaderClaimValidationContext,
+            leader_claim::LeaderClaimVerificationContext,
             sdp::{
-                SDPActiveValidationContext, SDPDeclareValidationContext,
+                SDPActiveValidationContext, SDPDeclareVerificationContext,
                 SDPWithdrawValidationContext,
             },
             transfer::TransferValidationContext,
@@ -233,7 +233,7 @@ impl SignedMantleTx<Preverified> {
                     channels: helper.get_channels(),
                     block_slot: helper.get_block_slot(),
                 };
-                op.validate(&channel_inscribe_context)
+                op.verify(&channel_inscribe_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(proof)) => {
@@ -242,7 +242,7 @@ impl SignedMantleTx<Preverified> {
                     tx_hash_view,
                     proof,
                 };
-                op.validate(&channel_config_context)
+                op.verify(&channel_config_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelDeposit(op), OpProof::ZkSig(proof)) => {
@@ -253,7 +253,7 @@ impl SignedMantleTx<Preverified> {
                     tx_hash_view,
                     proof,
                 };
-                op.validate(&channel_deposit_context)
+                op.verify(&channel_deposit_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelWithdraw(channel_withdraw_op), OpProof::ChannelMultiSigProof(proof)) => {
@@ -267,7 +267,7 @@ impl SignedMantleTx<Preverified> {
                     op_index,
                 };
                 channel_withdraw_op
-                    .validate(&channel_withdraw_context)
+                    .verify(&channel_withdraw_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(proof)) => {
@@ -280,7 +280,7 @@ impl SignedMantleTx<Preverified> {
                     op_index,
                     helper,
                 };
-                op.validate(&context)
+                op.verify(&context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (
@@ -290,7 +290,7 @@ impl SignedMantleTx<Preverified> {
                     ed25519_sig: proof_ed25519_signature,
                 },
             ) => {
-                let context = SDPDeclareValidationContext {
+                let context = SDPDeclareVerificationContext {
                     utxo_tree: helper.get_utxos(),
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
@@ -300,7 +300,7 @@ impl SignedMantleTx<Preverified> {
                     declarations: helper.get_declarations_by_service(op.service_type)?,
                     min_stake: helper.get_min_stake(),
                 };
-                op.validate(&context)
+                op.verify(&context)
                     .map_err(VerificationError::SDPVerificationError)
             }
             (Op::SDPWithdraw(op), OpProof::ZkSig(proof)) => {
@@ -311,7 +311,7 @@ impl SignedMantleTx<Preverified> {
                     tx_hash_view,
                     proof,
                 };
-                op.validate(&context)
+                op.verify(&context)
                     .map_err(VerificationError::SDPVerificationError)
             }
             (Op::SDPActive(op), OpProof::ZkSig(proof)) => {
@@ -321,17 +321,17 @@ impl SignedMantleTx<Preverified> {
                     proof,
                     epoch: helper.get_epoch(),
                 };
-                op.validate(&context)
+                op.verify(&context)
                     .map_err(VerificationError::SDPVerificationError)
             }
             (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
-                let context = LeaderClaimValidationContext {
+                let context = LeaderClaimVerificationContext {
                     nullifiers: helper.get_nullifiers(),
                     claimable_vouchers_root: helper.get_claimable_vouchers_root(),
                     proof,
                     tx_hash_view,
                 };
-                op.validate(&context)
+                op.verify(&context)
                     .map_err(VerificationError::LeaderClaimVerificationError)
             }
             (Op::Transfer(op), OpProof::ZkSig(proof)) => {
@@ -342,7 +342,7 @@ impl SignedMantleTx<Preverified> {
                     tx_hash_view,
                     proof,
                 };
-                op.validate(&context)
+                op.verify(&context)
                     .map_err(VerificationError::TransferVerificationError)
             }
             // SignedMantleTx<Preverified> invariant: Op/Proof pairs have been verified in

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -106,9 +106,9 @@ impl SignedMantleTx<Unverified> {
         })
     }
 
-    // TODO: Might drop proofs after verification. This TODO is carried over from
-    // the original code.
-    fn verify_stateless_op(
+    // TODO: Might drop proofs after verification.
+    //  This is carried over from the original code.
+    fn preverify_op(
         op_index: usize,
         op: &Op,
         proof: &OpProof,
@@ -174,11 +174,11 @@ impl SignedMantleTx<Unverified> {
         }
     }
 
-    fn verify_stateless_ops(&self) -> Result<(), VerificationError> {
+    fn preverify_ops(&self) -> Result<(), VerificationError> {
         let tx_hash = self.hash();
         let tx_hash_view = TxHashView::new(tx_hash);
         for (op_index, (op, proof)) in self.ops_with_proof().enumerate() {
-            Self::verify_stateless_op(op_index, op, proof, &tx_hash_view)?;
+            Self::preverify_op(op_index, op, proof, &tx_hash_view)?;
         }
         Ok(())
     }
@@ -199,7 +199,7 @@ impl SignedMantleTx<Unverified> {
     ///   and [`LeaderClaimOp`](crate::mantle::ops::leader_claim::LeaderClaimOp) have valid signatures/proofs.
     pub fn preverify(self) -> Result<SignedMantleTx<Preverified>, VerificationError> {
         self.ensure_one_proof_per_op()?;
-        self.verify_stateless_ops()?;
+        self.preverify_ops()?;
         Ok(self.into_preverified())
     }
 

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -510,7 +510,7 @@ impl DeclarationMessage {
         DeclarationId(hasher.finalize().into())
     }
 
-    pub fn verify_stateless(
+    pub fn preverify(
         &self,
         tx_hash_view: &TxHashView,
         proof_eddsa_signature: &Ed25519Signature,
@@ -532,24 +532,12 @@ pub struct WithdrawMessage {
     pub locked_note_id: NoteId,
 }
 
-impl WithdrawMessage {
-    pub const fn verify_stateless(&self) -> Result<(), SdpError> {
-        Ok(())
-    }
-}
-
 // ActiveMessage = DeclarationId Nonce Metadata — plain field-order concat.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, BinaryCodec)]
 pub struct ActiveMessage {
     pub declaration_id: DeclarationId,
     pub nonce: Nonce,
     pub metadata: ActivityMetadata,
-}
-
-impl ActiveMessage {
-    pub const fn verify_stateless(&self) -> Result<(), SdpError> {
-        Ok(())
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -735,7 +735,7 @@ mod tests {
                     inscribe::InscriptionOp,
                     withdraw::ChannelWithdrawOp,
                 },
-                leader_claim::{LeaderClaimError, LeaderClaimOp, LeaderClaimValidationContext},
+                leader_claim::{LeaderClaimError, LeaderClaimOp, LeaderClaimVerificationContext},
                 sdp::SDPActiveOp,
                 transfer::TransferOp,
             },
@@ -1928,7 +1928,7 @@ mod tests {
         let tx_hash = TxHash::from([0u8; 32]);
         let tx_hash_view = TxHashView::from(tx_hash);
         let err = op
-            .validate(&LeaderClaimValidationContext {
+            .verify(&LeaderClaimVerificationContext {
                 nullifiers: leaders.nullifiers(),
                 claimable_vouchers_root: leaders.vouchers_snapshot_root(),
                 // Use a dummy proof since duplication is detected before proof verification

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -14,7 +14,7 @@ use lb_core::{
         ledger::{Declarations, Operation},
         ops::sdp::{
             SDPActiveExecutionContext, SDPActiveOp, SDPDeclareExecutionContext, SDPDeclareOp,
-            SDPDeclareValidationContext, SDPWithdrawExecutionContext, SDPWithdrawOp,
+            SDPDeclareVerificationContext, SDPWithdrawExecutionContext, SDPWithdrawOp,
             declare::SDPDeclareGenesisValidationContext,
         },
     },
@@ -400,7 +400,7 @@ impl SdpLedger {
         // Validate SDP Declare
         // TODO: Genesis has a different verification flow than `SignedMantleTx`.
         // Refactor into a   type state.
-        op.validate(&SDPDeclareGenesisValidationContext {
+        op.verify(&SDPDeclareGenesisValidationContext {
             utxo_tree,
             channels,
             locked_notes: &self.locked_notes,
@@ -436,7 +436,7 @@ impl SdpLedger {
             return Err(Error::ServiceNotFound(op.service_type));
         };
 
-        let (result, events) = <SDPDeclareOp as Operation<SDPDeclareValidationContext>>::execute(
+        let (result, events) = <SDPDeclareOp as Operation<SDPDeclareVerificationContext>>::execute(
             op,
             SDPDeclareExecutionContext {
                 utxo_tree: utxo_tree.clone(),


### PR DESCRIPTION
## 1. What does this PR implement?
Adds a `preverify` stage to the `Operation` trait, splitting op verification into two typed steps:
- `preverify`: stateless, context-free checks
- `verify`: stateful checks against ledger state

`SignedMantleTx` now delegates verification to each `Op`.
Old `verify_stateless` (and similar) references have been removed as well in favour of a single naming style.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).