### PR TITLE
docs(wallet-service): fix comment: `lib_wallet_state` is populated at the first state update

### DIFF
--- a/services/wallet/src/states.rs
+++ b/services/wallet/src/states.rs
@@ -205,7 +205,7 @@ pub struct RecoveryState {
     next_new_voucher_index: VoucherIndex,
     vouchers: Vouchers<VoucherId>,
     /// [`WalletState`] at the last known LIB.
-    /// `None` on fresh start; populated after the first LIB update.
+    /// `None` until the first recovery state update.
     lib_wallet_state: Option<(HeaderId, WalletState)>,
     /// Voucher reservations for claim transactions that were built/submitted
     /// but have not reached LIB yet. Stale reservations are bounded by


### PR DESCRIPTION
## 1. What does this PR implement?

The wallet service's `RecoveryState::lib_wallet_state` was documented as "populated after the first LIB update", but that's wrong. The wallet service fetches the current LIB immediately from the chain service at startup, and update/persist `RecoveryState` whenever a new block is applied.

So, this PR fixes the comment.

FYI, the comment inaccuracy made me confused and open https://github.com/logos-blockchain/logos-blockchain/issues/2910, which is not a real issue. I thought that there is a window where the wallet service knows vouchers (because the node proposed blocks), but where `RecoveryState::lib_wallet_state` is not populated/persisted yet. You can find details from the issue, but in short, that window doesn't exist and we don't need to worry about the issue.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
