### PR TITLE
chore: update toolchain to rust 1.97(.1)

### DIFF
--- a/.github/actions/cargo-hack-check-cached/action.yml
+++ b/.github/actions/cargo-hack-check-cached/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Run Cache-Aware Cargo Hack Check
       shell: bash
       env:
-        RUSTFLAGS: "-D warnings"
+        CARGO_BUILD_WARNINGS: deny
       run: python3 ./scripts/cargo-hack-check/script.py --continue-on-failure
 
     - name: Save Cargo Hack Keys (main)

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746  # Version 1.0.6
         with:
           # The same version must be used in the `.pre-commit-config.yaml` file
-          toolchain: nightly-2026-04-11
+          toolchain: nightly-2026-05-22
           profile: minimal
           components: rustfmt
           override: true

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -57,7 +57,7 @@ jobs:
         run: cargo install cargo-deny --locked --version 0.19.0
 
       - name: Run cargo-deny
-        run: cargo-deny --locked --all-features check --hide-inclusion-graph -c .cargo-deny.toml --show-stats -D warnings
+        run: CARGO_BUILD_WARNINGS=deny cargo-deny --locked --all-features check --hide-inclusion-graph -c .cargo-deny.toml --show-stats
 
   workspace-deps:
     name: Check for correctly declared dependencies in the workspace
@@ -94,7 +94,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     env:
-      RUSTFLAGS: -D warnings
+      CARGO_BUILD_WARNINGS: deny
     steps:
       - name: Checkout repository
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2  # Version 4.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         # We're running `fmt` with `--all` and `pass_filenames: false` to format the entire workspace at once.
         # Otherwise, `pre-commit` passes staged files one by one, which can lead to inconsistent results
         # due to, presumably, the lack of full workspace context.
-        entry: cargo +nightly-2026-04-11 fmt
+        entry: cargo +nightly-2026-05-22 fmt
         pass_filenames: false
       - id: clippy
         name: cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,6 +401,8 @@ error_impl_error                   = { level = "allow" }
 impl_trait_in_params               = { level = "allow" }
 indexing_slicing                   = { level = "allow" }
 infinite_loop                      = { level = "allow" }
+inline_modules                     = { level = "allow" }
+inline_trait_bounds                = { level = "allow" }
 integer_division                   = { level = "allow" }
 large_stack_frames                 = { level = "allow" }
 missing_assert_message             = { level = "allow" }

--- a/blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/bootstrapping.rs
@@ -278,7 +278,7 @@ async fn incoming_attempt_with_duplicate_connection() {
                     }
                     // Listener swarm should not know about this
                     SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) => {
-                        assert!(peer_id != *dialer_swarm.local_peer_id());
+                        assert_ne!(peer_id, *dialer_swarm.local_peer_id());
                     }
                     _ => {}
                 }
@@ -286,7 +286,7 @@ async fn incoming_attempt_with_duplicate_connection() {
             // Neither should the dialer
             dialer_swarm_event = dialer_swarm.select_next_some() => {
                 if let SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) = dialer_swarm_event {
-                    assert!(peer_id != *dialer_swarm.local_peer_id());
+                    assert_ne!(peer_id, *dialer_swarm.local_peer_id());
                 }
             }
         }
@@ -438,7 +438,7 @@ async fn outgoing_attempt_with_duplicate_connection() {
                     }
                     // Listener swarm should not know about this
                     SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) => {
-                        assert!(peer_id != *dialer_swarm.local_peer_id());
+                        assert_ne!(peer_id, *dialer_swarm.local_peer_id());
                     }
                     _ => {}
                 }
@@ -446,7 +446,7 @@ async fn outgoing_attempt_with_duplicate_connection() {
             // Neither should the dialer
             dialer_swarm_event = dialer_swarm.select_next_some() => {
                 if let SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, _)) = dialer_swarm_event {
-                    assert!(peer_id != *dialer_swarm.local_peer_id());
+                    assert_ne!(peer_id, *dialer_swarm.local_peer_id());
                 }
             }
         }
@@ -622,26 +622,26 @@ async fn concurrent_reverse_connections_between_peers() {
         .unwrap();
     // If swarm 1 ID is lower, it must have closed its outgoing connection, so swarm
     // 2 will be the dialer, or viceversa.
-    assert!(
-        swarm_2_details_for_swarm_1.role
-            == if is_swarm_1_id_smaller {
-                Endpoint::Dialer
-            } else {
-                Endpoint::Listener
-            }
+    assert_eq!(
+        swarm_2_details_for_swarm_1.role,
+        if is_swarm_1_id_smaller {
+            Endpoint::Dialer
+        } else {
+            Endpoint::Listener
+        }
     );
     let swarm_1_details_for_swarm_2 = swarm_2
         .behaviour()
         .negotiated_peers
         .get(swarm_1.local_peer_id())
         .unwrap();
-    assert!(
-        swarm_1_details_for_swarm_2.role
-            == if is_swarm_1_id_smaller {
-                Endpoint::Listener
-            } else {
-                Endpoint::Dialer
-            }
+    assert_eq!(
+        swarm_1_details_for_swarm_2.role,
+        if is_swarm_1_id_smaller {
+            Endpoint::Listener
+        } else {
+            Endpoint::Dialer
+        }
     );
 }
 

--- a/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
+++ b/blend/network/src/core/with_core/behaviour/tests/connection_maintenance.rs
@@ -65,13 +65,13 @@ async fn detect_spammy_peer() {
                     SwarmEvent::Behaviour(Event::PeerDisconnected(peer_id, NegotiatedPeerState::Spammy(SpamReason::TooManyMessages))) => {
                         assert_eq!(peer_id, *dialing_swarm.local_peer_id());
                         assert!(listening_swarm.behaviour().negotiated_peers.is_empty());
-                        assert!(listening_swarm.behaviour().message_cache.messages_from_peer(dialing_swarm.local_peer_id()).count() == 2);
+                        assert_eq!(listening_swarm.behaviour().message_cache.messages_from_peer(dialing_swarm.local_peer_id()).count(), 2);
                         events_to_match -= 1;
                     }
                     SwarmEvent::ConnectionClosed { peer_id, endpoint, .. } => {
                         assert_eq!(peer_id, *dialing_swarm.local_peer_id());
                         assert!(endpoint.is_listener());
-                        assert!(listening_swarm.behaviour().message_cache.messages_from_peer(dialing_swarm.local_peer_id()).count() == 0);
+                        assert_eq!(listening_swarm.behaviour().message_cache.messages_from_peer(dialing_swarm.local_peer_id()).count(), 0);
                         events_to_match -= 1;
                     }
                     _ => {}
@@ -128,7 +128,7 @@ async fn detect_unhealthy_peer() {
             _ = dialing_swarm.select_next_some() => {}
             listening_event = listening_swarm.select_next_some() => {
                 if let SwarmEvent::Behaviour(Event::UnhealthyPeer(peer_id)) = listening_event {
-                    assert!(peer_id != *dialing_swarm.local_peer_id());
+                    assert_ne!(peer_id, *dialing_swarm.local_peer_id());
                 }
             }
         }

--- a/blend/proofs/src/quota/serde.rs
+++ b/blend/proofs/src/quota/serde.rs
@@ -26,10 +26,10 @@ mod tests {
 
         let deserialized_proof_as_verified =
             VerifiedProofOfQuota::from_bytes(&serialized_proof[..]).unwrap();
-        assert!(proof == deserialized_proof_as_verified);
+        assert_eq!(proof, deserialized_proof_as_verified);
 
         let deserialized_proof_as_unverified =
             ProofOfQuota::from_bytes(&serialized_proof[..]).unwrap();
-        assert!(proof == deserialized_proof_as_unverified);
+        assert_eq!(proof, deserialized_proof_as_unverified);
     }
 }

--- a/blend/proofs/src/selection/tests.rs
+++ b/blend/proofs/src/selection/tests.rs
@@ -99,9 +99,9 @@ fn serde_verified_and_unverified() {
 
     let deserialized_proof_as_verified =
         VerifiedProofOfSelection::from_bytes(&serialized_proof[..]).unwrap();
-    assert!(proof == deserialized_proof_as_verified);
+    assert_eq!(proof, deserialized_proof_as_verified);
 
     let deserialized_proof_as_unverified =
         ProofOfSelection::from_bytes(&serialized_proof[..]).unwrap();
-    assert!(proof == deserialized_proof_as_unverified);
+    assert_eq!(proof, deserialized_proof_as_unverified);
 }

--- a/core/src/mantle/nom/mod.rs
+++ b/core/src/mantle/nom/mod.rs
@@ -117,7 +117,7 @@ where
             decoded == fixture.value,
             "{type_name}: decode(bytes) != value\n  bytes (hex): {bytes}\n  decoded:  {decoded:?}\n  expected: {expected_value:?}",
             bytes = hex::encode(expected),
-            expected_value = &fixture.value,
+            expected_value = fixture.value,
         );
 
         // Round-trip: encode then decode is the identity (independent of the
@@ -132,7 +132,7 @@ where
         assert!(
             round_tripped == fixture.value,
             "{type_name}: round-trip changed the value\n  before: {before:?}\n  after:  {round_tripped:?}",
-            before = &fixture.value,
+            before = fixture.value,
         );
     }
 }

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -5,7 +5,7 @@
 # ===========================
 # BUILD IMAGE
 # ===========================
-FROM rust:1.96.0-slim-bookworm AS builder
+FROM rust:1.97.1-slim-bookworm AS builder
 
 WORKDIR /logos-blockchain
 COPY . .

--- a/deployment/l2-sequencer-archival-demo/archiver/src/block.rs
+++ b/deployment/l2-sequencer-archival-demo/archiver/src/block.rs
@@ -63,7 +63,7 @@ impl BlockStream {
 
                         println!("  {} Block at height {} ({})","🔗".blue(),
                             height.bright_white().bold(),
-                            &hex::encode(header_id.as_ref()
+                            hex::encode(header_id.as_ref()
                         ).dimmed());
 
                         let block = http_client.get_block_by_id(endpoint_url.clone(), header_id).await.unwrap().unwrap();

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     rust-overlay = {
-      url = "github:oxalica/rust-overlay/40b0a3a193e0840c76174b4a322874c8f6dd0a63";
+      url = "github:oxalica/rust-overlay/b99d48435bc3e34309d2c7ae6f7d45e77a156c38";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -53,7 +53,7 @@
           overlays = [ rust-overlay.overlays.default ];
         };
 
-      rustVersion = "1.96.0";
+      rustVersion = "1.97.1";
     in
     {
       packages = forAll (

--- a/hooks/cargo-hack.sh
+++ b/hooks/cargo-hack.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-RUSTFLAGS="-D warnings" cargo hack --feature-powerset --no-dev-deps --keep-going --all-targets check
+CARGO_BUILD_WARNINGS="deny" cargo hack --feature-powerset --no-dev-deps --keep-going --all-targets check

--- a/ledger/src/mantle/sdp/rewards/blend/current_epoch.rs
+++ b/ledger/src/mantle/sdp/rewards/blend/current_epoch.rs
@@ -177,7 +177,6 @@ impl CurrentEpochTracker {
         }
     }
 
-    #[expect(single_use_lifetimes, reason = "lifetime is required")]
     fn providers_and_zk_root<'d>(
         declarations: impl Iterator<Item = &'d Declaration>,
     ) -> (HashTrieMapSync<ProviderId, (ZkPublicKey, u64)>, ZkHash) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,12 +2,12 @@
 # Keep this version in sync also in the following places:
 # * flake.nix
 # * deployment/Dockerfile
-# * tests/testing_framework/assets/runtime/Dockerfile.node
+# * tests/testing_framework/assets/runtime/Dockerfile.node (2 places)
 # * tests/testing_framework/assets/runtime/Dockerfile.cfgsync
 # Also, update the version of the nightly toolchain to the latest nightly of the new version specified in the following places:
 # * .github/workflows/code-check.yml (fmt job)
 # * .pre-commit-config.yml (fmt hook)
 # Then, if there is any new allow-by-default rustc lint introduced/stabilized, add it to the respective entry in our `config.toml`.
-channel = "1.96.0"
+channel = "1.97.1"
 # Even if clippy should be included in the default profile, in some cases it is not installed. So we force it with an explicit declaration.
 components = ["clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,8 @@
+edition         = "2024"
+reorder_imports = true
+reorder_modules = true
+
+# Nightly-only settings
 group_imports       = "StdExternalCrate"
 imports_granularity = "Crate"
-reorder_imports     = true
-reorder_modules     = true
 wrap_comments       = true

--- a/scripts/cargo-hack-check/script.py
+++ b/scripts/cargo-hack-check/script.py
@@ -35,7 +35,7 @@ WORKSPACE_CARGO_LOCK = WORKSPACE_ROOT / "Cargo.lock"
 CACHE_DIRECTORY = WORKSPACE_ROOT / ".cache/cargo-hack-check"
 COMPUTE_CREATE_HASH_SCRIPT = CURRENT_FILE_DIRECTORY / "compute_crate_hash.sh"
 TAG = "[Cargo Hack Powerset]"
-STRICT_WARNING_FLAG = "-D warnings"
+STRICT_WARNING_FLAG = "deny"
 
 
 ###############
@@ -65,9 +65,9 @@ def normalize_path_to_workspace_root(str_path: str) -> Path:
 
 def build_cargo_environment() -> Dict[str, str]:
     env = os.environ.copy()
-    rustflags = env.get("RUSTFLAGS", "").strip()
+    rustflags = env.get("CARGO_BUILD_WARNINGS", "").strip()
     if STRICT_WARNING_FLAG not in rustflags:
-        env["RUSTFLAGS"] = f"{rustflags} {STRICT_WARNING_FLAG}".strip()
+        env["CARGO_BUILD_WARNINGS"] = f"{rustflags} {STRICT_WARNING_FLAG}".strip()
     return env
 
 

--- a/tests/src/cucumber/steps/manual_nodes/utils.rs
+++ b/tests/src/cucumber/steps/manual_nodes/utils.rs
@@ -1404,8 +1404,7 @@ async fn fetch_and_update_chain_info(
                 .get_mut(&started_node_name)
                 .ok_or(StepError::LogicalError {
                     message: format!(
-                        "Started node '{}' not found in chain info map",
-                        &started_node_name
+                        "Started node '{started_node_name}' not found in chain info map",
                     ),
                 })?;
         let chain_info = node_info.chain_info();

--- a/tests/testing_framework/assets/runtime/Dockerfile.cfgsync
+++ b/tests/testing_framework/assets/runtime/Dockerfile.cfgsync
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1.96.0-slim-bookworm AS builder
+FROM rust:1.97.1-slim-bookworm AS builder
 
 WORKDIR /logos-blockchain-testing
 COPY --from=logos_blockchain_testing . /logos-blockchain-testing

--- a/tests/testing_framework/assets/runtime/Dockerfile.node
+++ b/tests/testing_framework/assets/runtime/Dockerfile.node
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
 
-FROM rust:1.96.0-slim-bookworm AS cfgsync-builder
+FROM rust:1.97.1-slim-bookworm AS cfgsync-builder
 
 WORKDIR /logos-blockchain-testing
 COPY --from=logos_blockchain_testing . /logos-blockchain-testing
@@ -14,7 +14,7 @@ RUN cargo build --locked --release \
     -p cfgsync-runtime \
     --bin cfgsync-client
 
-FROM rust:1.96.0-slim-bookworm AS builder
+FROM rust:1.97.1-slim-bookworm AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
## 1. What does this PR implement?

Update toolchain to version 1.97.1 and fmt nightly version accordingly.

The new Clippy introduces two pedantic warnings that I decided to ignore for the time being, but that should be tackled at some point for consistent styling: [`inline_modules`](https://rust-lang.github.io/rust-clippy/master/index.html?search=inline_#inline_modules) and [`inline_trait_bounds`](https://rust-lang.github.io/rust-clippy/master/index.html?search=inline_#inline_trait_bounds).

Also, a new feature allows us to specify a cargo env variable to explicitly deny warnings, removing the need to specify the `RUSTFLAGS` env variable which would result in crate recompilation. Those flags can be re-introduced for something else than this now, if needed.

## 2. Does the code have enough context to be clearly understood?

Yes.

## 3. Who are the specification authors and who is accountable for this PR?

@ntn-x2 

## 4. Is the specification accurate and complete?

N/A

## 5. Does the implementation introduce changes in the specification?

No.