### PR TITLE
feat(sdp): switch locked notes to Blake2bTree

### DIFF
--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -87,6 +87,7 @@ impl SDPDeclareValidationExt for SDPDeclareOp {
             .lock(
                 &ctx.min_stake,
                 self.service_type,
+                declaration_id,
                 utxo.note,
                 &self.locked_note_id,
             )

--- a/core/src/sdp/locked_notes.rs
+++ b/core/src/sdp/locked_notes.rs
@@ -1,10 +1,12 @@
-use std::collections::HashSet;
-
+use lb_blake2btree::{Blake2bTree, LeafHash};
+use lb_utils::bounded::NonEmptyBoundedVec;
 use serde::{Deserialize, Serialize};
+use strum::EnumCount as _;
 
 use crate::{
+    crypto::{Digest as _, Hash, Hasher},
     mantle::{Note, NoteId},
-    sdp::{MinStake, ServiceType},
+    sdp::{DeclarationId, MinStake, ServiceType},
 };
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -29,37 +31,67 @@ pub enum Error {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct LockedNotes {
-    locked_notes: rpds::HashTrieMapSync<NoteId, LockedNote>,
+    locked_notes: Blake2bTree<NoteId, LockedNote>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct LockedNote {
     note: Note,
-    services: HashSet<ServiceType>,
+    // Declarations locking the note, in the order they appeared on chain, at
+    // most one per service.
+    declarations: NonEmptyBoundedVec<(ServiceType, DeclarationId), { ServiceType::COUNT }>,
+}
+
+impl LockedNote {
+    fn sdp_locked_note_hash(&self) -> Hash {
+        let mut h = Hasher::new();
+        h.update(b"LOCKED_NOTE_HASH_V1");
+        for (_, declaration_id) in &self.declarations {
+            h.update(declaration_id.0);
+        }
+        h.finalize().into()
+    }
+}
+
+// The note and the services are left out of the leaf: they are derivable from
+// the notes and the declarations trees, which commit them already.
+impl LeafHash<NoteId> for LockedNote {
+    fn leaf_hash(&self, note_id: &NoteId) -> Hash {
+        let mut h = Hasher::new();
+        h.update(note_id.as_bytes());
+        h.update(self.sdp_locked_note_hash());
+        h.finalize().into()
+    }
 }
 
 impl LockedNotes {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            locked_notes: rpds::HashTrieMapSync::new_sync(),
+            locked_notes: Blake2bTree::new(),
         }
     }
 
     #[must_use]
     pub fn get(&self, id: &NoteId) -> Option<&Note> {
-        self.locked_notes.get(id).map(|ln| &ln.note)
+        self.locked_notes.get_ref(id).map(|ln| &ln.note)
     }
 
     #[must_use]
     pub fn contains(&self, id: &NoteId) -> bool {
-        self.locked_notes.contains_key(id)
+        self.locked_notes.contains(id)
+    }
+
+    #[must_use]
+    pub fn root(&self) -> Hash {
+        self.locked_notes.root()
     }
 
     pub fn lock(
         mut self,
         min_stake: &MinStake,
         service_type: ServiceType,
+        declaration_id: DeclarationId,
         note: Note,
         note_id: &NoteId,
     ) -> Result<Self, Error> {
@@ -70,19 +102,33 @@ impl LockedNotes {
             });
         }
 
-        if let Some(locked) = self.locked_notes.get_mut(note_id) {
-            if locked.services.contains(&service_type) {
+        if let Some(locked) = self.locked_notes.get_ref(note_id) {
+            if locked
+                .declarations
+                .iter()
+                .any(|(service, _)| *service == service_type)
+            {
                 return Err(Error::NoteAlreadyUsedForService {
                     note_id: *note_id,
                     service_type,
                 });
             }
-            locked.services.insert(service_type);
-        } else {
-            let services = [service_type].into();
+            let mut locked = locked.clone();
+            locked
+                .declarations
+                .try_push((service_type, declaration_id))
+                .expect("a note is locked at most once per service");
             self.locked_notes = self
                 .locked_notes
-                .insert(*note_id, LockedNote { note, services });
+                .update(note_id, locked)
+                .expect("the note is in the tree");
+        } else {
+            let declarations = NonEmptyBoundedVec::try_from_iter([(service_type, declaration_id)])
+                .expect("a single declaration fits the bounds");
+            self.locked_notes = self
+                .locked_notes
+                .insert(*note_id, LockedNote { note, declarations })
+                .0;
         }
 
         Ok(self)
@@ -90,32 +136,48 @@ impl LockedNotes {
 
     #[must_use]
     pub fn is_locked_for_service(&self, note_id: &NoteId, service_type: &ServiceType) -> bool {
-        if let Some(locked) = self.locked_notes.get(note_id) {
-            if locked.services.contains(service_type) {
-                return true;
-            }
-            return false;
-        }
-        false
+        self.locked_notes.get_ref(note_id).is_some_and(|locked| {
+            locked
+                .declarations
+                .iter()
+                .any(|(service, _)| service == service_type)
+        })
     }
 
     pub fn unlock(&mut self, service_type: ServiceType, note_id: &NoteId) -> Result<Note, Error> {
-        if let Some(note) = self.locked_notes.get_mut(note_id) {
-            if !note.services.remove(&service_type) {
-                return Err(Error::NoteNotLockedForService {
-                    note_id: *note_id,
-                    service_type,
-                });
-            }
-            let res = note.note;
-            if note.services.is_empty() {
-                self.locked_notes = self.locked_notes.remove(note_id);
-            }
+        let Some(locked) = self.locked_notes.get_ref(note_id) else {
+            return Err(Error::NoteNotLocked(*note_id));
+        };
+        let Some(index) = locked
+            .declarations
+            .iter()
+            .position(|(service, _)| *service == service_type)
+        else {
+            return Err(Error::NoteNotLockedForService {
+                note_id: *note_id,
+                service_type,
+            });
+        };
+        let res = locked.note;
 
-            Ok(res)
+        // Removing the last declaration releases the note
+        self.locked_notes = if locked.declarations.len() == 1 {
+            self.locked_notes
+                .remove(note_id)
+                .expect("the note is in the tree")
+                .0
         } else {
-            Err(Error::NoteNotLocked(*note_id))
-        }
+            let mut locked = locked.clone();
+            locked
+                .declarations
+                .try_remove(index)
+                .expect("the note keeps at least one declaration");
+            self.locked_notes
+                .update(note_id, locked)
+                .expect("the note is in the tree")
+        };
+
+        Ok(res)
     }
 }
 
@@ -139,6 +201,10 @@ mod tests {
         }
     }
 
+    fn declaration_id(seed: u8) -> DeclarationId {
+        DeclarationId([seed; 32])
+    }
+
     #[test]
     fn test_lock_success() {
         let utxo = utxo();
@@ -150,16 +216,22 @@ mod tests {
         };
 
         let locked_notes_bn = locked_notes
-            .lock(&min_stake, ServiceType::BlendNetwork, utxo.note, &note_id)
+            .lock(
+                &min_stake,
+                ServiceType::BlendNetwork,
+                declaration_id(1),
+                utxo.note,
+                &note_id,
+            )
             .expect("Should be able to lock for BN service");
 
         assert!(locked_notes_bn.contains(&note_id));
         assert_eq!(
             locked_notes_bn
                 .locked_notes
-                .get(&note_id)
-                .map(|ln| &ln.services),
-            Some(&HashSet::from([ServiceType::BlendNetwork]))
+                .get_ref(&note_id)
+                .map(|ln| ln.declarations.as_slice()),
+            Some([(ServiceType::BlendNetwork, declaration_id(1))].as_slice())
         );
     }
 
@@ -174,11 +246,22 @@ mod tests {
         };
 
         let locked_notes_once = locked_notes
-            .lock(&min_stake, ServiceType::BlendNetwork, utxo.note, &note_id)
+            .lock(
+                &min_stake,
+                ServiceType::BlendNetwork,
+                declaration_id(1),
+                utxo.note,
+                &note_id,
+            )
             .unwrap();
 
-        let result =
-            locked_notes_once.lock(&min_stake, ServiceType::BlendNetwork, utxo.note, &note_id);
+        let result = locked_notes_once.lock(
+            &min_stake,
+            ServiceType::BlendNetwork,
+            declaration_id(2),
+            utxo.note,
+            &note_id,
+        );
 
         assert!(result.is_err());
         assert_eq!(
@@ -200,7 +283,13 @@ mod tests {
             timestamp: 0,
         };
 
-        let result = locked_notes.lock(&min_stake, ServiceType::BlendNetwork, utxo.note, &note_id);
+        let result = locked_notes.lock(
+            &min_stake,
+            ServiceType::BlendNetwork,
+            declaration_id(1),
+            utxo.note,
+            &note_id,
+        );
 
         assert!(result.is_err());
         assert_eq!(
@@ -222,7 +311,13 @@ mod tests {
             timestamp: 0,
         };
 
-        let result = locked_notes.lock(&min_stake, ServiceType::BlendNetwork, utxo.note, &note_id);
+        let result = locked_notes.lock(
+            &min_stake,
+            ServiceType::BlendNetwork,
+            declaration_id(1),
+            utxo.note,
+            &note_id,
+        );
 
         assert!(result.is_ok());
     }
@@ -235,7 +330,13 @@ mod tests {
             timestamp: 0,
         };
         let mut locked = LockedNotes::new()
-            .lock(&min_stake, ServiceType::BlendNetwork, utxo.note, &note_id)
+            .lock(
+                &min_stake,
+                ServiceType::BlendNetwork,
+                declaration_id(1),
+                utxo.note,
+                &note_id,
+            )
             .unwrap();
 
         locked
@@ -243,7 +344,7 @@ mod tests {
             .expect("Should unlock the last service");
 
         assert!(!locked.contains(&note_id));
-        assert!(locked.locked_notes.is_empty());
+        assert_eq!(locked.locked_notes.size(), 0);
     }
 
     #[test]
@@ -254,5 +355,99 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), Error::NoteNotLocked(note_id));
+    }
+
+    // Leaf commitment
+    fn locked_note(declaration_id: DeclarationId) -> LockedNote {
+        LockedNote {
+            note: utxo().note,
+            declarations: NonEmptyBoundedVec::try_from_iter([(
+                ServiceType::BlendNetwork,
+                declaration_id,
+            )])
+            .unwrap(),
+        }
+    }
+
+    // The encoding is spelled out field by field, so any change to `leaf_hash`
+    // has to be mirrored here and in the specification.
+    #[test]
+    fn locked_note_leaf_matches_the_specified_encoding() {
+        let note_id = utxo().id();
+        let locked = locked_note(declaration_id(1));
+
+        let mut locked_note_bytes = Vec::new();
+        locked_note_bytes.extend_from_slice(b"LOCKED_NOTE_HASH_V1");
+        locked_note_bytes.extend_from_slice(&declaration_id(1).0);
+        let locked_note_hash: Hash = Hasher::digest(&locked_note_bytes).into();
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&note_id.as_bytes());
+        bytes.extend_from_slice(&locked_note_hash);
+
+        let expected: Hash = Hasher::digest(&bytes).into();
+        assert_eq!(locked.leaf_hash(&note_id), expected);
+    }
+
+    #[test]
+    fn locked_note_leaf_binds_the_note_id() {
+        let locked = locked_note(declaration_id(1));
+        // `utxo` draws a random `op_id`, so the two notes have distinct ids.
+        let note_id = utxo().id();
+        let other_note_id = utxo().id();
+
+        assert_ne!(locked.leaf_hash(&note_id), locked.leaf_hash(&other_note_id));
+    }
+
+    #[test]
+    fn locked_note_leaf_binds_the_declaration() {
+        let note_id = utxo().id();
+
+        assert_ne!(
+            locked_note(declaration_id(1)).leaf_hash(&note_id),
+            locked_note(declaration_id(2)).leaf_hash(&note_id)
+        );
+    }
+
+    // The note is not committed, only the declarations locking it are.
+    #[test]
+    fn locked_note_leaf_ignores_the_note() {
+        let note_id = utxo().id();
+        let locked = locked_note(declaration_id(1));
+        let other_note = LockedNote {
+            note: Note::new(42, ZkKey::from(BigUint::from(7u64)).to_public_key()),
+            ..locked.clone()
+        };
+
+        assert_eq!(locked.leaf_hash(&note_id), other_note.leaf_hash(&note_id));
+    }
+
+    #[test]
+    fn root_tracks_lock_and_unlock() {
+        let utxo = utxo();
+        let note_id = utxo.id();
+        let min_stake = MinStake {
+            threshold: 1,
+            timestamp: 0,
+        };
+
+        let locked_notes = LockedNotes::new();
+        let empty_root = locked_notes.root();
+
+        let mut locked_notes = locked_notes
+            .lock(
+                &min_stake,
+                ServiceType::BlendNetwork,
+                declaration_id(1),
+                utxo.note,
+                &note_id,
+            )
+            .unwrap();
+        assert_ne!(locked_notes.root(), empty_root);
+
+        locked_notes
+            .unlock(ServiceType::BlendNetwork, &note_id)
+            .unwrap();
+        assert_eq!(locked_notes.root(), empty_root);
     }
 }

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -18,7 +18,7 @@ use nom::{
     error::{Error, ErrorKind},
 };
 use serde::{Deserialize, Serialize};
-use strum::EnumIter;
+use strum::{EnumCount, EnumIter};
 
 use crate::{
     block::BlockNumber,
@@ -241,7 +241,7 @@ impl NomDecode for Locator {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, EnumIter)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, EnumIter, EnumCount)]
 pub enum ServiceType {
     #[serde(rename = "BN")]
     BlendNetwork,


### PR DESCRIPTION
## 1. What does this PR implement?

This PR migrate locked notes and states structures to the blake2btree. This is to prepare the fast [bootstrapping RFC](<https://github.com/logos-co/logos-lips/pull/368>)
The services was before a `HashSet` but we need to order them in apparition order to keep the tree deterministic. So it was replaced by a NonEmptyBoundedVec of max size `ServiceCount`. 

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur 

## 4. Is the specification accurate and complete?

It doesn't change anything to the specs and the behavior of the locked notes.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).