### PR TITLE
feat(mantle): switch voucher nullifiers to Blake2bTree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,7 +4480,6 @@ dependencies = [
  "nom 8.0.0",
  "num-bigint",
  "rand 0.8.6",
- "rpds",
  "serde",
  "serde_json",
  "strum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,6 @@ lb-zksign                     = { workspace = true }
 multiaddr                     = { workspace = true }
 nom                           = { features = ["alloc"], workspace = true }
 num-bigint                    = { workspace = true }
-rpds                          = { workspace = true }
 serde                         = { features = ["derive"], workspace = true }
 strum                         = { features = ["derive"], workspace = true }
 thiserror                     = { workspace = true }

--- a/core/src/mantle/channel_notes.rs
+++ b/core/src/mantle/channel_notes.rs
@@ -1,4 +1,5 @@
 use lb_blake2btree::{Blake2bTree, LeafHash};
+use lb_groth16::fr_to_bytes;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -27,7 +28,7 @@ pub enum Error {
 impl LeafHash<NoteId> for ChannelId {
     fn leaf_hash(&self, note_id: &NoteId) -> Hash {
         let mut h = Hasher::new();
-        h.update(note_id.as_bytes());
+        h.update(fr_to_bytes(note_id.as_fr()));
         h.update(self.as_ref());
         h.finalize().into()
     }
@@ -115,7 +116,7 @@ mod tests {
         let channel_id = ChannelId::from([0u8; 32]);
 
         let mut bytes = Vec::new();
-        bytes.extend_from_slice(&note_id.as_bytes());
+        bytes.extend_from_slice(&fr_to_bytes(note_id.as_fr()));
         bytes.extend_from_slice(channel_id.as_ref());
 
         let expected: Hash = Hasher::digest(&bytes).into();

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -1,5 +1,6 @@
 use std::sync::LazyLock;
 
+use lb_blake2btree::{Blake2bTree, LeafHash};
 use lb_core_macros::NomCodec;
 use lb_groth16::{fr_from_bytes, fr_to_bytes, serde::serde_fr};
 use lb_key_management_system_keys::keys::ZkPublicKey;
@@ -8,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    crypto::ZkHasher,
+    crypto::{Hash, ZkHasher},
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, Utxo, Value,
@@ -38,6 +39,20 @@ pub struct VoucherSecret(#[serde(with = "serde_fr")] pub Fr);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize, NomCodec)]
 pub struct VoucherNullifier(#[serde(with = "serde_fr")] ZkHash);
+
+// The nullifier is the whole state, so the set holds nothing besides it and the
+// leaf is the nullifier value.
+impl LeafHash<VoucherNullifier> for () {
+    fn leaf_hash(&self, nullifier: &VoucherNullifier) -> Hash {
+        fr_to_bytes(&nullifier.0)
+    }
+}
+
+/// Nullifiers of the vouchers claimed since genesis.
+///
+/// The set is append-only: a nullifier is recorded when its voucher is claimed
+/// and never removed, so the leaves stay in the order they appeared on chain.
+pub type VoucherNullifiers = Blake2bTree<VoucherNullifier, ()>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 pub struct VoucherCm(#[serde(with = "serde_fr")] ZkHash);
@@ -159,14 +174,14 @@ pub enum LeaderClaimError {
 }
 
 pub struct LeaderClaimValidationContext<'a> {
-    pub nullifiers: &'a rpds::HashTrieSetSync<VoucherNullifier>,
+    pub nullifiers: &'a VoucherNullifiers,
     pub claimable_vouchers_root: &'a RewardsRoot,
     pub proof_of_claim: &'a Groth16LeaderClaimProof,
     pub tx_hash: &'a TxHash,
 }
 
 pub struct LeaderClaimExecutionContext {
-    pub nullifiers: rpds::HashTrieSetSync<VoucherNullifier>,
+    pub nullifiers: VoucherNullifiers,
     pub reward_amount: Value,
     pub claimable_rewards: Value,
     pub utxos: Utxos,
@@ -208,7 +223,7 @@ impl Operation<LeaderClaimValidationContext<'_>> for LeaderClaimOp {
         mut ctx: Self::ExecutionContext<'_>,
     ) -> Result<(Self::ExecutionContext<'_>, Vec<TxEvent>), Self::Error> {
         // Add the nullifier to the nullifier set
-        ctx.nullifiers = ctx.nullifiers.insert(self.voucher_nullifier);
+        ctx.nullifiers = ctx.nullifiers.insert(self.voucher_nullifier, ()).0;
 
         // Distribute the reward
         let utxo = self.utxo(ctx.reward_amount);
@@ -263,7 +278,7 @@ mod tests {
             voucher_nullifier: VoucherNullifier::from_secret(voucher_secret),
             pk: ZkPublicKey::zero(),
         };
-        let nullifiers = rpds::HashTrieSetSync::new_sync();
+        let nullifiers = VoucherNullifiers::new();
         let ctx = LeaderClaimValidationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
@@ -288,7 +303,7 @@ mod tests {
 
         let (ctx, events) = op
             .execute(LeaderClaimExecutionContext {
-                nullifiers: rpds::HashTrieSetSync::new_sync(),
+                nullifiers: VoucherNullifiers::new(),
                 reward_amount,
                 claimable_rewards: 100,
                 utxos: Utxos::new(),
@@ -360,7 +375,7 @@ mod tests {
             voucher_nullifier: bogus_nf,
             pk: ZkPublicKey::zero(),
         };
-        let nullifiers = rpds::HashTrieSetSync::new_sync();
+        let nullifiers = VoucherNullifiers::new();
         let ctx = LeaderClaimValidationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
@@ -372,5 +387,44 @@ mod tests {
         // match the proven voucher -> rejected. A voucher cannot be claimed under
         // a substituted nullifier.
         assert_eq!(op.validate(&ctx), Err(LeaderClaimError::InvalidPoC));
+    }
+
+    fn nullifier(secret: u64) -> VoucherNullifier {
+        VoucherNullifier::from_secret(VoucherSecret::from(Fr::from(secret)))
+    }
+
+    // The leaf is the nullifier value itself, so it has to stay the plain
+    // encoding, without any hashing on top.
+    #[test]
+    fn nullifier_leaf_is_the_nullifier_value() {
+        let nullifier = nullifier(7);
+
+        assert_eq!(().leaf_hash(&nullifier), fr_to_bytes(&nullifier.0));
+    }
+
+    #[test]
+    fn nullifiers_root_tracks_insertions() {
+        let nullifiers = VoucherNullifiers::new();
+        let empty_root = nullifiers.root();
+
+        let (nullifiers, _) = nullifiers.insert(nullifier(7), ());
+        let one_root = nullifiers.root();
+        assert_ne!(one_root, empty_root);
+
+        let (nullifiers, _) = nullifiers.insert(nullifier(8), ());
+        assert_ne!(nullifiers.root(), one_root);
+    }
+
+    // The set is append-only and its leaves keep the order they appeared on
+    // chain, so the same nullifiers claimed in another order commit differently.
+    #[test]
+    fn nullifiers_root_follows_the_claim_order() {
+        let (claimed_in_order, _) = VoucherNullifiers::new().insert(nullifier(7), ());
+        let (claimed_in_order, _) = claimed_in_order.insert(nullifier(8), ());
+
+        let (claimed_reversed, _) = VoucherNullifiers::new().insert(nullifier(8), ());
+        let (claimed_reversed, _) = claimed_reversed.insert(nullifier(7), ());
+
+        assert_ne!(claimed_in_order.root(), claimed_reversed.root());
     }
 }

--- a/core/src/mantle/transactions/verification_helper.rs
+++ b/core/src/mantle/transactions/verification_helper.rs
@@ -8,7 +8,7 @@ use crate::{
         ledger::{Declarations, Utxos},
         ops::{
             channel::{ChannelId, ChannelKeyIndex},
-            leader_claim::{RewardsRoot, VoucherNullifier},
+            leader_claim::{RewardsRoot, VoucherNullifiers},
         },
     },
     sdp::{DeclarationId, MinStake, ServiceType, locked_notes::LockedNotes},
@@ -37,7 +37,7 @@ pub trait OperationVerificationHelper {
 
     fn get_block_slot(&self) -> Slot;
 
-    fn get_nullifiers(&self) -> &rpds::HashTrieSetSync<VoucherNullifier>;
+    fn get_nullifiers(&self) -> &VoucherNullifiers;
 
     fn get_claimable_vouchers_root(&self) -> &RewardsRoot;
 
@@ -58,7 +58,6 @@ pub mod test_utils {
     use std::collections::HashMap;
 
     use lb_cryptarchia_engine::{Epoch, Slot};
-    use rpds::HashTrieSetSync;
 
     use crate::{
         mantle::{
@@ -67,7 +66,7 @@ pub mod test_utils {
             ledger::{Declarations, Utxos},
             ops::{
                 channel::{ChannelId, ChannelKeyIndex, Ed25519PublicKey},
-                leader_claim::{RewardsRoot, VoucherNullifier},
+                leader_claim::{RewardsRoot, VoucherNullifiers},
             },
             transactions::OperationVerificationHelper,
         },
@@ -83,7 +82,7 @@ pub mod test_utils {
         min_stake: MinStake,
         epoch: Epoch,
         block_slot: Slot,
-        nullifiers: HashTrieSetSync<VoucherNullifier>,
+        nullifiers: VoucherNullifiers,
         claimable_vouchers_root: RewardsRoot,
     }
 
@@ -105,7 +104,7 @@ pub mod test_utils {
                 },
                 epoch: Epoch::from(0u32),
                 block_slot: Slot::from(0u64),
-                nullifiers: HashTrieSetSync::new_sync(),
+                nullifiers: VoucherNullifiers::new(),
                 claimable_vouchers_root: RewardsRoot::default(),
             }
         }
@@ -158,7 +157,7 @@ pub mod test_utils {
             self.block_slot
         }
 
-        fn get_nullifiers(&self) -> &HashTrieSetSync<VoucherNullifier> {
+        fn get_nullifiers(&self) -> &VoucherNullifiers {
             &self.nullifiers
         }
 

--- a/core/src/sdp/locked_notes.rs
+++ b/core/src/sdp/locked_notes.rs
@@ -1,4 +1,5 @@
 use lb_blake2btree::{Blake2bTree, LeafHash};
+use lb_groth16::fr_to_bytes;
 use lb_utils::bounded::NonEmptyBoundedVec;
 use serde::{Deserialize, Serialize};
 use strum::EnumCount as _;
@@ -58,7 +59,7 @@ impl LockedNote {
 impl LeafHash<NoteId> for LockedNote {
     fn leaf_hash(&self, note_id: &NoteId) -> Hash {
         let mut h = Hasher::new();
-        h.update(note_id.as_bytes());
+        h.update(fr_to_bytes(note_id.as_fr()));
         h.update(self.sdp_locked_note_hash());
         h.finalize().into()
     }
@@ -382,7 +383,7 @@ mod tests {
         let locked_note_hash: Hash = Hasher::digest(&locked_note_bytes).into();
 
         let mut bytes = Vec::new();
-        bytes.extend_from_slice(&note_id.as_bytes());
+        bytes.extend_from_slice(&fr_to_bytes(note_id.as_fr()));
         bytes.extend_from_slice(&locked_note_hash);
 
         let expected: Hash = Hasher::digest(&bytes).into();

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -11,6 +11,7 @@ use blake2::{Blake2b, Digest as _};
 use bytes::Bytes;
 use lb_blake2btree::LeafHash;
 use lb_cryptarchia_engine::Epoch;
+use lb_groth16::fr_to_bytes;
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_utils::bounded::{BoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
 use multiaddr::{Multiaddr, Protocol};
@@ -410,10 +411,8 @@ impl Declaration {
             h.update(locator.0.as_ref());
         }
         h.update(self.provider_id.0);
-        for number in self.zk_id.as_fr().0.0 {
-            h.update(number.to_le_bytes());
-        }
-        h.update(self.locked_note_id.as_bytes());
+        h.update(fr_to_bytes(self.zk_id.as_fr()));
+        h.update(fr_to_bytes(self.locked_note_id.as_fr()));
         h.update(self.created.into_inner().to_le_bytes());
         h.update(self.active.into_inner().to_le_bytes());
         h.update(self.withdraw_at.map_or(0, Epoch::into_inner).to_le_bytes());
@@ -563,7 +562,7 @@ impl NomDecode for ActivityMetadata {
 mod tests {
     use lb_blake2btree::LeafHash as _;
     use lb_cryptarchia_engine::Epoch;
-    use lb_groth16::{AdditiveGroup as _, Fr};
+    use lb_groth16::{AdditiveGroup as _, Fr, fr_to_bytes};
     use lb_key_management_system_keys::keys::{Ed25519Key, ZkPublicKey};
     use multiaddr::Multiaddr;
 
@@ -693,10 +692,8 @@ mod tests {
             info.extend_from_slice(locator.as_ref());
         }
         info.extend_from_slice(declaration.provider_id.0.as_bytes());
-        for number in declaration.zk_id.as_fr().0.0 {
-            info.extend_from_slice(&number.to_le_bytes());
-        }
-        info.extend_from_slice(&declaration.locked_note_id.as_bytes());
+        info.extend_from_slice(&fr_to_bytes(declaration.zk_id.as_fr()));
+        info.extend_from_slice(&fr_to_bytes(declaration.locked_note_id.as_fr()));
         info.extend_from_slice(&4u32.to_le_bytes());
         info.extend_from_slice(&5u32.to_le_bytes());
         info.extend_from_slice(&6u32.to_le_bytes());

--- a/ledger/src/mantle/helpers.rs
+++ b/ledger/src/mantle/helpers.rs
@@ -4,7 +4,7 @@ use lb_core::{
         ledger::{Declarations, Utxos},
         ops::{
             channel::{ChannelId, ChannelKeyIndex},
-            leader_claim::{RewardsRoot, VoucherNullifier},
+            leader_claim::{RewardsRoot, VoucherNullifiers},
             sdp::SdpError,
         },
         transactions::{OperationVerificationHelper, VerificationError},
@@ -13,7 +13,6 @@ use lb_core::{
 };
 use lb_cryptarchia_engine::{Epoch, Slot};
 use lb_key_management_system_keys::keys::Ed25519PublicKey;
-use rpds::HashTrieSetSync;
 
 use crate::mantle::LedgerState;
 
@@ -87,7 +86,7 @@ impl OperationVerificationHelper for MantleOperationVerificationHelper<'_> {
         self.cryptarchia_ledger.slot
     }
 
-    fn get_nullifiers(&self) -> &HashTrieSetSync<VoucherNullifier> {
+    fn get_nullifiers(&self) -> &VoucherNullifiers {
         self.ledger_state.leaders.nullifiers()
     }
 

--- a/ledger/src/mantle/leader.rs
+++ b/ledger/src/mantle/leader.rs
@@ -1,10 +1,10 @@
 use std::cmp::Ordering;
 
 use lb_core::{
-    crypto::ZkHasher,
+    crypto::{Hash, ZkHasher},
     mantle::{
         Value,
-        ops::leader_claim::{RewardsRoot, VoucherCm, VoucherNullifier},
+        ops::leader_claim::{RewardsRoot, VoucherCm, VoucherNullifiers},
     },
 };
 use lb_cryptarchia_engine::Epoch;
@@ -22,7 +22,7 @@ pub struct LeaderState {
     /// A snapshot of voucher commitments, updated once at each epoch start.
     vouchers_snapshot: VouchersSnapshot,
     /// Nullifiers of vouchers that have been claimed since genesis
-    nfs: rpds::HashTrieSetSync<VoucherNullifier>,
+    nfs: VoucherNullifiers,
     /// Rewards to be distributed.
     /// At the start of each epoch this is increased by the amount of rewards
     /// that have been collected in the previous epoch.
@@ -72,7 +72,7 @@ impl LeaderState {
                 root: RewardsRoot::default(),
                 count: 0,
             },
-            nfs: rpds::HashTrieSetSync::new_sync(),
+            nfs: VoucherNullifiers::new(),
             pending_rewards: 0,
             claimable_rewards: 0,
             vouchers: MerkleMountainRange::new(),
@@ -80,17 +80,22 @@ impl LeaderState {
     }
 
     #[must_use]
-    pub const fn nullifiers(&self) -> &rpds::HashTrieSetSync<VoucherNullifier> {
+    pub const fn nullifiers(&self) -> &VoucherNullifiers {
         &self.nfs
     }
 
     #[must_use]
-    pub fn nullifiers_cloned(&self) -> rpds::HashTrieSetSync<VoucherNullifier> {
+    pub fn nullifiers_cloned(&self) -> VoucherNullifiers {
         self.nfs.clone()
     }
 
-    pub fn update_nullifiers(&mut self, nullifiers: rpds::HashTrieSetSync<VoucherNullifier>) {
+    pub fn update_nullifiers(&mut self, nullifiers: VoucherNullifiers) {
         self.nfs = nullifiers;
+    }
+
+    #[must_use]
+    pub fn nullifiers_root(&self) -> Hash {
+        self.nfs.root()
     }
 
     pub const fn update_rewards(&mut self, claimable_rewards: Value) {


### PR DESCRIPTION
## 1. What does this PR implement?

This PR migrate voucher nullifiers to the blake2btree. This is to prepare the fast [bootstrapping RFC](<https://github.com/logos-co/logos-lips/pull/368>).

It also correct the old bad way of converting Fr to bytes in the other trees (it was using the Montgomery form instead of the fr_to_bytes() method).

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur 

## 4. Is the specification accurate and complete?

It doesn't change anything to the specs and the behavior of the nullifiers.

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).