### PR TITLE
fix(sdp): encode zk_id canonically in the declaration id

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Logos Blockchain is a core component of the [Logos][logos-website] technology stack.
 It combines zero-knowledge proofs, a mix network for anonymity, and a modular service architecture to provide a foundation for sovereign digital communities.
 
-This node represents the reference implementation of the Logos Blockchain specifications defined in the [Logos specifications space][notion-specs].
+This node represents the reference implementation of the Logos Blockchain specifications defined in the [Logos specifications space][specs].
 
 ## Quick Start
 
@@ -372,7 +372,7 @@ Dual-licensed under your choice of:
 - [Twitter / X][logos-x]
 - [logos.co][logos-website]
 
-[notion-specs]: https://www.notion.so/nomos-tech/Research-Specifications-1fd261aa09df814da916ecefa410571f
+[specs]: https://lip.logos.co/blockchain/index.html
 [overwatch-github]: https://github.com/logos-co/Overwatch
 [graphviz-online]: https://dreampuf.github.io/GraphvizOnline/
 [github-releases-page]: https://github.com/logos-blockchain/logos-blockchain/releases

--- a/blend/crypto/src/merkle.rs
+++ b/blend/crypto/src/merkle.rs
@@ -45,7 +45,7 @@ impl rs_merkle_tree::hasher::Hasher for InnerTreeZkHasher {
 /// A membership-specific Merkle tree that indices information about core nodes'
 /// ZK keys.
 ///
-/// It is a fixed-height tree, with the height expected by the [`PoQ` specification](https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#215261aa09df81ec850ad7965bf6e76b).
+/// It is a fixed-height tree, with the height expected by the [`PoQ` specification](https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-quota).
 /// It is a wrapped around an instance of an [`rs_merkle_tree`], configured with
 /// our [`lb_core::crypto::ZkHasher`] and additional information to make it
 /// suitable for `PoQ` usage.
@@ -74,7 +74,7 @@ impl Debug for MerkleTree {
 impl MerkleTree {
     /// Create a new merkle tree with the provided keys.
     ///
-    /// Keys are internally sorted by their numeric value, as described in the [`PoQ` specification](https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#215261aa09df81ec850ad7965bf6e76b).
+    /// Keys are internally sorted by their numeric value, as described in the [`PoQ` specification](https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-quota).
     pub fn new(mut keys: Vec<ZkPublicKey>) -> Result<Self, Error> {
         // Sort the input keys by their decimal representation, relying on `Fr`'s
         // implementation of `PartialOrd`.
@@ -82,7 +82,7 @@ impl MerkleTree {
         Self::new_from_ordered(keys)
     }
 
-    /// Create a new merkle tree with the provided, already-sorted keys, as described in the [`PoQ` specification](https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#215261aa09df81ec850ad7965bf6e76b).
+    /// Create a new merkle tree with the provided, already-sorted keys, as described in the [`PoQ` specification](https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-quota).
     ///
     /// If the input vector is empty or if it is larger than the maximum number
     /// of leaves supported by this fixed-height Merkle tree, it returns an

--- a/blend/message/src/encap/encapsulated.rs
+++ b/blend/message/src/encap/encapsulated.rs
@@ -124,13 +124,13 @@ impl EncapsulatedMessage {
     where
         Verifier: ProofsVerifier,
     {
-        // Verify signature according to the Blend spec: <https://www.notion.so/nomos-tech/Blend-Protocol-215261aa09df81ae8857d71066a80084?source=copy_link#215261aa09df81859cebf5e3d2a5cd8f>.
+        // Verify signature according to the Blend spec: <https://lip.logos.co/blockchain/raw/blend-protocol.html#processing>.
         self.public_header.verify_signature(&signing_body(
             &self.encapsulated_part.private_header,
             &self.encapsulated_part.payload,
         ))?;
         let (_, signing_key, proof_of_quota, signature) = self.public_header.into_components();
-        // Verify the Proof of Quota according to the Blend spec: <https://www.notion.so/nomos-tech/Blend-Protocol-215261aa09df81ae8857d71066a80084?source=copy_link#215261aa09df81b593ddce00cffd24a8>.
+        // Verify the Proof of Quota according to the Blend spec: <https://lip.logos.co/blockchain/raw/blend-protocol.html#processing>.
         let verified_proof_of_quota = verifier
             .verify_proof_of_quota(proof_of_quota, &signing_key)
             .map_err(|_| Error::ProofOfQuotaVerificationFailed(quota::Error::InvalidProof))?;
@@ -493,7 +493,7 @@ impl EncapsulatedPrivateHeader {
             signature,
             signing_pubkey,
         } = self.first().try_deserialize()?;
-        // Verify PoSel according to the Blend spec: <https://www.notion.so/nomos-tech/Blend-Protocol-215261aa09df81ae8857d71066a80084?source=copy_link#215261aa09df81dd8cbedc8af4649a6a>.
+        // Verify PoSel according to the Blend spec: <https://lip.logos.co/blockchain/raw/blend-protocol.html#processing>.
         let verified_proof_of_selection = verifier
             .verify_proof_of_selection(proof_of_selection, posel_verification_input)
             .map_err(|_| {

--- a/blend/message/src/encap/tests.rs
+++ b/blend/message/src/encap/tests.rs
@@ -125,7 +125,7 @@ fn encapsulate_and_decapsulate() {
 
     // NOTE: We expect that the decapsulations can be done
     // in the "reverse" order of blend_node_enc_keys.
-    // (following the notion in the spec)
+    // (following the spec)
 
     // We can decapsulate with the correct private key.
     let DecapsulationOutput::Incompleted {

--- a/blend/network/src/core/with_core/behaviour/mod.rs
+++ b/blend/network/src/core/with_core/behaviour/mod.rs
@@ -95,7 +95,7 @@ impl RemotePeerConnectionDetails {
 /// A [`NetworkBehaviour`] that processes incoming Blend messages, and
 /// propagates messages from the Blend service to the rest of the Blend network.
 ///
-/// The public header signature and uniqueness of incoming messages is validated according to the [Blend v1 specification](https://www.notion.so/nomos-tech/Blend-Protocol-Version-1-215261aa09df81ae8857d71066a80084) before the message is propagated to the swarm and to the Blend service.
+/// The public header signature and uniqueness of incoming messages is validated according to the [Blend specification](https://lip.logos.co/blockchain/raw/blend-protocol.html) before the message is propagated to the swarm and to the Blend service.
 pub struct Behaviour<ObservationWindowClockProvider> {
     /// Tracks connections between this node and other core nodes.
     ///

--- a/blend/proofs/src/quota/inputs/prove/private.rs
+++ b/blend/proofs/src/quota/inputs/prove/private.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 
-/// Private inputs for all types of Proof of Quota. Spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#215261aa09df81a18576f67b910d34d4>.
+/// Private inputs for all types of Proof of Quota. Spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html#witness>.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Inputs {
@@ -47,7 +47,7 @@ impl Inputs {
         }
     }
 
-    /// Return the right `sk` for a Proof of Quota depending on the proof type, as per the spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#25a261aa09df80e0a410f708190ac802>.
+    /// Return the right `sk` for a Proof of Quota depending on the proof type, as per the spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html#constraints>.
     #[must_use]
     pub fn get_secret_selection_randomness_sk(
         &self,

--- a/blend/proofs/src/quota/inputs/prove/public.rs
+++ b/blend/proofs/src/quota/inputs/prove/public.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ZkHash, quota::Ed25519PublicKey};
 
-/// Public inputs for all types of Proof of Quota. Spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#25a261aa09df80ce943dce35dd5403ac>.
+/// Public inputs for all types of Proof of Quota. Spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html#public-values>.
 #[derive(Clone, Copy)]
 pub struct Inputs {
     pub signing_key: Ed25519PublicKey,

--- a/blend/proofs/src/quota/mod.rs
+++ b/blend/proofs/src/quota/mod.rs
@@ -43,7 +43,7 @@ pub enum Error {
     InvalidProof,
 }
 
-/// A Proof of Quota as described in the Blend v1 spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#26a261aa09df80f4b119f900fbb36f3f>.
+/// A Proof of Quota as described in the Blend spec: <https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-quota>.
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ProofOfQuota {
     #[serde(with = "lb_groth16::serde::serde_fr")]
@@ -222,7 +222,7 @@ static DOMAIN_SEPARATION_TAG_FR: LazyLock<ZkHash> = LazyLock::new(|| {
     fr_from_bytes(&DOMAIN_SEPARATION_TAG[..])
         .expect("DST for secret selection randomness calculation must be correct.")
 });
-// As per Proof of Quota v1 spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#215261aa09df81adb8ccd1448c9afd68>.
+// As per Proof of Quota spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html>.
 fn generate_secret_selection_randomness(
     input: &SelectionRandomnessSecretInput,
     key_index: u64,

--- a/blend/proofs/src/quota/tests.rs
+++ b/blend/proofs/src/quota/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 
 #[test]
 fn secret_selection_randomness_dst_encoding() {
-    // Blend spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#25e261aa09df802d87edfc54d1d60b80>
+    // Blend spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html>
     assert_eq!(
         *DOMAIN_SEPARATION_TAG_FR,
         fr_from_bytes_unchecked(

--- a/blend/proofs/src/selection/mod.rs
+++ b/blend/proofs/src/selection/mod.rs
@@ -39,7 +39,7 @@ pub enum Error {
     EmptyMembershipSet,
 }
 
-/// A Proof of Selection as described in the Blend v1 spec: <https://www.notion.so/nomos-tech/Blend-Protocol-215261aa09df81ae8857d71066a80084?source=copy_link#215261aa09df81d6bb3febd62b598138>.
+/// A Proof of Selection as described in the Blend spec: <https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-selection>.
 #[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ProofOfSelection {
     #[serde(with = "lb_groth16::serde::serde_fr")]
@@ -53,7 +53,7 @@ impl ProofOfSelection {
         if membership_size == 0 {
             return Err(Error::EmptyMembershipSet);
         }
-        // Condition 1: https://www.notion.so/nomos-tech/Blend-Protocol-215261aa09df81ae8857d71066a80084?source=copy_link#215261aa09df819991e6f9455ff7ec92
+        // Condition 1: https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-selection
         let selection_randomness_bytes = fr_to_bytes(&self.selection_randomness);
         let pseudo_random_output: u64 = {
             let pseudo_random_output_bytes =
@@ -90,7 +90,7 @@ impl ProofOfSelection {
             });
         }
 
-        // Condition 2: https://www.notion.so/nomos-tech/Blend-Protocol-215261aa09df81ae8857d71066a80084?source=copy_link#215261aa09df814da8e8ec1f1fcf4fe6
+        // Condition 2: https://lip.logos.co/blockchain/raw/blend-protocol.html#proof-of-selection
         let calculated_key_nullifier =
             derive_key_nullifier_from_secret_selection_randomness(self.selection_randomness);
         if calculated_key_nullifier != *key_nullifier {
@@ -186,7 +186,7 @@ static KEY_NULLIFIER_DERIVATION_DOMAIN_SEPARATION_TAG_FR: LazyLock<ZkHash> = Laz
         "DST for key nullifier derivation from secret selection randomness must be correct.",
     )
 });
-// As per Proof of Quota v1 spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#215261aa09df81adb8ccd1448c9afd68>.
+// As per Proof of Quota spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html#constraints>.
 #[must_use]
 pub fn derive_key_nullifier_from_secret_selection_randomness(
     secret_selection_randomness: ZkHash,

--- a/blend/proofs/src/selection/tests.rs
+++ b/blend/proofs/src/selection/tests.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[test]
 fn secret_selection_randomness_to_key_nullifier_dst_encoding() {
-    // Blend spec: <https://www.notion.so/nomos-tech/Proof-of-Quota-Specification-215261aa09df81d88118ee22205cbafe?source=copy_link#26c261aa09df802f9dbcd0780dc7ac6e>
+    // PoQ spec: <https://lip.logos.co/blockchain/raw/proof-of-quota.html>
 
     assert_eq!(
         *KEY_NULLIFIER_DERIVATION_DOMAIN_SEPARATION_TAG_FR,

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -465,7 +465,7 @@ impl Utxo {
     #[must_use]
     pub fn id(&self) -> NoteId {
         // constants and structure as defined in the Mantle spec:
-        // https://www.notion.so/nomos-tech/v1-4-Mantle-Specification-335261aa09df8065a38acff4b25aee82
+        // https://lip.logos.co/blockchain/raw/bedrock-v1.1-mantle-specification.html
 
         let op_id: Fr = Fr::from_le_bytes_mod_order(self.op_id.as_ref());
         let output_index =

--- a/core/src/mantle/traits/genesis.rs
+++ b/core/src/mantle/traits/genesis.rs
@@ -6,7 +6,7 @@ use crate::mantle::{
 };
 
 /// A genesis transaction as specified in the
-/// [Spec](https://www.notion.so/nomos-tech/v1-1-Bedrock-Genesis-Block-32e261aa09df80689540ec445172b00d).
+/// [Spec](https://lip.logos.co/blockchain/raw/bedrock-genesis-block.html).
 pub trait GenesisTx: Hashable<Hash = TxHash> {
     fn genesis_transfer(&self) -> &TransferOp;
     fn genesis_inscription(&self) -> &InscriptionOp;

--- a/core/src/mantle/transactions/gas.rs
+++ b/core/src/mantle/transactions/gas.rs
@@ -4,7 +4,7 @@ use crate::mantle::gas::GasPrice;
 
 /// Initial storage gas price at genesis
 ///
-/// [Spec](https://www.notion.so/nomos-tech/v1-1-Storage-Markets-Specification-326261aa09df804ab483f573f522baf5?source=copy_link#326261aa09df804280b1fd5da1120a14):
+/// [Spec](https://lip.logos.co/blockchain/raw/storage-markets.html):
 /// `P_STR(0)` = 1 LGO/gas
 pub const GENESIS_STORAGE_GAS_PRICE: GasPrice = GasPrice::new(1);
 

--- a/core/src/mantle/transactions/mantle_tx.rs
+++ b/core/src/mantle/transactions/mantle_tx.rs
@@ -102,7 +102,7 @@ impl Hashable for MantleTx {
 
     fn as_signing(&self) -> Vec<u8> {
         // constant and structure as defined in the Mantle specification:
-        // https://www.notion.so/nomos-tech/v1-3-Mantle-Specification-31e261aa09df818f9327ee87e5a6d433#31e261aa09df80aea7cff4eb98d61b6e
+        // https://lip.logos.co/blockchain/raw/bedrock-v1.1-mantle-specification.html
         let mut buffer = MANTLE_TX_HASH_V1_BYTES.to_vec();
         buffer.extend(self.encode());
         buffer

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -498,9 +498,7 @@ impl DeclarationMessage {
         // declaration_id = Hash(service||provider_id||zk_id||locators)
         hasher.update(service.as_bytes());
         hasher.update(self.provider_id.0);
-        for number in self.zk_id.as_fr().0.0 {
-            hasher.update(number.to_le_bytes());
-        }
+        hasher.update(fr_to_bytes(self.zk_id.as_fr()));
         for locator in &self.locators {
             hasher.update(locator.0.as_ref());
         }

--- a/core/src/sdp/mod.rs
+++ b/core/src/sdp/mod.rs
@@ -11,6 +11,7 @@ use blake2::{Blake2b, Digest as _};
 use bytes::Bytes;
 use lb_blake2btree::LeafHash;
 use lb_cryptarchia_engine::Epoch;
+use lb_groth16::fr_to_bytes;
 use lb_key_management_system_keys::keys::ZkPublicKey;
 use lb_utils::bounded::{BoundedVec, NonEmptyBoundedVec, UpperBoundedVec};
 use multiaddr::{Multiaddr, Protocol};
@@ -494,7 +495,7 @@ impl DeclarationMessage {
         };
 
         // From the
-        // [spec](https://www.notion.so/nomos-tech/Service-Declaration-Protocol-Specification-1fd261aa09df819ca9f8eb2bdfd4ec1dw):
+        // [spec](https://lip.logos.co/blockchain/raw/bedrock-service-declaration-protocol.html#declaration-storage):
         // declaration_id = Hash(service||provider_id||zk_id||locators)
         hasher.update(service.as_bytes());
         hasher.update(self.provider_id.0);

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -489,7 +489,7 @@ impl LedgerState {
 
     fn update_nonce(self, contrib: &Fr, slot: Slot) -> Self {
         // constants and structure as defined in the Mantle spec:
-        // https://www.notion.so/Cryptarchia-v1-Protocol-Specification-21c261aa09df810cb85eff1c76e5798c
+        // https://lip.logos.co/blockchain/raw/cryptarchia-v1-protocol.html
         static EPOCH_NONCE_V1: LazyLock<Fr> =
             LazyLock::new(|| fr_from_bytes(b"EPOCH_NONCE_V1").unwrap());
         let mut hasher = ZkHasher::new();
@@ -688,7 +688,7 @@ impl LedgerState {
 
 // This function upgrade the storage Gas price when a new epoch starts assuming
 // the structure contains how much storage gas was consumed in the previous
-// epoch according to <https://www.notion.so/nomos-tech/v1-1-Storage-Markets-Specification-326261aa09df804ab483f573f522baf5>
+// epoch according to <https://lip.logos.co/blockchain/raw/storage-markets.html>
 fn update_storage_market(
     storage_gas_price: GasPrice,
     storage_gas_consumed_in_epoch: Gas,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -291,7 +291,7 @@ impl LedgerState {
 
     /// total estimated stake and on the average of fees consumed per block over
     /// the last `BLOCK_REWARD_WINDOW_SIZE` blocks. See the block rewards
-    /// specification: <https://www.notion.so/nomos-tech/v1-1-Block-Rewards-Specification-326261aa09df80579edddaf092057b3d>
+    /// specification: <https://lip.logos.co/blockchain/raw/block-rewards.html>
     fn compute_block_rewards(
         mut self,
         total_fee_burned: GasCost,
@@ -347,7 +347,7 @@ impl LedgerState {
     /// consumption are updated based on the total execution gas consumed in the
     /// block and the smoothed average consumption. This function updates the
     /// `average_execution_gas` and the `execution_base_fee` stored in the
-    /// cryptarchia ledger. See the specification <https://www.notion.so/nomos-tech/v1-2-Execution-Market-Specification-326261aa09df8022b1cfcfe968bdb5e1>
+    /// cryptarchia ledger. See the specification <https://lip.logos.co/blockchain/raw/execution-market.html>
     fn update_execution_market(self, block_execution_gas_consumed: Gas) -> Self {
         Self {
             cryptarchia_ledger: self

--- a/zk/proofs/pol/src/lottery.rs
+++ b/zk/proofs/pol/src/lottery.rs
@@ -8,7 +8,7 @@ use num_traits::{CheckedSub as _, Num as _};
 
 /// The BN254 scalar field order,
 ///
-/// The value is defined in [Proof of Leadership spec](https://nomos-tech.notion.site/v1-1-Proof-of-Leadership-Specification-2e9261aa09df80058244c902defc6da2#2e9261aa09df807abe78c815e7a31809)
+/// The value is defined in [Proof of Leadership spec](https://lip.logos.co/blockchain/raw/cryptarchia-proof-of-leadership.html)
 pub static P: LazyLock<BigUint> = LazyLock::new(|| {
     BigUint::from_str_radix(
         "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
@@ -37,7 +37,7 @@ impl LotteryConstants {
     /// Where `p` is the BN254 scalar field order and `f` is the slot activation
     /// coefficient.
     ///
-    /// The calculations are defined in the [Proof of Leadership spec](https://nomos-tech.notion.site/v1-1-Proof-of-Leadership-Specification-2e9261aa09df80058244c902defc6da2#2e9261aa09df807abe78c815e7a31809).
+    /// The calculations are defined in the [Proof of Leadership spec](https://lip.logos.co/blockchain/raw/cryptarchia-proof-of-leadership.html).
     #[expect(clippy::doc_markdown, reason = "math formulas")]
     #[must_use]
     pub fn new(f: NonNegativeRatio) -> Self {


### PR DESCRIPTION
## 1. What does this PR implement?

It fixes the declaration id computation. Previously it was using the Montgomery form of the Fr element and was hasing the 4 64-bits limbs one by one. The correct and expected behavior is to instead call the fr_to_bytes() method.
<img width="526" height="98" alt="image" src="https://github.com/user-attachments/assets/ffd0e120-ccda-460a-83ed-e6353c943682" />


It also updates all the old notion spec links to the new lip links.

## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@thomaslavaur 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?
No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
