### PR TITLE
test(cucumber): fees - cover tip headroom across price updates

### DIFF
--- a/tests/cucumber_tests/features/fees.feature
+++ b/tests/cucumber_tests/features/fees.feature
@@ -46,8 +46,11 @@ Feature: Fees
   # update and move its price at an epoch boundary. Together these guard the
   # consensus math and that the storage market remains connected to network
   # usage; price viability is covered by ledger market-liveness tests. With
-  # k=3 and f=1/2 below, each epoch is 60 slots long. Priority tips are not
-  # inputs to either price update, so the traffic transactions use zero tip.
+  # k=3 and f=1/2 below, each epoch is 60 slots long. The traffic transactions
+  # use zero tip because tips do not drive prices. A separate transaction is
+  # prepared with positive fee headroom before the storage-price update and
+  # submitted afterwards to show that it remains valid as the effective tip
+  # absorbs the higher mandatory fee.
   @fees_ci
   Scenario: Execution and storage gas prices respond according to the fee market rules
     Given the cluster uses cryptarchia security parameter 3
@@ -58,12 +61,15 @@ Feature: Fees
       | account_index | token_count | token_amount |
       | 1             | 1           | 10000        |
       | 2             | 1           | 10000        |
+      | 3             | 1           | 10000        |
     And I have a cluster with capacity of 1 nodes
     And I start nodes with wallet resources:
       | node_name | account_index | wallet_name | connected_to |
       | NODE_1    | 1             | WALLET_1A   |              |
       | NODE_1    | 2             | WALLET_2A   |              |
+      | NODE_1    | 3             | WALLET_3A   |              |
     When node "NODE_1" is at height 1 in 180 seconds
+    And I prepare a self-transfer with a 1000 LGO tip from wallet "WALLET_3A" via node "NODE_1" as "BUFFERED"
     And I submit an exactly funded self-transfer from wallet "WALLET_1A" via node "NODE_1" as "TRAFFIC_A"
     And I submit an exactly funded self-transfer from wallet "WALLET_2A" via node "NODE_1" as "TRAFFIC_B"
     And I record per-block gas prices on node "NODE_1" for 125 slots in 300 seconds
@@ -72,6 +78,9 @@ Feature: Fees
     And recorded gas prices cross a 60-slot epoch boundary
     And recorded execution gas prices follow the execution market spec reference
     And recorded storage gas prices respond to network usage
+    And transaction "BUFFERED" prepared with a 1000 LGO tip remains funded with a smaller tip at current prices on node "NODE_1"
+    When I submit prepared transaction "BUFFERED" via node "NODE_1"
+    Then transaction "BUFFERED" is included on node "NODE_1" in 60 seconds
     Then I stop all nodes
 
   # The fee rule at its exact boundary: balance == fee is included and

--- a/tests/src/common/fee_spec.rs
+++ b/tests/src/common/fee_spec.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use lb_common_http_client::ApiBlock;
 use lb_core::mantle::{
     Note, Op, SignedMantleTx, Utxo,
-    gas::MainnetGasConstants,
+    gas::{GasCalculator as _, MainnetGasConstants},
     traits::Hashable as _,
     transactions::{
         GasPrices, MantleTxBuilder, MantleTxContext, MantleTxGasContext,
@@ -265,4 +265,26 @@ pub fn net_balance_against<State: VerificationState>(
         }
     }
     Ok(input_sum - output_sum)
+}
+
+/// Surplus balance left after charging a transaction at `prices`.
+///
+/// A non-negative value means the transaction remains funded; the surplus is
+/// its effective tip at those prices.
+///
+/// # Errors
+///
+/// Returns an error when the transaction's balance or gas cost cannot be
+/// calculated.
+pub fn fee_surplus_at<State: VerificationState>(
+    genesis_utxos: &[Utxo],
+    tx: &SignedMantleTx<State>,
+    prices: &GasPrices,
+) -> Result<i128, String> {
+    let paid = net_balance_against(genesis_utxos, tx)?;
+    let required = tx
+        .total_gas_cost::<MainnetGasConstants>(prices)
+        .map_err(|source| format!("transaction gas cost calculation failed: {source}"))?;
+
+    Ok(i128::from(paid) - i128::from(required.into_inner()))
 }

--- a/tests/src/cucumber/steps/fees/actions.rs
+++ b/tests/src/cucumber/steps/fees/actions.rs
@@ -28,9 +28,9 @@ use crate::{
 };
 
 /// Builds a self-transfer whose balance is the mandatory fee plus `tip` at
-/// the live gas prices, checks the size predictor against the actual
-/// encoding, submits it, and records it under the alias.
-pub async fn submit_self_transfer_with_tip(
+/// the live gas prices, checks the size predictor against the actual encoding,
+/// and records it for later submission.
+pub async fn prepare_self_transfer_with_tip(
     world: &mut CucumberWorld,
     step: &Step,
     wallet_name: &str,
@@ -51,6 +51,29 @@ pub async fn submit_self_transfer_with_tip(
         }
     })?;
 
+    info!(
+        target: TARGET,
+        "Prepared self-transfer `{transaction_alias}` ({:?}) from wallet \
+         '{wallet_name}' with tip {tip} at prices execution={:?} storage={:?}",
+        signed_tx.hash(),
+        prices.execution_base_gas_price, prices.storage_gas_price,
+    );
+
+    world.remember_prepared_transaction(transaction_alias, signed_tx);
+
+    Ok(())
+}
+
+/// Submits a previously prepared transaction and records its hash under the
+/// same alias.
+pub async fn submit_prepared_transaction(
+    world: &mut CucumberWorld,
+    step: &Step,
+    node_name: &str,
+    transaction_alias: &str,
+) -> StepResult {
+    let client = world.resolve_node_http_client(node_name)?;
+    let signed_tx = world.resolve_prepared_transaction(transaction_alias)?;
     let tx_hash = signed_tx.hash();
 
     client
@@ -65,15 +88,35 @@ pub async fn submit_self_transfer_with_tip(
 
     info!(
         target: TARGET,
-        "Submitted self-transfer `{transaction_alias}` ({tx_hash:?}) from wallet \
-         '{wallet_name}' with tip {tip} at prices execution={:?} storage={:?}",
-        prices.execution_base_gas_price, prices.storage_gas_price,
+        "Submitted prepared transaction `{transaction_alias}` ({tx_hash:?}) via node \
+         '{node_name}'",
     );
 
-    world.remember_submitted_transaction(transaction_alias.clone(), tx_hash);
-    world.remember_prepared_transaction(transaction_alias, signed_tx);
+    world.remember_submitted_transaction(transaction_alias.to_owned(), tx_hash);
 
     Ok(())
+}
+
+/// Prepares and immediately submits a self-transfer at the live gas prices.
+pub async fn submit_self_transfer_with_tip(
+    world: &mut CucumberWorld,
+    step: &Step,
+    wallet_name: &str,
+    node_name: &str,
+    transaction_alias: String,
+    tip: i128,
+) -> StepResult {
+    prepare_self_transfer_with_tip(
+        world,
+        step,
+        wallet_name,
+        node_name,
+        transaction_alias.clone(),
+        tip,
+    )
+    .await?;
+
+    submit_prepared_transaction(world, step, node_name, &transaction_alias).await
 }
 
 /// Records the gas prices after every block into the world, for the

--- a/tests/src/cucumber/steps/fees/assertions.rs
+++ b/tests/src/cucumber/steps/fees/assertions.rs
@@ -124,6 +124,45 @@ pub async fn wallet_debited_exactly_fee(
     })
 }
 
+/// Checks that a prepared transaction remains funded with a smaller tip.
+///
+/// This proves that a fee increase consumed some of its original headroom
+/// without invalidating it.
+pub async fn prepared_transaction_tip_absorbed_fee_increase(
+    world: &CucumberWorld,
+    step: &Step,
+    transaction_alias: &str,
+    original_tip: u64,
+    node_name: &str,
+) -> StepResult {
+    let signed_tx = world.resolve_prepared_transaction(transaction_alias)?;
+    let client = world.resolve_node_http_client(node_name)?;
+    let prices = actions::live_gas_prices(&client, step).await?;
+    let remaining_tip = fee_spec::fee_surplus_at(&world.genesis_block_utxos, &signed_tx, &prices)
+        .map_err(|message| StepError::StepFail {
+        message: format!("Step `{}` error: {message}", step.value),
+    })?;
+
+    if !(0 < remaining_tip && remaining_tip < i128::from(original_tip)) {
+        return Err(StepError::StepFail {
+            message: format!(
+                "Step `{}` error: transaction `{transaction_alias}` was prepared with tip \
+                 {original_tip}, but its effective tip at current prices is {remaining_tip}; \
+                 expected the fee increase to consume part, but not all, of the original tip",
+                step.value
+            ),
+        });
+    }
+
+    info!(
+        target: TARGET,
+        "Transaction `{transaction_alias}` remains funded after its effective tip fell from \
+         {original_tip} to {remaining_tip}",
+    );
+
+    Ok(())
+}
+
 /// Replays the recorded prices through the spec's price calculation and
 /// checks the node reported the same price after every block.
 pub fn execution_prices_follow_spec_reference(world: &CucumberWorld, step: &Step) -> StepResult {

--- a/tests/src/cucumber/steps/fees/steps.rs
+++ b/tests/src/cucumber/steps/fees/steps.rs
@@ -175,6 +175,64 @@ async fn step_submit_underfunded_self_transfer(
     .await
 }
 
+#[when(
+    expr = "I prepare a self-transfer with a {int} LGO tip from wallet {string} via node \
+            {string} as {string}"
+)]
+async fn step_prepare_self_transfer_with_tip(
+    world: &mut CucumberWorld,
+    step: &Step,
+    tip: u64,
+    wallet_name: String,
+    node_name: String,
+    transaction_alias: String,
+) -> StepResult {
+    actions::prepare_self_transfer_with_tip(
+        world,
+        step,
+        &wallet_name,
+        &node_name,
+        transaction_alias,
+        i128::from(tip),
+    )
+    .await
+}
+
+#[when(expr = "I submit prepared transaction {string} via node {string}")]
+async fn step_submit_prepared_transaction(
+    world: &mut CucumberWorld,
+    step: &Step,
+    transaction_alias: String,
+    node_name: String,
+) -> StepResult {
+    actions::submit_prepared_transaction(world, step, &node_name, &transaction_alias).await
+}
+
+#[then(
+    expr = "transaction {string} prepared with a {int} LGO tip remains funded with a smaller \
+            tip at current prices on node {string}"
+)]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber step entrypoints must take `&mut World`"
+)]
+async fn step_prepared_transaction_tip_absorbed_fee_increase(
+    world: &mut CucumberWorld,
+    step: &Step,
+    transaction_alias: String,
+    original_tip: u64,
+    node_name: String,
+) -> StepResult {
+    assertions::prepared_transaction_tip_absorbed_fee_increase(
+        world,
+        step,
+        &transaction_alias,
+        original_tip,
+        &node_name,
+    )
+    .await
+}
+
 #[then(
     expr = "wallet {string} is debited exactly the fee of transaction {string} in {int} seconds"
 )]


### PR DESCRIPTION
## 1. What does this PR implement?

Adds coverage showing that transaction tips provide enough fee headroom for transactions to remain valid when gas prices increase before inclusion.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@andrussal 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
