### PR TITLE
feat(operation): Proof trait

### DIFF
--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -12,7 +12,10 @@ use crate::{
     mantle::{
         Note, Op, OpProof, SignedMantleTx,
         ledger::{BoundedOutputs, Inputs, Outputs},
-        ops::{channel::inscribe::InscriptionOp, sdp::SDPDeclareOp, transfer::TransferOp},
+        ops::{
+            ZkAndEd25519Proof, channel::inscribe::InscriptionOp, sdp::SDPDeclareOp,
+            transfer::TransferOp,
+        },
         transactions::{
             GenesisTx, MAX_OPS_PER_TX, Ops, OpsProofs, VerificationError, genesis_tx,
             mantle_tx::RawMantleTx,
@@ -1243,11 +1246,12 @@ impl GenesisBlockBuilder<WithAll> {
             OpProof::Ed25519Sig(Ed25519Signature::zero()),
         ]);
         for _ in 0..n - 2 {
+            let proof = ZkAndEd25519Proof {
+                zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+                ed25519_sig: Ed25519Signature::zero(),
+            };
             ops_proofs
-                .try_push(OpProof::ZkAndEd25519Sigs {
-                    zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
-                    ed25519_sig: Ed25519Signature::zero(),
-                })
+                .try_push(OpProof::ZkAndEd25519Sigs(proof))
                 .expect("genesis transaction proofs are bounded");
         }
         let signed_tx = SignedMantleTx::new_trusted(RawMantleTx(capped_ops), ops_proofs);
@@ -1359,10 +1363,13 @@ mod tests {
             Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
                 CompressedGroth16Proof::from_bytes(&[0u8; 128]),
             )),
-            Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
-                zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
-                ed25519_sig: Ed25519Signature::zero(),
-            },
+            Op::SDPDeclare(_) => {
+                let proof = ZkAndEd25519Proof {
+                    zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+                    ed25519_sig: Ed25519Signature::zero(),
+                };
+                OpProof::ZkAndEd25519Sigs(proof)
+            }
             other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
         }))
         .expect("genesis transaction proofs are bounded");

--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -49,15 +49,29 @@ pub mod verification_mode {
     impl VerificationMode for StandardMode {}
 }
 
+pub trait ProvableOperation {
+    type Proof;
+}
+
 // TODO: Specific proof type check?
-pub trait VerifiableOperation<Mode: verification_mode::VerificationMode> {
+pub trait VerifiableOperation<Mode: verification_mode::VerificationMode>:
+    ProvableOperation
+{
     type PreverificationContext<'a>;
     type VerificationContext<'a>;
     type Error;
 
-    fn preverify(&self, context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error>;
+    fn preverify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error>;
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error>;
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error>;
 }
 
 pub trait ExecutableOperation {

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -7,8 +7,8 @@ use crate::{
         TxHash,
         channel::{Channels, Error},
         ledger::{
-            ExecutableOperation, Inputs, Outputs, Utxo, Utxos, VerifiableOperation,
-            verification_mode,
+            ExecutableOperation, Inputs, Outputs, ProvableOperation, Utxo, Utxos,
+            VerifiableOperation, verification_mode,
         },
         ops::{
             OpId,
@@ -45,7 +45,6 @@ pub struct ChannelTransferValidationContext<'a> {
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ChannelMultiSigProof,
     pub op_index: usize,
     pub helper: &'a dyn OperationVerificationHelper,
 }
@@ -56,22 +55,34 @@ pub struct ChannelTransferExecutionContext {
     pub tx_hash: TxHash,
 }
 
+impl ProvableOperation for ChannelTransferOp {
+    type Proof = ChannelMultiSigProof;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {
     type PreverificationContext<'a> = ();
     type VerificationContext<'a> = ChannelTransferValidationContext<'a>;
     type Error = Error;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the outputs are valid
         self.outputs.validate()?;
 
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         verify_channel_multi_sig(
             &self.channel_id,
-            context.proof,
+            proof,
             context.tx_hash_view.as_bytes(),
             context.helper,
             context.op_index,
@@ -103,7 +114,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp 
         }
 
         // Check there is enough signatures
-        let signatures = context.proof.signatures();
+        let signatures = proof.signatures();
         if signatures.len() != channel.transfer_threshold as usize {
             return Err(Error::ThresholdUnmet {
                 channel_id: self.channel_id,

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -9,7 +9,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
-        ledger::{ExecutableOperation, VerifiableOperation, verification_mode},
+        ledger::{ExecutableOperation, ProvableOperation, VerifiableOperation, verification_mode},
         transactions::hash::TxHashView,
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
@@ -40,7 +40,6 @@ impl ChannelConfigOp {
 pub struct ChannelConfigValidationContext<'a> {
     pub channels: &'a Channels,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ChannelMultiSigProof,
 }
 
 pub struct ChannelConfigExecutionContext {
@@ -48,12 +47,20 @@ pub struct ChannelConfigExecutionContext {
     pub block_slot: Slot,
 }
 
+impl ProvableOperation for ChannelConfigOp {
+    type Proof = ChannelMultiSigProof;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
     type PreverificationContext<'a> = ();
     type VerificationContext<'a> = ChannelConfigValidationContext<'a>;
     type Error = Error;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check config is well-formed
         if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
         {
@@ -63,18 +70,22 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the indexes are unique and there is the same number of proof and
         // index. This is enforced by the proof structure that enforces it.
 
         if let Some(channel) = context.channels.channel_state(&self.channel) {
             // Check there is enough signatures
-            let signatures = context.proof.signatures();
+            let signatures = proof.signatures();
             if signatures.len() != channel.configuration_threshold as usize {
                 return Err(Error::ThresholdUnmet {
                     channel_id: self.channel,
                     threshold: channel.configuration_threshold,
-                    actual: context.proof.signatures().len(),
+                    actual: proof.signatures().len(),
                 });
             }
 

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -8,8 +8,8 @@ use crate::{
     mantle::{
         channel::{Channels, Error},
         ledger::{
-            ExecutableOperation, Inputs, InputsError, Outputs, Utxos, VerifiableOperation,
-            verification_mode,
+            ExecutableOperation, Inputs, InputsError, Outputs, ProvableOperation, Utxos,
+            VerifiableOperation, verification_mode,
         },
         ops::{OpId, channel::ChannelId},
         transactions::hash::{TxHash, TxHashView},
@@ -56,7 +56,6 @@ pub struct DepositValidationContext<'a> {
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ZkSignature,
 }
 
 pub struct DepositExecutionContext {
@@ -65,16 +64,28 @@ pub struct DepositExecutionContext {
     pub tx_hash: TxHash,
 }
 
+impl ProvableOperation for DepositOp {
+    type Proof = ZkSignature;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
     type PreverificationContext<'a> = ();
     type VerificationContext<'a> = DepositValidationContext<'a>;
     type Error = Error;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the channel exist
         if !context.channels.contains_channel(&self.channel_id) {
             return Err(Error::ChannelNotFound {
@@ -91,7 +102,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
 
         // Check the signature
         let public_keys = self.inputs.get_pk(context.utxos)?;
-        if !ZkPublicKey::verify_multi(&public_keys, context.tx_hash_view.as_fr(), context.proof) {
+        if !ZkPublicKey::verify_multi(&public_keys, context.tx_hash_view.as_fr(), proof) {
             return Err(Error::InvalidSignature);
         }
 

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -13,7 +13,7 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error},
-        ledger::{ExecutableOperation, VerifiableOperation, verification_mode},
+        ledger::{ExecutableOperation, ProvableOperation, VerifiableOperation, verification_mode},
         ops::channel::config::Keys,
         transactions::hash::TxHashView,
     },
@@ -47,7 +47,6 @@ impl InscriptionOp {
 
 pub struct InscriptionPreverificationContext<'a> {
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a Ed25519Signature,
 }
 
 pub struct InscriptionValidationContext<'a> {
@@ -60,21 +59,33 @@ pub struct InscriptionExecutionContext {
     pub block_slot: Slot,
 }
 
+impl ProvableOperation for InscriptionOp {
+    type Proof = Ed25519Signature;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
     type PreverificationContext<'a> = InscriptionPreverificationContext<'a>;
     type VerificationContext<'a> = InscriptionValidationContext<'a>;
     type Error = Error;
 
-    fn preverify(&self, context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check the signature
         self.signer
-            .verify(context.tx_hash_view.as_bytes(), context.proof)
+            .verify(context.tx_hash_view.as_bytes(), proof)
             .map_err(|_error| Error::InvalidSignature)?;
 
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        _proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check if the channel exist otherwise the inscription is valid only if and
         // only if parent == ZERO
         if let Some(channel) = context.channels.channel_state(&self.channel_id) {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -6,7 +6,10 @@ use crate::{
     mantle::{
         TxHash,
         channel::{Channels, Error},
-        ledger::{ExecutableOperation, Inputs, Utxos, VerifiableOperation, verification_mode},
+        ledger::{
+            ExecutableOperation, Inputs, ProvableOperation, Utxos, VerifiableOperation,
+            verification_mode,
+        },
         ops::{
             OpId,
             channel::{ChannelId, verification::verify_channel_multi_sig},
@@ -35,7 +38,6 @@ pub struct WithdrawValidationContext<'a> {
     pub locked_notes: &'a LockedNotes,
     pub utxos: &'a Utxos,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ChannelMultiSigProof,
     pub op_index: usize,
     pub helper: &'a dyn OperationVerificationHelper,
 }
@@ -45,19 +47,31 @@ pub struct WithdrawExecutionContext {
     pub tx_hash: TxHash,
 }
 
+impl ProvableOperation for ChannelWithdrawOp {
+    type Proof = ChannelMultiSigProof;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {
     type PreverificationContext<'a> = ();
     type VerificationContext<'a> = WithdrawValidationContext<'a>;
     type Error = Error;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         verify_channel_multi_sig(
             &self.channel_id,
-            context.proof,
+            proof,
             context.tx_hash_view.as_bytes(),
             context.helper,
             context.op_index,
@@ -82,7 +96,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp 
         )?;
 
         // Check there is enough signatures
-        let signatures = context.proof.signatures();
+        let signatures = proof.signatures();
         if signatures.len() != channel.transfer_threshold as usize {
             return Err(Error::ThresholdUnmet {
                 channel_id: self.channel_id,

--- a/core/src/mantle/ops/codec.rs
+++ b/core/src/mantle/ops/codec.rs
@@ -2,7 +2,7 @@ use lb_codec::{BinaryDecodeExt as _, BinaryEncode as _, DecodeError};
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
 
 use crate::{
-    mantle::{Op, OpProof, transactions::OpsProofs},
+    mantle::{Op, OpProof, ops::ZkAndEd25519Proof, transactions::OpsProofs},
     proofs::{
         channel_multi_sig_proof::ChannelMultiSigProof, leader_claim_proof::Groth16LeaderClaimProof,
     },
@@ -38,13 +38,11 @@ fn decode_op_proof<'a>(input: &'a [u8], op: &Op) -> Result<(&'a [u8], OpProof), 
         Op::SDPDeclare(_) => {
             let (input, zk_sig) = ZkSignature::decode(input)?;
             let (input, ed25519_sig) = Ed25519Signature::decode(input)?;
-            Ok((
-                input,
-                OpProof::ZkAndEd25519Sigs {
-                    zk_sig,
-                    ed25519_sig,
-                },
-            ))
+            let proof = ZkAndEd25519Proof {
+                zk_sig,
+                ed25519_sig,
+            };
+            Ok((input, OpProof::ZkAndEd25519Sigs(proof)))
         }
 
         // ZkSigProof = ZkSignature
@@ -70,12 +68,9 @@ fn encode_op_proof(proof: &OpProof, op: &Op) -> Vec<u8> {
         match proof {
             OpProof::Ed25519Sig(sig) => sig.encode_to_vec(),
             OpProof::ChannelMultiSigProof(proof) => proof.encode_to_vec(),
-            OpProof::ZkAndEd25519Sigs {
-                zk_sig,
-                ed25519_sig,
-            } => {
-                let mut bytes = zk_sig.encode_to_vec();
-                bytes.extend(ed25519_sig.encode_to_vec());
+            OpProof::ZkAndEd25519Sigs(proof) => {
+                let mut bytes = proof.zk_sig.encode_to_vec();
+                bytes.extend(proof.ed25519_sig.encode_to_vec());
                 bytes
             }
             OpProof::ZkSig(sig) => sig.encode_to_vec(),

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -13,7 +13,9 @@ use crate::{
     events::{TxEvent, TxEventPayload},
     mantle::{
         Note, Utxo, Value,
-        ledger::{ExecutableOperation, Utxos, VerifiableOperation, verification_mode},
+        ledger::{
+            ExecutableOperation, ProvableOperation, Utxos, VerifiableOperation, verification_mode,
+        },
         ops::OpId,
         transactions::hash::{TxHash, TxHashView},
     },
@@ -174,13 +176,11 @@ pub enum LeaderClaimError {
 
 pub struct LeaderClaimPreverificationContext<'a> {
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a Groth16LeaderClaimProof,
 }
 
 pub struct LeaderClaimVerificationContext<'a> {
     pub nullifiers: &'a VoucherNullifiers,
     pub claimable_vouchers_root: &'a RewardsRoot,
-    pub proof: &'a Groth16LeaderClaimProof,
     pub tx_hash_view: &'a TxHashView,
 }
 
@@ -192,13 +192,21 @@ pub struct LeaderClaimExecutionContext {
     pub tx_hash: TxHash,
 }
 
+impl ProvableOperation for LeaderClaimOp {
+    type Proof = Groth16LeaderClaimProof;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
     type PreverificationContext<'a> = LeaderClaimPreverificationContext<'a>;
     type VerificationContext<'a> = LeaderClaimVerificationContext<'a>;
     type Error = LeaderClaimError;
 
-    fn preverify(&self, context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
-        let is_verified = context.proof.verify(&LeaderClaimPublic {
+    fn preverify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
+        let is_verified = proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: self.rewards_root.into(),
             mantle_tx_hash: *context.tx_hash_view.as_fr(),
@@ -211,7 +219,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
         }
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the nullifier isn't in the set
         if context.nullifiers.contains(&self.voucher_nullifier) {
             return Err(LeaderClaimError::DuplicatedVoucherNullifier);
@@ -223,7 +235,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
         }
 
         // Check the proof of claim
-        if !context.proof.verify(&LeaderClaimPublic {
+        if !proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
             voucher_root: context.claimable_vouchers_root.0,
             mantle_tx_hash: *context.tx_hash_view.as_fr(),
@@ -307,11 +319,10 @@ mod tests {
         let context = LeaderClaimVerificationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
-            proof: &proof,
             tx_hash_view: &tx_hash_view,
         };
 
-        assert_eq!(op.verify(&context), Ok(()));
+        assert_eq!(op.verify(&proof, &context), Ok(()));
     }
 
     #[test]
@@ -408,14 +419,16 @@ mod tests {
         let context = LeaderClaimVerificationContext {
             nullifiers: &nullifiers,
             claimable_vouchers_root: &voucher_root,
-            proof: &proof,
             tx_hash_view: &tx_hash_view,
         };
 
         // The proof is verified against `op.voucher_nullifier`, which does not
         // match the proven voucher -> rejected. A voucher cannot be claimed under
         // a substituted nullifier.
-        assert_eq!(op.verify(&context), Err(LeaderClaimError::InvalidPoC));
+        assert_eq!(
+            op.verify(&proof, &context),
+            Err(LeaderClaimError::InvalidPoC)
+        );
     }
 
     fn nullifier(secret: u64) -> VoucherNullifier {

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -247,13 +247,16 @@ impl Op {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkAndEd25519Proof {
+    pub zk_sig: ZkSignature,
+    pub ed25519_sig: Ed25519Signature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OpProof {
     Ed25519Sig(Ed25519Signature),
     ZkSig(ZkSignature),
-    ZkAndEd25519Sigs {
-        zk_sig: ZkSignature,
-        ed25519_sig: Ed25519Signature,
-    },
+    ZkAndEd25519Sigs(ZkAndEd25519Proof),
     PoC(Groth16LeaderClaimProof),
     ChannelMultiSigProof(ChannelMultiSigProof),
 }

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -7,7 +7,10 @@ use super::{SDPActiveOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        ledger::{Declarations, ExecutableOperation, VerifiableOperation, verification_mode},
+        ledger::{
+            Declarations, ExecutableOperation, ProvableOperation, VerifiableOperation,
+            verification_mode,
+        },
         transactions::hash::TxHashView,
     },
 };
@@ -17,7 +20,6 @@ const LOG_TARGET: &str = mantle::sdp::message::ACTIVE;
 pub struct SDPActiveValidationContext<'a> {
     pub declarations: &'a Declarations,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ZkSignature,
     pub epoch: Epoch,
 }
 
@@ -26,16 +28,28 @@ pub struct SDPActiveExecutionContext {
     pub declarations: Declarations,
 }
 
+impl ProvableOperation for SDPActiveOp {
+    type Proof = ZkSignature;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
     type PreverificationContext<'a> = ();
     type VerificationContext<'a> = SDPActiveValidationContext<'a>;
     type Error = SdpError;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check the declaration exists
         let Some(declaration) = context.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
@@ -61,11 +75,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
         }
 
         // Check the signature over the `zk_id`
-        if !ZkPublicKey::verify_multi(
-            &[declaration.zk_id],
-            context.tx_hash_view.as_fr(),
-            context.proof,
-        ) {
+        if !ZkPublicKey::verify_multi(&[declaration.zk_id], context.tx_hash_view.as_fr(), proof) {
             return Err(SdpError::InvalidZkSignature);
         }
 

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -1,5 +1,5 @@
 use lb_cryptarchia_engine::Epoch;
-use lb_key_management_system_keys::keys::{Ed25519Signature, ZkPublicKey, ZkSignature};
+use lb_key_management_system_keys::keys::ZkPublicKey;
 
 use super::{SDPDeclareOp, SdpError};
 use crate::{
@@ -8,8 +8,10 @@ use crate::{
         Note,
         channel::Channels,
         ledger::{
-            Declarations, ExecutableOperation, Utxos, VerifiableOperation, verification_mode,
+            Declarations, ExecutableOperation, ProvableOperation, Utxos, VerifiableOperation,
+            verification_mode,
         },
+        ops::ZkAndEd25519Proof,
         transactions::hash::TxHashView,
     },
     sdp::{Declaration, MinStake, locked_notes::LockedNotes},
@@ -127,7 +129,6 @@ fn validate_service_scoped_uniqueness(
 
 pub struct SDPDeclarePreverificationContext<'a> {
     pub tx_hash_view: &'a TxHashView,
-    pub proof_ed25519: &'a Ed25519Signature,
 }
 
 pub struct SDPDeclareVerificationContext<'a> {
@@ -135,8 +136,6 @@ pub struct SDPDeclareVerificationContext<'a> {
     pub channels: &'a Channels,
     pub locked_notes: &'a LockedNotes,
     pub tx_hash_view: &'a TxHashView,
-    pub proof_zk_signature: &'a ZkSignature,
-    pub proof_ed25519_signature: &'a Ed25519Signature,
     pub declarations: &'a Declarations,
     pub min_stake: &'a MinStake,
 }
@@ -157,16 +156,28 @@ pub struct SDPDeclareExecutionContext {
     pub min_stake: MinStake,
 }
 
+impl ProvableOperation for SDPDeclareOp {
+    type Proof = ZkAndEd25519Proof;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
     type PreverificationContext<'a> = SDPDeclarePreverificationContext<'a>;
     type VerificationContext<'a> = SDPDeclareVerificationContext<'a>;
     type Error = SdpError;
 
-    fn preverify(&self, context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
-        self.preverify(context.tx_hash_view, context.proof_ed25519)
+    fn preverify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
+        self.preverify(context.tx_hash_view, &proof.ed25519_sig)
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the note exist
         let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));
@@ -177,7 +188,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
         if !ZkPublicKey::verify_multi(
             &[note.pk, self.zk_id],
             context.tx_hash_view.as_fr(),
-            context.proof_zk_signature,
+            &proof.zk_sig,
         ) {
             return Err(SdpError::InvalidZkSignature);
         }
@@ -198,11 +209,19 @@ impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
     type VerificationContext<'a> = SDPDeclareGenesisValidationContext<'a>;
     type Error = SdpError;
 
-    fn preverify(&self, context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
-        self.preverify(context.tx_hash_view, context.proof_ed25519)
+    fn preverify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
+        self.preverify(context.tx_hash_view, &proof.ed25519_sig)
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        _proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the note exist
         let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -7,7 +7,10 @@ use super::{SDPWithdrawOp, SdpError};
 use crate::{
     events::TxEvent,
     mantle::{
-        ledger::{Declarations, ExecutableOperation, VerifiableOperation, verification_mode},
+        ledger::{
+            Declarations, ExecutableOperation, ProvableOperation, VerifiableOperation,
+            verification_mode,
+        },
         transactions::hash::TxHashView,
     },
     sdp::{self, locked_notes::LockedNotes},
@@ -20,7 +23,6 @@ pub struct SDPWithdrawValidationContext<'a> {
     pub epoch: Epoch,
     pub locked_notes: &'a LockedNotes,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ZkSignature,
 }
 
 pub struct SDPWithdrawExecutionContext {
@@ -29,16 +31,28 @@ pub struct SDPWithdrawExecutionContext {
     pub epoch: Epoch,
 }
 
+impl ProvableOperation for SDPWithdrawOp {
+    type Proof = ZkSignature;
+}
+
 impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
     type PreverificationContext<'a> = ();
     type VerificationContext<'a> = SDPWithdrawValidationContext<'a>;
     type Error = SdpError;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Check that the declaration exists
         let Some(declaration) = context.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));
@@ -81,7 +95,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
         if !ZkPublicKey::verify_multi(
             &[note.pk, declaration.zk_id],
             context.tx_hash_view.as_fr(),
-            context.proof,
+            proof,
         ) {
             return Err(SdpError::InvalidZkSignature);
         }

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -8,8 +8,8 @@ use crate::{
     mantle::{
         channel::Channels,
         ledger::{
-            self, ExecutableOperation, Inputs, Outputs, Utxo, Utxos, VerifiableOperation,
-            verification_mode,
+            self, ExecutableOperation, Inputs, Outputs, ProvableOperation, Utxo, Utxos,
+            VerifiableOperation, verification_mode,
         },
         ops::OpId,
         transactions::hash::TxHashView,
@@ -82,7 +82,10 @@ pub struct TransferValidationContext<'a> {
     pub channels: &'a Channels,
     pub utxos: &'a Utxos,
     pub tx_hash_view: &'a TxHashView,
-    pub proof: &'a ZkSignature,
+}
+
+impl ProvableOperation for TransferOp {
+    type Proof = ZkSignature;
 }
 
 impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
@@ -90,7 +93,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
     type VerificationContext<'a> = TransferValidationContext<'a>;
     type Error = TransferError;
 
-    fn preverify(&self, _context: &Self::PreverificationContext<'_>) -> Result<(), Self::Error> {
+    fn preverify(
+        &self,
+        _proof: &Self::Proof,
+        _context: &Self::PreverificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Ensure the inputs is non-empty
         if self.inputs.is_empty() {
             return Err(TransferError::NoInputTransfer);
@@ -102,7 +109,11 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
         Ok(())
     }
 
-    fn verify(&self, context: &Self::VerificationContext<'_>) -> Result<(), Self::Error> {
+    fn verify(
+        &self,
+        proof: &Self::Proof,
+        context: &Self::VerificationContext<'_>,
+    ) -> Result<(), Self::Error> {
         // Validate Inputs
         self.inputs.validate_not_in_channel(
             context.locked_notes,
@@ -112,7 +123,7 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
 
         // Check the transfer Proof
         let pks = self.inputs.get_pk(context.utxos)?;
-        if !ZkPublicKey::verify_multi(&pks, context.tx_hash_view.as_fr(), context.proof) {
+        if !ZkPublicKey::verify_multi(&pks, context.tx_hash_view.as_fr(), proof) {
             return Err(TransferError::InvalidProof);
         }
 

--- a/core/src/mantle/transactions/codec.rs
+++ b/core/src/mantle/transactions/codec.rs
@@ -117,6 +117,7 @@ mod tests {
             Note, NoteId, OpProof, Utxo,
             ledger::{BoundedInputs, BoundedOutputs, Inputs, Outputs},
             ops::{
+                ZkAndEd25519Proof,
                 channel::{
                     ChannelId, MsgId,
                     config::{ChannelConfigOp, Keys},
@@ -524,14 +525,11 @@ mod tests {
 
         // Create a signed tx and encode it to get actual size
         let tx_hash = mantle_tx.hash();
-        let signed_tx = SignedMantleTx::new(
-            mantle_tx,
-            [OpProof::ZkAndEd25519Sigs {
-                zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &tx_hash.to_fr()).unwrap(),
-                ed25519_sig: Ed25519Signature::from_bytes(&[0u8; 64]),
-            }]
-            .into(),
-        );
+        let proof = ZkAndEd25519Proof {
+            zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &tx_hash.to_fr()).unwrap(),
+            ed25519_sig: Ed25519Signature::from_bytes(&[0u8; 64]),
+        };
+        let signed_tx = SignedMantleTx::new(mantle_tx, [OpProof::ZkAndEd25519Sigs(proof)].into());
         let encoded = encode_signed_mantle_tx(&signed_tx);
         let actual_size = encoded.len();
 
@@ -767,15 +765,16 @@ mod tests {
         let tx_hash = mantle_tx.hash();
         let op_ed25519_sig = signing_key1.sign_payload(&tx_hash.as_signing_bytes());
         let config_proof = ChannelMultiSigProof::try_new([].into()).unwrap();
+        let zk_and_ed25519_proof = ZkAndEd25519Proof {
+            zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &tx_hash.to_fr()).unwrap(),
+            ed25519_sig: op_ed25519_sig,
+        };
         let signed_tx = SignedMantleTx::new(
             mantle_tx,
             [
                 OpProof::Ed25519Sig(op_ed25519_sig),
                 OpProof::ChannelMultiSigProof(config_proof),
-                OpProof::ZkAndEd25519Sigs {
-                    zk_sig: ZkKey::multi_sign(&[locked_note_sk, zk_sk], &tx_hash.to_fr()).unwrap(),
-                    ed25519_sig: op_ed25519_sig,
-                },
+                OpProof::ZkAndEd25519Sigs(zk_and_ed25519_proof),
                 OpProof::ZkSig(ZkKey::multi_sign(&[], &Fr::ZERO).unwrap()),
             ]
             .into(),

--- a/core/src/mantle/transactions/genesis_tx.rs
+++ b/core/src/mantle/transactions/genesis_tx.rs
@@ -402,7 +402,10 @@ mod tests {
     use crate::{
         mantle::{
             ledger::{Inputs, Note, Outputs, Utxo, Value},
-            ops::channel::{Ed25519PublicKey, inscribe::Inscription},
+            ops::{
+                ZkAndEd25519Proof,
+                channel::{Ed25519PublicKey, inscribe::Inscription},
+            },
             transactions::{Ops, OpsProofs},
         },
         sdp::{Locator, ProviderId, ServiceType},
@@ -456,10 +459,13 @@ mod tests {
             Op::Transfer(_) => OpProof::ZkSig(ZkSignature::new(
                 CompressedGroth16Proof::from_bytes(&[0u8; 128]),
             )),
-            Op::SDPDeclare(_) => OpProof::ZkAndEd25519Sigs {
-                zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
-                ed25519_sig: Ed25519Signature::zero(),
-            },
+            Op::SDPDeclare(_) => {
+                let proof = ZkAndEd25519Proof {
+                    zk_sig: ZkSignature::new(CompressedGroth16Proof::from_bytes(&[0u8; 128])),
+                    ed25519_sig: Ed25519Signature::zero(),
+                };
+                OpProof::ZkAndEd25519Sigs(proof)
+            }
             other => unreachable!("unexpected genesis op in tests: {}", other.as_str()),
         }
     }

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -118,55 +118,40 @@ impl SignedMantleTx<Unverified> {
         // TODO: Add more info to errors (e.g. op_index)
         match (op, proof) {
             (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => {
-                let context = InscriptionPreverificationContext {
-                    tx_hash_view,
-                    proof,
-                };
-                op.preverify(&context)
+                let context = InscriptionPreverificationContext { tx_hash_view };
+                op.preverify(proof, &context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
-            (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(_proof)) => op
-                .preverify(&())
+            (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::ChannelVerificationError),
-            (Op::ChannelDeposit(op), OpProof::ZkSig(_proof)) => op
-                .preverify(&())
+            (Op::ChannelDeposit(op), OpProof::ZkSig(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::ChannelVerificationError),
-            (Op::ChannelWithdraw(op), OpProof::ChannelMultiSigProof(_proof)) => op
-                .preverify(&())
+            (Op::ChannelWithdraw(op), OpProof::ChannelMultiSigProof(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::ChannelVerificationError),
-            (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(_proof)) => op
-                .preverify(&())
+            (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::ChannelVerificationError),
-            (
-                Op::SDPDeclare(op),
-                OpProof::ZkAndEd25519Sigs {
-                    zk_sig: _proof_zk,
-                    ed25519_sig: proof_ed25519,
-                },
-            ) => {
-                let context = SDPDeclarePreverificationContext {
-                    tx_hash_view,
-                    proof_ed25519,
-                };
-                <SDPDeclareOp as VerifiableOperation<StandardMode>>::preverify(op, &context)
+            (Op::SDPDeclare(op), OpProof::ZkAndEd25519Sigs(proof)) => {
+                let context = SDPDeclarePreverificationContext { tx_hash_view };
+                <SDPDeclareOp as VerifiableOperation<StandardMode>>::preverify(op, proof, &context)
                     .map_err(VerificationError::SDPVerificationError)
             }
-            (Op::SDPWithdraw(op), OpProof::ZkSig(_proof)) => op
-                .preverify(&())
+            (Op::SDPWithdraw(op), OpProof::ZkSig(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::SDPVerificationError),
-            (Op::SDPActive(op), OpProof::ZkSig(_proof)) => op
-                .preverify(&())
+            (Op::SDPActive(op), OpProof::ZkSig(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::SDPVerificationError),
             (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
-                let context = LeaderClaimPreverificationContext {
-                    tx_hash_view,
-                    proof,
-                };
-                op.preverify(&context)
+                let context = LeaderClaimPreverificationContext { tx_hash_view };
+                op.preverify(proof, &context)
                     .map_err(VerificationError::LeaderClaimVerificationError)
             }
-            (Op::Transfer(op), OpProof::ZkSig(_proof)) => op
-                .preverify(&())
+            (Op::Transfer(op), OpProof::ZkSig(proof)) => op
+                .preverify(proof, &())
                 .map_err(VerificationError::TransferVerificationError),
             _ => Err(VerificationError::IncorrectProofType {
                 op_type: op.as_str(),
@@ -246,21 +231,20 @@ impl SignedMantleTx<Preverified> {
         helper: &impl OperationVerificationHelper,
     ) -> Result<(), VerificationError> {
         match (op, proof) {
-            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(_proof)) => {
+            (Op::ChannelInscribe(op), OpProof::Ed25519Sig(proof)) => {
                 let channel_inscribe_context = InscriptionValidationContext {
                     channels: helper.get_channels(),
                     block_slot: helper.get_block_slot(),
                 };
-                op.verify(&channel_inscribe_context)
+                op.verify(proof, &channel_inscribe_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelConfig(op), OpProof::ChannelMultiSigProof(proof)) => {
                 let channel_config_context = ChannelConfigValidationContext {
                     channels: helper.get_channels(),
                     tx_hash_view,
-                    proof,
                 };
-                op.verify(&channel_config_context)
+                op.verify(proof, &channel_config_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelDeposit(op), OpProof::ZkSig(proof)) => {
@@ -269,9 +253,8 @@ impl SignedMantleTx<Preverified> {
                     locked_notes: helper.get_locked_notes(),
                     utxos: helper.get_utxos(),
                     tx_hash_view,
-                    proof,
                 };
-                op.verify(&channel_deposit_context)
+                op.verify(proof, &channel_deposit_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelWithdraw(channel_withdraw_op), OpProof::ChannelMultiSigProof(proof)) => {
@@ -280,12 +263,11 @@ impl SignedMantleTx<Preverified> {
                     locked_notes: helper.get_locked_notes(),
                     utxos: helper.get_utxos(),
                     tx_hash_view,
-                    proof,
                     helper,
                     op_index,
                 };
                 channel_withdraw_op
-                    .verify(&channel_withdraw_context)
+                    .verify(proof, &channel_withdraw_context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
             (Op::ChannelTransfer(op), OpProof::ChannelMultiSigProof(proof)) => {
@@ -294,31 +276,22 @@ impl SignedMantleTx<Preverified> {
                     channels: helper.get_channels(),
                     utxos: helper.get_utxos(),
                     tx_hash_view,
-                    proof,
                     op_index,
                     helper,
                 };
-                op.verify(&context)
+                op.verify(proof, &context)
                     .map_err(VerificationError::ChannelVerificationError)
             }
-            (
-                Op::SDPDeclare(op),
-                OpProof::ZkAndEd25519Sigs {
-                    zk_sig: proof_zk_signature,
-                    ed25519_sig: proof_ed25519_signature,
-                },
-            ) => {
+            (Op::SDPDeclare(op), OpProof::ZkAndEd25519Sigs(proof)) => {
                 let context = SDPDeclareVerificationContext {
                     utxo_tree: helper.get_utxos(),
                     channels: helper.get_channels(),
                     locked_notes: helper.get_locked_notes(),
                     tx_hash_view,
-                    proof_zk_signature,
-                    proof_ed25519_signature,
                     declarations: helper.get_declarations_by_service(op.service_type)?,
                     min_stake: helper.get_min_stake(),
                 };
-                <SDPDeclareOp as VerifiableOperation<StandardMode>>::verify(op, &context)
+                <SDPDeclareOp as VerifiableOperation<StandardMode>>::verify(op, proof, &context)
                     .map_err(VerificationError::SDPVerificationError)
             }
             (Op::SDPWithdraw(op), OpProof::ZkSig(proof)) => {
@@ -327,29 +300,26 @@ impl SignedMantleTx<Preverified> {
                     epoch: helper.get_epoch(),
                     locked_notes: helper.get_locked_notes(),
                     tx_hash_view,
-                    proof,
                 };
-                op.verify(&context)
+                op.verify(proof, &context)
                     .map_err(VerificationError::SDPVerificationError)
             }
             (Op::SDPActive(op), OpProof::ZkSig(proof)) => {
                 let context = SDPActiveValidationContext {
                     declarations: helper.get_declarations_by_id(&op.declaration_id)?,
                     tx_hash_view,
-                    proof,
                     epoch: helper.get_epoch(),
                 };
-                op.verify(&context)
+                op.verify(proof, &context)
                     .map_err(VerificationError::SDPVerificationError)
             }
             (Op::LeaderClaim(op), OpProof::PoC(proof)) => {
                 let context = LeaderClaimVerificationContext {
                     nullifiers: helper.get_nullifiers(),
                     claimable_vouchers_root: helper.get_claimable_vouchers_root(),
-                    proof,
                     tx_hash_view,
                 };
-                op.verify(&context)
+                op.verify(proof, &context)
                     .map_err(VerificationError::LeaderClaimVerificationError)
             }
             (Op::Transfer(op), OpProof::ZkSig(proof)) => {
@@ -358,9 +328,8 @@ impl SignedMantleTx<Preverified> {
                     channels: helper.get_channels(),
                     utxos: helper.get_utxos(),
                     tx_hash_view,
-                    proof,
                 };
-                op.verify(&context)
+                op.verify(proof, &context)
                     .map_err(VerificationError::TransferVerificationError)
             }
             // SignedMantleTx<Preverified> invariant: Op/Proof pairs have been verified in

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1928,16 +1928,17 @@ mod tests {
         // Try to claim the reward using the same nullifier.
         let tx_hash = TxHash::from([0u8; 32]);
         let tx_hash_view = TxHashView::from(tx_hash);
+        // Use a dummy proof since duplication is detected before proof verification
+        let proof = Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(&[0u8; 128]));
         let err = op
-            .verify(&LeaderClaimVerificationContext {
-                nullifiers: leaders.nullifiers(),
-                claimable_vouchers_root: leaders.vouchers_snapshot_root(),
-                // Use a dummy proof since duplication is detected before proof verification
-                proof: &Groth16LeaderClaimProof::new(CompressedGroth16Proof::from_bytes(
-                    &[0u8; 128],
-                )),
-                tx_hash_view: &tx_hash_view,
-            })
+            .verify(
+                &proof,
+                &LeaderClaimVerificationContext {
+                    nullifiers: leaders.nullifiers(),
+                    claimable_vouchers_root: leaders.vouchers_snapshot_root(),
+                    tx_hash_view: &tx_hash_view,
+                },
+            )
             .unwrap_err();
         assert_eq!(err, LeaderClaimError::DuplicatedVoucherNullifier);
     }

--- a/ledger/src/mantle/sdp/mod.rs
+++ b/ledger/src/mantle/sdp/mod.rs
@@ -307,9 +307,31 @@ impl SdpLedger {
             .with_blend_service(&config.service_rewards_params.blend, epoch_state);
 
         let mut all_events = Vec::new();
-        for (op, _) in ops {
-            let (result, events) =
-                sdp.try_apply_genesis_sdp_declaration(utxo_tree, channels, op, config)?;
+        for (op, proof) in ops {
+            // TODO: remove this match once op/proof pairing is enforced by
+            // construction (e.g. via `SignedOp`) instead of at this call site.
+            let OpProof::ZkAndEd25519Sigs(proof) = proof else {
+                return Err(Error::InvalidProof);
+            };
+
+            let service_state = sdp
+                .services
+                .get(&op.service_type)
+                .ok_or(Error::ServiceNotFound(op.service_type))?;
+
+            <SDPDeclareOp as VerifiableOperation<GenesisMode>>::verify(
+                op,
+                proof,
+                &SDPDeclareGenesisValidationContext {
+                    utxo_tree,
+                    channels,
+                    locked_notes: &sdp.locked_notes,
+                    declarations: service_state.declarations(),
+                    min_stake: &config.min_stake,
+                },
+            )?;
+
+            let (result, events) = sdp.try_apply_genesis_sdp_declaration(utxo_tree, op, config)?;
             sdp = result;
             all_events.extend(events);
         }
@@ -391,27 +413,12 @@ impl SdpLedger {
     pub fn try_apply_genesis_sdp_declaration(
         mut self,
         utxo_tree: &UtxoTree,
-        channels: &Channels,
         op: &SDPDeclareOp,
         config: &Config,
     ) -> Result<(Self, Vec<TxEvent>), Error> {
         let Some(service_state) = self.services.get_mut(&op.service_type) else {
             return Err(Error::ServiceNotFound(op.service_type));
         };
-
-        // Validate SDP Declare
-        // TODO: Genesis has a different verification flow than `SignedMantleTx`.
-        // Refactor into a type state.
-        <SDPDeclareOp as VerifiableOperation<GenesisMode>>::verify(
-            op,
-            &SDPDeclareGenesisValidationContext {
-                utxo_tree,
-                channels,
-                locked_notes: &self.locked_notes,
-                declarations: service_state.declarations(),
-                min_stake: &config.min_stake,
-            },
-        )?;
 
         // Execute SDP Declare
         let (result, events) = <SDPDeclareOp as ExecutableOperation>::execute(

--- a/services/wallet/src/lib.rs
+++ b/services/wallet/src/lib.rs
@@ -20,6 +20,7 @@ use lb_core::{
         gas::{GasCost, GasOverflow, MainnetGasConstants},
         ledger::Inputs,
         ops::{
+            ZkAndEd25519Proof,
             channel::{ChannelId, config::ChannelConfigOp, inscribe::InscriptionOp},
             leader_claim::{
                 LeaderClaimOp, RewardsRoot, VoucherCm, VoucherNullifier, VoucherSecret,
@@ -810,10 +811,11 @@ where
         let zk_sig = Self::sign_zksig(tx_hash, [note.pk, declare_op.zk_id], kms).await?;
         let ed25519_sig = Self::sign_ed25519(tx_hash, declare_op.provider_id.0, kms).await?;
 
-        Ok(OpProof::ZkAndEd25519Sigs {
+        let proof = ZkAndEd25519Proof {
             zk_sig,
             ed25519_sig,
-        })
+        };
+        Ok(OpProof::ZkAndEd25519Sigs(proof))
     }
 
     async fn sign_sdp_withdraw(

--- a/tests/src/tests/mantle/sdp/ops.rs
+++ b/tests/src/tests/mantle/sdp/ops.rs
@@ -12,7 +12,11 @@ use std::{
 use lb_chain_service::Epoch;
 use lb_common_http_client::Error;
 use lb_core::{
-    mantle::{NoteId, OpProof, Utxo, ops::Op, traits::Hashable as _},
+    mantle::{
+        NoteId, OpProof, Utxo,
+        ops::{Op, ZkAndEd25519Proof},
+        traits::Hashable as _,
+    },
     sdp::{
         Declaration, DeclarationId, DeclarationMessage, Locator, ProviderId, ServiceType,
         WithdrawMessage,
@@ -122,10 +126,11 @@ async fn sdp_ops_e2e() {
             )
             .expect("SDP declare zk proof should build");
 
-            OpProof::ZkAndEd25519Sigs {
+            let proof = ZkAndEd25519Proof {
                 zk_sig,
                 ed25519_sig,
-            }
+            };
+            OpProof::ZkAndEd25519Sigs(proof)
         },
     )
     .await;

--- a/tools/config/src/consensus.rs
+++ b/tools/config/src/consensus.rs
@@ -7,7 +7,7 @@ use lb_core::{
     mantle::{
         CryptarchiaParameter, GenesisTime, Note, NoteId, OpProof, RawMantleTx, Utxo,
         ops::{
-            Op, OpId as _,
+            Op, OpId as _, ZkAndEd25519Proof,
             channel::{
                 ChannelId, Ed25519PublicKey, MsgId,
                 inscribe::{Inscription, InscriptionOp},
@@ -321,11 +321,12 @@ pub fn create_genesis_block_with_declarations(
         let ed25519_sig = provider
             .provider_sk
             .sign_payload(mantle_tx_hash.as_signing_bytes().as_ref());
+        let proof = ZkAndEd25519Proof {
+            zk_sig,
+            ed25519_sig,
+        };
         ops_proofs
-            .try_push(OpProof::ZkAndEd25519Sigs {
-                zk_sig,
-                ed25519_sig,
-            })
+            .try_push(OpProof::ZkAndEd25519Sigs(proof))
             .expect("genesis transaction proofs are bounded");
     }
 


### PR DESCRIPTION
## 1. What does this PR implement?
Another PR towards the operation typestate:
- Add `ProvableOperation`, which holds the `Proof`. `preverify` and `verify` on `VerifiableOperation` now take `proof: &Self::Proof` as an explicit argument instead of it being a field buried in the context struct.
   Prerequisite for `SignedOp` (upcoming PR), the typestate wrapper holding an `Operation` and its proof.

- Add a specific type for `OpProof::ZkAndEd25519Sigs`: `ZkAndEd25519Proof`.
  Handier to use and it's used in a few places.

- Moved a `verify` call in Genesis out of `try_apply_genesis_sdp_declaration` (execute only fn).
   Not ideal form but best-effort before the `SignedOp` is finished.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).