### PR TITLE
fix(zone-sdk): shed orphans on config update

### DIFF
--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -474,16 +474,19 @@ where
             Some(update) => {
                 Self::log_channel_update(&update);
 
+                let new_channel_tip = update.new_channel_tip;
+                let built = self.build_channel_update(update);
+
                 let has_pending = self
                     .state
                     .as_ref()
                     .is_some_and(TxState::has_pending_inscriptions);
 
-                if !update.orphaned.is_empty() || !has_pending {
-                    self.last_msg_id = update.new_channel_tip;
+                if !built.orphaned.is_empty() || !has_pending {
+                    self.last_msg_id = new_channel_tip;
                 }
 
-                self.build_channel_update(update)
+                built
             }
             None => ChannelUpdate {
                 orphaned: Vec::new(),
@@ -596,11 +599,13 @@ mod tests {
         header::HeaderId,
         mantle::{
             MantleTx, Note, Op, SignedMantleTx, Utxo,
+            channel::{SlotTimeframe, SlotTimeout},
             ledger::Inputs,
             ops::{
                 OpProof,
                 channel::{
                     ChannelId, MsgId,
+                    config::{ChannelConfigOp, Keys},
                     deposit::DepositOp,
                     inscribe::{Inscription, InscriptionOp},
                     withdraw::ChannelWithdrawOp,
@@ -778,6 +783,109 @@ mod tests {
                 .iter()
                 .any(|op| matches!(op, Op::ChannelInscribe(_))),
             "posted tx should carry the inscription published during reconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_only_block_sheds_pending_and_advances_checkpoint() {
+        let channel_id = ChannelId::from([0; 32]);
+        let sequencer_key = Ed25519Key::from_bytes(&[0; 32]);
+
+        let config_op = ChannelConfigOp {
+            channel: channel_id,
+            keys: Keys::try_from(vec![Ed25519Key::from_bytes(&[0; 32]).public_key()]).unwrap(),
+            posting_timeframe: SlotTimeframe::from(0u32),
+            posting_timeout: SlotTimeout::from(0u32),
+            configuration_threshold: 1,
+            transfer_threshold: 1,
+        };
+        let config_msg = config_op.id();
+        let config_tx = unverified_tx_with_ops(vec![Op::ChannelConfig(config_op)]);
+        let config_block = api_block(2, 1, 2, vec![config_tx]);
+
+        // Second connection (the config block) is gated behind `up` so it
+        // cannot be consumed before the publish is in.
+        let (up_tx, up_rx) = watch::channel(true);
+        let node = MockNode {
+            up: Some(up_rx),
+            scripts: scripts(vec![
+                StreamScript {
+                    events: vec![live_event(&api_block(1, 0, 1, Vec::new()))],
+                    then: StreamEnd::Hang,
+                },
+                StreamScript {
+                    events: vec![live_event(&config_block)],
+                    then: StreamEnd::Hang,
+                },
+            ]),
+            ..MockNode::default()
+        };
+        let config = SequencerConfig {
+            reconnect_delay: std::time::Duration::from_millis(20),
+            resubmit_interval: std::time::Duration::from_millis(20),
+            ..SequencerConfig::default()
+        };
+        let mut sequencer =
+            ZoneSequencer::init_with_config(channel_id, sequencer_key, node, config, None);
+        let client = sequencer.client();
+
+        loop {
+            if matches!(sequencer.next_event().await, Event::Ready) {
+                break;
+            }
+        }
+
+        let publish = client.publish(b"cut-by-config".into());
+        let (result, _checkpoint) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                tokio::select! {
+                    result = publish => result,
+                    () = async { loop { drop(sequencer.next_event().await); } } => unreachable!(),
+                }
+            })
+            .await
+            .expect("publish must resolve")
+            .expect("publish should be accepted after Ready");
+        let p_hash = result.inscription_id();
+
+        // Keep driving between the toggles so the down-edge is observed.
+        up_tx.send(false).unwrap();
+        let (checkpoint, update) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let toggle = async {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                up_tx.send(true).unwrap();
+            };
+            let drive = async {
+                loop {
+                    if let Event::BlocksProcessed {
+                        checkpoint,
+                        channel_update,
+                        ..
+                    } = sequencer.next_event().await
+                        && !channel_update.orphaned.is_empty()
+                    {
+                        return (checkpoint, channel_update);
+                    }
+                }
+            };
+            let ((), out) = tokio::join!(toggle, drive);
+            out
+        })
+        .await
+        .expect("the config-only block must surface the shed orphan");
+
+        assert!(
+            update.orphaned.iter().any(|tx| tx.tx_hash() == p_hash),
+            "cut-off pending inscription must be emitted as orphaned; got {:?}",
+            update.orphaned
+        );
+        assert_eq!(
+            checkpoint.last_msg_id, config_msg,
+            "checkpoint must use the config tip as last_msg_id"
+        );
+        assert!(
+            checkpoint.pending_txs.iter().all(|(h, _)| *h != p_hash),
+            "the shed inscription must be removed from pending state"
         );
     }
 

--- a/zone-sdk/src/sequencer/block_fetch.rs
+++ b/zone-sdk/src/sequencer/block_fetch.rs
@@ -183,18 +183,15 @@ where
     // whose `orphaned` is empty by construction), report only entries the
     // sequencer didn't already track: its own publishes land on the channel
     // through its own action and must not echo back. On a branch change the
-    // full delta flows through unfiltered. Updates emptied by the filter are
-    // dropped entirely.
-    let channel_update = channel_update
-        .map(|mut update| {
-            if update.orphaned.is_empty() {
-                update
-                    .adopted
-                    .retain(|tx| !tracked_before.contains(&tx.tx_hash()));
-            }
+    // full delta flows through unfiltered.
+    let channel_update = channel_update.map(|mut update| {
+        if update.orphaned.is_empty() {
             update
-        })
-        .filter(|update| !(update.orphaned.is_empty() && update.adopted.is_empty()));
+                .adopted
+                .retain(|tx| !tracked_before.contains(&tx.tx_hash()));
+        }
+        update
+    });
 
     Ok(BlockEventResult {
         finalized_items,

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -803,7 +803,10 @@ impl TxState {
     /// Content at or below the finalized boundary is excluded from both
     /// sides: it is immutable on every branch and surfaces via `finalized`.
     ///
-    /// Returns `None` if no channel state change.
+    /// Returns `None` only when the channel did not change at all. A change
+    /// made purely of non-reportable entries (a config landing alone) yields
+    /// `Some` with empty `adopted`/`orphaned` — the tip still moved, and
+    /// callers must run their shed pass on every reported update.
     #[must_use]
     pub fn detect_channel_update(
         &self,
@@ -823,21 +826,28 @@ impl TxState {
         let mut finalized = self.finalized_prefix_ids(old_lineage);
         finalized.extend(self.finalized_prefix_ids(&new_lineage));
 
-        let adopted = self.update_txs_from_infos(
-            new_lineage
-                .iter()
-                .filter(|i| !old_ids.contains(&i.this_msg) && !finalized.contains(&i.this_msg)),
-        );
+        let adopted_infos: Vec<&InscriptionInfo> = new_lineage
+            .iter()
+            .filter(|i| !old_ids.contains(&i.this_msg) && !finalized.contains(&i.this_msg))
+            .collect();
 
-        let orphaned = self.update_txs_from_infos(
-            old_lineage
-                .iter()
-                .filter(|i| !new_ids.contains(&i.this_msg) && !finalized.contains(&i.this_msg)),
-        );
+        let orphaned_infos: Vec<&InscriptionInfo> = old_lineage
+            .iter()
+            .filter(|i| !new_ids.contains(&i.this_msg) && !finalized.contains(&i.this_msg))
+            .collect();
 
-        if orphaned.is_empty() && adopted.is_empty() {
+        // Decide "did the channel change" on the RAW diff, before the
+        // reportability filtering below: a change consisting solely of
+        // non-reportable entries (configs map to `None` in `to_update_tx`)
+        // still moves the tip, and the caller's shed pass must run so pending
+        // txs cut off by the tip reset are surfaced as orphaned and cleaned
+        // up rather than silently stranded.
+        if adopted_infos.is_empty() && orphaned_infos.is_empty() {
             return None;
         }
+
+        let adopted = self.update_txs_from_infos(adopted_infos.into_iter());
+        let orphaned = self.update_txs_from_infos(orphaned_infos.into_iter());
 
         Some(ChannelUpdateInfo {
             orphaned,
@@ -1255,6 +1265,74 @@ mod tests {
         let hash = tx.mantle_tx().hash();
         state.submit_inscription(tx, parent_msg, this_msg, [data].into());
         hash
+    }
+
+    /// A config landing ALONE resets the channel tip, cutting off pending
+    /// inscriptions anchored at the previous tip. Configs are non-reportable
+    /// (`to_update_tx` maps them to `None`), so with the change-detection
+    /// keyed on the filtered lists the update collapsed to `None`, the
+    /// caller's shed pass never ran, and the cut-off pending was neither
+    /// surfaced as orphaned nor cleaned up. The raw diff must decide instead:
+    /// the update reports (with empty lists), and shed rescues the pending.
+    #[test]
+    fn config_landing_alone_reports_update_so_stale_pending_is_shed() {
+        let genesis = header_id(0);
+        let b1 = header_id(1);
+        let b2 = header_id(2);
+        let mut state = TxState::new(genesis, MsgId::root());
+
+        // Mined inscription M establishes channel tip m.
+        let m_info = InscriptionInfo {
+            tx_hash: make_dummy_tx(1).mantle_tx().hash(),
+            parent_msg: MsgId::root(),
+            this_msg: msg_id(1),
+            payload: [1].into(),
+        };
+        state.process_block(
+            b1,
+            genesis,
+            genesis,
+            vec![],
+            vec![BlockChannelTx::Inscription(m_info)],
+        );
+
+        // Local pending inscription P chained on m (published, not mined).
+        let p_hash = submit_fake_inscription(&mut state, 2, msg_id(1), msg_id(2));
+
+        let old_lineage = state.channel_lineage(b1);
+
+        // Config C lands alone; the tip resets to c.
+        let c_info = InscriptionInfo {
+            tx_hash: make_dummy_tx(3).mantle_tx().hash(),
+            parent_msg: msg_id(1),
+            this_msg: msg_id(3),
+            payload: [3].into(),
+        };
+        state.process_block(
+            b2,
+            b1,
+            genesis,
+            vec![],
+            vec![BlockChannelTx::Config(c_info)],
+        );
+
+        let update = state
+            .detect_channel_update(&old_lineage, b2)
+            .expect("a config-only landing changes the channel and must report");
+        assert_eq!(update.new_channel_tip, msg_id(3));
+        assert!(
+            update.adopted.is_empty() && update.orphaned.is_empty(),
+            "configs are non-reportable; the update carries the tip change only"
+        );
+
+        // P no longer reaches the tip: excluded from resubmission and
+        // rescued by the shed pass the reported update triggers.
+        assert!(state.pending_txs(b2).iter().all(|(h, _)| *h != p_hash));
+        let shed = state.shed_off_branch_pending(b2);
+        assert!(
+            shed.iter().any(|p| p.tx_hash() == p_hash),
+            "the cut-off pending inscription must be shed for republish"
+        );
     }
 
     /// After a checkpoint restore the finalized entry's parent is unknown

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -836,12 +836,9 @@ impl TxState {
             .filter(|i| !new_ids.contains(&i.this_msg) && !finalized.contains(&i.this_msg))
             .collect();
 
-        // Decide "did the channel change" on the RAW diff, before the
-        // reportability filtering below: a change consisting solely of
-        // non-reportable entries (configs map to `None` in `to_update_tx`)
-        // still moves the tip, and the caller's shed pass must run so pending
-        // txs cut off by the tip reset are surfaced as orphaned and cleaned
-        // up rather than silently stranded.
+        // Decide on the raw diff, before reportability filtering: a
+        // config-only change maps to no reportable entries but still moves
+        // the tip, and callers must run their shed pass on it.
         if adopted_infos.is_empty() && orphaned_infos.is_empty() {
             return None;
         }


### PR DESCRIPTION
## 1. What does this PR implement?

There was a bug in zone-sdk as it was not emitting orphaned inscriptions on config update. This PR fixes this by considering config update as well on `detect_channel_update`.

Closes https://github.com/logos-blockchain/logos-blockchain/issues/3236.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?

@pradovic 

## 4. Is the specification accurate and complete?

Yes
## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [ ] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [ ] 2. Description added.
* [ ] 3. Context and links to Specification document(s) added.
* [ ] 4. Main contact(s) (developers and specification authors) added
* [ ] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [ ] 6. Link PR to a specific milestone.
* [ ] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
