### PR TITLE
feat(core): DRAFT: uncle-ref 1/4: add `uncles` field to `Header`

### DIFF
--- a/core/src/block/deser.rs
+++ b/core/src/block/deser.rs
@@ -5,6 +5,7 @@ mod tests {
 
     use crate::{
         block::{Block, BlockTransactions, tests::create_proof},
+        header::UncleRefs,
         mantle::MantleTx,
     };
 
@@ -13,6 +14,7 @@ mod tests {
         Block::create(
             [0u8; 32].into(),
             Slot::from(1u64),
+            UncleRefs::empty(),
             create_proof(),
             BlockTransactions::empty(),
             &signing_key,
@@ -76,6 +78,7 @@ mod tests {
         const PARENT_BLOCK: usize = 32;
         const SLOT: usize = 8;
         const BLOCK_ROOT: usize = 32;
+        const UNCLES: usize = 32 * UncleRefs::MAX_UNCLES;
         const POL_PROOF: usize = 128;
         const ENTROPY_CONTRIBUTION: usize = 32;
         const LEADER_KEY: usize = 32;
@@ -86,6 +89,7 @@ mod tests {
             + PARENT_BLOCK
             + SLOT
             + BLOCK_ROOT
+            + UNCLES
             + POL_PROOF
             + ENTROPY_CONTRIBUTION
             + LEADER_KEY

--- a/core/src/block/mod.rs
+++ b/core/src/block/mod.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
     codec::{DeserializeOp as _, SerializeOp as _},
-    header::{ContentId, Header, HeaderId},
+    header::{ContentId, Header, HeaderId, UncleRefs},
     mantle::{
         traits::{Hashable, StorageSize},
         transactions::hash::TxHash,
@@ -141,6 +141,7 @@ impl<Tx> Block<Tx> {
     pub fn create(
         parent_block: HeaderId,
         slot: Slot,
+        uncles: UncleRefs,
         proof_of_leadership: Groth16LeaderProof,
         transactions: BlockTransactions<Tx>,
         signing_key: &Ed25519Key,
@@ -161,7 +162,7 @@ impl<Tx> Block<Tx> {
 
         // 3. Block root & header
         let block_root = Self::calculate_content_id(transactions.as_slice());
-        let header = Header::new(parent_block, block_root, slot, proof_of_leadership);
+        let header = Header::new(parent_block, block_root, slot, uncles, proof_of_leadership);
 
         // 4. Signature over the header
         let signature = header.sign(signing_key)?;
@@ -449,6 +450,7 @@ mod tests {
         let valid_block = Block::create(
             parent_block,
             slot,
+            UncleRefs::empty(),
             proof_of_leadership,
             transactions.clone(),
             &valid_signing_key,
@@ -486,6 +488,7 @@ mod tests {
         let _valid_block: Block<MantleTx> = Block::create(
             parent_block,
             slot,
+            UncleRefs::empty(),
             proof_of_leadership.clone(),
             transactions,
             &signing_key,
@@ -496,6 +499,7 @@ mod tests {
         let _valid_block: Block<MantleTx> = Block::create(
             parent_block,
             slot,
+            UncleRefs::empty(),
             proof_of_leadership,
             transactions,
             &signing_key,
@@ -532,6 +536,7 @@ mod tests {
         let proposal = Block::create(
             parent_block,
             Slot::from(42u64),
+            UncleRefs::empty(),
             create_proof(),
             transactions,
             &signing_key,
@@ -549,6 +554,7 @@ mod tests {
         let block = Block::create(
             parent_block,
             Slot::from(42u64),
+            UncleRefs::empty(),
             create_proof(),
             BlockTransactions::<MantleTx>::try_from(create_tx(MAX_BLOCK_TRANSACTIONS)).unwrap(),
             &signing_key,
@@ -581,6 +587,7 @@ mod tests {
         let proposal = Block::create(
             [0u8; 32].into(),
             Slot::from(42u64),
+            UncleRefs::empty(),
             create_proof(),
             BlockTransactions::<MantleTx>::empty(),
             &signing_key,
@@ -636,6 +643,7 @@ mod tests {
         let _valid_block: Block<MantleTx> = Block::create(
             parent_block,
             slot,
+            UncleRefs::empty(),
             proof_of_leadership.clone(),
             transactions,
             &signing_key,
@@ -647,6 +655,7 @@ mod tests {
         let _valid_block = Block::create(
             parent_block,
             slot,
+            UncleRefs::empty(),
             proof_of_leadership.clone(),
             transactions,
             &signing_key,
@@ -659,6 +668,7 @@ mod tests {
         let invalid_transaction_inputs_result = Block::create(
             parent_block,
             slot,
+            UncleRefs::empty(),
             proof_of_leadership,
             oversized,
             &signing_key,
@@ -690,8 +700,15 @@ mod tests {
         // Build a syntactically valid non-genesis block first.
         let txs = BlockTransactions::<MantleTx>::empty();
         let key = Ed25519Key::from_bytes(&[0; 32]);
-        let block_result =
-            Block::create(parent_block, Slot::from(0u64), proof, txs, &key).unwrap_err();
+        let block_result = Block::create(
+            parent_block,
+            Slot::from(0u64),
+            UncleRefs::empty(),
+            proof,
+            txs,
+            &key,
+        )
+        .unwrap_err();
 
         assert!(
             matches!(block_result, Error::Validation(msg) if msg == "expected non-genesis slot")
@@ -709,6 +726,7 @@ mod tests {
         let valid = Block::create(
             parent_block,
             Slot::from(1u64),
+            UncleRefs::empty(),
             proof.clone(),
             BlockTransactions::<MantleTx>::empty(),
             &key,
@@ -721,6 +739,7 @@ mod tests {
             parent_block,
             *valid.header().block_root(),
             Slot::genesis(),
+            UncleRefs::empty(),
             proof,
         );
         let genesis_signature = genesis_header

--- a/core/src/header/mod.rs
+++ b/core/src/header/mod.rs
@@ -19,6 +19,11 @@ use crate::{
 #[derive(Clone, Eq, PartialEq, Copy, Hash, PartialOrd, Ord)]
 pub struct HeaderId([u8; 32]);
 
+impl HeaderId {
+    /// The all-zero ID, used as a sentinel where no block is referenced.
+    pub const ZERO: Self = Self([0; 32]);
+}
+
 impl Debug for HeaderId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "HeaderId({})", hex::encode(self.0))
@@ -117,6 +122,7 @@ pub struct Header {
     parent_block: HeaderId,
     slot: Slot,
     block_root: ContentId,
+    uncles: UncleRefs,
     proof_of_leadership: Groth16LeaderProof,
 }
 
@@ -137,6 +143,9 @@ impl Header {
         h.update(self.parent_block.0);
         h.update(self.slot.to_le_bytes());
         h.update(self.block_root.0);
+        for uncle in self.uncles.iter() {
+            h.update(uncle.0);
+        }
         h.update(self.proof_of_leadership.voucher_cm().to_bytes());
         h.update(fr_to_bytes(&self.proof_of_leadership.entropy()));
         h.update(self.proof_of_leadership.proof().to_bytes());
@@ -161,6 +170,11 @@ impl Header {
     }
 
     #[must_use]
+    pub const fn uncles(&self) -> &UncleRefs {
+        &self.uncles
+    }
+
+    #[must_use]
     pub const fn slot(&self) -> Slot {
         self.slot
     }
@@ -180,6 +194,7 @@ impl Header {
         parent_block: HeaderId,
         block_root: ContentId,
         slot: Slot,
+        uncles: UncleRefs,
         proof_of_leadership: Groth16LeaderProof,
     ) -> Self {
         Self {
@@ -187,6 +202,7 @@ impl Header {
             parent_block,
             slot,
             block_root,
+            uncles,
             proof_of_leadership,
         }
     }
@@ -198,6 +214,7 @@ impl Header {
             HeaderId([0; 32]),
             ContentId(block_root),
             Slot::from(0u64),
+            UncleRefs::empty(),
             Groth16LeaderProof::genesis(),
         )
     }
@@ -254,6 +271,28 @@ serde_bytes_newtype!(HeaderId, 32);
 serde_bytes_newtype!(ContentId, 32);
 serde_bytes_newtype!(Nonce, 32);
 
+/// The uncle references carried by a block header.
+///
+/// Always [`Self::MAX_UNCLES`] entries wide for fixed-size block encoding.
+/// Unused placeholders hold [`HeaderId::ZERO`].
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct UncleRefs([HeaderId; Self::MAX_UNCLES]);
+
+impl UncleRefs {
+    pub const MAX_UNCLES: usize = 4;
+
+    /// Creates a new [`UncleRefs`] with [`Self::MAX_UNCLES`] placeholders.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self([HeaderId::ZERO; Self::MAX_UNCLES])
+    }
+
+    /// Iterates over all [`Self::MAX_UNCLES`] entries, including placeholders.
+    pub fn iter(&self) -> impl Iterator<Item = &HeaderId> {
+        self.0.iter()
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Invalid header id size: {0}")]
@@ -298,7 +337,7 @@ fn test_serde() {
 /// all-zero leaves and hashes inner nodes as `blake2b256(left || right)`.
 ///
 /// `HeaderId (block_id) = blake2b256( b"BLOCK_ID_V1" || bedrock_version (1B)
-/// ||` `parent_block (32B) || slot_le (8B) || block_root (32B) ||
+/// ||` `parent_block (32B) || slot_le (8B) || block_root (32B) || uncles (MAX_UNCLES * 32B) ||
 /// leader_voucher` `(32B) || entropy_contribution (32B) || proof (128B) ||
 /// leader_key (32B) )`.
 ///
@@ -482,7 +521,7 @@ mod block_root_test_vectors {
         println!("block_root = Merkle( blake2b256(b\"MANTLE_TXHASH_V1\" || tx_bytes) leaves )");
         println!(
             "block_id   = blake2b256( b\"BLOCK_ID_V1\" || bedrock_version || parent_block || \
-             slot_le || block_root || leader_voucher || entropy_contribution || proof || \
+             slot_le || block_root || uncles || leader_voucher || entropy_contribution || proof || \
              leader_key )"
         );
 
@@ -519,7 +558,13 @@ mod block_root_test_vectors {
             Ed25519Key::from_bytes(&[0x33u8; 32]).public_key(), // leader_key
             VoucherCm::from(Fr::from(0x4444u64)), // leader_voucher
         );
-        let header = Header::new(parent_block, ContentId(block_root), slot, proof);
+        let header = Header::new(
+            parent_block,
+            ContentId(block_root),
+            slot,
+            UncleRefs::empty(),
+            proof,
+        );
         let header_id = header.id();
 
         // Self-check: recompute the preimage from the public accessors and make
@@ -532,6 +577,9 @@ mod block_root_test_vectors {
         h.update(parent_block.0);
         h.update(slot.to_le_bytes());
         h.update(block_root);
+        for uncle in header.uncles().iter() {
+            h.update(uncle.0);
+        }
         h.update(proof.voucher_cm().to_bytes());
         h.update(fr_to_bytes(&proof.entropy()));
         h.update(proof.proof().to_bytes());
@@ -553,6 +601,9 @@ mod block_root_test_vectors {
         println!("{:20}: {}", "parent_block", hex::encode(parent_block.0));
         println!("{:20}: {}", "slot", u64::from(slot));
         println!("{:20}: {}", "block_root", hex::encode(block_root));
+        for (i, uncle) in header.uncles().iter().enumerate() {
+            println!("{:20}: {}", format!("uncles[{i}]"), hex::encode(uncle.0));
+        }
         // proof_of_leadership fields (here, the deterministic genesis proof).
         println!(
             "{:20}: {}",

--- a/ledger/src/cryptarchia/mod.rs
+++ b/ledger/src/cryptarchia/mod.rs
@@ -502,6 +502,7 @@ impl LedgerState {
         Self { nonce, ..self }
     }
 
+    // TODO: also count slots occupied by uncles
     fn increment_block_density(self, slot: Slot) -> Self {
         let mut block_density = self.block_density.clone();
         block_density.increment_block_density(slot);

--- a/nodes/node/binary/src/api/serializers/blocks.rs
+++ b/nodes/node/binary/src/api/serializers/blocks.rs
@@ -2,7 +2,7 @@ use lb_api_service::http::mantle::BlockWithChainState;
 use lb_chain_service::Slot;
 use lb_core::{
     block::Block,
-    header::{ContentId, Header, HeaderId},
+    header::{ContentId, Header, HeaderId, UncleRefs},
     mantle::{SignedMantleTx, transactions::states::VerificationState},
     proofs::leader_proof::Groth16LeaderProof,
 };
@@ -69,6 +69,8 @@ pub struct ApiHeaderSerializer {
     slot: Slot,
     #[serde(getter = "Header::block_root")]
     block_root: ContentId,
+    #[serde(getter = "Header::uncles")]
+    uncles: UncleRefs,
     #[serde(getter = "Header::leader_proof")]
     proof_of_leadership: Groth16LeaderProof,
 }

--- a/services/chain/chain-leader/src/lib.rs
+++ b/services/chain/chain-leader/src/lib.rs
@@ -18,7 +18,7 @@ use lb_chain_service::{
 };
 use lb_core::{
     block::{Block, BlockTransactions, Error as BlockError, MAX_BLOCK_TRANSACTIONS_SIZE},
-    header::HeaderId,
+    header::{HeaderId, UncleRefs},
     mantle::{
         SignedMantleTx,
         gas::MainnetGasConstants,
@@ -671,7 +671,9 @@ where
         let valid_tx_stream = stream::iter(valid_txs);
         let txs = txs_for_block(valid_tx_stream).await;
 
-        let block = Block::create(parent, slot, proof, txs, signing_key)?;
+        // TODO: select the uncles to reference.
+        let uncles = UncleRefs::empty();
+        let block = Block::create(parent, slot, uncles, proof, txs, signing_key)?;
 
         info!(
             "proposed block {:?} with {} transactions ({} removed)",

--- a/services/chain/chain-service/src/lib.rs
+++ b/services/chain/chain-service/src/lib.rs
@@ -376,6 +376,8 @@ impl Cryptarchia {
             });
         }
 
+        // TODO: validate the uncle references and resolve their slots for the TSI.
+
         // A block number of this block if it's applied to the chain.
         let (_, state, events) = self
             .ledger

--- a/services/chain/chain-service/src/sync/block_provider.rs
+++ b/services/chain/chain-service/src/sync/block_provider.rs
@@ -591,6 +591,7 @@ mod tests {
         codec::DeserializeOp as _,
         crypto::ZkHasher,
         events::Events,
+        header::UncleRefs,
         mantle::{
             MantleTx, Note, SignedMantleTx, ledger::Utxo, ops::leader_claim::VoucherCm,
             transactions::states::Unverified,
@@ -907,6 +908,7 @@ mod tests {
             Block::create(
                 prev_header,
                 slot,
+                UncleRefs::empty(),
                 self.proof.clone(),
                 BlockTransactions::empty(),
                 &dummy_signing_key,

--- a/services/chain/chain-service/src/tests/mod.rs
+++ b/services/chain/chain-service/src/tests/mod.rs
@@ -8,6 +8,7 @@ use std::{
 use futures::StreamExt as _;
 use lb_core::{
     block::{Block, BlockTransactions},
+    header::UncleRefs,
     mantle::{
         Note, SignedMantleTx, Utxo,
         ops::leader_claim::{VoucherCm, VoucherSecret},
@@ -426,6 +427,7 @@ pub fn try_build_block(
             Block::create(
                 parent,
                 slot.into(),
+                UncleRefs::empty(),
                 proof,
                 BlockTransactions::empty(),
                 &signing_key,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -859,6 +859,7 @@ mod tests {
 
     use lb_core::{
         crypto::ZkDigest as _,
+        header::UncleRefs,
         mantle::{
             MantleTx, Note, OpProof, SignedMantleTx,
             channel::Channels,
@@ -2260,6 +2261,7 @@ mod tests {
         let source_block = Block::create(
             HeaderId::from([0; 32]),
             Slot::from(1),
+            UncleRefs::empty(),
             test_leader_proof(),
             source_transactions,
             &Ed25519Key::from_bytes(&[0; 32]),


### PR DESCRIPTION
# DRAFT
# DRAFT
# DRAFT

## 1. What does this PR implement?

Closes #3238 
(I won't merge this PR before other 3 subsequent PRs are approved and merged into this PR).

Now, the `Header` struct has a new field `uncles`, which is a fixed-size array `[HeaderId; MAX_UNCLES]`, where `MAX_UNCLES = 4`, as defined in the [RFC: Cryptarchia with Uncle References](https://github.com/logos-co/logos-lips/pull/385).

(In short, we're introducing the uncle reference to improve TSI accuracy.)

This PR touches only the block header definition and the related tests/fixtures.

In next PRs, I'm going to implement selecting uncles, validating uncles, and using uncles in the total stake inference.


## 2. Does the code have enough context to be clearly understood?

Yes

## 3. Who are the specification authors and who is accountable for this PR?

@youngjoon-lee 
spec: @madxor 

## 4. Is the specification accurate and complete?

Yes

## 5. Does the implementation introduce changes in the specification?

No

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [x] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [x] 2. Description added.
* [x] 3. Context and links to Specification document(s) added.
* [x] 4. Main contact(s) (developers and specification authors) added
* [x] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [x] 6. Link PR to a specific milestone.
* [x] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
