### PR TITLE
feat(operation): basic `SignedOp` implementation 

### DIFF
--- a/core/src/mantle/ledger.rs
+++ b/core/src/mantle/ledger.rs
@@ -51,25 +51,26 @@ pub trait ProvableOperation {
     type Proof;
 }
 
-// TODO: Specific proof type check?
-pub trait VerifiableOperation<Mode: verification_mode::VerificationMode>:
+pub trait PreverifiableOperation<Mode: verification_mode::VerificationMode>:
     ProvableOperation
 {
-    type PreverificationContext<'a>;
-    type VerificationContext<'a>;
+    type Context<'a>;
     type Error;
 
     fn preverify(
         &self,
         proof: &Self::Proof,
-        context: &Self::PreverificationContext<'_>,
+        context: &Self::Context<'_>,
     ) -> Result<(), Self::Error>;
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error>;
+pub trait VerifiableOperation<Mode: verification_mode::VerificationMode>:
+    ProvableOperation
+{
+    type Context<'a>;
+    type Error;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error>;
 }
 
 pub trait ExecutableOperation {
@@ -83,11 +84,17 @@ pub trait ExecutableOperation {
 }
 
 pub trait Operation<Mode: verification_mode::VerificationMode>:
-    VerifiableOperation<Mode> + ExecutableOperation
+    ProvableOperation + PreverifiableOperation<Mode> + VerifiableOperation<Mode> + ExecutableOperation
 {
 }
-impl<T: VerifiableOperation<Mode> + ExecutableOperation, Mode: verification_mode::VerificationMode>
-    Operation<Mode> for T
+
+impl<
+    T: ProvableOperation
+        + PreverifiableOperation<Mode>
+        + VerifiableOperation<Mode>
+        + ExecutableOperation,
+    Mode: verification_mode::VerificationMode,
+> Operation<Mode> for T
 {
 }
 

--- a/core/src/mantle/ops/channel/channel_transfer.rs
+++ b/core/src/mantle/ops/channel/channel_transfer.rs
@@ -7,8 +7,8 @@ use crate::{
         TxHash,
         channel::{Channels, Error},
         ledger::{
-            ExecutableOperation, Inputs, Outputs, ProvableOperation, Utxo, Utxos,
-            VerifiableOperation, verification_mode,
+            ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation, Utxo,
+            Utxos, VerifiableOperation, verification_mode,
         },
         ops::{
             OpId,
@@ -59,27 +59,27 @@ impl ProvableOperation for ChannelTransferOp {
     type Proof = ChannelMultiSigProof;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = ChannelTransferValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {
+    type Context<'a> = ();
     type Error = Error;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         // Check that the outputs are valid
         self.outputs.validate()?;
 
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for ChannelTransferOp {
+    type Context<'a> = ChannelTransferValidationContext<'a>;
+    type Error = Error;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         verify_channel_multi_sig(
             &self.channel_id,
             proof,

--- a/core/src/mantle/ops/channel/config.rs
+++ b/core/src/mantle/ops/channel/config.rs
@@ -9,7 +9,10 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error, SlotTimeframe, SlotTimeout},
-        ledger::{ExecutableOperation, ProvableOperation, VerifiableOperation, verification_mode},
+        ledger::{
+            ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
+            verification_mode,
+        },
         transactions::hash::TxHashView,
     },
     proofs::channel_multi_sig_proof::ChannelMultiSigProof,
@@ -51,15 +54,14 @@ impl ProvableOperation for ChannelConfigOp {
     type Proof = ChannelMultiSigProof;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = ChannelConfigValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
+    type Context<'a> = ();
     type Error = Error;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         // Check config is well-formed
         if self.configuration_threshold == 0 || self.transfer_threshold == 0 || self.keys.is_empty()
@@ -69,12 +71,13 @@ impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
 
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for ChannelConfigOp {
+    type Context<'a> = ChannelConfigValidationContext<'a>;
+    type Error = Error;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check that the indexes are unique and there is the same number of proof and
         // index. This is enforced by the proof structure that enforces it.
 

--- a/core/src/mantle/ops/channel/deposit.rs
+++ b/core/src/mantle/ops/channel/deposit.rs
@@ -8,8 +8,8 @@ use crate::{
     mantle::{
         channel::{Channels, Error},
         ledger::{
-            ExecutableOperation, Inputs, InputsError, Outputs, ProvableOperation, Utxos,
-            VerifiableOperation, verification_mode,
+            ExecutableOperation, Inputs, InputsError, Outputs, PreverifiableOperation,
+            ProvableOperation, Utxos, VerifiableOperation, verification_mode,
         },
         ops::{OpId, channel::ChannelId},
         transactions::hash::{TxHash, TxHashView},
@@ -68,24 +68,24 @@ impl ProvableOperation for DepositOp {
     type Proof = ZkSignature;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = DepositValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for DepositOp {
+    type Context<'a> = ();
     type Error = Error;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for DepositOp {
+    type Context<'a> = DepositValidationContext<'a>;
+    type Error = Error;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check that the channel exist
         if !context.channels.channels.contains_key(&self.channel_id) {
             return Err(Error::ChannelNotFound {

--- a/core/src/mantle/ops/channel/inscribe.rs
+++ b/core/src/mantle/ops/channel/inscribe.rs
@@ -13,7 +13,10 @@ use crate::{
     events::TxEvent,
     mantle::{
         channel::{ChannelState, Channels, Error},
-        ledger::{ExecutableOperation, ProvableOperation, VerifiableOperation, verification_mode},
+        ledger::{
+            ExecutableOperation, PreverifiableOperation, ProvableOperation, VerifiableOperation,
+            verification_mode,
+        },
         ops::channel::config::Keys,
         transactions::hash::TxHashView,
     },
@@ -63,15 +66,14 @@ impl ProvableOperation for InscriptionOp {
     type Proof = Ed25519Signature;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
-    type PreverificationContext<'a> = InscriptionPreverificationContext<'a>;
-    type VerificationContext<'a> = InscriptionValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for InscriptionOp {
+    type Context<'a> = InscriptionPreverificationContext<'a>;
     type Error = Error;
 
     fn preverify(
         &self,
         proof: &Self::Proof,
-        context: &Self::PreverificationContext<'_>,
+        context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         // Check the signature
         self.signer
@@ -80,12 +82,13 @@ impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
 
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        _proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for InscriptionOp {
+    type Context<'a> = InscriptionValidationContext<'a>;
+    type Error = Error;
+
+    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check if the channel exist otherwise the inscription is valid only if and
         // only if parent == ZERO
         if let Some(channel) = context.channels.channels.get(&self.channel_id).cloned() {

--- a/core/src/mantle/ops/channel/withdraw.rs
+++ b/core/src/mantle/ops/channel/withdraw.rs
@@ -7,8 +7,8 @@ use crate::{
         TxHash,
         channel::{Channels, Error},
         ledger::{
-            ExecutableOperation, Inputs, ProvableOperation, Utxos, VerifiableOperation,
-            verification_mode,
+            ExecutableOperation, Inputs, PreverifiableOperation, ProvableOperation, Utxos,
+            VerifiableOperation, verification_mode,
         },
         ops::{
             OpId,
@@ -51,24 +51,24 @@ impl ProvableOperation for ChannelWithdrawOp {
     type Proof = ChannelMultiSigProof;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = WithdrawValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {
+    type Context<'a> = ();
     type Error = Error;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for ChannelWithdrawOp {
+    type Context<'a> = WithdrawValidationContext<'a>;
+    type Error = Error;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         verify_channel_multi_sig(
             &self.channel_id,
             proof,

--- a/core/src/mantle/ops/leader_claim.rs
+++ b/core/src/mantle/ops/leader_claim.rs
@@ -13,7 +13,8 @@ use crate::{
     mantle::{
         Note, Utxo, Value,
         ledger::{
-            ExecutableOperation, ProvableOperation, Utxos, VerifiableOperation, verification_mode,
+            ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
+            VerifiableOperation, verification_mode,
         },
         ops::OpId,
         transactions::hash::{TxHash, TxHashView},
@@ -181,15 +182,14 @@ impl ProvableOperation for LeaderClaimOp {
     type Proof = Groth16LeaderClaimProof;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
-    type PreverificationContext<'a> = LeaderClaimPreverificationContext<'a>;
-    type VerificationContext<'a> = LeaderClaimVerificationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
+    type Context<'a> = LeaderClaimPreverificationContext<'a>;
     type Error = LeaderClaimError;
 
     fn preverify(
         &self,
         proof: &Self::Proof,
-        context: &Self::PreverificationContext<'_>,
+        context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         let is_verified = proof.verify(&LeaderClaimPublic {
             voucher_nullifier: self.voucher_nullifier.into(),
@@ -203,12 +203,13 @@ impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
             Err(LeaderClaimError::InvalidPoC)
         }
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for LeaderClaimOp {
+    type Context<'a> = LeaderClaimVerificationContext<'a>;
+    type Error = LeaderClaimError;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check that the nullifier isn't in the set
         if context.nullifiers.contains(&self.voucher_nullifier) {
             return Err(LeaderClaimError::DuplicatedVoucherNullifier);

--- a/core/src/mantle/ops/mod.rs
+++ b/core/src/mantle/ops/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod internal;
 
 pub(crate) mod codec;
 mod serde_;
+pub mod signed_op;
 
 use std::sync::LazyLock;
 
@@ -17,6 +18,7 @@ use channel::{
 use lb_codec::{BinaryDecode, BinaryEncode, DecodeError};
 use lb_key_management_system_keys::keys::{Ed25519Signature, ZkSignature};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+pub use signed_op::SignedOp;
 
 use super::{
     gas::{Gas, GasConstants},

--- a/core/src/mantle/ops/sdp/active.rs
+++ b/core/src/mantle/ops/sdp/active.rs
@@ -8,8 +8,8 @@ use crate::{
     events::TxEvent,
     mantle::{
         ledger::{
-            Declarations, ExecutableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode,
+            Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
+            VerifiableOperation, verification_mode,
         },
         transactions::hash::TxHashView,
     },
@@ -32,24 +32,24 @@ impl ProvableOperation for SDPActiveOp {
     type Proof = ZkSignature;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = SDPActiveValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
+    type Context<'a> = ();
     type Error = SdpError;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for SDPActiveOp {
+    type Context<'a> = SDPActiveValidationContext<'a>;
+    type Error = SdpError;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check the declaration exists
         let Some(declaration) = context.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));

--- a/core/src/mantle/ops/sdp/declare.rs
+++ b/core/src/mantle/ops/sdp/declare.rs
@@ -8,8 +8,8 @@ use crate::{
         Note,
         channel::Channels,
         ledger::{
-            Declarations, ExecutableOperation, ProvableOperation, Utxos, VerifiableOperation,
-            verification_mode,
+            Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation, Utxos,
+            VerifiableOperation, verification_mode,
         },
         ops::ZkAndEd25519Proof,
         transactions::hash::TxHashView,
@@ -158,24 +158,24 @@ impl ProvableOperation for SDPDeclareOp {
     type Proof = ZkAndEd25519Proof;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
-    type PreverificationContext<'a> = SDPDeclarePreverificationContext<'a>;
-    type VerificationContext<'a> = SDPDeclareVerificationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
+    type Context<'a> = SDPDeclarePreverificationContext<'a>;
     type Error = SdpError;
 
     fn preverify(
         &self,
         proof: &Self::Proof,
-        context: &Self::PreverificationContext<'_>,
+        context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         self.preverify(context.tx_hash_view, &proof.ed25519_sig)
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
+    type Context<'a> = SDPDeclareVerificationContext<'a>;
+    type Error = SdpError;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check that the note exist
         let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));
@@ -202,24 +202,24 @@ impl VerifiableOperation<verification_mode::StandardMode> for SDPDeclareOp {
     }
 }
 
-impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
-    type PreverificationContext<'a> = SDPDeclarePreverificationContext<'a>;
-    type VerificationContext<'a> = SDPDeclareGenesisValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
+    type Context<'a> = SDPDeclarePreverificationContext<'a>;
     type Error = SdpError;
 
     fn preverify(
         &self,
         proof: &Self::Proof,
-        context: &Self::PreverificationContext<'_>,
+        context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         self.preverify(context.tx_hash_view, &proof.ed25519_sig)
     }
+}
 
-    fn verify(
-        &self,
-        _proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::GenesisMode> for SDPDeclareOp {
+    type Context<'a> = SDPDeclareGenesisValidationContext<'a>;
+    type Error = SdpError;
+
+    fn verify(&self, _proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check that the note exist
         let Some((utxo, _)) = context.utxo_tree.utxos().get(&self.locked_note_id) else {
             return Err(SdpError::InexistingNote(self.locked_note_id));

--- a/core/src/mantle/ops/sdp/withdraw.rs
+++ b/core/src/mantle/ops/sdp/withdraw.rs
@@ -8,8 +8,8 @@ use crate::{
     events::TxEvent,
     mantle::{
         ledger::{
-            Declarations, ExecutableOperation, ProvableOperation, VerifiableOperation,
-            verification_mode,
+            Declarations, ExecutableOperation, PreverifiableOperation, ProvableOperation,
+            VerifiableOperation, verification_mode,
         },
         transactions::hash::TxHashView,
     },
@@ -35,24 +35,24 @@ impl ProvableOperation for SDPWithdrawOp {
     type Proof = ZkSignature;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = SDPWithdrawValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
+    type Context<'a> = ();
     type Error = SdpError;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for SDPWithdrawOp {
+    type Context<'a> = SDPWithdrawValidationContext<'a>;
+    type Error = SdpError;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Check that the declaration exists
         let Some(declaration) = context.declarations.get(&self.declaration_id) else {
             return Err(SdpError::DeclarationNotFound(self.declaration_id));

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -4,8 +4,8 @@ use crate::{
     events::TxEvent,
     mantle::{
         ledger::{
-            ExecutableOperation, Operation, ProvableOperation, VerifiableOperation,
-            verification_mode::VerificationMode,
+            ExecutableOperation, Operation, PreverifiableOperation, ProvableOperation,
+            VerifiableOperation, verification_mode::VerificationMode,
         },
         transactions::states::{Preverified, Unverified, VerificationState, Verified},
     },
@@ -57,24 +57,20 @@ impl<T: ProvableOperation, Mode: VerificationMode> SignedOp<T, Unverified, Mode>
     }
 }
 
-impl<T: ProvableOperation + VerifiableOperation<Mode>, Mode: VerificationMode>
-    SignedOp<T, Unverified, Mode>
-{
+impl<T: PreverifiableOperation<Mode>, Mode: VerificationMode> SignedOp<T, Unverified, Mode> {
     pub fn preverify(
         self,
-        context: &T::PreverificationContext<'_>,
+        context: &T::Context<'_>,
     ) -> Result<SignedOp<T, Preverified, Mode>, T::Error> {
         self.operation.preverify(&self.proof, context)?;
         Ok(self.into_state())
     }
 }
 
-impl<T: ProvableOperation + VerifiableOperation<Mode>, Mode: VerificationMode>
-    SignedOp<T, Preverified, Mode>
-{
+impl<T: VerifiableOperation<Mode>, Mode: VerificationMode> SignedOp<T, Preverified, Mode> {
     pub fn verify(
         self,
-        context: &T::VerificationContext<'_>,
+        context: &T::Context<'_>,
     ) -> Result<SignedOp<T, Verified, Mode>, (Self, T::Error)> {
         let verify_result = self.operation.verify(&self.proof, context);
         match verify_result {

--- a/core/src/mantle/ops/signed_op.rs
+++ b/core/src/mantle/ops/signed_op.rs
@@ -1,0 +1,97 @@
+use std::marker::PhantomData;
+
+use crate::{
+    events::TxEvent,
+    mantle::{
+        ledger::{
+            ExecutableOperation, Operation, ProvableOperation, VerifiableOperation,
+            verification_mode::VerificationMode,
+        },
+        transactions::states::{Preverified, Unverified, VerificationState, Verified},
+    },
+};
+
+pub struct SignedOp<T: ProvableOperation, State: VerificationState, Mode: VerificationMode> {
+    operation: T,
+    proof: T::Proof,
+    _marker: PhantomData<(State, Mode)>,
+}
+
+impl<T: ProvableOperation, State: VerificationState, Mode: VerificationMode>
+    SignedOp<T, State, Mode>
+{
+    #[must_use]
+    fn into_state<NewState: VerificationState>(self) -> SignedOp<T, NewState, Mode> {
+        let Self {
+            operation,
+            proof,
+            _marker,
+        } = self;
+
+        SignedOp::<T, NewState, Mode> {
+            operation,
+            proof,
+            _marker: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub const fn operation(&self) -> &T {
+        &self.operation
+    }
+
+    #[must_use]
+    pub const fn proof(&self) -> &T::Proof {
+        &self.proof
+    }
+}
+
+impl<T: ProvableOperation, Mode: VerificationMode> SignedOp<T, Unverified, Mode> {
+    #[must_use]
+    pub const fn new(operation: T, proof: T::Proof) -> Self {
+        Self {
+            operation,
+            proof,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: ProvableOperation + VerifiableOperation<Mode>, Mode: VerificationMode>
+    SignedOp<T, Unverified, Mode>
+{
+    pub fn preverify(
+        self,
+        context: &T::PreverificationContext<'_>,
+    ) -> Result<SignedOp<T, Preverified, Mode>, T::Error> {
+        self.operation.preverify(&self.proof, context)?;
+        Ok(self.into_state())
+    }
+}
+
+impl<T: ProvableOperation + VerifiableOperation<Mode>, Mode: VerificationMode>
+    SignedOp<T, Preverified, Mode>
+{
+    pub fn verify(
+        self,
+        context: &T::VerificationContext<'_>,
+    ) -> Result<SignedOp<T, Verified, Mode>, (Self, T::Error)> {
+        let verify_result = self.operation.verify(&self.proof, context);
+        match verify_result {
+            Ok(()) => Ok(self.into_state()),
+            Err(error) => Err((self, error)),
+        }
+    }
+}
+
+impl<T: Operation<Mode>, Mode: VerificationMode> SignedOp<T, Verified, Mode> {
+    pub fn execute<'a>(
+        &self,
+        context: <T as ExecutableOperation>::Context<'a>,
+    ) -> Result<
+        (<T as ExecutableOperation>::Context<'a>, Vec<TxEvent>),
+        <T as ExecutableOperation>::Error,
+    > {
+        self.operation.execute(context)
+    }
+}

--- a/core/src/mantle/ops/transfer.rs
+++ b/core/src/mantle/ops/transfer.rs
@@ -8,8 +8,8 @@ use crate::{
     mantle::{
         channel::Channels,
         ledger::{
-            self, ExecutableOperation, Inputs, Outputs, ProvableOperation, Utxo, Utxos,
-            VerifiableOperation, verification_mode,
+            self, ExecutableOperation, Inputs, Outputs, PreverifiableOperation, ProvableOperation,
+            Utxo, Utxos, VerifiableOperation, verification_mode,
         },
         ops::OpId,
         transactions::hash::TxHashView,
@@ -88,15 +88,14 @@ impl ProvableOperation for TransferOp {
     type Proof = ZkSignature;
 }
 
-impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
-    type PreverificationContext<'a> = ();
-    type VerificationContext<'a> = TransferValidationContext<'a>;
+impl PreverifiableOperation<verification_mode::StandardMode> for TransferOp {
+    type Context<'a> = ();
     type Error = TransferError;
 
     fn preverify(
         &self,
         _proof: &Self::Proof,
-        _context: &Self::PreverificationContext<'_>,
+        _context: &Self::Context<'_>,
     ) -> Result<(), Self::Error> {
         // Ensure the inputs is non-empty
         if self.inputs.is_empty() {
@@ -108,12 +107,13 @@ impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
 
         Ok(())
     }
+}
 
-    fn verify(
-        &self,
-        proof: &Self::Proof,
-        context: &Self::VerificationContext<'_>,
-    ) -> Result<(), Self::Error> {
+impl VerifiableOperation<verification_mode::StandardMode> for TransferOp {
+    type Context<'a> = TransferValidationContext<'a>;
+    type Error = TransferError;
+
+    fn verify(&self, proof: &Self::Proof, context: &Self::Context<'_>) -> Result<(), Self::Error> {
         // Validate Inputs
         self.inputs.validate_not_in_channel(
             context.locked_notes,

--- a/core/src/mantle/transactions/signed_mantle_tx.rs
+++ b/core/src/mantle/transactions/signed_mantle_tx.rs
@@ -7,7 +7,7 @@ use crate::{
     mantle::{
         RawMantleTx, Value, VerificationError,
         gas::{Gas, GasCalculator, GasConstants, GasCost, GasOverflow},
-        ledger::{VerifiableOperation, verification_mode::StandardMode},
+        ledger::{PreverifiableOperation, VerifiableOperation, verification_mode::StandardMode},
         ops::{
             Op, OpProof,
             channel::{
@@ -136,8 +136,10 @@ impl SignedMantleTx<Unverified> {
                 .map_err(VerificationError::ChannelVerificationError),
             (Op::SDPDeclare(op), OpProof::ZkAndEd25519Sigs(proof)) => {
                 let context = SDPDeclarePreverificationContext { tx_hash_view };
-                <SDPDeclareOp as VerifiableOperation<StandardMode>>::preverify(op, proof, &context)
-                    .map_err(VerificationError::SDPVerificationError)
+                <SDPDeclareOp as PreverifiableOperation<StandardMode>>::preverify(
+                    op, proof, &context,
+                )
+                .map_err(VerificationError::SDPVerificationError)
             }
             (Op::SDPWithdraw(op), OpProof::ZkSig(proof)) => op
                 .preverify(proof, &())

--- a/core/src/mantle/transactions/states.rs
+++ b/core/src/mantle/transactions/states.rs
@@ -1,12 +1,12 @@
 /// Marker trait for valid verification states of a transaction
 pub trait VerificationState {}
 
-/// Unverified state of a Transaction
+/// Unverified state of a Transaction/Operation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Unverified;
 impl VerificationState for Unverified {}
 
-/// Partially verified state of a Transaction
+/// Partially verified state of a Transaction/Operation
 ///
 /// This state indicates that the transaction has passed stateless checks. That
 /// is, checks that do not require access to the blockchain state, such as
@@ -14,3 +14,8 @@ impl VerificationState for Unverified {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Preverified;
 impl VerificationState for Preverified {}
+
+/// Fully verified state of a Transaction/Operation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Verified;
+impl VerificationState for Verified {}


### PR DESCRIPTION
## 1. What does this PR implement?
Almost there:
1. Add `SignedOp<T, State, Mode>`, the `Op` typestate wrapper.
   Not yet wired, though.
2. Split `VerifiableOperation<Mode>` into `PreverifiableOperation<Mode>` and `VerifiableOperation<Mode>`.
   These enables each state _just_ having the bare minimum to work and, therefore, not being able to call one method from the wrong state.
3. Propagate the split.

## 2. Does the code have enough context to be clearly understood?
Yes

## 3. Who are the specification authors and who is accountable for this PR?
@strinnityk 

## 4. Is the specification accurate and complete?
N/A

## 5. Does the implementation introduce changes in the specification?
N/A

## Checklist

> [!WARNING]  
> Do not merge the PR if any of the following is missing:

* [X] 1. The PR title follows the Conventional Commits [specification](https://www.notion.so/How-to-open-a-Pull-Request-215261aa09df80deb538ed59f5e4e0b5).
* [X] 2. Description added.
* [X] 3. Context and links to Specification document(s) added.
* [X] 4. Main contact(s) (developers and specification authors) added
* [X] 5. Implementation and Specification are 100% in sync including changes. This is critical.
* [X] 6. Link PR to a specific milestone.
* [X] 7. New or changed logs were reviewed against the [logging guidelines](https://github.com/logos-blockchain/logos-blockchain/blob/master/CONTRIBUTING.md#logging-guidelines).
