### PR TITLE
fix(zone-sdk): update correct tip on bundle custom txs

### DIFF
--- a/zone-sdk/src/sequencer/actor.rs
+++ b/zone-sdk/src/sequencer/actor.rs
@@ -832,6 +832,74 @@ mod tests {
         );
     }
 
+    /// A `submit_signed_tx` bundle whose last tip-advancing op is a config
+    /// must chain subsequent publishes off the config's id — even when the
+    /// caller passes the inscription's id as `msg_id`. Otherwise the next
+    /// publish claims the same channel position as the bundle and the two
+    /// race, permanently invalidating one side.
+    #[tokio::test]
+    async fn publish_after_bundle_chains_on_the_bundle_config_tip() {
+        let channel_id = ChannelId::from([0; 32]);
+        let sequencer_key = Ed25519Key::from_bytes(&[0; 32]);
+        let node = MockNode::default();
+        let mut sequencer = ZoneSequencer::init(
+            channel_id,
+            sequencer_key.clone(),
+            node,
+            funding_config(),
+            None,
+        );
+
+        loop {
+            if matches!(sequencer.next_event().await, Event::Ready) {
+                break;
+            }
+        }
+
+        let inscribe = InscriptionOp {
+            channel_id,
+            inscription: b"bundle".to_vec().try_into().unwrap(),
+            parent: MsgId::root(),
+            signer: sequencer_key.public_key(),
+        };
+        let config = ChannelConfigOp {
+            channel: channel_id,
+            keys: Keys::try_from(vec![sequencer_key.public_key()]).unwrap(),
+            posting_timeframe: SlotTimeframe::from(0u32),
+            posting_timeout: SlotTimeout::from(0u32),
+            configuration_threshold: 1,
+            transfer_threshold: 1,
+        };
+        let inscribe_msg = inscribe.id();
+        let config_msg = config.id();
+        let bundle = unverified_tx_with_ops(vec![
+            Op::ChannelInscribe(inscribe),
+            Op::ChannelConfig(config),
+        ]);
+
+        // The caller passes the *inscription's* id — the mistake this guards.
+        let (result, _cp) = sequencer
+            .handle()
+            .submit_signed_tx(bundle, inscribe_msg)
+            .expect("bundle submit should be accepted");
+        assert_eq!(
+            result.tx.inscription().this_msg,
+            config_msg,
+            "the bundle's resulting tip is its config op"
+        );
+
+        let (published, _cp) = sequencer
+            .handle()
+            .publish(b"after-bundle".into())
+            .await
+            .expect("publish after bundle should be accepted");
+        assert_eq!(
+            published.tx.inscription().parent_msg,
+            config_msg,
+            "the next publish must chain after the pending bundle's config tip"
+        );
+    }
+
     #[tokio::test]
     async fn config_only_block_sheds_pending_and_advances_checkpoint() {
         let channel_id = ChannelId::from([0; 32]);

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -43,15 +43,24 @@ struct PendingOtherTx {
     signed_tx: SignedMantleTx<Unverified>,
     first_parent: Option<MsgId>,
     last_msg: Option<MsgId>,
+    /// True when the tx bundles an inscription with its other ops (an atomic
+    /// bundle): it is part of the message chain, so publishes must chain
+    /// after it. A pure config cut carries no inscription and is not chained
+    /// — it orphans whatever it cuts off when it lands.
+    is_atomic_bundle: bool,
+    /// Submission order, for picking the newest chain restart among
+    /// config-led atomic bundles (see [`TxState::publish_parent`]).
+    seq: u64,
 }
 
 fn opaque_lineage(
     tx: &SignedMantleTx<Unverified>,
     channel_id: ChannelId,
-) -> (Option<MsgId>, Option<MsgId>) {
+) -> (Option<MsgId>, Option<MsgId>, bool) {
     let mut first_parent = None;
     let mut first_seen = false;
     let mut last_msg = None;
+    let mut is_atomic_bundle = false;
     for op in tx.mantle_tx().ops() {
         match op {
             Op::ChannelInscribe(inscribe) if inscribe.channel_id == channel_id => {
@@ -60,6 +69,7 @@ fn opaque_lineage(
                     first_parent = Some(inscribe.parent);
                 }
                 last_msg = Some(inscribe.id());
+                is_atomic_bundle = true;
             }
             Op::ChannelConfig(config) if config.channel == channel_id => {
                 first_seen = true;
@@ -68,7 +78,7 @@ fn opaque_lineage(
             _ => {}
         }
     }
-    (first_parent, last_msg)
+    (first_parent, last_msg, is_atomic_bundle)
 }
 
 /// Local pending inscription with lineage metadata.
@@ -110,6 +120,8 @@ pub struct TxState {
     block_txs: HashMap<HeaderId, Vec<BlockChannelTx>>,
     /// Last finalized channel tip — used as parent when pending is empty.
     finalized_msg: MsgId,
+    /// Monotonic submission counter for [`Self::pending_other`] entries.
+    next_other_seq: u64,
     /// Lineage-parent of the entry behind [`Self::finalized_msg`]. Config ids
     /// are payload-only hashes, so an id alone does not identify a lineage
     /// position — the pair does. `None` when the finalized entry is unknown
@@ -175,6 +187,7 @@ impl TxState {
             block_txs: HashMap::new(),
             finalized_msg,
             finalized_parent_msg: None,
+            next_other_seq: 0,
         }
     }
 
@@ -304,14 +317,18 @@ impl TxState {
         channel_id: ChannelId,
     ) -> Option<MsgId> {
         let tx_hash = signed_tx.mantle_tx().hash();
-        let (first_parent, last_msg) = opaque_lineage(&signed_tx, channel_id);
+        let (first_parent, last_msg, is_atomic_bundle) = opaque_lineage(&signed_tx, channel_id);
         self.track_local_tx(tx_hash);
+        let seq = self.next_other_seq;
+        self.next_other_seq += 1;
         self.pending_other.insert(
             tx_hash,
             PendingOtherTx {
                 signed_tx,
                 first_parent,
                 last_msg,
+                is_atomic_bundle,
+                seq,
             },
         );
         last_msg
@@ -738,8 +755,23 @@ impl TxState {
     #[must_use]
     pub fn publish_parent(&self, tip: HeaderId) -> MsgId {
         let channel_tip = self.channel_tip_at(tip);
-        let tail = self.pending_publish_tail(channel_tip);
-        tail.unwrap_or(channel_tip)
+        // A pending config-led atomic bundle (`first_parent == None` but
+        // carrying an inscription) is part of the message chain even though
+        // nothing anchors it — the config resets the tip wherever it lands —
+        // so it acts as a chain restart: the walk starts from the newest
+        // one's last tip-advancing op instead of the mined channel tip. A
+        // pure config cut (no inscription) is deliberately NOT chained: it
+        // lands whenever it lands and orphans what it cut off, which is the
+        // shed/republish recovery contract.
+        let restart = self
+            .pending_other
+            .values()
+            .filter(|other| other.first_parent.is_none() && other.is_atomic_bundle)
+            .max_by_key(|other| other.seq)
+            .and_then(|other| other.last_msg);
+        let start = restart.unwrap_or(channel_tip);
+        let tail = self.pending_publish_tail(start);
+        tail.unwrap_or(start)
     }
 
     /// Walk local pending lineage from `from_msg` to find the tail,
@@ -1307,6 +1339,92 @@ mod tests {
             state.publish_parent(tip),
             MsgId::root(),
             "walk must stop before a contested position"
+        );
+    }
+
+    /// A pending config-led tx (`[config, inscribe]`, nothing anchoring it to
+    /// the chain) acts as a chain restart: the next publish chains on its
+    /// last tip-advancing op, and anchored pending links continue from there.
+    #[test]
+    fn publish_parent_restarts_at_pending_config_led_tx() {
+        use lb_core::mantle::{
+            channel::{SlotTimeframe, SlotTimeout},
+            ops::channel::config::{ChannelConfigOp, Keys},
+        };
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+        state.process_block(tip, genesis, genesis, vec![], vec![]);
+
+        let config = ChannelConfigOp {
+            channel: [0u8; 32].into(),
+            keys: Keys::try_from(vec![Ed25519PublicKey::from_bytes(&[0u8; 32]).unwrap()]).unwrap(),
+            posting_timeframe: SlotTimeframe::from(0u32),
+            posting_timeout: SlotTimeout::from(0u32),
+            configuration_threshold: 1,
+            transfer_threshold: 1,
+        };
+        let inscribe = InscriptionOp {
+            channel_id: [0u8; 32].into(),
+            inscription: [7].into(),
+            parent: config.id(),
+            signer: Ed25519PublicKey::from_bytes(&[0u8; 32]).unwrap(),
+        };
+        let inscribe_msg = inscribe.id();
+        let tx = SignedMantleTx::new(
+            RawMantleTx([Op::ChannelConfig(config), ChannelInscribe(inscribe)].into()),
+            OpsProofs::empty(),
+        );
+
+        let derived = state.submit_other(tx, channel_id);
+        assert_eq!(derived, Some(inscribe_msg), "tip is the tx's last op");
+        assert_eq!(
+            state.publish_parent(tip),
+            inscribe_msg,
+            "walk restarts at the pending config-led tx's last op"
+        );
+
+        // Anchored pending links continue from the restart point.
+        state.submit_inscription(make_dummy_tx(9), inscribe_msg, msg_id(90), [9].into());
+        assert_eq!(state.publish_parent(tip), msg_id(90));
+    }
+
+    /// A pure config cut (no inscription in the tx) is NOT chained: it lands
+    /// whenever it lands and orphans what it cut off — publishes keep
+    /// chaining on the existing pending chain meanwhile.
+    #[test]
+    fn publish_parent_ignores_pending_pure_config_cut() {
+        use lb_core::mantle::{
+            channel::{SlotTimeframe, SlotTimeout},
+            ops::channel::config::{ChannelConfigOp, Keys},
+        };
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+        state.process_block(tip, genesis, genesis, vec![], vec![]);
+
+        state.submit_inscription(make_dummy_tx(1), MsgId::root(), msg_id(10), [1].into());
+
+        let config = ChannelConfigOp {
+            channel: [0u8; 32].into(),
+            keys: Keys::try_from(vec![Ed25519PublicKey::from_bytes(&[0u8; 32]).unwrap()]).unwrap(),
+            posting_timeframe: SlotTimeframe::from(0u32),
+            posting_timeout: SlotTimeout::from(0u32),
+            configuration_threshold: 1,
+            transfer_threshold: 1,
+        };
+        let cut = SignedMantleTx::new(
+            RawMantleTx([Op::ChannelConfig(config)].into()),
+            OpsProofs::empty(),
+        );
+        state.submit_other(cut, channel_id);
+
+        assert_eq!(
+            state.publish_parent(tip),
+            msg_id(10),
+            "a pure config cut must not divert the publish chain"
         );
     }
 

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -468,10 +468,11 @@ impl TxState {
     /// Pending txs eligible for resubmission: not yet safe at tip AND
     /// part of the local suffix reachable from canonical channel tip.
     ///
-    /// Returned in parent-before-child order (BFS from channel tip via
-    /// `pending_by_parent`) so the node's mempool sees the parent before
-    /// any child — matters on checkpoint resume, where `HashMap`
-    /// iteration order is arbitrary.
+    /// Returned in parent-before-child order so the node's mempool sees the
+    /// parent before any child: inscriptions via BFS from channel tip
+    /// (`pending_by_parent`), opaque txs by submission order (`seq`) — a
+    /// locally chained bundle can only be built after the bundle that
+    /// establishes its parent tip, so submission order is dependency order.
     pub fn pending_txs(&self, tip: HeaderId) -> Vec<(TxHash, SignedMantleTx<Unverified>)> {
         let safe = self
             .block_states
@@ -489,12 +490,19 @@ impl TxState {
                     .get(&info.tx_hash)
                     .map(|p| (info.tx_hash, p.signed_tx.clone()))
             });
-        let others = self
+        let mut others: Vec<_> = self
             .pending_other
             .iter()
             .filter(|(hash, _)| !safe.contains(hash))
-            .map(|(hash, entry)| (*hash, entry.signed_tx.clone()));
-        inscriptions.chain(others).collect()
+            .collect();
+        others.sort_unstable_by_key(|(_, entry)| entry.seq);
+        inscriptions
+            .chain(
+                others
+                    .into_iter()
+                    .map(|(hash, entry)| (*hash, entry.signed_tx.clone())),
+            )
+            .collect()
     }
 
     /// Number of pending transactions (all types).
@@ -723,11 +731,15 @@ impl TxState {
             .pending
             .iter()
             .map(|(hash, p)| (*hash, p.signed_tx.clone()));
-        let others = self
-            .pending_other
-            .iter()
-            .map(|(hash, entry)| (*hash, entry.signed_tx.clone()));
-        inscriptions.chain(others).collect()
+        let mut others: Vec<_> = self.pending_other.iter().collect();
+        others.sort_unstable_by_key(|(_, entry)| entry.seq);
+        inscriptions
+            .chain(
+                others
+                    .into_iter()
+                    .map(|(hash, entry)| (*hash, entry.signed_tx.clone())),
+            )
+            .collect()
     }
 
     /// Remove a pending inscription and return its signed tx.
@@ -1298,6 +1310,35 @@ mod tests {
             state.publish_parent(tip),
             config_msg,
             "next publish must chain after the pending bundle"
+        );
+    }
+
+    #[test]
+    fn pending_txs_orders_chained_bundles_parent_before_child() {
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+        state.process_block(tip, genesis, genesis, vec![], vec![]);
+
+        let mut parent = MsgId::root();
+        let mut hashes = Vec::new();
+        for data in 1..=6u8 {
+            let (bundle, _inscribe_msg, config_msg) = bundle_tx(parent, data);
+            hashes.push(bundle.mantle_tx().hash());
+            state.submit_other(bundle, channel_id);
+            parent = config_msg;
+        }
+
+        let resubmit: Vec<TxHash> = state.pending_txs(tip).iter().map(|(h, _)| *h).collect();
+        assert_eq!(
+            resubmit, hashes,
+            "resubmission must return chained bundles parent-before-child"
+        );
+        let checkpoint: Vec<TxHash> = state.all_pending_txs().iter().map(|(h, _)| *h).collect();
+        assert_eq!(
+            checkpoint, hashes,
+            "checkpoint serialization must preserve bundle submission order"
         );
     }
 

--- a/zone-sdk/src/sequencer/state.rs
+++ b/zone-sdk/src/sequencer/state.rs
@@ -296,7 +296,13 @@ impl TxState {
             .collect()
     }
 
-    pub fn submit_other(&mut self, signed_tx: SignedMantleTx<Unverified>, channel_id: ChannelId) {
+    /// Returns the channel tip the tx leaves behind once mined (its last
+    /// tip-advancing op), or `None` when it carries none for this channel.
+    pub fn submit_other(
+        &mut self,
+        signed_tx: SignedMantleTx<Unverified>,
+        channel_id: ChannelId,
+    ) -> Option<MsgId> {
         let tx_hash = signed_tx.mantle_tx().hash();
         let (first_parent, last_msg) = opaque_lineage(&signed_tx, channel_id);
         self.track_local_tx(tx_hash);
@@ -308,6 +314,7 @@ impl TxState {
                 last_msg,
             },
         );
+        last_msg
     }
 
     fn track_local_tx(&mut self, tx_hash: TxHash) {
@@ -742,19 +749,52 @@ impl TxState {
         let mut current = from_msg;
         let mut found_any = false;
 
-        loop {
-            let Some(children) = self.pending_by_parent.get(&current) else {
+        // Bounded by the pending population: a longer walk would mean a
+        // cycle in (possibly inconsistent) pending lineage data.
+        for _ in 0..=(self.pending.len() + self.pending_other.len()) {
+            let Some(next) = self.single_pending_child(current) else {
                 return found_any.then_some(current);
             };
-            if children.len() != 1 {
-                return found_any.then_some(current);
-            }
-            let Some(pending) = self.pending.get(&children[0]) else {
-                return found_any.then_some(current);
-            };
-            current = pending.this_msg;
+            current = next;
             found_any = true;
         }
+        found_any.then_some(current)
+    }
+
+    /// The unique pending link chaining off `current`, considering both plain
+    /// pending inscriptions and opaque pending txs (`submit_signed_tx`
+    /// bundles), which enter the chain at their first inscription's parent
+    /// and leave it at their last tip-advancing op. A contested position
+    /// (multiple candidates) yields `None` so the caller stops before it.
+    fn single_pending_child(&self, current: MsgId) -> Option<MsgId> {
+        let mut candidate: Option<MsgId> = None;
+        let mut push = |msg: MsgId| -> bool {
+            if candidate.is_some() && candidate != Some(msg) {
+                return false;
+            }
+            candidate = Some(msg);
+            true
+        };
+
+        if let Some(children) = self.pending_by_parent.get(&current) {
+            for tx_hash in children {
+                if let Some(pending) = self.pending.get(tx_hash)
+                    && !push(pending.this_msg)
+                {
+                    return None;
+                }
+            }
+        }
+        for other in self.pending_other.values() {
+            if other.first_parent == Some(current)
+                && let Some(last_msg) = other.last_msg
+                && last_msg != current
+                && !push(last_msg)
+            {
+                return None;
+            }
+        }
+        candidate
     }
 
     /// Derive the channel tip `MsgId` at a given L1 block by walking backwards
@@ -1175,6 +1215,99 @@ mod tests {
 
         // At b2 tip, tx is back in pending_txs (different branch)
         assert!(state.pending_txs(b2).iter().any(|(h, _)| *h == hash));
+    }
+
+    /// Build an `[inscribe(parent), config]` bundle tx for the zero channel.
+    fn bundle_tx(parent: MsgId, data: u8) -> (SignedMantleTx<Unverified>, MsgId, MsgId) {
+        use lb_core::mantle::{
+            channel::{SlotTimeframe, SlotTimeout},
+            ops::channel::config::{ChannelConfigOp, Keys},
+        };
+        let inscribe = InscriptionOp {
+            channel_id: [0u8; 32].into(),
+            inscription: [data].into(),
+            parent,
+            signer: Ed25519PublicKey::from_bytes(&[0u8; 32]).unwrap(),
+        };
+        let config = ChannelConfigOp {
+            channel: [0u8; 32].into(),
+            keys: Keys::try_from(vec![Ed25519PublicKey::from_bytes(&[0u8; 32]).unwrap()]).unwrap(),
+            posting_timeframe: SlotTimeframe::from(0u32),
+            posting_timeout: SlotTimeout::from(0u32),
+            configuration_threshold: 1,
+            transfer_threshold: 1,
+        };
+        let inscribe_msg = inscribe.id();
+        let config_msg = config.id();
+        let tx = SignedMantleTx::new(
+            RawMantleTx([ChannelInscribe(inscribe), Op::ChannelConfig(config)].into()),
+            OpsProofs::empty(),
+        );
+        (tx, inscribe_msg, config_msg)
+    }
+
+    /// A pending `submit_signed_tx` bundle must participate in publish-parent
+    /// chaining: the next publish chains off the bundle's *last* tip-advancing
+    /// op (the config), not the pre-bundle tip — otherwise the two txs race
+    /// for the same channel position and one is permanently invalidated.
+    #[test]
+    fn publish_parent_chains_through_pending_bundle() {
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+        state.process_block(tip, genesis, genesis, vec![], vec![]);
+
+        let (bundle, _inscribe_msg, config_msg) = bundle_tx(MsgId::root(), 1);
+        let derived = state.submit_other(bundle, channel_id);
+        assert_eq!(derived, Some(config_msg), "bundle tip is its config op");
+
+        assert_eq!(
+            state.publish_parent(tip),
+            config_msg,
+            "next publish must chain after the pending bundle"
+        );
+    }
+
+    /// The chain walk composes across kinds: pending inscription, then a
+    /// bundle chained on it, then another pending inscription on the bundle's
+    /// config tip.
+    #[test]
+    fn publish_parent_walks_mixed_pending_chain() {
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+        state.process_block(tip, genesis, genesis, vec![], vec![]);
+
+        state.submit_inscription(make_dummy_tx(1), MsgId::root(), msg_id(10), [1].into());
+        let (bundle, _i, config_msg) = bundle_tx(msg_id(10), 2);
+        state.submit_other(bundle, channel_id);
+        state.submit_inscription(make_dummy_tx(3), config_msg, msg_id(30), [3].into());
+
+        assert_eq!(state.publish_parent(tip), msg_id(30));
+    }
+
+    /// A contested position (pending inscription and bundle both claiming the
+    /// same parent) stops the walk before the conflict, as for competing
+    /// inscriptions.
+    #[test]
+    fn publish_parent_stops_at_contested_bundle_position() {
+        let genesis = header_id(0);
+        let tip = header_id(1);
+        let channel_id = ChannelId::from([0u8; 32]);
+        let mut state = TxState::new(genesis, MsgId::root());
+        state.process_block(tip, genesis, genesis, vec![], vec![]);
+
+        state.submit_inscription(make_dummy_tx(1), MsgId::root(), msg_id(10), [1].into());
+        let (bundle, _i, _c) = bundle_tx(MsgId::root(), 2);
+        state.submit_other(bundle, channel_id);
+
+        assert_eq!(
+            state.publish_parent(tip),
+            MsgId::root(),
+            "walk must stop before a contested position"
+        );
     }
 
     #[test]

--- a/zone-sdk/src/sequencer/zone_sequencer.rs
+++ b/zone-sdk/src/sequencer/zone_sequencer.rs
@@ -853,9 +853,20 @@ where
         // Safe to unwrap — `ensure_ready` checks state.
         let state = self.state.as_mut().unwrap();
         let id = tx.mantle_tx().hash();
-        track_pending_tx(state, tx.clone(), self.channel_id);
+        let derived_tip = track_pending_tx(state, tx.clone(), self.channel_id);
         let parent_msg = self.last_msg_id;
-        self.last_msg_id = msg_id;
+        // The tip the tx leaves behind is defined by its ops (the last
+        // tip-advancing one — e.g. a config after an inscribe resets it), so
+        // the caller's `msg_id` is only a fallback for txs without one.
+        let new_tip = derived_tip.unwrap_or(msg_id);
+        if new_tip != msg_id {
+            warn!(target: TARGET,
+                "submit_signed_tx: caller msg_id {:?} is not the tx's resulting channel tip {:?}; \
+                 using the derived tip",
+                msg_id, new_tip
+            );
+        }
+        self.last_msg_id = new_tip;
         self.queue_tx_status(id, TxStatus::AcceptedLocally);
 
         info!(target: TARGET, "Submitted tx including inscription {:?}", id);
@@ -883,7 +894,7 @@ where
                 tx: PendingTx::Inscription(InscriptionInfo {
                     tx_hash: id,
                     parent_msg,
-                    this_msg: msg_id,
+                    this_msg: new_tip,
                     payload,
                 }),
             },
@@ -1065,22 +1076,30 @@ fn restored_pending_channel_tip(
 
 /// Track a signed tx in pending state: publish-shaped txs enter the
 /// inscription lineage, everything else is tracked opaquely.
+/// Returns the channel tip the tx leaves behind once mined (its last
+/// tip-advancing op), or `None` when the tx carries none for this channel.
 pub(super) fn track_pending_tx(
     state: &mut TxState,
     tx: SignedMantleTx<Unverified>,
     channel_id: ChannelId,
-) {
+) -> Option<MsgId> {
     match classify_channel_tx(&tx, channel_id, &mut None) {
         Some(BlockChannelTx::Inscription(i)) => {
-            state.submit_inscription(tx, i.parent_msg, i.this_msg, i.payload);
+            let this_msg = i.this_msg;
+            state.submit_inscription(tx, i.parent_msg, this_msg, i.payload);
+            Some(this_msg)
         }
-        Some(BlockChannelTx::AtomicWithdraw(aw)) => state.submit_atomic_withdraw(
-            tx,
-            aw.inscription.parent_msg,
-            aw.inscription.this_msg,
-            aw.inscription.payload,
-            aw.withdraws,
-        ),
+        Some(BlockChannelTx::AtomicWithdraw(aw)) => {
+            let this_msg = aw.inscription.this_msg;
+            state.submit_atomic_withdraw(
+                tx,
+                aw.inscription.parent_msg,
+                this_msg,
+                aw.inscription.payload,
+                aw.withdraws,
+            );
+            Some(this_msg)
+        }
         _ => state.submit_other(tx, channel_id),
     }
 }


### PR DESCRIPTION
## 1. What does this PR implement?

There is a bug in updating the tip on custom tx bundle with multiple ops. The tip was correct after mined but not in local pending state.

There are 2 cases:
1. If custom tx does not carry inscriptions it does not matter, config updates would reset the tip and orphan non valid inscriptions
2. if custom tx does have an inscription it needs  to chain properly to preserve the inscription order correctly.