### PR TITLE
fix(release): quick-start must install blockchain_module 0.2.1 (0.2.0 cannot sync the 0.2.1 chain)

### DIFF
--- a/.github/release/release-content.md
+++ b/.github/release/release-content.md
@@ -11,14 +11,14 @@
 2. Download the Logos Blockchain module using the Logos Package Downloader:
 
 ```bash
-lgpd download blockchain_module --version 0.2.0 --output ./
-# writes ./blockchain_module-0.2.0.lgx
+lgpd download blockchain_module --version 0.2.1 --output ./
+# writes ./blockchain_module-0.2.1.lgx
 ```
 
 3. Install the Logos Blockchain module using the Logos Package Manager:
 
 ```bash
-lgpm --modules-dir ./modules install --file blockchain_module-0.2.0.lgx
+lgpm --modules-dir ./modules install --file blockchain_module-0.2.1.lgx
 ```
 
 4. Launch the Logos Core CLI in daemon mode and load the blockchain module:


### PR DESCRIPTION
Fixes #3262.

The 0.2.1 release quick-start (`.github/release/release-content.md`) instructs `blockchain_module --version 0.2.0`. A 0.2.0 module **cannot negotiate libp2p/QUIC with the 0.2.1 bootstrap peers** (`Failed to negotiate transport protocol(s) → handshake timed out`, all peers; UDP reachable — protocol skew, not connectivity), then the Blend service fails and the daemon self-shuts-down. So every operator following the published quick-start gets a node that never syncs.

`blockchain_module 0.2.1` is published (`2026-08-05T09:38:38Z`). With it, an otherwise identical config connects to all 4 peers, completes IBD, and reaches Online on genesis `1785920400000`.

### Change
Bump the three `blockchain_module` version references in the quick-start to `0.2.1` (download `--version`, the written `.lgx` filename, and the `lgpm install --file`). Verified on-device.

### Left out on purpose
- The `lgpd`/`logoscore` tool tags (L7–L9) still point at `0.2.0`. I ran 0.2.1 tools successfully but did **not** verify that 0.2.0 tools fail, so I left those unchanged — maintainers may want to confirm/bump separately.
- The already-published 0.2.1 release **body** is a snapshot and won't pick up this repo change; it should be re-edited to match.
- Systemic: this file hardcodes versions while `Dockerfile` uses `$LB_NODE_VERSION`. Templating the module version here would prevent the same drift next release.

---
*Opened by an independent EcoDev trial participant with AI-agent assistance (Claude).*
