### PR TITLE
fix: lru vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5401,9 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 
 [[package]]
 name = "lru-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ libp2p                             = { default-features = false, version = "0.56
 libp2p-stream                      = { default-features = false, version = "0.4.0-alpha" }
 libp2p-swarm-test                  = { default-features = false, version = "0.6" }
 log                                = { default-features = false, version = "0.4" }
-lru                                = { default-features = false, version = "0.12" }
+lru                                = { default-features = false, version = "0.18.2" }
 multiaddr                          = { default-features = false, version = "0.18" }
 natpmp                             = { default-features = false, version = "0.5" }
 netdev                             = { default-features = false, version = "0.31" }


### PR DESCRIPTION
## 1. What does this PR implement?

Fixes https://github.com/logos-blockchain/logos-blockchain/security/dependabot/3. The current libp2p version also pulls a vulnerable version of `lru`, but that will be gone once https://github.com/logos-blockchain/logos-blockchain/pull/3267 (and this) are merged.